### PR TITLE
Core: compatibility manifest and connect-time tuple evaluation

### DIFF
--- a/Packages/GuesthouseCore/Package.swift
+++ b/Packages/GuesthouseCore/Package.swift
@@ -25,6 +25,9 @@ let package = Package(
     targets: [
         .target(
             name: "GuesthouseCore",
+            resources: [
+                .copy("Resources/compatibility-manifest.json")
+            ],
             swiftSettings: coreSwiftSettings
         ),
         .testTarget(

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -85,9 +85,12 @@ public enum CompatibilityEvaluator: Sendable {
         // Official evidence for this exact combination counts regardless of what else the user
         // connected before; only then does unrelated history mean drift. Host ranges may
         // overlap, so every matching entry is asked, not only the first: one entry per tested
-        // host build is the natural way to record two verifications of one combination.
+        // host build is the natural way to record two verifications of one combination. When
+        // several cover this exact host, report its last successful connection (§5).
         let matching = manifest.tested.filter { $0.matches(exact) }
-        if let verification = matching.compactMap(\.verification).first(where: { $0.covers(exact) }) {
+        if let verification = matching.compactMap(\.verification)
+            .filter({ $0.covers(exact) })
+            .max(by: { $0.verifiedAt < $1.verifiedAt }) {
             return .verified(recordedAt: verification.verifiedAt)
         }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -6,8 +6,9 @@ public enum CompatibilityState: Codable, Hashable, Sendable {
     case verified(recordedAt: Date)
     /// Handoff is allowed only after the user performs and confirms a real desktop connection.
     case needsValidation(NeedsValidationReason)
-    /// Handoff is blocked. Console access, shutdown, and work export stay available.
-    case incompatible(reason: String)
+    /// Handoff is blocked. Console access, shutdown, and work export stay available; the
+    /// rule names what else the user can do.
+    case incompatible(reason: String, recoveryActions: [RecoveryAction])
 
     public enum NeedsValidationReason: Codable, Hashable, Sendable {
         /// At least one component could not be identified. Never guess; ask for validation.
@@ -43,7 +44,7 @@ public enum CompatibilityEvaluator: Sendable {
         history: [ConnectionVerificationRecord]
     ) -> CompatibilityState {
         if let rule = manifest.incompatibilities.first(where: { $0.applies(to: observed) }) {
-            return .incompatible(reason: rule.reason)
+            return .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions)
         }
 
         let unknown = observed.unknownFields

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -50,6 +50,12 @@ public enum CompatibilityEvaluator: Sendable {
             return .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions)
         }
 
+        // No probe can see fewer than zero executables, so a count that says so is corrupt
+        // rather than a report of the single unambiguous installation a handoff needs.
+        if let installations = observed.codexCLIInstallations, installations < 0 {
+            return .needsValidation(.unknownFields([.codexCLIInstallations]))
+        }
+
         // A probe that found no executable is decisive on its own, whatever else is unknown.
         if observed.codexCLIInstallations == 0 {
             return .needsValidation(.codexCLIMissing)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -59,20 +59,23 @@ public enum CompatibilityEvaluator: Sendable {
             return .verified(recordedAt: record.verifiedAt)
         }
 
+        // Official evidence for this exact combination counts regardless of what else the user
+        // connected before; only then does unrelated history mean drift.
+        let tested = manifest.tested.first(where: { $0.matches(exact) })
+        if let verification = tested?.verification, verification.covers(exact) {
+            return .verified(recordedAt: verification.verifiedAt)
+        }
+
         if let latest = history.max(by: { $0.verifiedAt < $1.verifiedAt }) {
             return .needsValidation(.changedSinceLastVerified(exact.differences(from: latest.tuple)))
         }
 
-        guard let tested = manifest.tested.first(where: { $0.matches(exact) }) else {
+        guard let tested else {
             return .needsValidation(.untestedCombination)
         }
-
-        guard let verification = tested.verification else {
+        guard tested.verification != nil else {
             return .needsValidation(.neverConnected)
         }
-        guard verification.covers(exact) else {
-            return .needsValidation(.verifiedOnDifferentHost)
-        }
-        return .verified(recordedAt: verification.verifiedAt)
+        return .needsValidation(.verifiedOnDifferentHost)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -15,6 +15,9 @@ public enum CompatibilityState: Codable, Hashable, Sendable {
         case unknownFields([CompatibilityField])
         /// The guest login shell can see more than one Codex executable.
         case competingInstallations(count: Int)
+        /// The guest login shell can see no Codex executable at all: a missing prerequisite,
+        /// not something a real desktop connection could validate.
+        case codexCLIMissing
         /// A known combination, but no real connection has ever been recorded for it.
         case neverConnected
         /// The manifest records a connection for this combination, but on a different host
@@ -47,12 +50,17 @@ public enum CompatibilityEvaluator: Sendable {
             return .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions)
         }
 
+        // A probe that found no executable is decisive on its own, whatever else is unknown.
+        if observed.codexCLIInstallations == 0 {
+            return .needsValidation(.codexCLIMissing)
+        }
+
         let unknown = observed.unknownFields
         guard unknown.isEmpty, let exact = observed.exact else {
             return .needsValidation(.unknownFields(unknown))
         }
 
-        if exact.codexCLIInstallations != 1 {
+        if exact.codexCLIInstallations > 1 {
             return .needsValidation(.competingInstallations(count: exact.codexCLIInstallations))
         }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -56,9 +56,21 @@ public enum CompatibilityEvaluator: Sendable {
             return .needsValidation(.unknownFields([.codexCLIInstallations]))
         }
 
+        // No protocol version is below zero either, and a corrupt one must not become part of
+        // an exact tuple that a later, equally corrupt observation could match as verified.
+        if let protocolVersion = observed.runtimeProtocolVersion, protocolVersion < 0 {
+            return .needsValidation(.unknownFields([.runtimeProtocolVersion]))
+        }
+
         // A probe that found no executable is decisive on its own, whatever else is unknown.
         if observed.codexCLIInstallations == 0 {
             return .needsValidation(.codexCLIMissing)
+        }
+
+        // So is a probe that found several: refusing to name one of them is why the version and
+        // path are unknown, and reporting that as missing fields hides the actual problem.
+        if let installations = observed.codexCLIInstallations, installations > 1 {
+            return .needsValidation(.competingInstallations(count: installations))
         }
 
         let unknown = observed.unknownFields
@@ -66,18 +78,16 @@ public enum CompatibilityEvaluator: Sendable {
             return .needsValidation(.unknownFields(unknown))
         }
 
-        if exact.codexCLIInstallations > 1 {
-            return .needsValidation(.competingInstallations(count: exact.codexCLIInstallations))
-        }
-
         if let record = history.filter({ $0.tuple == exact }).max(by: { $0.verifiedAt < $1.verifiedAt }) {
             return .verified(recordedAt: record.verifiedAt)
         }
 
         // Official evidence for this exact combination counts regardless of what else the user
-        // connected before; only then does unrelated history mean drift.
-        let tested = manifest.tested.first(where: { $0.matches(exact) })
-        if let verification = tested?.verification, verification.covers(exact) {
+        // connected before; only then does unrelated history mean drift. Host ranges may
+        // overlap, so every matching entry is asked, not only the first: one entry per tested
+        // host build is the natural way to record two verifications of one combination.
+        let matching = manifest.tested.filter { $0.matches(exact) }
+        if let verification = matching.compactMap(\.verification).first(where: { $0.covers(exact) }) {
             return .verified(recordedAt: verification.verifiedAt)
         }
 
@@ -85,10 +95,10 @@ public enum CompatibilityEvaluator: Sendable {
             return .needsValidation(.changedSinceLastVerified(exact.differences(from: latest.tuple)))
         }
 
-        guard let tested else {
+        guard !matching.isEmpty else {
             return .needsValidation(.untestedCombination)
         }
-        guard tested.verification != nil else {
+        guard matching.contains(where: \.isVerified) else {
             return .needsValidation(.neverConnected)
         }
         return .needsValidation(.verifiedOnDifferentHost)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -32,7 +32,7 @@ public enum CompatibilityState: Codable, Hashable, Sendable {
 }
 
 /// Pure decision logic. No I/O; the caller supplies what it observed and what it remembers.
-public enum CompatibilityEvaluator {
+public enum CompatibilityEvaluator: Sendable {
     /// - Parameters:
     ///   - observed: what was read from the host, desktop app, and guest right now.
     ///   - manifest: the shipped list of tested combinations.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+/// The three states MVP-PLAN.md §5 defines for a Codex handoff.
+public enum CompatibilityState: Codable, Hashable, Sendable {
+    /// This exact combination has a recorded real desktop connection.
+    case verified(recordedAt: Date)
+    /// Handoff is allowed only after the user performs and confirms a real desktop connection.
+    case needsValidation(NeedsValidationReason)
+    /// Handoff is blocked. Console access, shutdown, and work export stay available.
+    case incompatible(reason: String)
+
+    public enum NeedsValidationReason: Codable, Hashable, Sendable {
+        /// At least one component could not be identified. Never guess; ask for validation.
+        case unknownFields([CompatibilityField])
+        /// A known combination, but no real connection has ever been recorded for it.
+        case neverConnected
+        /// Something changed since the last recorded connection.
+        case changedSinceLastVerified([CompatibilityField])
+        /// This combination is not in the manifest at all.
+        case untestedCombination
+    }
+
+    public var allowsHandoff: Bool {
+        if case .verified = self { return true }
+        return false
+    }
+}
+
+/// Pure decision logic. No I/O; the caller supplies what it observed and what it remembers.
+public enum CompatibilityEvaluator {
+    /// - Parameters:
+    ///   - observed: what was read from the host, desktop app, and guest right now.
+    ///   - manifest: the shipped list of tested combinations.
+    ///   - history: previously recorded real connections, newest last or in any order.
+    public static func evaluate(
+        observed: ObservedTuple,
+        manifest: CompatibilityManifest,
+        history: [ConnectionVerificationRecord]
+    ) -> CompatibilityState {
+        if let rule = manifest.incompatibilities.first(where: { $0.applies(to: observed) }) {
+            return .incompatible(reason: rule.reason)
+        }
+
+        let unknown = observed.unknownFields
+        guard unknown.isEmpty, let exact = observed.exact else {
+            return .needsValidation(.unknownFields(unknown))
+        }
+
+        if let record = history.filter({ $0.tuple == exact }).max(by: { $0.verifiedAt < $1.verifiedAt }) {
+            return .verified(recordedAt: record.verifiedAt)
+        }
+
+        if let latest = history.max(by: { $0.verifiedAt < $1.verifiedAt }) {
+            return .needsValidation(.changedSinceLastVerified(exact.differences(from: latest.tuple)))
+        }
+
+        guard let tested = manifest.tested.first(where: { $0.matches(exact) }) else {
+            return .needsValidation(.untestedCombination)
+        }
+
+        if let verifiedAt = tested.verifiedAt {
+            return .verified(recordedAt: verifiedAt)
+        }
+        return .needsValidation(.neverConnected)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -12,8 +12,13 @@ public enum CompatibilityState: Codable, Hashable, Sendable {
     public enum NeedsValidationReason: Codable, Hashable, Sendable {
         /// At least one component could not be identified. Never guess; ask for validation.
         case unknownFields([CompatibilityField])
+        /// The guest login shell can see more than one Codex executable.
+        case competingInstallations(count: Int)
         /// A known combination, but no real connection has ever been recorded for it.
         case neverConnected
+        /// The manifest records a connection for this combination, but on a different host
+        /// version or build than the one observed.
+        case verifiedOnDifferentHost
         /// Something changed since the last recorded connection.
         case changedSinceLastVerified([CompatibilityField])
         /// This combination is not in the manifest at all.
@@ -31,7 +36,7 @@ public enum CompatibilityEvaluator {
     /// - Parameters:
     ///   - observed: what was read from the host, desktop app, and guest right now.
     ///   - manifest: the shipped list of tested combinations.
-    ///   - history: previously recorded real connections, newest last or in any order.
+    ///   - history: previously recorded real connections, in any order.
     public static func evaluate(
         observed: ObservedTuple,
         manifest: CompatibilityManifest,
@@ -46,6 +51,10 @@ public enum CompatibilityEvaluator {
             return .needsValidation(.unknownFields(unknown))
         }
 
+        if exact.codexCLIInstallations != 1 {
+            return .needsValidation(.competingInstallations(count: exact.codexCLIInstallations))
+        }
+
         if let record = history.filter({ $0.tuple == exact }).max(by: { $0.verifiedAt < $1.verifiedAt }) {
             return .verified(recordedAt: record.verifiedAt)
         }
@@ -58,9 +67,12 @@ public enum CompatibilityEvaluator {
             return .needsValidation(.untestedCombination)
         }
 
-        if let verifiedAt = tested.verifiedAt {
-            return .verified(recordedAt: verifiedAt)
+        guard let verification = tested.verification else {
+            return .needsValidation(.neverConnected)
         }
-        return .needsValidation(.neverConnected)
+        guard verification.covers(exact) else {
+            return .needsValidation(.verifiedOnDifferentHost)
+        }
+        return .verified(recordedAt: verification.verifiedAt)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -196,9 +196,42 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     /// `recoveryActions` straight to the GUI, so both invariants below have to survive from
     /// construction to the moment the rule fires.
     public struct KnownIncompatibility: Codable, Hashable, Sendable {
-        /// What stays available when a rule fires: the console, work export, and stopping the
-        /// environment (the persistent stop control is never an error button).
-        public static let defaultRecoveryActions: [RecoveryAction] = [.openConsole, .exportWork, .cancel]
+        /// What stays available when a rule fires: a targeted repair of the tools whose
+        /// combination is blocked, the console, work export, and stopping the environment (the
+        /// persistent stop control is never an error button).
+        ///
+        /// The repair leads: a blocked combination that offered only console access and export
+        /// would refuse every new handoff with no way out of it, and MVP-PLAN.md §5 asks for a
+        /// route back rather than a dead end.
+        public static let defaultRecoveryActions: [RecoveryAction] = [.repair(.tools), .openConsole, .exportWork, .cancel]
+
+        /// A rule's own actions with everything §5 requires of a blocked state added back.
+        ///
+        /// MVP-PLAN.md §5 asks for an idle-time repair path for known-incompatible versions and
+        /// says to "preserve console access, shutdown, and work export in **every** state", so
+        /// this is not something a rule gets to choose. Expecting each rule to name the right
+        /// actions itself was enough while the manifest was written here, but the rules are data:
+        /// a `[.cancel]` in a decoded manifest, or an updated one that simply lists fewer, would
+        /// otherwise hand the GUI a blocked handoff and a single dead end.
+        ///
+        /// The rule's own actions keep their order and lead, because they were written for this
+        /// combination — except that a repair goes in front of them when the rule names none,
+        /// which is where `defaultRecoveryActions` puts it and why. A repair the rule does name
+        /// counts as the repair whatever it repairs: some incompatibilities are not fixed by the
+        /// tools flow, and offering a second button that cannot help is worse than none.
+        static func completed(_ actions: [RecoveryAction]) -> [RecoveryAction] {
+            let namesARepair = actions.contains { if case .repair = $0 { true } else { false } }
+            var completed: [RecoveryAction] = namesARepair ? [] : [.repair(.tools)]
+            completed += actions
+            for required in defaultRecoveryActions {
+                // A repair is present either way by now, its own or the default one; asking
+                // whether *this* repair is present would add the tools flow beside it.
+                if case .repair = required { continue }
+                guard !completed.contains(required) else { continue }
+                completed.append(required)
+            }
+            return completed
+        }
 
         public let hostMacOS: VersionRange?
         public let hostMacOSBuild: String?
@@ -256,7 +289,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.githubCLIVersion = githubCLIVersion
             self.provisioningScriptVersion = provisioningScriptVersion
             self.reason = reason
-            self.recoveryActions = recoveryActions.isEmpty ? Self.defaultRecoveryActions : recoveryActions
+            self.recoveryActions = Self.completed(recoveryActions)
         }
 
         private static func isBlank(_ text: String) -> Bool {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -30,29 +30,41 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
 
     /// Evidence of a real desktop connection for one exact host, attached to a tested entry.
     public struct Verification: Codable, Hashable, Sendable {
-        public var verifiedAt: Date
-        public var hostMacOSVersion: SemanticVersion
-        public var hostMacOSBuild: String
+        /// Rounded at construction to the precision the encoded form carries, so a value and
+        /// its own decoded form compare equal and hash alike.
+        public let verifiedAt: Date
+        public let hostMacOSVersion: SemanticVersion
+        public let hostMacOSBuild: String
         /// Where the evidence lives, for example `docs/phase0/compat.md`.
-        public var evidence: String
+        public let evidence: String
 
         public init(verifiedAt: Date, hostMacOSVersion: SemanticVersion, hostMacOSBuild: String, evidence: String) {
-            self.verifiedAt = verifiedAt
+            self.verifiedAt = Self.encodablePrecision(verifiedAt)
             self.hostMacOSVersion = hostMacOSVersion
             self.hostMacOSBuild = hostMacOSBuild
             self.evidence = evidence
         }
 
-        /// `verifiedAt` has one fixed representation, an ISO 8601 string with fractional
-        /// seconds, whatever encoder or decoder is used, so a manifest produced with
-        /// `JSONEncoder` reads back through `decode(from:)`.
+        /// The instant `verifiedAt` becomes once encoded. A `Date` carries far more precision
+        /// than the encoded form does, and keeping the extra digits would mean a value that
+        /// never compares equal to itself after a round trip.
+        private static func encodablePrecision(_ date: Date) -> Date {
+            Date(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate.rounded())
+        }
+
+        /// `verifiedAt` has one fixed representation, an ISO 8601 string in whole seconds,
+        /// whatever encoder or decoder is used, so a manifest produced with `JSONEncoder`
+        /// reads back through `decode(from:)`. Whole seconds because `ISO8601FormatStyle`'s
+        /// fractional seconds do not survive their own round trip, and when a connection was
+        /// recorded is not a sub-second fact. A document written with fractional seconds still
+        /// decodes; it is rounded like any other input.
         private enum CodingKeys: String, CodingKey { case verifiedAt, hostMacOSVersion, hostMacOSBuild, evidence }
-        private static let dateStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+        private static let dateStyle = Date.ISO8601FormatStyle()
 
         public init(from decoder: any Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
             let text = try c.decode(String.self, forKey: .verifiedAt)
-            guard let date = (try? Self.dateStyle.parse(text)) ?? (try? Date.ISO8601FormatStyle().parse(text)) else {
+            guard let date = (try? Self.dateStyle.parse(text)) ?? (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(text)) else {
                 throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not an ISO 8601 date")
             }
             self.init(
@@ -77,23 +89,27 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     }
 
     /// One tested combination. Host macOS is a range; every other field is exact.
+    ///
+    /// Immutable throughout: `verification` names evidence for the combination the other fields
+    /// spell out, so editing one field in place would leave the evidence attached to a
+    /// combination it never covered. Replacing the whole entry states the pairing again.
     public struct TestedTuple: Codable, Hashable, Sendable {
-        public var hostMacOS: VersionRange
-        public var codexDesktopVersion: String
-        public var codexDesktopBuild: String
-        public var codexDesktopPath: String
-        public var runtimeProtocolVersion: Int
-        public var tartVersion: String
-        public var guestMacOSBuild: String
-        public var xcodeBuild: String
-        public var codexCLIVersion: String
-        public var codexCLIPath: String
-        public var codexCLICapabilities: [String]
-        public var githubCLIVersion: String
-        public var provisioningScriptVersion: String
+        public let hostMacOS: VersionRange
+        public let codexDesktopVersion: String
+        public let codexDesktopBuild: String
+        public let codexDesktopPath: String
+        public let runtimeProtocolVersion: Int
+        public let tartVersion: String
+        public let guestMacOSBuild: String
+        public let xcodeBuild: String
+        public let codexCLIVersion: String
+        public let codexCLIPath: String
+        public let codexCLICapabilities: [String]
+        public let githubCLIVersion: String
+        public let provisioningScriptVersion: String
         /// Present only when a real desktop connection was recorded, and then only for the exact
         /// host it names.
-        public var verification: Verification?
+        public let verification: Verification?
 
         public init(
             hostMacOS: VersionRange,
@@ -140,7 +156,9 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 xcodeBuild: try c.decode(String.self, forKey: .xcodeBuild),
                 codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
                 codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
-                codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities) ?? [],
+                // Required, never defaulted: a manifest that omits the key is stale rather than
+                // one that reports a CLI with no capabilities, and the difference decides matches.
+                codexCLICapabilities: try c.decode([String].self, forKey: .codexCLICapabilities),
                 githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
                 provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion),
                 verification: try c.decodeIfPresent(Verification.self, forKey: .verification)
@@ -163,7 +181,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 && codexCLIVersion == tuple.codexCLIVersion
                 && codexCLIPath == tuple.codexCLIPath
                 && tuple.codexCLIInstallations == 1
-                && codexCLICapabilities == tuple.codexCLICapabilities
+                && codexCLICapabilities == CompatibilityTuple.normalize(tuple.codexCLICapabilities)
                 && githubCLIVersion == tuple.githubCLIVersion
                 && provisioningScriptVersion == tuple.provisioningScriptVersion
         }
@@ -173,30 +191,37 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     /// for the rule to apply; an unknown observed field never triggers it. A rule can single
     /// out one CLI executable, one capability set, or one desktop bundle, so a broken
     /// installation can be blocked without blocking a working one of the same version.
+    ///
+    /// Immutable throughout: a rule blocks handoff, and the evaluator hands its `reason` and
+    /// `recoveryActions` straight to the GUI, so both invariants below have to survive from
+    /// construction to the moment the rule fires.
     public struct KnownIncompatibility: Codable, Hashable, Sendable {
         /// What stays available when a rule fires: the console, work export, and stopping the
         /// environment (the persistent stop control is never an error button).
         public static let defaultRecoveryActions: [RecoveryAction] = [.openConsole, .exportWork, .cancel]
 
-        public var hostMacOS: VersionRange?
-        public var hostMacOSBuild: String?
-        public var codexDesktopVersion: String?
-        public var codexDesktopBuild: String?
-        public var codexDesktopPath: String?
-        public var runtimeProtocolVersion: Int?
-        public var tartVersion: String?
-        public var guestMacOSBuild: String?
-        public var xcodeBuild: String?
-        public var codexCLIVersion: String?
-        public var codexCLIPath: String?
+        public let hostMacOS: VersionRange?
+        public let hostMacOSBuild: String?
+        public let codexDesktopVersion: String?
+        public let codexDesktopBuild: String?
+        public let codexDesktopPath: String?
+        public let runtimeProtocolVersion: Int?
+        public let tartVersion: String?
+        public let guestMacOSBuild: String?
+        public let xcodeBuild: String?
+        public let codexCLIVersion: String?
+        public let codexCLIPath: String?
         /// Matches when the observed capability list, normalized, equals this list.
-        public var codexCLICapabilities: [String]?
-        public var githubCLIVersion: String?
-        public var provisioningScriptVersion: String?
-        public var reason: String
+        public let codexCLICapabilities: [String]?
+        public let githubCLIVersion: String?
+        public let provisioningScriptVersion: String?
+        /// Why handoff is blocked, in the user's words. Never empty.
+        public let reason: String
         /// What the GUI offers when this rule fires. Never empty.
-        public var recoveryActions: [RecoveryAction]
+        public let recoveryActions: [RecoveryAction]
 
+        /// - Precondition: `reason` is not empty or whitespace only. A rule that blocks handoff
+        ///   without saying why leaves the GUI with a button and no explanation.
         public init(
             hostMacOS: VersionRange? = nil,
             hostMacOSBuild: String? = nil,
@@ -215,6 +240,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             reason: String,
             recoveryActions: [RecoveryAction] = KnownIncompatibility.defaultRecoveryActions
         ) {
+            precondition(!Self.isBlank(reason), "an incompatibility rule must explain itself")
             self.hostMacOS = hostMacOS
             self.hostMacOSBuild = hostMacOSBuild
             self.codexDesktopVersion = codexDesktopVersion
@@ -233,8 +259,16 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.recoveryActions = recoveryActions.isEmpty ? Self.defaultRecoveryActions : recoveryActions
         }
 
+        private static func isBlank(_ text: String) -> Bool {
+            text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+
         public init(from decoder: any Decoder) throws {
             let c = try decoder.container(keyedBy: CodingKeys.self)
+            let reason = try c.decode(String.self, forKey: .reason)
+            guard !Self.isBlank(reason) else {
+                throw DecodingError.dataCorruptedError(forKey: .reason, in: c, debugDescription: "an incompatibility rule must explain itself")
+            }
             self.init(
                 hostMacOS: try c.decodeIfPresent(VersionRange.self, forKey: .hostMacOS),
                 hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
@@ -250,7 +284,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities),
                 githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
                 provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion),
-                reason: try c.decode(String.self, forKey: .reason),
+                reason: reason,
                 recoveryActions: try c.decodeIfPresent([RecoveryAction].self, forKey: .recoveryActions) ?? Self.defaultRecoveryActions
             )
         }
@@ -279,38 +313,72 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 && check(xcodeBuild, observed.xcodeBuild)
                 && check(codexCLIVersion, observed.codexCLIVersion)
                 && check(codexCLIPath, observed.codexCLIPath)
-                && check(codexCLICapabilities, observed.codexCLICapabilities)
+                // The rule's list is normalized at construction; an observation assembled field
+                // by field need not be, and order must never decide whether a rule fires.
+                && check(codexCLICapabilities, observed.codexCLICapabilities.map(CompatibilityTuple.normalize))
                 && check(githubCLIVersion, observed.githubCLIVersion)
                 && check(provisioningScriptVersion, observed.provisioningScriptVersion)
         }
     }
 
-    /// The manifest shipped inside this package.
-    public static func bundled() throws -> CompatibilityManifest {
-        guard let url = Bundle.module.url(forResource: "compatibility-manifest", withExtension: "json") else {
-            throw CocoaError(.fileNoSuchFile)
+    /// Refuses any schema this build cannot interpret: a newer document may carry a
+    /// compatibility dimension this evaluator would silently ignore. The check lives here so
+    /// that a plain `JSONDecoder().decode(CompatibilityManifest.self, from:)` enforces it too.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try c.decode(SchemaVersion.self, forKey: .schemaVersion)
+        guard schemaVersion == SchemaVersion.current else {
+            throw CompatibilityManifestError.unsupportedSchema(found: schemaVersion, supported: .current)
         }
-        return try decode(from: try Data(contentsOf: url))
+        self.init(
+            schemaVersion: schemaVersion,
+            manifestVersion: try c.decode(Int.self, forKey: .manifestVersion),
+            notes: try c.decodeIfPresent(String.self, forKey: .notes),
+            tested: try c.decode([TestedTuple].self, forKey: .tested),
+            incompatibilities: try c.decode([KnownIncompatibility].self, forKey: .incompatibilities)
+        )
     }
 
-    /// Decodes a manifest and refuses any schema this build cannot interpret: a newer document
-    /// may carry a compatibility dimension this evaluator would silently ignore.
-    public static func decode(from data: Data) throws -> CompatibilityManifest {
-        let manifest = try JSONDecoder().decode(CompatibilityManifest.self, from: data)
-        guard manifest.schemaVersion == SchemaVersion.current else {
-            throw CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)
+    /// The manifest shipped inside this package.
+    public static func bundled() throws -> CompatibilityManifest {
+        guard let url = Bundle.module.url(forResource: "compatibility-manifest", withExtension: "json"),
+              let data = try? Data(contentsOf: url)
+        else {
+            throw CompatibilityManifestError.unreadableManifest
         }
-        return manifest
+        return try decode(from: data)
+    }
+
+    /// Decodes a manifest, reporting every failure as something the user can act on rather than
+    /// as a raw decoding fault: the only manifest the app reads is one it shipped with, so a
+    /// failure here means the installation, not the document, is wrong.
+    public static func decode(from data: Data) throws -> CompatibilityManifest {
+        do {
+            return try JSONDecoder().decode(CompatibilityManifest.self, from: data)
+        } catch let error as CompatibilityManifestError {
+            throw error
+        } catch {
+            throw CompatibilityManifestError.malformedManifest
+        }
     }
 }
 
 public enum CompatibilityManifestError: Error, Hashable, Sendable, LocalizedError {
     case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
+    /// The shipped resource is missing from the bundle or could not be read.
+    case unreadableManifest
+    /// The document is not a compatibility manifest this build can parse. What was found is
+    /// deliberately not quoted; resource content does not belong in a user-facing message.
+    case malformedManifest
 
     public var userMessage: String {
         switch self {
         case .unsupportedSchema(let found, let supported):
             "The compatibility list shipped with this copy of Guesthouse uses format \(found.rawValue), which this version reads as \(supported.rawValue). The app and its resources do not match; reinstall Guesthouse."
+        case .unreadableManifest:
+            "The compatibility list shipped with this copy of Guesthouse is missing or cannot be read. The installation is damaged; reinstall Guesthouse."
+        case .malformedManifest:
+            "The compatibility list shipped with this copy of Guesthouse is not a list this version can read. The installation is damaged; reinstall Guesthouse."
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -3,8 +3,9 @@ import Foundation
 /// The versioned list of combinations Guesthouse has tested, shipped with the app
 /// (MVP-PLAN.md §10, Phase 2: "Keep a versioned compatibility manifest").
 ///
-/// A tested tuple is not the same as a verified one. `verified` is set only when a phase-0
-/// or release run recorded a real Codex desktop connection for exactly that combination.
+/// A tested tuple is not the same as a verified one. A tested entry supports a range of host
+/// macOS versions; its `verification`, if any, names the exact host version and build on
+/// which a real Codex desktop connection was recorded, and only that exact host counts.
 public struct CompatibilityManifest: Codable, Hashable, Sendable {
     public var schemaVersion: SchemaVersion
     /// Monotonic manifest revision, independent of the record schema.
@@ -27,6 +28,26 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
         self.incompatibilities = incompatibilities
     }
 
+    /// Evidence of a real desktop connection for one exact host, attached to a tested entry.
+    public struct Verification: Codable, Hashable, Sendable {
+        public var verifiedAt: Date
+        public var hostMacOSVersion: SemanticVersion
+        public var hostMacOSBuild: String
+        /// Where the evidence lives, for example `docs/phase0/compat.md`.
+        public var evidence: String
+
+        public init(verifiedAt: Date, hostMacOSVersion: SemanticVersion, hostMacOSBuild: String, evidence: String) {
+            self.verifiedAt = verifiedAt
+            self.hostMacOSVersion = hostMacOSVersion
+            self.hostMacOSBuild = hostMacOSBuild
+            self.evidence = evidence
+        }
+
+        public func covers(_ tuple: CompatibilityTuple) -> Bool {
+            hostMacOSVersion == tuple.hostMacOSVersion && hostMacOSBuild == tuple.hostMacOSBuild
+        }
+    }
+
     /// One tested combination. Host macOS is a range; every other field is exact.
     public struct TestedTuple: Codable, Hashable, Sendable {
         public var hostMacOS: VersionRange
@@ -37,12 +58,13 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
         public var guestMacOSBuild: String
         public var xcodeBuild: String
         public var codexCLIVersion: String
+        public var codexCLIPath: String
+        public var codexCLICapabilities: [String]
         public var githubCLIVersion: String
         public var provisioningScriptVersion: String
-        /// Present only when a real desktop connection was recorded for this exact combination.
-        public var verifiedAt: Date?
-        /// Where the evidence lives, for example `docs/phase0/compat.md`.
-        public var evidence: String?
+        /// Present only when a real desktop connection was recorded, and then only for the exact
+        /// host it names.
+        public var verification: Verification?
 
         public init(
             hostMacOS: VersionRange,
@@ -53,10 +75,11 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             guestMacOSBuild: String,
             xcodeBuild: String,
             codexCLIVersion: String,
+            codexCLIPath: String,
+            codexCLICapabilities: [String] = [],
             githubCLIVersion: String,
             provisioningScriptVersion: String,
-            verifiedAt: Date? = nil,
-            evidence: String? = nil
+            verification: Verification? = nil
         ) {
             self.hostMacOS = hostMacOS
             self.codexDesktopVersion = codexDesktopVersion
@@ -66,14 +89,17 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.guestMacOSBuild = guestMacOSBuild
             self.xcodeBuild = xcodeBuild
             self.codexCLIVersion = codexCLIVersion
+            self.codexCLIPath = codexCLIPath
+            self.codexCLICapabilities = codexCLICapabilities.sorted()
             self.githubCLIVersion = githubCLIVersion
             self.provisioningScriptVersion = provisioningScriptVersion
-            self.verifiedAt = verifiedAt
-            self.evidence = evidence
+            self.verification = verification
         }
 
-        public var isVerified: Bool { verifiedAt != nil }
+        public var isVerified: Bool { verification != nil }
 
+        /// Whether the observed combination is one this entry was tested with. A single CLI
+        /// installation is part of the tested condition.
         public func matches(_ tuple: CompatibilityTuple) -> Bool {
             hostMacOS.contains(tuple.hostMacOSVersion)
                 && codexDesktopVersion == tuple.codexDesktopVersion
@@ -83,14 +109,19 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 && guestMacOSBuild == tuple.guestMacOSBuild
                 && xcodeBuild == tuple.xcodeBuild
                 && codexCLIVersion == tuple.codexCLIVersion
+                && codexCLIPath == tuple.codexCLIPath
+                && tuple.codexCLIInstallations == 1
+                && codexCLICapabilities == tuple.codexCLICapabilities
                 && githubCLIVersion == tuple.githubCLIVersion
                 && provisioningScriptVersion == tuple.provisioningScriptVersion
         }
     }
 
-    /// A combination known not to work. Every specified field must equal the observed value
+    /// A combination known not to work. Every specified field must match the observed value
     /// for the rule to apply; an unknown observed field never triggers it.
     public struct KnownIncompatibility: Codable, Hashable, Sendable {
+        public var hostMacOS: VersionRange?
+        public var hostMacOSBuild: String?
         public var codexDesktopVersion: String?
         public var codexDesktopBuild: String?
         public var runtimeProtocolVersion: Int?
@@ -99,9 +130,12 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
         public var xcodeBuild: String?
         public var codexCLIVersion: String?
         public var githubCLIVersion: String?
+        public var provisioningScriptVersion: String?
         public var reason: String
 
         public init(
+            hostMacOS: VersionRange? = nil,
+            hostMacOSBuild: String? = nil,
             codexDesktopVersion: String? = nil,
             codexDesktopBuild: String? = nil,
             runtimeProtocolVersion: Int? = nil,
@@ -110,8 +144,11 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             xcodeBuild: String? = nil,
             codexCLIVersion: String? = nil,
             githubCLIVersion: String? = nil,
+            provisioningScriptVersion: String? = nil,
             reason: String
         ) {
+            self.hostMacOS = hostMacOS
+            self.hostMacOSBuild = hostMacOSBuild
             self.codexDesktopVersion = codexDesktopVersion
             self.codexDesktopBuild = codexDesktopBuild
             self.runtimeProtocolVersion = runtimeProtocolVersion
@@ -120,6 +157,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.xcodeBuild = xcodeBuild
             self.codexCLIVersion = codexCLIVersion
             self.githubCLIVersion = githubCLIVersion
+            self.provisioningScriptVersion = provisioningScriptVersion
             self.reason = reason
         }
 
@@ -129,7 +167,16 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 guard let value else { return false }
                 return rule == value
             }
-            return check(codexDesktopVersion, observed.codexDesktopVersion)
+            let hostInRange: Bool
+            if let hostMacOS {
+                guard let version = observed.hostMacOSVersion else { return false }
+                hostInRange = hostMacOS.contains(version)
+            } else {
+                hostInRange = true
+            }
+            return hostInRange
+                && check(hostMacOSBuild, observed.hostMacOSBuild)
+                && check(codexDesktopVersion, observed.codexDesktopVersion)
                 && check(codexDesktopBuild, observed.codexDesktopBuild)
                 && check(runtimeProtocolVersion, observed.runtimeProtocolVersion)
                 && check(tartVersion, observed.tartVersion)
@@ -137,6 +184,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 && check(xcodeBuild, observed.xcodeBuild)
                 && check(codexCLIVersion, observed.codexCLIVersion)
                 && check(githubCLIVersion, observed.githubCLIVersion)
+                && check(provisioningScriptVersion, observed.provisioningScriptVersion)
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -53,6 +53,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
         public var hostMacOS: VersionRange
         public var codexDesktopVersion: String
         public var codexDesktopBuild: String
+        public var codexDesktopPath: String
         public var runtimeProtocolVersion: Int
         public var tartVersion: String
         public var guestMacOSBuild: String
@@ -70,6 +71,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             hostMacOS: VersionRange,
             codexDesktopVersion: String,
             codexDesktopBuild: String,
+            codexDesktopPath: String,
             runtimeProtocolVersion: Int,
             tartVersion: String,
             guestMacOSBuild: String,
@@ -84,16 +86,37 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.hostMacOS = hostMacOS
             self.codexDesktopVersion = codexDesktopVersion
             self.codexDesktopBuild = codexDesktopBuild
+            self.codexDesktopPath = codexDesktopPath
             self.runtimeProtocolVersion = runtimeProtocolVersion
             self.tartVersion = tartVersion
             self.guestMacOSBuild = guestMacOSBuild
             self.xcodeBuild = xcodeBuild
             self.codexCLIVersion = codexCLIVersion
             self.codexCLIPath = codexCLIPath
-            self.codexCLICapabilities = codexCLICapabilities.sorted()
+            self.codexCLICapabilities = CompatibilityTuple.normalize(codexCLICapabilities)
             self.githubCLIVersion = githubCLIVersion
             self.provisioningScriptVersion = provisioningScriptVersion
             self.verification = verification
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(
+                hostMacOS: try c.decode(VersionRange.self, forKey: .hostMacOS),
+                codexDesktopVersion: try c.decode(String.self, forKey: .codexDesktopVersion),
+                codexDesktopBuild: try c.decode(String.self, forKey: .codexDesktopBuild),
+                codexDesktopPath: try c.decode(String.self, forKey: .codexDesktopPath),
+                runtimeProtocolVersion: try c.decode(Int.self, forKey: .runtimeProtocolVersion),
+                tartVersion: try c.decode(String.self, forKey: .tartVersion),
+                guestMacOSBuild: try c.decode(String.self, forKey: .guestMacOSBuild),
+                xcodeBuild: try c.decode(String.self, forKey: .xcodeBuild),
+                codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
+                codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
+                codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities) ?? [],
+                githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
+                provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion),
+                verification: try c.decodeIfPresent(Verification.self, forKey: .verification)
+            )
         }
 
         public var isVerified: Bool { verification != nil }
@@ -104,6 +127,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             hostMacOS.contains(tuple.hostMacOSVersion)
                 && codexDesktopVersion == tuple.codexDesktopVersion
                 && codexDesktopBuild == tuple.codexDesktopBuild
+                && codexDesktopPath == tuple.codexDesktopPath
                 && runtimeProtocolVersion == tuple.runtimeProtocolVersion
                 && tartVersion == tuple.tartVersion
                 && guestMacOSBuild == tuple.guestMacOSBuild
@@ -118,47 +142,89 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     }
 
     /// A combination known not to work. Every specified field must match the observed value
-    /// for the rule to apply; an unknown observed field never triggers it.
+    /// for the rule to apply; an unknown observed field never triggers it. A rule can single
+    /// out one CLI executable, one capability set, or one desktop bundle, so a broken
+    /// installation can be blocked without blocking a working one of the same version.
     public struct KnownIncompatibility: Codable, Hashable, Sendable {
+        /// What stays available when a rule fires: the console, work export, and stopping the
+        /// environment (the persistent stop control is never an error button).
+        public static let defaultRecoveryActions: [RecoveryAction] = [.openConsole, .exportWork, .cancel]
+
         public var hostMacOS: VersionRange?
         public var hostMacOSBuild: String?
         public var codexDesktopVersion: String?
         public var codexDesktopBuild: String?
+        public var codexDesktopPath: String?
         public var runtimeProtocolVersion: Int?
         public var tartVersion: String?
         public var guestMacOSBuild: String?
         public var xcodeBuild: String?
         public var codexCLIVersion: String?
+        public var codexCLIPath: String?
+        /// Matches when the observed capability list, normalized, equals this list.
+        public var codexCLICapabilities: [String]?
         public var githubCLIVersion: String?
         public var provisioningScriptVersion: String?
         public var reason: String
+        /// What the GUI offers when this rule fires. Never empty.
+        public var recoveryActions: [RecoveryAction]
 
         public init(
             hostMacOS: VersionRange? = nil,
             hostMacOSBuild: String? = nil,
             codexDesktopVersion: String? = nil,
             codexDesktopBuild: String? = nil,
+            codexDesktopPath: String? = nil,
             runtimeProtocolVersion: Int? = nil,
             tartVersion: String? = nil,
             guestMacOSBuild: String? = nil,
             xcodeBuild: String? = nil,
             codexCLIVersion: String? = nil,
+            codexCLIPath: String? = nil,
+            codexCLICapabilities: [String]? = nil,
             githubCLIVersion: String? = nil,
             provisioningScriptVersion: String? = nil,
-            reason: String
+            reason: String,
+            recoveryActions: [RecoveryAction] = KnownIncompatibility.defaultRecoveryActions
         ) {
             self.hostMacOS = hostMacOS
             self.hostMacOSBuild = hostMacOSBuild
             self.codexDesktopVersion = codexDesktopVersion
             self.codexDesktopBuild = codexDesktopBuild
+            self.codexDesktopPath = codexDesktopPath
             self.runtimeProtocolVersion = runtimeProtocolVersion
             self.tartVersion = tartVersion
             self.guestMacOSBuild = guestMacOSBuild
             self.xcodeBuild = xcodeBuild
             self.codexCLIVersion = codexCLIVersion
+            self.codexCLIPath = codexCLIPath
+            self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
             self.githubCLIVersion = githubCLIVersion
             self.provisioningScriptVersion = provisioningScriptVersion
             self.reason = reason
+            self.recoveryActions = recoveryActions.isEmpty ? Self.defaultRecoveryActions : recoveryActions
+        }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(
+                hostMacOS: try c.decodeIfPresent(VersionRange.self, forKey: .hostMacOS),
+                hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
+                codexDesktopVersion: try c.decodeIfPresent(String.self, forKey: .codexDesktopVersion),
+                codexDesktopBuild: try c.decodeIfPresent(String.self, forKey: .codexDesktopBuild),
+                codexDesktopPath: try c.decodeIfPresent(String.self, forKey: .codexDesktopPath),
+                runtimeProtocolVersion: try c.decodeIfPresent(Int.self, forKey: .runtimeProtocolVersion),
+                tartVersion: try c.decodeIfPresent(String.self, forKey: .tartVersion),
+                guestMacOSBuild: try c.decodeIfPresent(String.self, forKey: .guestMacOSBuild),
+                xcodeBuild: try c.decodeIfPresent(String.self, forKey: .xcodeBuild),
+                codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
+                codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
+                codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities),
+                githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
+                provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion),
+                reason: try c.decode(String.self, forKey: .reason),
+                recoveryActions: try c.decodeIfPresent([RecoveryAction].self, forKey: .recoveryActions) ?? Self.defaultRecoveryActions
+            )
         }
 
         public func applies(to observed: ObservedTuple) -> Bool {
@@ -178,11 +244,14 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
                 && check(hostMacOSBuild, observed.hostMacOSBuild)
                 && check(codexDesktopVersion, observed.codexDesktopVersion)
                 && check(codexDesktopBuild, observed.codexDesktopBuild)
+                && check(codexDesktopPath, observed.codexDesktopPath)
                 && check(runtimeProtocolVersion, observed.runtimeProtocolVersion)
                 && check(tartVersion, observed.tartVersion)
                 && check(guestMacOSBuild, observed.guestMacOSBuild)
                 && check(xcodeBuild, observed.xcodeBuild)
                 && check(codexCLIVersion, observed.codexCLIVersion)
+                && check(codexCLIPath, observed.codexCLIPath)
+                && check(codexCLICapabilities, observed.codexCLICapabilities)
                 && check(githubCLIVersion, observed.githubCLIVersion)
                 && check(provisioningScriptVersion, observed.provisioningScriptVersion)
         }
@@ -196,9 +265,19 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
         return try decode(from: try Data(contentsOf: url))
     }
 
+    /// Decodes a manifest and refuses any schema this build cannot interpret: a newer document
+    /// may carry a compatibility dimension this evaluator would silently ignore.
     public static func decode(from data: Data) throws -> CompatibilityManifest {
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
-        return try decoder.decode(CompatibilityManifest.self, from: data)
+        let manifest = try decoder.decode(CompatibilityManifest.self, from: data)
+        guard manifest.schemaVersion == SchemaVersion.current else {
+            throw CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)
+        }
+        return manifest
     }
+}
+
+public enum CompatibilityManifestError: Error, Hashable, Sendable {
+    case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -43,6 +43,34 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
             self.evidence = evidence
         }
 
+        /// `verifiedAt` has one fixed representation, an ISO 8601 string with fractional
+        /// seconds, whatever encoder or decoder is used, so a manifest produced with
+        /// `JSONEncoder` reads back through `decode(from:)`.
+        private enum CodingKeys: String, CodingKey { case verifiedAt, hostMacOSVersion, hostMacOSBuild, evidence }
+        private static let dateStyle = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            let text = try c.decode(String.self, forKey: .verifiedAt)
+            guard let date = (try? Self.dateStyle.parse(text)) ?? (try? Date.ISO8601FormatStyle().parse(text)) else {
+                throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not an ISO 8601 date")
+            }
+            self.init(
+                verifiedAt: date,
+                hostMacOSVersion: try c.decode(SemanticVersion.self, forKey: .hostMacOSVersion),
+                hostMacOSBuild: try c.decode(String.self, forKey: .hostMacOSBuild),
+                evidence: try c.decode(String.self, forKey: .evidence)
+            )
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            try c.encode(Self.dateStyle.format(verifiedAt), forKey: .verifiedAt)
+            try c.encode(hostMacOSVersion, forKey: .hostMacOSVersion)
+            try c.encode(hostMacOSBuild, forKey: .hostMacOSBuild)
+            try c.encode(evidence, forKey: .evidence)
+        }
+
         public func covers(_ tuple: CompatibilityTuple) -> Bool {
             hostMacOSVersion == tuple.hostMacOSVersion && hostMacOSBuild == tuple.hostMacOSBuild
         }
@@ -268,9 +296,7 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     /// Decodes a manifest and refuses any schema this build cannot interpret: a newer document
     /// may carry a compatibility dimension this evaluator would silently ignore.
     public static func decode(from data: Data) throws -> CompatibilityManifest {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let manifest = try decoder.decode(CompatibilityManifest.self, from: data)
+        let manifest = try JSONDecoder().decode(CompatibilityManifest.self, from: data)
         guard manifest.schemaVersion == SchemaVersion.current else {
             throw CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)
         }
@@ -278,6 +304,16 @@ public struct CompatibilityManifest: Codable, Hashable, Sendable {
     }
 }
 
-public enum CompatibilityManifestError: Error, Hashable, Sendable {
+public enum CompatibilityManifestError: Error, Hashable, Sendable, LocalizedError {
     case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
+
+    public var userMessage: String {
+        switch self {
+        case .unsupportedSchema(let found, let supported):
+            "The compatibility list shipped with this copy of Guesthouse uses format \(found.rawValue), which this version reads as \(supported.rawValue). The app and its resources do not match; reinstall Guesthouse."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.reinstallApp, .cancel] }
+    public var errorDescription: String? { userMessage }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+/// The versioned list of combinations Guesthouse has tested, shipped with the app
+/// (MVP-PLAN.md §10, Phase 2: "Keep a versioned compatibility manifest").
+///
+/// A tested tuple is not the same as a verified one. `verified` is set only when a phase-0
+/// or release run recorded a real Codex desktop connection for exactly that combination.
+public struct CompatibilityManifest: Codable, Hashable, Sendable {
+    public var schemaVersion: SchemaVersion
+    /// Monotonic manifest revision, independent of the record schema.
+    public var manifestVersion: Int
+    public var notes: String?
+    public var tested: [TestedTuple]
+    public var incompatibilities: [KnownIncompatibility]
+
+    public init(
+        schemaVersion: SchemaVersion = .current,
+        manifestVersion: Int,
+        notes: String? = nil,
+        tested: [TestedTuple],
+        incompatibilities: [KnownIncompatibility] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.manifestVersion = manifestVersion
+        self.notes = notes
+        self.tested = tested
+        self.incompatibilities = incompatibilities
+    }
+
+    /// One tested combination. Host macOS is a range; every other field is exact.
+    public struct TestedTuple: Codable, Hashable, Sendable {
+        public var hostMacOS: VersionRange
+        public var codexDesktopVersion: String
+        public var codexDesktopBuild: String
+        public var runtimeProtocolVersion: Int
+        public var tartVersion: String
+        public var guestMacOSBuild: String
+        public var xcodeBuild: String
+        public var codexCLIVersion: String
+        public var githubCLIVersion: String
+        public var provisioningScriptVersion: String
+        /// Present only when a real desktop connection was recorded for this exact combination.
+        public var verifiedAt: Date?
+        /// Where the evidence lives, for example `docs/phase0/compat.md`.
+        public var evidence: String?
+
+        public init(
+            hostMacOS: VersionRange,
+            codexDesktopVersion: String,
+            codexDesktopBuild: String,
+            runtimeProtocolVersion: Int,
+            tartVersion: String,
+            guestMacOSBuild: String,
+            xcodeBuild: String,
+            codexCLIVersion: String,
+            githubCLIVersion: String,
+            provisioningScriptVersion: String,
+            verifiedAt: Date? = nil,
+            evidence: String? = nil
+        ) {
+            self.hostMacOS = hostMacOS
+            self.codexDesktopVersion = codexDesktopVersion
+            self.codexDesktopBuild = codexDesktopBuild
+            self.runtimeProtocolVersion = runtimeProtocolVersion
+            self.tartVersion = tartVersion
+            self.guestMacOSBuild = guestMacOSBuild
+            self.xcodeBuild = xcodeBuild
+            self.codexCLIVersion = codexCLIVersion
+            self.githubCLIVersion = githubCLIVersion
+            self.provisioningScriptVersion = provisioningScriptVersion
+            self.verifiedAt = verifiedAt
+            self.evidence = evidence
+        }
+
+        public var isVerified: Bool { verifiedAt != nil }
+
+        public func matches(_ tuple: CompatibilityTuple) -> Bool {
+            hostMacOS.contains(tuple.hostMacOSVersion)
+                && codexDesktopVersion == tuple.codexDesktopVersion
+                && codexDesktopBuild == tuple.codexDesktopBuild
+                && runtimeProtocolVersion == tuple.runtimeProtocolVersion
+                && tartVersion == tuple.tartVersion
+                && guestMacOSBuild == tuple.guestMacOSBuild
+                && xcodeBuild == tuple.xcodeBuild
+                && codexCLIVersion == tuple.codexCLIVersion
+                && githubCLIVersion == tuple.githubCLIVersion
+                && provisioningScriptVersion == tuple.provisioningScriptVersion
+        }
+    }
+
+    /// A combination known not to work. Every specified field must equal the observed value
+    /// for the rule to apply; an unknown observed field never triggers it.
+    public struct KnownIncompatibility: Codable, Hashable, Sendable {
+        public var codexDesktopVersion: String?
+        public var codexDesktopBuild: String?
+        public var runtimeProtocolVersion: Int?
+        public var tartVersion: String?
+        public var guestMacOSBuild: String?
+        public var xcodeBuild: String?
+        public var codexCLIVersion: String?
+        public var githubCLIVersion: String?
+        public var reason: String
+
+        public init(
+            codexDesktopVersion: String? = nil,
+            codexDesktopBuild: String? = nil,
+            runtimeProtocolVersion: Int? = nil,
+            tartVersion: String? = nil,
+            guestMacOSBuild: String? = nil,
+            xcodeBuild: String? = nil,
+            codexCLIVersion: String? = nil,
+            githubCLIVersion: String? = nil,
+            reason: String
+        ) {
+            self.codexDesktopVersion = codexDesktopVersion
+            self.codexDesktopBuild = codexDesktopBuild
+            self.runtimeProtocolVersion = runtimeProtocolVersion
+            self.tartVersion = tartVersion
+            self.guestMacOSBuild = guestMacOSBuild
+            self.xcodeBuild = xcodeBuild
+            self.codexCLIVersion = codexCLIVersion
+            self.githubCLIVersion = githubCLIVersion
+            self.reason = reason
+        }
+
+        public func applies(to observed: ObservedTuple) -> Bool {
+            func check<T: Equatable>(_ rule: T?, _ value: T?) -> Bool {
+                guard let rule else { return true }
+                guard let value else { return false }
+                return rule == value
+            }
+            return check(codexDesktopVersion, observed.codexDesktopVersion)
+                && check(codexDesktopBuild, observed.codexDesktopBuild)
+                && check(runtimeProtocolVersion, observed.runtimeProtocolVersion)
+                && check(tartVersion, observed.tartVersion)
+                && check(guestMacOSBuild, observed.guestMacOSBuild)
+                && check(xcodeBuild, observed.xcodeBuild)
+                && check(codexCLIVersion, observed.codexCLIVersion)
+                && check(githubCLIVersion, observed.githubCLIVersion)
+        }
+    }
+
+    /// The manifest shipped inside this package.
+    public static func bundled() throws -> CompatibilityManifest {
+        guard let url = Bundle.module.url(forResource: "compatibility-manifest", withExtension: "json") else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return try decode(from: try Data(contentsOf: url))
+    }
+
+    public static func decode(from data: Data) throws -> CompatibilityManifest {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(CompatibilityManifest.self, from: data)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -2,7 +2,9 @@
 /// (MVP-PLAN.md §5, "Connect-time compatibility, not only update-time checks").
 ///
 /// Host macOS is tracked as both a product version and a build: a build replacement that keeps
-/// the product version is still OS drift (§4). The Codex CLI is tracked by version, resolved
+/// the product version is still OS drift (§4). The Codex desktop app is tracked by version,
+/// build, and the selected bundle's path, so a replaced or re-selected bundle that reports the
+/// same version is still a change (§5). The Codex CLI is tracked by version, resolved
 /// login-shell path, number of competing installations, and reported capabilities, because the
 /// same version string can belong to a different executable (§5).
 public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterable {
@@ -10,6 +12,7 @@ public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterabl
     case hostMacOSBuild
     case codexDesktopVersion
     case codexDesktopBuild
+    case codexDesktopPath
     case runtimeProtocolVersion
     case tartVersion
     case guestMacOSBuild
@@ -28,6 +31,8 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public var hostMacOSBuild: String
     public var codexDesktopVersion: String
     public var codexDesktopBuild: String
+    /// The selected desktop application bundle, resolved.
+    public var codexDesktopPath: String
     public var runtimeProtocolVersion: Int
     public var tartVersion: String
     public var guestMacOSBuild: String
@@ -37,7 +42,8 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public var codexCLIPath: String
     /// How many `codex` executables the login shell can see. Anything but 1 is ambiguous.
     public var codexCLIInstallations: Int
-    /// Capability identifiers the CLI reports, sorted. Empty when it reports none.
+    /// Capability identifiers the CLI reports, sorted and without duplicates. Empty when it
+    /// reports none.
     public var codexCLICapabilities: [String]
     public var githubCLIVersion: String
     public var provisioningScriptVersion: String
@@ -47,6 +53,7 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         hostMacOSBuild: String,
         codexDesktopVersion: String,
         codexDesktopBuild: String,
+        codexDesktopPath: String,
         runtimeProtocolVersion: Int,
         tartVersion: String,
         guestMacOSBuild: String,
@@ -62,6 +69,7 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         self.hostMacOSBuild = hostMacOSBuild
         self.codexDesktopVersion = codexDesktopVersion
         self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
         self.runtimeProtocolVersion = runtimeProtocolVersion
         self.tartVersion = tartVersion
         self.guestMacOSBuild = guestMacOSBuild
@@ -69,9 +77,37 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         self.codexCLIVersion = codexCLIVersion
         self.codexCLIPath = codexCLIPath
         self.codexCLIInstallations = codexCLIInstallations
-        self.codexCLICapabilities = codexCLICapabilities.sorted()
+        self.codexCLICapabilities = Self.normalize(codexCLICapabilities)
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    /// Decoding goes through the initializer so a document with capabilities in another
+    /// order or listed twice compares equal to the normalized form.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            hostMacOSVersion: try c.decode(SemanticVersion.self, forKey: .hostMacOSVersion),
+            hostMacOSBuild: try c.decode(String.self, forKey: .hostMacOSBuild),
+            codexDesktopVersion: try c.decode(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decode(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decode(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decode(Int.self, forKey: .runtimeProtocolVersion),
+            tartVersion: try c.decode(String.self, forKey: .tartVersion),
+            guestMacOSBuild: try c.decode(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decode(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
+            codexCLIInstallations: try c.decode(Int.self, forKey: .codexCLIInstallations),
+            codexCLICapabilities: try c.decode([String].self, forKey: .codexCLICapabilities),
+            githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion)
+        )
+    }
+
+    /// Sorted, without duplicates: the canonical form every comparison uses.
+    public static func normalize(_ capabilities: [String]) -> [String] {
+        Array(Set(capabilities)).sorted()
     }
 
     /// The fields whose values differ between two tuples.
@@ -81,6 +117,7 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         if hostMacOSBuild != other.hostMacOSBuild { changed.append(.hostMacOSBuild) }
         if codexDesktopVersion != other.codexDesktopVersion { changed.append(.codexDesktopVersion) }
         if codexDesktopBuild != other.codexDesktopBuild { changed.append(.codexDesktopBuild) }
+        if codexDesktopPath != other.codexDesktopPath { changed.append(.codexDesktopPath) }
         if runtimeProtocolVersion != other.runtimeProtocolVersion { changed.append(.runtimeProtocolVersion) }
         if tartVersion != other.tartVersion { changed.append(.tartVersion) }
         if guestMacOSBuild != other.guestMacOSBuild { changed.append(.guestMacOSBuild) }
@@ -102,6 +139,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
     public var hostMacOSBuild: String?
     public var codexDesktopVersion: String?
     public var codexDesktopBuild: String?
+    public var codexDesktopPath: String?
     public var runtimeProtocolVersion: Int?
     public var tartVersion: String?
     public var guestMacOSBuild: String?
@@ -118,6 +156,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         hostMacOSBuild: String? = nil,
         codexDesktopVersion: String? = nil,
         codexDesktopBuild: String? = nil,
+        codexDesktopPath: String? = nil,
         runtimeProtocolVersion: Int? = nil,
         tartVersion: String? = nil,
         guestMacOSBuild: String? = nil,
@@ -133,6 +172,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         self.hostMacOSBuild = hostMacOSBuild
         self.codexDesktopVersion = codexDesktopVersion
         self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
         self.runtimeProtocolVersion = runtimeProtocolVersion
         self.tartVersion = tartVersion
         self.guestMacOSBuild = guestMacOSBuild
@@ -140,9 +180,30 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         self.codexCLIVersion = codexCLIVersion
         self.codexCLIPath = codexCLIPath
         self.codexCLIInstallations = codexCLIInstallations
-        self.codexCLICapabilities = codexCLICapabilities?.sorted()
+        self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            hostMacOSVersion: try c.decodeIfPresent(SemanticVersion.self, forKey: .hostMacOSVersion),
+            hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
+            codexDesktopVersion: try c.decodeIfPresent(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decodeIfPresent(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decodeIfPresent(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decodeIfPresent(Int.self, forKey: .runtimeProtocolVersion),
+            tartVersion: try c.decodeIfPresent(String.self, forKey: .tartVersion),
+            guestMacOSBuild: try c.decodeIfPresent(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decodeIfPresent(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
+            codexCLIInstallations: try c.decodeIfPresent(Int.self, forKey: .codexCLIInstallations),
+            codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities),
+            githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion)
+        )
     }
 
     public init(_ tuple: CompatibilityTuple) {
@@ -151,6 +212,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             hostMacOSBuild: tuple.hostMacOSBuild,
             codexDesktopVersion: tuple.codexDesktopVersion,
             codexDesktopBuild: tuple.codexDesktopBuild,
+            codexDesktopPath: tuple.codexDesktopPath,
             runtimeProtocolVersion: tuple.runtimeProtocolVersion,
             tartVersion: tuple.tartVersion,
             guestMacOSBuild: tuple.guestMacOSBuild,
@@ -171,6 +233,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         if hostMacOSBuild == nil { unknown.append(.hostMacOSBuild) }
         if codexDesktopVersion == nil { unknown.append(.codexDesktopVersion) }
         if codexDesktopBuild == nil { unknown.append(.codexDesktopBuild) }
+        if codexDesktopPath == nil { unknown.append(.codexDesktopPath) }
         if runtimeProtocolVersion == nil { unknown.append(.runtimeProtocolVersion) }
         if tartVersion == nil { unknown.append(.tartVersion) }
         if guestMacOSBuild == nil { unknown.append(.guestMacOSBuild) }
@@ -187,7 +250,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
     /// The fully known tuple, or `nil` if any field is unknown.
     public var exact: CompatibilityTuple? {
         guard let hostMacOSVersion, let hostMacOSBuild, let codexDesktopVersion, let codexDesktopBuild,
-              let runtimeProtocolVersion, let tartVersion, let guestMacOSBuild, let xcodeBuild,
+              let codexDesktopPath, let runtimeProtocolVersion, let tartVersion, let guestMacOSBuild, let xcodeBuild,
               let codexCLIVersion, let codexCLIPath, let codexCLIInstallations, let codexCLICapabilities,
               let githubCLIVersion, let provisioningScriptVersion
         else { return nil }
@@ -196,6 +259,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             hostMacOSBuild: hostMacOSBuild,
             codexDesktopVersion: codexDesktopVersion,
             codexDesktopBuild: codexDesktopBuild,
+            codexDesktopPath: codexDesktopPath,
             runtimeProtocolVersion: runtimeProtocolVersion,
             tartVersion: tartVersion,
             guestMacOSBuild: guestMacOSBuild,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -44,7 +44,13 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public var codexCLIInstallations: Int
     /// Capability identifiers the CLI reports, sorted and without duplicates. Empty when it
     /// reports none.
-    public var codexCLICapabilities: [String]
+    ///
+    /// Renormalized on assignment, not only at construction: equality decides whether a
+    /// recorded connection is found again, and a tuple whose list was replaced field by field
+    /// would never match the freshly normalized observation of the same guest.
+    public var codexCLICapabilities: [String] {
+        didSet { codexCLICapabilities = Self.normalize(codexCLICapabilities) }
+    }
     public var githubCLIVersion: String
     public var provisioningScriptVersion: String
 
@@ -82,10 +88,22 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         self.provisioningScriptVersion = provisioningScriptVersion
     }
 
+    /// The most capability identifiers one report may carry. A CLI names a handful, so a
+    /// longer list is noise or a hostile probe; it is refused before it is normalized, because
+    /// building a set of it and persisting it would cost CPU, memory, and state-file space in
+    /// proportion to whatever the guest chose to send.
+    public static let maximumCapabilities = 64
+
+    static let capabilityCountMessage = "a capability list may name at most \(maximumCapabilities) identifiers"
+
     /// Decoding goes through the initializer so a document with capabilities in another
     /// order or listed twice compares equal to the normalized form.
     public init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        let capabilities = try c.decode([String].self, forKey: .codexCLICapabilities)
+        guard capabilities.count <= Self.maximumCapabilities else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: Self.capabilityCountMessage)
+        }
         self.init(
             hostMacOSVersion: try c.decode(SemanticVersion.self, forKey: .hostMacOSVersion),
             hostMacOSBuild: try c.decode(String.self, forKey: .hostMacOSBuild),
@@ -99,15 +117,25 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
             codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
             codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
             codexCLIInstallations: try c.decode(Int.self, forKey: .codexCLIInstallations),
-            codexCLICapabilities: try c.decode([String].self, forKey: .codexCLICapabilities),
+            codexCLICapabilities: capabilities,
             githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
             provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion)
         )
     }
 
     /// Sorted, without duplicates: the canonical form every comparison uses.
+    ///
+    /// A list longer than the maximum is not canonicalized. Deduplicating it first would
+    /// collapse a million repetitions of one identifier into a one-element list that
+    /// `ConnectionVerificationRecord.validate` then accepts and persists, and building a set of
+    /// whatever a guest chose to send costs CPU and memory in proportion to it. The bounded
+    /// prefix that comes back instead is still longer than the maximum, so a construction or an
+    /// assignment the decoders' own count check never saw is refused rather than repaired.
     public static func normalize(_ capabilities: [String]) -> [String] {
-        Array(Set(capabilities)).sorted()
+        guard capabilities.count <= maximumCapabilities else {
+            return Array(capabilities.prefix(maximumCapabilities + 1))
+        }
+        return Array(Set(capabilities)).sorted()
     }
 
     /// The fields whose values differ between two tuples.
@@ -187,6 +215,10 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
 
     public init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
+        let capabilities = try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities)
+        guard (capabilities?.count ?? 0) <= CompatibilityTuple.maximumCapabilities else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: CompatibilityTuple.capabilityCountMessage)
+        }
         self.init(
             hostMacOSVersion: try c.decodeIfPresent(SemanticVersion.self, forKey: .hostMacOSVersion),
             hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
@@ -200,7 +232,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
             codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
             codexCLIInstallations: try c.decodeIfPresent(Int.self, forKey: .codexCLIInstallations),
-            codexCLICapabilities: try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities),
+            codexCLICapabilities: capabilities,
             githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
             provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion)
         )

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -1,0 +1,158 @@
+/// The components whose combination decides whether a Codex handoff is known to work
+/// (MVP-PLAN.md §5, "Connect-time compatibility, not only update-time checks").
+public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterable {
+    case hostMacOSVersion
+    case codexDesktopVersion
+    case codexDesktopBuild
+    case runtimeProtocolVersion
+    case tartVersion
+    case guestMacOSBuild
+    case xcodeBuild
+    case codexCLIVersion
+    case githubCLIVersion
+    case provisioningScriptVersion
+}
+
+/// A fully known combination. Every field has a value.
+public struct CompatibilityTuple: Codable, Hashable, Sendable {
+    public var hostMacOSVersion: SemanticVersion
+    public var codexDesktopVersion: String
+    public var codexDesktopBuild: String
+    public var runtimeProtocolVersion: Int
+    public var tartVersion: String
+    public var guestMacOSBuild: String
+    public var xcodeBuild: String
+    public var codexCLIVersion: String
+    public var githubCLIVersion: String
+    public var provisioningScriptVersion: String
+
+    public init(
+        hostMacOSVersion: SemanticVersion,
+        codexDesktopVersion: String,
+        codexDesktopBuild: String,
+        runtimeProtocolVersion: Int,
+        tartVersion: String,
+        guestMacOSBuild: String,
+        xcodeBuild: String,
+        codexCLIVersion: String,
+        githubCLIVersion: String,
+        provisioningScriptVersion: String
+    ) {
+        self.hostMacOSVersion = hostMacOSVersion
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.tartVersion = tartVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    /// The fields whose values differ between two tuples.
+    public func differences(from other: CompatibilityTuple) -> [CompatibilityField] {
+        var changed: [CompatibilityField] = []
+        if hostMacOSVersion != other.hostMacOSVersion { changed.append(.hostMacOSVersion) }
+        if codexDesktopVersion != other.codexDesktopVersion { changed.append(.codexDesktopVersion) }
+        if codexDesktopBuild != other.codexDesktopBuild { changed.append(.codexDesktopBuild) }
+        if runtimeProtocolVersion != other.runtimeProtocolVersion { changed.append(.runtimeProtocolVersion) }
+        if tartVersion != other.tartVersion { changed.append(.tartVersion) }
+        if guestMacOSBuild != other.guestMacOSBuild { changed.append(.guestMacOSBuild) }
+        if xcodeBuild != other.xcodeBuild { changed.append(.xcodeBuild) }
+        if codexCLIVersion != other.codexCLIVersion { changed.append(.codexCLIVersion) }
+        if githubCLIVersion != other.githubCLIVersion { changed.append(.githubCLIVersion) }
+        if provisioningScriptVersion != other.provisioningScriptVersion { changed.append(.provisioningScriptVersion) }
+        return changed
+    }
+}
+
+/// What was actually observed at connect time. `nil` means unknown, and unknown is never
+/// treated as matching anything: the plan requires reporting "unknown" rather than guessing.
+public struct ObservedTuple: Codable, Hashable, Sendable {
+    public var hostMacOSVersion: SemanticVersion?
+    public var codexDesktopVersion: String?
+    public var codexDesktopBuild: String?
+    public var runtimeProtocolVersion: Int?
+    public var tartVersion: String?
+    public var guestMacOSBuild: String?
+    public var xcodeBuild: String?
+    public var codexCLIVersion: String?
+    public var githubCLIVersion: String?
+    public var provisioningScriptVersion: String?
+
+    public init(
+        hostMacOSVersion: SemanticVersion? = nil,
+        codexDesktopVersion: String? = nil,
+        codexDesktopBuild: String? = nil,
+        runtimeProtocolVersion: Int? = nil,
+        tartVersion: String? = nil,
+        guestMacOSBuild: String? = nil,
+        xcodeBuild: String? = nil,
+        codexCLIVersion: String? = nil,
+        githubCLIVersion: String? = nil,
+        provisioningScriptVersion: String? = nil
+    ) {
+        self.hostMacOSVersion = hostMacOSVersion
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.tartVersion = tartVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    public init(_ tuple: CompatibilityTuple) {
+        self.init(
+            hostMacOSVersion: tuple.hostMacOSVersion,
+            codexDesktopVersion: tuple.codexDesktopVersion,
+            codexDesktopBuild: tuple.codexDesktopBuild,
+            runtimeProtocolVersion: tuple.runtimeProtocolVersion,
+            tartVersion: tuple.tartVersion,
+            guestMacOSBuild: tuple.guestMacOSBuild,
+            xcodeBuild: tuple.xcodeBuild,
+            codexCLIVersion: tuple.codexCLIVersion,
+            githubCLIVersion: tuple.githubCLIVersion,
+            provisioningScriptVersion: tuple.provisioningScriptVersion
+        )
+    }
+
+    /// The fields that are unknown.
+    public var unknownFields: [CompatibilityField] {
+        var unknown: [CompatibilityField] = []
+        if hostMacOSVersion == nil { unknown.append(.hostMacOSVersion) }
+        if codexDesktopVersion == nil { unknown.append(.codexDesktopVersion) }
+        if codexDesktopBuild == nil { unknown.append(.codexDesktopBuild) }
+        if runtimeProtocolVersion == nil { unknown.append(.runtimeProtocolVersion) }
+        if tartVersion == nil { unknown.append(.tartVersion) }
+        if guestMacOSBuild == nil { unknown.append(.guestMacOSBuild) }
+        if xcodeBuild == nil { unknown.append(.xcodeBuild) }
+        if codexCLIVersion == nil { unknown.append(.codexCLIVersion) }
+        if githubCLIVersion == nil { unknown.append(.githubCLIVersion) }
+        if provisioningScriptVersion == nil { unknown.append(.provisioningScriptVersion) }
+        return unknown
+    }
+
+    /// The fully known tuple, or `nil` if any field is unknown.
+    public var exact: CompatibilityTuple? {
+        guard let hostMacOSVersion, let codexDesktopVersion, let codexDesktopBuild,
+              let runtimeProtocolVersion, let tartVersion, let guestMacOSBuild, let xcodeBuild,
+              let codexCLIVersion, let githubCLIVersion, let provisioningScriptVersion
+        else { return nil }
+        return CompatibilityTuple(
+            hostMacOSVersion: hostMacOSVersion,
+            codexDesktopVersion: codexDesktopVersion,
+            codexDesktopBuild: codexDesktopBuild,
+            runtimeProtocolVersion: runtimeProtocolVersion,
+            tartVersion: tartVersion,
+            guestMacOSBuild: guestMacOSBuild,
+            xcodeBuild: xcodeBuild,
+            codexCLIVersion: codexCLIVersion,
+            githubCLIVersion: githubCLIVersion,
+            provisioningScriptVersion: provisioningScriptVersion
+        )
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -1,7 +1,13 @@
 /// The components whose combination decides whether a Codex handoff is known to work
 /// (MVP-PLAN.md §5, "Connect-time compatibility, not only update-time checks").
+///
+/// Host macOS is tracked as both a product version and a build: a build replacement that keeps
+/// the product version is still OS drift (§4). The Codex CLI is tracked by version, resolved
+/// login-shell path, number of competing installations, and reported capabilities, because the
+/// same version string can belong to a different executable (§5).
 public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterable {
     case hostMacOSVersion
+    case hostMacOSBuild
     case codexDesktopVersion
     case codexDesktopBuild
     case runtimeProtocolVersion
@@ -9,6 +15,9 @@ public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterabl
     case guestMacOSBuild
     case xcodeBuild
     case codexCLIVersion
+    case codexCLIPath
+    case codexCLIInstallations
+    case codexCLICapabilities
     case githubCLIVersion
     case provisioningScriptVersion
 }
@@ -16,6 +25,7 @@ public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterabl
 /// A fully known combination. Every field has a value.
 public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public var hostMacOSVersion: SemanticVersion
+    public var hostMacOSBuild: String
     public var codexDesktopVersion: String
     public var codexDesktopBuild: String
     public var runtimeProtocolVersion: Int
@@ -23,11 +33,18 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public var guestMacOSBuild: String
     public var xcodeBuild: String
     public var codexCLIVersion: String
+    /// The executable the guest login shell resolves, as reported by `which -a codex`.
+    public var codexCLIPath: String
+    /// How many `codex` executables the login shell can see. Anything but 1 is ambiguous.
+    public var codexCLIInstallations: Int
+    /// Capability identifiers the CLI reports, sorted. Empty when it reports none.
+    public var codexCLICapabilities: [String]
     public var githubCLIVersion: String
     public var provisioningScriptVersion: String
 
     public init(
         hostMacOSVersion: SemanticVersion,
+        hostMacOSBuild: String,
         codexDesktopVersion: String,
         codexDesktopBuild: String,
         runtimeProtocolVersion: Int,
@@ -35,10 +52,14 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         guestMacOSBuild: String,
         xcodeBuild: String,
         codexCLIVersion: String,
+        codexCLIPath: String,
+        codexCLIInstallations: Int,
+        codexCLICapabilities: [String],
         githubCLIVersion: String,
         provisioningScriptVersion: String
     ) {
         self.hostMacOSVersion = hostMacOSVersion
+        self.hostMacOSBuild = hostMacOSBuild
         self.codexDesktopVersion = codexDesktopVersion
         self.codexDesktopBuild = codexDesktopBuild
         self.runtimeProtocolVersion = runtimeProtocolVersion
@@ -46,6 +67,9 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         self.guestMacOSBuild = guestMacOSBuild
         self.xcodeBuild = xcodeBuild
         self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLIInstallations = codexCLIInstallations
+        self.codexCLICapabilities = codexCLICapabilities.sorted()
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
     }
@@ -54,6 +78,7 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
     public func differences(from other: CompatibilityTuple) -> [CompatibilityField] {
         var changed: [CompatibilityField] = []
         if hostMacOSVersion != other.hostMacOSVersion { changed.append(.hostMacOSVersion) }
+        if hostMacOSBuild != other.hostMacOSBuild { changed.append(.hostMacOSBuild) }
         if codexDesktopVersion != other.codexDesktopVersion { changed.append(.codexDesktopVersion) }
         if codexDesktopBuild != other.codexDesktopBuild { changed.append(.codexDesktopBuild) }
         if runtimeProtocolVersion != other.runtimeProtocolVersion { changed.append(.runtimeProtocolVersion) }
@@ -61,6 +86,9 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
         if guestMacOSBuild != other.guestMacOSBuild { changed.append(.guestMacOSBuild) }
         if xcodeBuild != other.xcodeBuild { changed.append(.xcodeBuild) }
         if codexCLIVersion != other.codexCLIVersion { changed.append(.codexCLIVersion) }
+        if codexCLIPath != other.codexCLIPath { changed.append(.codexCLIPath) }
+        if codexCLIInstallations != other.codexCLIInstallations { changed.append(.codexCLIInstallations) }
+        if codexCLICapabilities != other.codexCLICapabilities { changed.append(.codexCLICapabilities) }
         if githubCLIVersion != other.githubCLIVersion { changed.append(.githubCLIVersion) }
         if provisioningScriptVersion != other.provisioningScriptVersion { changed.append(.provisioningScriptVersion) }
         return changed
@@ -71,6 +99,7 @@ public struct CompatibilityTuple: Codable, Hashable, Sendable {
 /// treated as matching anything: the plan requires reporting "unknown" rather than guessing.
 public struct ObservedTuple: Codable, Hashable, Sendable {
     public var hostMacOSVersion: SemanticVersion?
+    public var hostMacOSBuild: String?
     public var codexDesktopVersion: String?
     public var codexDesktopBuild: String?
     public var runtimeProtocolVersion: Int?
@@ -78,11 +107,15 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
     public var guestMacOSBuild: String?
     public var xcodeBuild: String?
     public var codexCLIVersion: String?
+    public var codexCLIPath: String?
+    public var codexCLIInstallations: Int?
+    public var codexCLICapabilities: [String]?
     public var githubCLIVersion: String?
     public var provisioningScriptVersion: String?
 
     public init(
         hostMacOSVersion: SemanticVersion? = nil,
+        hostMacOSBuild: String? = nil,
         codexDesktopVersion: String? = nil,
         codexDesktopBuild: String? = nil,
         runtimeProtocolVersion: Int? = nil,
@@ -90,10 +123,14 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         guestMacOSBuild: String? = nil,
         xcodeBuild: String? = nil,
         codexCLIVersion: String? = nil,
+        codexCLIPath: String? = nil,
+        codexCLIInstallations: Int? = nil,
+        codexCLICapabilities: [String]? = nil,
         githubCLIVersion: String? = nil,
         provisioningScriptVersion: String? = nil
     ) {
         self.hostMacOSVersion = hostMacOSVersion
+        self.hostMacOSBuild = hostMacOSBuild
         self.codexDesktopVersion = codexDesktopVersion
         self.codexDesktopBuild = codexDesktopBuild
         self.runtimeProtocolVersion = runtimeProtocolVersion
@@ -101,6 +138,9 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         self.guestMacOSBuild = guestMacOSBuild
         self.xcodeBuild = xcodeBuild
         self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLIInstallations = codexCLIInstallations
+        self.codexCLICapabilities = codexCLICapabilities?.sorted()
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
     }
@@ -108,6 +148,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
     public init(_ tuple: CompatibilityTuple) {
         self.init(
             hostMacOSVersion: tuple.hostMacOSVersion,
+            hostMacOSBuild: tuple.hostMacOSBuild,
             codexDesktopVersion: tuple.codexDesktopVersion,
             codexDesktopBuild: tuple.codexDesktopBuild,
             runtimeProtocolVersion: tuple.runtimeProtocolVersion,
@@ -115,6 +156,9 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             guestMacOSBuild: tuple.guestMacOSBuild,
             xcodeBuild: tuple.xcodeBuild,
             codexCLIVersion: tuple.codexCLIVersion,
+            codexCLIPath: tuple.codexCLIPath,
+            codexCLIInstallations: tuple.codexCLIInstallations,
+            codexCLICapabilities: tuple.codexCLICapabilities,
             githubCLIVersion: tuple.githubCLIVersion,
             provisioningScriptVersion: tuple.provisioningScriptVersion
         )
@@ -124,6 +168,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
     public var unknownFields: [CompatibilityField] {
         var unknown: [CompatibilityField] = []
         if hostMacOSVersion == nil { unknown.append(.hostMacOSVersion) }
+        if hostMacOSBuild == nil { unknown.append(.hostMacOSBuild) }
         if codexDesktopVersion == nil { unknown.append(.codexDesktopVersion) }
         if codexDesktopBuild == nil { unknown.append(.codexDesktopBuild) }
         if runtimeProtocolVersion == nil { unknown.append(.runtimeProtocolVersion) }
@@ -131,6 +176,9 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         if guestMacOSBuild == nil { unknown.append(.guestMacOSBuild) }
         if xcodeBuild == nil { unknown.append(.xcodeBuild) }
         if codexCLIVersion == nil { unknown.append(.codexCLIVersion) }
+        if codexCLIPath == nil { unknown.append(.codexCLIPath) }
+        if codexCLIInstallations == nil { unknown.append(.codexCLIInstallations) }
+        if codexCLICapabilities == nil { unknown.append(.codexCLICapabilities) }
         if githubCLIVersion == nil { unknown.append(.githubCLIVersion) }
         if provisioningScriptVersion == nil { unknown.append(.provisioningScriptVersion) }
         return unknown
@@ -138,12 +186,14 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
 
     /// The fully known tuple, or `nil` if any field is unknown.
     public var exact: CompatibilityTuple? {
-        guard let hostMacOSVersion, let codexDesktopVersion, let codexDesktopBuild,
+        guard let hostMacOSVersion, let hostMacOSBuild, let codexDesktopVersion, let codexDesktopBuild,
               let runtimeProtocolVersion, let tartVersion, let guestMacOSBuild, let xcodeBuild,
-              let codexCLIVersion, let githubCLIVersion, let provisioningScriptVersion
+              let codexCLIVersion, let codexCLIPath, let codexCLIInstallations, let codexCLICapabilities,
+              let githubCLIVersion, let provisioningScriptVersion
         else { return nil }
         return CompatibilityTuple(
             hostMacOSVersion: hostMacOSVersion,
+            hostMacOSBuild: hostMacOSBuild,
             codexDesktopVersion: codexDesktopVersion,
             codexDesktopBuild: codexDesktopBuild,
             runtimeProtocolVersion: runtimeProtocolVersion,
@@ -151,6 +201,9 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             guestMacOSBuild: guestMacOSBuild,
             xcodeBuild: xcodeBuild,
             codexCLIVersion: codexCLIVersion,
+            codexCLIPath: codexCLIPath,
+            codexCLIInstallations: codexCLIInstallations,
+            codexCLICapabilities: codexCLICapabilities,
             githubCLIVersion: githubCLIVersion,
             provisioningScriptVersion: provisioningScriptVersion
         )

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -6,15 +6,45 @@ import Foundation
 ///
 /// A record can only be created from `DesktopConnectionEvidence`. Version queries such as
 /// `codex --version` are not evidence and have no way to produce one.
-public struct ConnectionVerificationRecord: Codable, Hashable, Sendable {
+public struct ConnectionVerificationRecord: Hashable, Sendable {
+    /// Record-level schema version, so the state store can migrate history when the tuple
+    /// changes shape instead of misreading old evidence under a new schema.
+    public let schemaVersion: SchemaVersion
     public let tuple: CompatibilityTuple
     public let verifiedAt: Date
     public let evidence: DesktopConnectionEvidence
 
     public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) {
+        schemaVersion = .current
         self.tuple = tuple
         self.verifiedAt = verifiedAt
         self.evidence = evidence
+    }
+}
+
+extension ConnectionVerificationRecord: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, tuple, verifiedAt, evidence
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
+        guard version <= SchemaVersion.current else {
+            throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "record schema \(version) is newer than \(SchemaVersion.current)")
+        }
+        schemaVersion = version
+        tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)
+        verifiedAt = try container.decode(Date.self, forKey: .verifiedAt)
+        evidence = try container.decode(DesktopConnectionEvidence.self, forKey: .evidence)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(tuple, forKey: .tuple)
+        try container.encode(verifiedAt, forKey: .verifiedAt)
+        try container.encode(evidence, forKey: .evidence)
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Proof that Codex desktop really opened a guest workspace with an exact combination
+/// of versions (MVP-PLAN.md §5: "Record connection verification for that exact tuple only
+/// after the real desktop flow succeeds").
+///
+/// A record can only be created from `DesktopConnectionEvidence`. Version queries such as
+/// `codex --version` are not evidence and have no way to produce one.
+public struct ConnectionVerificationRecord: Codable, Hashable, Sendable {
+    public let tuple: CompatibilityTuple
+    public let verifiedAt: Date
+    public let evidence: DesktopConnectionEvidence
+
+    public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) {
+        self.tuple = tuple
+        self.verifiedAt = verifiedAt
+        self.evidence = evidence
+    }
+}
+
+/// How a real desktop connection was confirmed.
+public enum DesktopConnectionEvidence: Codable, Hashable, Sendable {
+    /// The user confirmed in the GUI that the workspace opened in Codex desktop. This is the
+    /// expected path while no machine-readable connection status exists.
+    case userConfirmedWorkspaceOpened
+    /// A supported, machine-readable status from the desktop application. Record its source
+    /// so a future change in that interface is visible in diagnostics.
+    case machineReadableStatus(source: String)
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -14,12 +14,61 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
     public let verifiedAt: Date
     public let evidence: DesktopConnectionEvidence
 
-    public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) {
+    /// - Throws: `CompatibilityRecordError.implausibleObservation` when a guest-reported string
+    ///   is empty, too long, carries control or format characters, or is something the
+    ///   redactor would change: such an observation is never written to persisted history.
+    public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
+        try Self.validate(tuple)
         schemaVersion = .current
         self.tuple = tuple
         self.verifiedAt = verifiedAt
         self.evidence = evidence
     }
+
+    public static let maximumObservationLength = 256
+
+    /// Every string in the tuple must be a plausible version, build, or path.
+    public static func validate(_ tuple: CompatibilityTuple) throws(CompatibilityRecordError) {
+        let fields: [(CompatibilityField, [String])] = [
+            (.hostMacOSBuild, [tuple.hostMacOSBuild]), (.codexDesktopVersion, [tuple.codexDesktopVersion]),
+            (.codexDesktopBuild, [tuple.codexDesktopBuild]), (.codexDesktopPath, [tuple.codexDesktopPath]),
+            (.tartVersion, [tuple.tartVersion]), (.guestMacOSBuild, [tuple.guestMacOSBuild]), (.xcodeBuild, [tuple.xcodeBuild]),
+            (.codexCLIVersion, [tuple.codexCLIVersion]), (.codexCLIPath, [tuple.codexCLIPath]),
+            (.codexCLICapabilities, tuple.codexCLICapabilities), (.githubCLIVersion, [tuple.githubCLIVersion]),
+            (.provisioningScriptVersion, [tuple.provisioningScriptVersion]),
+        ]
+        for (field, values) in fields {
+            for value in values where !isPlausibleObservation(value) {
+                throw .implausibleObservation(field)
+            }
+        }
+    }
+
+    static func isPlausibleObservation(_ value: String) -> Bool {
+        guard !value.isEmpty, value.unicodeScalars.count <= maximumObservationLength else { return false }
+        let clean = value.unicodeScalars.allSatisfy { scalar in
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned: false
+            default: true
+            }
+        }
+        return clean && Redactor().redact(fieldValue: value) == value
+    }
+}
+
+public enum CompatibilityRecordError: Error, Hashable, Sendable, LocalizedError {
+    /// A guest-reported value did not look like a version, build, or path.
+    case implausibleObservation(CompatibilityField)
+
+    public var userMessage: String {
+        switch self {
+        case .implausibleObservation(let field):
+            "The development Mac reported a \(field.rawValue) value that does not look like a version, build, or path, so this connection was not recorded. Check the tools on the development Mac before trying again."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.inspectState, .repair(.tools), .cancel] }
+    public var errorDescription: String? { userMessage }
 }
 
 extension ConnectionVerificationRecord: Codable {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -17,8 +17,10 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
     /// - Throws: `CompatibilityRecordError.implausibleObservation` when a guest-reported string
     ///   is empty, too long, carries control or format characters, or is something the
     ///   redactor would change: such an observation is never written to persisted history.
+    ///   `.implausibleEvidenceSource` when the evidence names its source the same way.
     public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
         try Self.validate(tuple)
+        try Self.validate(evidence)
         schemaVersion = .current
         self.tuple = tuple
         self.verifiedAt = verifiedAt
@@ -26,26 +28,42 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
     }
 
     public static let maximumObservationLength = 256
+    /// A full path is bounded by the file system, not by the shape of a version string: a
+    /// deeply nested but entirely valid bundle or executable must still be recordable.
+    public static let maximumPathLength = 1024
 
     /// Every string in the tuple must be a plausible version, build, or path.
     public static func validate(_ tuple: CompatibilityTuple) throws(CompatibilityRecordError) {
-        let fields: [(CompatibilityField, [String])] = [
-            (.hostMacOSBuild, [tuple.hostMacOSBuild]), (.codexDesktopVersion, [tuple.codexDesktopVersion]),
-            (.codexDesktopBuild, [tuple.codexDesktopBuild]), (.codexDesktopPath, [tuple.codexDesktopPath]),
-            (.tartVersion, [tuple.tartVersion]), (.guestMacOSBuild, [tuple.guestMacOSBuild]), (.xcodeBuild, [tuple.xcodeBuild]),
-            (.codexCLIVersion, [tuple.codexCLIVersion]), (.codexCLIPath, [tuple.codexCLIPath]),
-            (.codexCLICapabilities, tuple.codexCLICapabilities), (.githubCLIVersion, [tuple.githubCLIVersion]),
-            (.provisioningScriptVersion, [tuple.provisioningScriptVersion]),
+        let fields: [(CompatibilityField, [String], Int)] = [
+            (.hostMacOSBuild, [tuple.hostMacOSBuild], maximumObservationLength),
+            (.codexDesktopVersion, [tuple.codexDesktopVersion], maximumObservationLength),
+            (.codexDesktopBuild, [tuple.codexDesktopBuild], maximumObservationLength),
+            (.codexDesktopPath, [tuple.codexDesktopPath], maximumPathLength),
+            (.tartVersion, [tuple.tartVersion], maximumObservationLength),
+            (.guestMacOSBuild, [tuple.guestMacOSBuild], maximumObservationLength),
+            (.xcodeBuild, [tuple.xcodeBuild], maximumObservationLength),
+            (.codexCLIVersion, [tuple.codexCLIVersion], maximumObservationLength),
+            (.codexCLIPath, [tuple.codexCLIPath], maximumPathLength),
+            (.codexCLICapabilities, tuple.codexCLICapabilities, maximumObservationLength),
+            (.githubCLIVersion, [tuple.githubCLIVersion], maximumObservationLength),
+            (.provisioningScriptVersion, [tuple.provisioningScriptVersion], maximumObservationLength),
         ]
-        for (field, values) in fields {
-            for value in values where !isPlausibleObservation(value) {
+        for (field, values, limit) in fields {
+            for value in values where !isPlausibleObservation(value, limit: limit) {
                 throw .implausibleObservation(field)
             }
         }
     }
 
-    static func isPlausibleObservation(_ value: String) -> Bool {
-        guard !value.isEmpty, value.unicodeScalars.count <= maximumObservationLength else { return false }
+    /// The evidence names where a machine-readable status came from, and that name is written
+    /// to persisted history too, so it is held to the same bar as the tuple's strings.
+    public static func validate(_ evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
+        guard case .machineReadableStatus(let source) = evidence else { return }
+        guard isPlausibleObservation(source) else { throw .implausibleEvidenceSource }
+    }
+
+    static func isPlausibleObservation(_ value: String, limit: Int = maximumObservationLength) -> Bool {
+        guard !value.isEmpty, value.unicodeScalars.count <= limit else { return false }
         let clean = value.unicodeScalars.allSatisfy { scalar in
             switch scalar.properties.generalCategory {
             case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned: false
@@ -59,11 +77,15 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
 public enum CompatibilityRecordError: Error, Hashable, Sendable, LocalizedError {
     /// A guest-reported value did not look like a version, build, or path.
     case implausibleObservation(CompatibilityField)
+    /// The evidence named a source that does not look like an interface name.
+    case implausibleEvidenceSource
 
     public var userMessage: String {
         switch self {
         case .implausibleObservation(let field):
             "The development Mac reported a \(field.rawValue) value that does not look like a version, build, or path, so this connection was not recorded. Check the tools on the development Mac before trying again."
+        case .implausibleEvidenceSource:
+            "The Codex desktop app reported a connection status whose source does not look like an interface name, so this connection was not recorded. Check the tools on the development Mac before trying again."
         }
     }
 
@@ -85,9 +107,15 @@ extension ConnectionVerificationRecord: Codable {
             throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "record schema \(version) is not \(SchemaVersion.current)")
         }
         schemaVersion = version
-        tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)
+        let tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)
+        let evidence = try container.decode(DesktopConnectionEvidence.self, forKey: .evidence)
+        // History on disk is as untrusted as the probe that first produced it: an implausible
+        // value must not become verification evidence by having survived one round trip.
+        try Self.validate(tuple)
+        try Self.validate(evidence)
+        self.tuple = tuple
+        self.evidence = evidence
         verifiedAt = try container.decode(Date.self, forKey: .verifiedAt)
-        evidence = try container.decode(DesktopConnectionEvidence.self, forKey: .evidence)
     }
 
     public func encode(to encoder: any Encoder) throws {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -30,8 +30,10 @@ extension ConnectionVerificationRecord: Codable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let version = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
-        guard version <= SchemaVersion.current else {
-            throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "record schema \(version) is newer than \(SchemaVersion.current)")
+        // Exactly the current schema until an explicit migration exists: an older or newer
+        // record would otherwise be interpreted under a shape it was never written in.
+        guard version == SchemaVersion.current else {
+            throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "record schema \(version) is not \(SchemaVersion.current)")
         }
         schemaVersion = version
         tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -5,11 +5,23 @@ import Foundation
 /// after the real desktop flow succeeds").
 ///
 /// A record can only be created from `DesktopConnectionEvidence`. Version queries such as
-/// `codex --version` are not evidence and have no way to produce one.
+/// `codex --version` are not evidence and have no way to name themselves one: the source of a
+/// machine-readable status has to be an interface on `supportedStatusInterfaces`.
 public struct ConnectionVerificationRecord: Hashable, Sendable {
     /// Record-level schema version, so the state store can migrate history when the tuple
     /// changes shape instead of misreading old evidence under a new schema.
     public let schemaVersion: SchemaVersion
+
+    /// The record layout this build writes, and the only one `init(from:)` accepts.
+    ///
+    /// Its own number rather than `SchemaVersion.current`: that epoch moves whenever any
+    /// persisted record in the package changes shape, so measuring this record against it
+    /// would make every unchanged connection record unreadable after a release that only
+    /// altered an environment or VM-slot format. This number moves when this record's shape
+    /// moves, together with the migration that reads the previous one. `SchemaVersion` only
+    /// refuses a number below 1, so the fallback below is unreachable; it is written this way
+    /// so a layout number can never be a crash.
+    public static let currentSchema = SchemaVersion(1) ?? .current
     public let tuple: CompatibilityTuple
     public let verifiedAt: Date
     public let evidence: DesktopConnectionEvidence
@@ -17,11 +29,12 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
     /// - Throws: `CompatibilityRecordError.implausibleObservation` when a guest-reported string
     ///   is empty, too long, carries control or format characters, or is something the
     ///   redactor would change: such an observation is never written to persisted history.
-    ///   `.implausibleEvidenceSource` when the evidence names its source the same way.
+    ///   `.implausibleEvidenceSource` when the evidence names a status interface this build
+    ///   does not read.
     public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
         try Self.validate(tuple)
         try Self.validate(evidence)
-        schemaVersion = .current
+        schemaVersion = Self.currentSchema
         self.tuple = tuple
         self.verifiedAt = verifiedAt
         self.evidence = evidence
@@ -34,16 +47,19 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
 
     /// Every string in the tuple must be a plausible version, build, or path.
     public static func validate(_ tuple: CompatibilityTuple) throws(CompatibilityRecordError) {
+        // Bounded in count as well as in length: the per-value checks below say nothing about
+        // how many values a guest may report, and the whole list is what gets persisted.
+        guard tuple.codexCLICapabilities.count <= CompatibilityTuple.maximumCapabilities else {
+            throw .implausibleObservation(.codexCLICapabilities)
+        }
         let fields: [(CompatibilityField, [String], Int)] = [
             (.hostMacOSBuild, [tuple.hostMacOSBuild], maximumObservationLength),
             (.codexDesktopVersion, [tuple.codexDesktopVersion], maximumObservationLength),
             (.codexDesktopBuild, [tuple.codexDesktopBuild], maximumObservationLength),
-            (.codexDesktopPath, [tuple.codexDesktopPath], maximumPathLength),
             (.tartVersion, [tuple.tartVersion], maximumObservationLength),
             (.guestMacOSBuild, [tuple.guestMacOSBuild], maximumObservationLength),
             (.xcodeBuild, [tuple.xcodeBuild], maximumObservationLength),
             (.codexCLIVersion, [tuple.codexCLIVersion], maximumObservationLength),
-            (.codexCLIPath, [tuple.codexCLIPath], maximumPathLength),
             (.codexCLICapabilities, tuple.codexCLICapabilities, maximumObservationLength),
             (.githubCLIVersion, [tuple.githubCLIVersion], maximumObservationLength),
             (.provisioningScriptVersion, [tuple.provisioningScriptVersion], maximumObservationLength),
@@ -53,43 +69,115 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
                 throw .implausibleObservation(field)
             }
         }
+        // The two paths are identity, not description, so they are held to more than
+        // plausibility (MVP-PLAN.md §5).
+        let paths: [(CompatibilityField, String)] = [
+            (.codexDesktopPath, tuple.codexDesktopPath),
+            (.codexCLIPath, tuple.codexCLIPath),
+        ]
+        for (field, value) in paths where !isResolvedPath(value) {
+            throw .implausibleObservation(field)
+        }
     }
 
-    /// The evidence names where a machine-readable status came from, and that name is written
-    /// to persisted history too, so it is held to the same bar as the tuple's strings.
+    /// Whether a path names the same file wherever it is read from.
+    ///
+    /// A login shell whose `PATH` carries a relative entry answers `which -a codex` with
+    /// `codex` or `../bin/codex`, and a compromised probe can answer with either on purpose.
+    /// Recording one as identity would let a different executable of the same name pass as the
+    /// verified one from another working directory, which is exactly the substitution
+    /// MVP-PLAN.md §5 tracks the resolved path to catch.
+    static func isResolvedPath(_ value: String) -> Bool {
+        guard isPlausibleObservation(value, limit: maximumPathLength), value.hasPrefix("/") else { return false }
+        // `.` and `..` resolve against a working directory the record does not carry, so a path
+        // holding either is not yet the one the probe was standing on.
+        return !value.split(separator: "/").contains { $0 == "." || $0 == ".." }
+    }
+
+    /// The machine-readable connection-status interfaces this build reads.
+    ///
+    /// MVP-PLAN.md §5 records verification for a tuple only after the real desktop flow
+    /// succeeds and never equates `codex --version` with a successful desktop connection. A
+    /// caller that names its own source can do exactly that — labeling any successful probe
+    /// `.machineReadableStatus(source: "codex --version")` — so a name that merely looks like an
+    /// interface is not one; it has to be on this list. Codex documents no such interface today,
+    /// which is why the list is empty and the user's explicit confirmation in the GUI is the
+    /// only evidence there is. An interface joins this list together with the code that reads it.
+    public static let supportedStatusInterfaces: Set<String> = []
+
+    /// The evidence names where a machine-readable status came from. That name goes into
+    /// persisted history and decides whether a later handoff is allowed without asking, so it
+    /// has to be an interface this build supports rather than a plausible-looking string.
     public static func validate(_ evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
         guard case .machineReadableStatus(let source) = evidence else { return }
-        guard isPlausibleObservation(source) else { throw .implausibleEvidenceSource }
+        guard supportedStatusInterfaces.contains(source) else { throw .implausibleEvidenceSource }
     }
 
     static func isPlausibleObservation(_ value: String, limit: Int = maximumObservationLength) -> Bool {
         guard !value.isEmpty, value.unicodeScalars.count <= limit else { return false }
+        // Spaces are neither empty nor a rejected category, and the redactor leaves them, so a
+        // probe that answered with blanks would otherwise make an unknown component look like
+        // an exact identity and be recorded as verification evidence for it.
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines) == value else { return false }
         let clean = value.unicodeScalars.allSatisfy { scalar in
             switch scalar.properties.generalCategory {
             case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned: false
             default: true
             }
         }
-        return clean && Redactor().redact(fieldValue: value) == value
+        guard clean, Redactor().redact(fieldValue: value) == value else { return false }
+        // A combining mark or a no-break space inside a credential label splits it out of the
+        // redactor's reach while belonging to no category refused above: `passwo´rd=hunter2`
+        // reads as ordinary text to every rule. The scan is therefore repeated on the reading
+        // `GuesthouseError.sanitize` normalizes to, with the marks and the spaces that are not
+        // word boundaries removed. Only the scan uses that reading — a guest path may carry a
+        // mark for its own sake, and what is recorded is what was reported.
+        let joined = String(String.UnicodeScalarView(value.unicodeScalars.filter { scalar in
+            switch scalar.properties.generalCategory {
+            case .nonspacingMark, .spacingMark, .enclosingMark: false
+            case .spaceSeparator: scalar == " "
+            default: true
+            }
+        }))
+        guard joined != value else { return true }
+        return Redactor().redact(fieldValue: joined) == joined
     }
 }
 
 public enum CompatibilityRecordError: Error, Hashable, Sendable, LocalizedError {
     /// A guest-reported value did not look like a version, build, or path.
     case implausibleObservation(CompatibilityField)
-    /// The evidence named a source that does not look like an interface name.
+    /// The evidence named a status interface this build does not read.
     case implausibleEvidenceSource
+    /// The stored history was written in a record layout this build does not read.
+    case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
+    /// The stored history is not connection history this build can parse.
+    case malformedHistory
 
     public var userMessage: String {
         switch self {
         case .implausibleObservation(let field):
             "The development Mac reported a \(field.rawValue) value that does not look like a version, build, or path, so this connection was not recorded. Check the tools on the development Mac before trying again."
         case .implausibleEvidenceSource:
-            "The Codex desktop app reported a connection status whose source does not look like an interface name, so this connection was not recorded. Check the tools on the development Mac before trying again."
+            "The Codex desktop app reported a connection status from an interface Guesthouse does not read, so this connection was not recorded. Confirm in Guesthouse that the workspace opened, or check the tools on the development Mac before trying again."
+        case .unsupportedSchema(let found, let supported):
+            "Guesthouse's record of successful Codex connections is in format \(found.rawValue), and this version reads format \(supported.rawValue). The earlier connections cannot be counted, so the next handoff asks you to confirm a connection once more."
+        case .malformedHistory:
+            "Guesthouse's record of successful Codex connections could not be read. The earlier connections cannot be counted, so the next handoff asks you to confirm a connection once more."
         }
     }
 
-    public var recoveryActions: [RecoveryAction] { [.inspectState, .repair(.tools), .cancel] }
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .implausibleObservation, .implausibleEvidenceSource:
+            [.inspectState, .repair(.tools), .cancel]
+        // Unreadable history is not damage to repair: confirming one connection writes it
+        // again, so the way forward is the handoff itself.
+        case .unsupportedSchema, .malformedHistory:
+            [.inspectState, .retry, .cancel]
+        }
+    }
+
     public var errorDescription: String? { userMessage }
 }
 
@@ -101,10 +189,10 @@ extension ConnectionVerificationRecord: Codable {
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let version = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
-        // Exactly the current schema until an explicit migration exists: an older or newer
+        // Exactly this record's layout until an explicit migration exists: an older or newer
         // record would otherwise be interpreted under a shape it was never written in.
-        guard version == SchemaVersion.current else {
-            throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "record schema \(version) is not \(SchemaVersion.current)")
+        guard version == Self.currentSchema else {
+            throw CompatibilityRecordError.unsupportedSchema(found: version, supported: Self.currentSchema)
         }
         schemaVersion = version
         let tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)
@@ -116,6 +204,19 @@ extension ConnectionVerificationRecord: Codable {
         self.tuple = tuple
         self.evidence = evidence
         verifiedAt = try container.decode(Date.self, forKey: .verifiedAt)
+    }
+
+    /// Reads persisted connection history. Every failure becomes something the user can act
+    /// on rather than a decoder's internal complaint: history that cannot be read decides
+    /// whether the next handoff is allowed, so the state store has to be able to say so.
+    public static func decodeHistory(from data: Data, using decoder: JSONDecoder = JSONDecoder()) throws(CompatibilityRecordError) -> [ConnectionVerificationRecord] {
+        do {
+            return try decoder.decode([ConnectionVerificationRecord].self, from: data)
+        } catch let error as CompatibilityRecordError {
+            throw error
+        } catch {
+            throw .malformedHistory
+        }
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -132,7 +233,8 @@ public enum DesktopConnectionEvidence: Codable, Hashable, Sendable {
     /// The user confirmed in the GUI that the workspace opened in Codex desktop. This is the
     /// expected path while no machine-readable connection status exists.
     case userConfirmedWorkspaceOpened
-    /// A supported, machine-readable status from the desktop application. Record its source
-    /// so a future change in that interface is visible in diagnostics.
+    /// A supported, machine-readable status from the desktop application. Its source is one of
+    /// `ConnectionVerificationRecord.supportedStatusInterfaces` and is recorded so a future
+    /// change in that interface is visible in diagnostics.
     case machineReadableStatus(source: String)
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
@@ -63,9 +63,21 @@ public struct VersionRange: Codable, Hashable, Sendable {
     public var minimum: SemanticVersion
     public var maximum: SemanticVersion?
 
+    /// An inverted range would contain nothing and let a rule silently never fire.
     public init(minimum: SemanticVersion, maximum: SemanticVersion? = nil) {
+        precondition(maximum.map { minimum <= $0 } ?? true, "inverted version range")
         self.minimum = minimum
         self.maximum = maximum
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let minimum = try c.decode(SemanticVersion.self, forKey: .minimum)
+        let maximum = try c.decodeIfPresent(SemanticVersion.self, forKey: .maximum)
+        if let maximum, maximum < minimum {
+            throw DecodingError.dataCorruptedError(forKey: .maximum, in: c, debugDescription: "maximum is below minimum")
+        }
+        self.init(minimum: minimum, maximum: maximum)
     }
 
     public func contains(_ version: SemanticVersion) -> Bool {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
@@ -1,0 +1,73 @@
+/// A dotted numeric version such as `26.5.2` or `2.36.0`, compared component by component.
+///
+/// Missing trailing components count as zero, so `26.5` equals `26.5.0`. Anything that is not
+/// a dotted sequence of integers fails to parse; callers must then treat the version as unknown
+/// rather than guess.
+public struct SemanticVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
+    public let components: [Int]
+
+    public init(_ components: [Int]) {
+        var trimmed = components
+        while trimmed.count > 1, trimmed.last == 0 {
+            trimmed.removeLast()
+        }
+        self.components = trimmed.isEmpty ? [0] : trimmed
+    }
+
+    public init?(_ string: String) {
+        let parts = string.split(separator: ".", omittingEmptySubsequences: false)
+        var parsed: [Int] = []
+        for part in parts {
+            guard let value = Int(part), value >= 0 else { return nil }
+            parsed.append(value)
+        }
+        guard !parsed.isEmpty else { return nil }
+        self.init(parsed)
+    }
+
+    public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0..<count {
+            let l = index < lhs.components.count ? lhs.components[index] : 0
+            let r = index < rhs.components.count ? rhs.components[index] : 0
+            if l != r { return l < r }
+        }
+        return false
+    }
+
+    public var description: String {
+        components.map(String.init).joined(separator: ".")
+    }
+}
+
+extension SemanticVersion: Codable {
+    public init(from decoder: any Decoder) throws {
+        let string = try decoder.singleValueContainer().decode(String.self)
+        guard let version = SemanticVersion(string) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "not a dotted numeric version: \(string)"))
+        }
+        self = version
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+}
+
+/// An inclusive version range; `maximum == nil` means open-ended.
+public struct VersionRange: Codable, Hashable, Sendable {
+    public var minimum: SemanticVersion
+    public var maximum: SemanticVersion?
+
+    public init(minimum: SemanticVersion, maximum: SemanticVersion? = nil) {
+        self.minimum = minimum
+        self.maximum = maximum
+    }
+
+    public func contains(_ version: SemanticVersion) -> Bool {
+        if version < minimum { return false }
+        if let maximum, maximum < version { return false }
+        return true
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
@@ -6,7 +6,10 @@
 public struct SemanticVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
     public let components: [Int]
 
+    /// Components must be nonnegative; the string initializer already enforces this, and an
+    /// encoded negative component could never be decoded again.
     public init(_ components: [Int]) {
+        precondition(components.allSatisfy { $0 >= 0 }, "version components must be nonnegative")
         var trimmed = components
         while trimmed.count > 1, trimmed.last == 0 {
             trimmed.removeLast()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
@@ -59,9 +59,12 @@ extension SemanticVersion: Codable {
 }
 
 /// An inclusive version range; `maximum == nil` means open-ended.
+///
+/// The bounds are immutable: a range that could be inverted after construction would let a
+/// rule that once matched silently stop firing, without passing any of the checks below.
 public struct VersionRange: Codable, Hashable, Sendable {
-    public var minimum: SemanticVersion
-    public var maximum: SemanticVersion?
+    public let minimum: SemanticVersion
+    public let maximum: SemanticVersion?
 
     /// An inverted range would contain nothing and let a rule silently never fire.
     public init(minimum: SemanticVersion, maximum: SemanticVersion? = nil) {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -1,0 +1,20 @@
+{
+  "schemaVersion": 1,
+  "manifestVersion": 1,
+  "notes": "Seed manifest from MVP-PLAN.md §4 (Tahoe host and guest, Xcode 26.6, Tart 2.36.0). Values marked TBD are placeholders that can never match a real observation. Phase-0 gate #41 replaces this entry with the measured combination and sets verifiedAt only after a real Codex desktop connection (docs/phase0/compat.md).",
+  "tested": [
+    {
+      "hostMacOS": { "minimum": "26.4" },
+      "codexDesktopVersion": "TBD",
+      "codexDesktopBuild": "TBD",
+      "runtimeProtocolVersion": 1,
+      "tartVersion": "2.36.0",
+      "guestMacOSBuild": "25F84",
+      "xcodeBuild": "17F113",
+      "codexCLIVersion": "TBD",
+      "githubCLIVersion": "TBD",
+      "provisioningScriptVersion": "TBD"
+    }
+  ],
+  "incompatibilities": []
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "manifestVersion": 1,
-  "notes": "Seed manifest from MVP-PLAN.md §4 (Tahoe host and guest, Xcode 26.6, Tart 2.36.0). Values marked TBD are placeholders that can never match a real observation. Phase-0 gate #41 replaces this entry with the measured combination and sets verifiedAt only after a real Codex desktop connection (docs/phase0/compat.md).",
+  "notes": "Seed manifest from MVP-PLAN.md §4 (Tahoe host and guest, Xcode 26.6, Tart 2.36.0). Values marked TBD are placeholders that can never match a real observation. Phase-0 gate #41 replaces this entry with the measured combination and adds a verification only after a real Codex desktop connection on an exact host version and build (docs/phase0/compat.md).",
   "tested": [
     {
       "hostMacOS": { "minimum": "26.4" },
@@ -12,6 +12,8 @@
       "guestMacOSBuild": "25F84",
       "xcodeBuild": "17F113",
       "codexCLIVersion": "TBD",
+      "codexCLIPath": "TBD",
+      "codexCLICapabilities": [],
       "githubCLIVersion": "TBD",
       "provisioningScriptVersion": "TBD"
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -7,6 +7,7 @@
       "hostMacOS": { "minimum": "26.4" },
       "codexDesktopVersion": "TBD",
       "codexDesktopBuild": "TBD",
+      "codexDesktopPath": "TBD",
       "runtimeProtocolVersion": 1,
       "tartVersion": "2.36.0",
       "guestMacOSBuild": "25F84",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -94,21 +94,31 @@ import Testing
     }
 
     @Test func decodedRecordsAreRevalidatedIncludingTheirEvidence() throws {
-        let record = try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .machineReadableStatus(source: "desktop-status"))
-        let json = String(decoding: try JSONEncoder().encode(record), as: UTF8.self)
+        let record = try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .userConfirmedWorkspaceOpened)
+        let data = try JSONEncoder().encode(record)
+        let json = String(decoding: data, as: UTF8.self)
         let secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
         let poisonedTuple = json.replacingOccurrences(of: #""0.50.0""#, with: #""0.50.0 \#(secret)""#)
         #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIVersion)) {
             try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(poisonedTuple.utf8))
         }
-        let poisonedEvidence = json.replacingOccurrences(of: "desktop-status", with: "desktop-status \(secret)")
+        var claimed = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        claimed["evidence"] = ["machineReadableStatus": ["source": "codex --version"]]
         #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
-            try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(poisonedEvidence.utf8))
-        }
-        #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
-            try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(), evidence: .machineReadableStatus(source: "status\u{1B}[31m"))
+            try JSONDecoder().decode(ConnectionVerificationRecord.self, from: JSONSerialization.data(withJSONObject: claimed))
         }
         #expect(!CompatibilityRecordError.implausibleEvidenceSource.userMessage.isEmpty)
+    }
+
+    @Test func aVersionProbeCannotNameItselfAConnectionStatus() {
+        // MVP-PLAN.md §5: `codex --version` is never evidence of a desktop connection, so a
+        // source the caller invents is not a supported interface however plausible it reads.
+        #expect(ConnectionVerificationRecord.supportedStatusInterfaces.isEmpty)
+        for source in ["codex --version", "desktop-status", "codex login status"] {
+            #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
+                try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(), evidence: .machineReadableStatus(source: source))
+            }
+        }
     }
 
     @Test func fullLengthPathsAreRecordableButUnboundedOnesAreNot() throws {
@@ -130,6 +140,60 @@ import Testing
         }
     }
 
+    @Test func aFloodOfDuplicateCapabilitiesIsRefusedRatherThanCollapsed() throws {
+        // Normalizing first would turn any number of repetitions of one identifier into a
+        // one-element list the count check then accepts, after doing the set work the guest
+        // asked for. The list stays over the bound instead, whichever way it was set.
+        let repeated = Array(repeating: "remote-app-server", count: CompatibilityTuple.maximumCapabilities + 1)
+        #expect(CompatibilityTuple.normalize(repeated).count > CompatibilityTuple.maximumCapabilities)
+        var assigned = Fixtures.tuple()
+        assigned.codexCLICapabilities = repeated
+        for tuple in [assigned, Fixtures.tuple(capabilities: repeated)] {
+            #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLICapabilities)) {
+                try ConnectionVerificationRecord(tuple: tuple, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+            }
+        }
+    }
+
+    @Test func onlyAResolvedPathIsAnIdentity() throws {
+        // MVP-PLAN.md §5 identifies the CLI by the executable the login shell resolves. A
+        // relative entry in that shell's `PATH`, or a probe that answers with one on purpose,
+        // names a different executable from a different working directory.
+        for path in ["codex", "./codex", "../bin/codex", "/opt/homebrew/../bin/codex"] {
+            var relative = Fixtures.tuple(path: path)
+            #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIPath)) {
+                try ConnectionVerificationRecord(tuple: relative, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+            }
+            relative = Fixtures.tuple()
+            relative.codexDesktopPath = path.replacingOccurrences(of: "codex", with: "Codex.app")
+            #expect(throws: CompatibilityRecordError.implausibleObservation(.codexDesktopPath)) {
+                try ConnectionVerificationRecord(tuple: relative, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+            }
+        }
+        #expect(throws: Never.self) {
+            try ConnectionVerificationRecord(tuple: Fixtures.tuple(path: "/usr/local/bin/codex"), verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+    }
+
+    @Test func aCredentialSplitByACombiningMarkIsNotRecordable() throws {
+        // The mark belongs to no category the plausibility check refuses, and it hides the
+        // label from the redactor, so the value would be persisted in connection history whole.
+        var poisoned = Fixtures.tuple()
+        poisoned.codexCLIVersion = "0.50.0 passwo\u{0301}rd=hunter2"
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIVersion)) {
+            try ConnectionVerificationRecord(tuple: poisoned, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        var spaced = Fixtures.tuple()
+        spaced.guestMacOSBuild = "25F84\u{2007}token=abc123"
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.guestMacOSBuild)) {
+            try ConnectionVerificationRecord(tuple: spaced, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        // A path that carries a mark for its own sake is still recordable, unchanged.
+        let accented = Fixtures.tuple(path: "/Users/jose\u{0301}/bin/codex")
+        let record = try ConnectionVerificationRecord(tuple: accented, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        #expect(record.tuple.codexCLIPath == "/Users/jose\u{0301}/bin/codex")
+    }
+
     @Test func invertedRangesAreRejectedWhenDecoding() {
         #expect(throws: DecodingError.self) {
             try JSONDecoder().decode(VersionRange.self, from: Data(#"{"minimum":"26.5","maximum":"26.4"}"#.utf8))
@@ -145,7 +209,9 @@ import Testing
         ]
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: manifest, history: []) == .needsValidation(.neverConnected))
         let broken = ObservedTuple(Fixtures.tuple(path: "/usr/local/bin/codex"))
-        #expect(CompatibilityEvaluator.evaluate(observed: broken, manifest: manifest, history: []) == .incompatible(reason: "bottle is broken", recoveryActions: [.repair(.tools), .cancel]))
+        // The rule's own actions lead; console access and work export are added back, because
+        // §5 keeps them in every blocked state whatever a rule lists.
+        #expect(CompatibilityEvaluator.evaluate(observed: broken, manifest: manifest, history: []) == .incompatible(reason: "bottle is broken", recoveryActions: [.repair(.tools), .cancel, .openConsole, .exportWork]))
         let legacy = ObservedTuple(Fixtures.tuple(capabilities: ["legacy-transport"]))
         #expect(CompatibilityEvaluator.evaluate(observed: legacy, manifest: manifest, history: []) == .incompatible(reason: "legacy transport", recoveryActions: defaults))
         var beta = Fixtures.tuple()
@@ -197,6 +263,120 @@ import Testing
         none.codexCLIPath = nil
         #expect(CompatibilityEvaluator.evaluate(observed: none, manifest: manifest, history: []) == .needsValidation(.codexCLIMissing))
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple(installations: 2)), manifest: manifest, history: []) == .needsValidation(.competingInstallations(count: 2)))
+    }
+
+    @Test func capabilitiesStayCanonicalWhenTheFieldIsAssigned() throws {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        var rebuilt = Fixtures.tuple()
+        rebuilt.codexCLICapabilities = ["remote-app-server", "apply-patch", "apply-patch"]
+        #expect(rebuilt.codexCLICapabilities == ["apply-patch", "remote-app-server"])
+        let day = Date(timeIntervalSince1970: 1_800_000_000)
+        let record = try ConnectionVerificationRecord(tuple: rebuilt, verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(rebuilt), manifest: manifest, history: [record]) == .verified(recordedAt: day))
+    }
+
+    @Test func overlongCapabilityListsAreRefused() throws {
+        let many = (0...CompatibilityTuple.maximumCapabilities).map { "capability-\($0)" }
+        var noisy = Fixtures.tuple()
+        noisy.codexCLICapabilities = many
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLICapabilities)) {
+            try ConnectionVerificationRecord(tuple: noisy, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        let encoded = String(decoding: try JSONEncoder().encode(Fixtures.tuple()), as: UTF8.self)
+        let list = many.map { "\"\($0)\"" }.joined(separator: ",")
+        let flooded = encoded.replacingOccurrences(of: #"["remote-app-server"]"#, with: "[\(list)]")
+        #expect(flooded != encoded, "the capability list was replaced")
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(CompatibilityTuple.self, from: Data(flooded.utf8)) }
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ObservedTuple.self, from: Data(flooded.utf8)) }
+    }
+
+    @Test func unreadableHistoryReportsSomethingTheUserCanDo() throws {
+        let record = try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .userConfirmedWorkspaceOpened)
+        let data = try JSONEncoder().encode([record])
+        #expect(try ConnectionVerificationRecord.decodeHistory(from: data) == [record])
+        let future = String(decoding: data, as: UTF8.self)
+            .replacingOccurrences(of: "\"schemaVersion\":\(ConnectionVerificationRecord.currentSchema.rawValue)", with: "\"schemaVersion\":99")
+        #expect(throws: CompatibilityRecordError.unsupportedSchema(found: SchemaVersion(99)!, supported: ConnectionVerificationRecord.currentSchema)) {
+            try ConnectionVerificationRecord.decodeHistory(from: Data(future.utf8))
+        }
+        #expect(throws: CompatibilityRecordError.malformedHistory) {
+            try ConnectionVerificationRecord.decodeHistory(from: Data("not history".utf8))
+        }
+        for error: CompatibilityRecordError in [.malformedHistory, .unsupportedSchema(found: SchemaVersion(99)!, supported: .current)] {
+            #expect(!error.userMessage.isEmpty)
+            #expect(!error.recoveryActions.isEmpty)
+        }
+    }
+
+    @Test func aLaterTestedEntryCanCarryTheCoveringVerification() {
+        let day = Date(timeIntervalSince1970: 1_800_000_000)
+        let elsewhere = CompatibilityManifest.Verification(verifiedAt: day.addingTimeInterval(-86_400), hostMacOSVersion: SemanticVersion("26.4")!, hostMacOSBuild: "25E20", evidence: "docs/phase0/compat.md")
+        let here = CompatibilityManifest.Verification(verifiedAt: day, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        // Both entries describe the same combination over overlapping host ranges; only the
+        // second one was verified on the host being evaluated.
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested(verification: elsewhere), Fixtures.tested(verification: here)])
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: manifest, history: []) == .verified(recordedAt: day))
+        let unverifiedFirst = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested(), Fixtures.tested(verification: here)])
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: unverifiedFirst, history: []) == .verified(recordedAt: day))
+    }
+
+    @Test func negativeProtocolVersionsAreNeverVerified() throws {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        var impossible = Fixtures.tuple()
+        impossible.runtimeProtocolVersion = -1
+        let history = [try ConnectionVerificationRecord(tuple: impossible, verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .userConfirmedWorkspaceOpened)]
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(impossible), manifest: manifest, history: history) == .needsValidation(.unknownFields([.runtimeProtocolVersion])))
+    }
+
+    @Test func competingInstallationsAreNamedBeforeMissingFields() {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        // A probe that refuses to pick between several `which -a` candidates reports the count
+        // and nothing else about the CLI.
+        var ambiguous = ObservedTuple(Fixtures.tuple(installations: 3))
+        ambiguous.codexCLIVersion = nil
+        ambiguous.codexCLIPath = nil
+        #expect(CompatibilityEvaluator.evaluate(observed: ambiguous, manifest: manifest, history: []) == .needsValidation(.competingInstallations(count: 3)))
+    }
+
+    @Test func blankObservationsAreNeverRecorded() {
+        for blank in ["   ", " 25F84", "25F84 ", "\u{00A0}"] {
+            var padded = Fixtures.tuple()
+            padded.guestMacOSBuild = blank
+            #expect(throws: CompatibilityRecordError.implausibleObservation(.guestMacOSBuild)) {
+                try ConnectionVerificationRecord(tuple: padded, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+            }
+        }
+        // An interior space is part of a real bundle name and stays recordable.
+        var spaced = Fixtures.tuple()
+        spaced.codexDesktopPath = "/Applications/Codex Beta.app"
+        #expect(throws: Never.self) { try ConnectionVerificationRecord(tuple: spaced, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened) }
+    }
+
+    @Test func aBlockedCombinationOffersARepairByDefault() {
+        #expect(defaults.contains(.repair(.tools)))
+        #expect(defaults.first == .repair(.tools))
+        let rule = CompatibilityManifest.KnownIncompatibility(codexCLIVersion: "0.50.0", reason: "0.50.0 cannot start the remote app-server")
+        #expect(rule.recoveryActions.contains(where: { if case .repair = $0 { true } else { false } }))
+    }
+
+    @Test func aRuleCannotTakeAwayWhatEveryBlockedStateKeeps() {
+        // MVP-PLAN.md §5: block the handoff, offer an idle-time repair, and preserve console
+        // access, shutdown, and work export in every state. The rules are data, so a manifest
+        // that lists fewer actions cannot be trusted to have meant it.
+        func actions(_ named: [RecoveryAction]) -> [RecoveryAction] {
+            CompatibilityManifest.KnownIncompatibility(reason: "blocked", recoveryActions: named).recoveryActions
+        }
+        #expect(actions([.cancel]) == [.repair(.tools), .cancel, .openConsole, .exportWork])
+        #expect(actions([.openConsole, .cancel]) == [.repair(.tools), .openConsole, .cancel, .exportWork])
+        #expect(actions([]) == defaults)
+        // A repair the rule names itself is the repair: some combinations are not fixed by the
+        // tools flow, and a second button that cannot help is worse than none.
+        #expect(actions([.repair(.xcodeComponents)]) == [.repair(.xcodeComponents), .openConsole, .exportWork, .cancel])
+        let decoded = try? JSONDecoder().decode(
+            CompatibilityManifest.KnownIncompatibility.self,
+            from: Data(#"{"reason":"blocked","recoveryActions":[{"cancel":{}}]}"#.utf8)
+        )
+        #expect(decoded?.recoveryActions == [.repair(.tools), .cancel, .openConsole, .exportWork])
     }
 
     @Test func replacedDesktopBundleIsDrift() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -45,8 +45,13 @@ import Testing
 
     @Test func testedEntriesMustDeclareTheirCapabilities() throws {
         let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
-        let json = String(decoding: try JSONEncoder().encode(manifest), as: UTF8.self)
+        // Sorted, so the key this test removes is always followed by a comma: an encoder that
+        // happened to put it last would leave the JSON valid and the test would prove nothing.
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let json = String(decoding: try encoder.encode(manifest), as: UTF8.self)
         let stale = json.replacingOccurrences(of: #""codexCLICapabilities":["remote-app-server"],"#, with: "")
+        #expect(stale != json, "the capabilities key was removed")
         #expect(throws: CompatibilityManifestError.malformedManifest) {
             try CompatibilityManifest.decode(from: Data(stale.utf8))
         }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -25,6 +25,104 @@ import Testing
         #expect(throws: CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)) {
             try CompatibilityManifest.decode(from: data)
         }
+        // The helper is a convenience, not the only gate: a caller reaching for Codable directly
+        // must not get a manifest whose extra dimensions this build would ignore.
+        #expect(throws: CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)) {
+            try JSONDecoder().decode(CompatibilityManifest.self, from: data)
+        }
+    }
+
+    @Test func damagedManifestResourcesReportSomethingTheUserCanDo() {
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: Data("not a manifest".utf8))
+        }
+        for error: CompatibilityManifestError in [.unreadableManifest, .malformedManifest] {
+            #expect(!error.userMessage.isEmpty)
+            #expect(error.recoveryActions.contains(.reinstallApp))
+        }
+        #expect(throws: Never.self) { try CompatibilityManifest.bundled() }
+    }
+
+    @Test func testedEntriesMustDeclareTheirCapabilities() throws {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        let json = String(decoding: try JSONEncoder().encode(manifest), as: UTF8.self)
+        let stale = json.replacingOccurrences(of: #""codexCLICapabilities":["remote-app-server"],"#, with: "")
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: Data(stale.utf8))
+        }
+    }
+
+    @Test func rulesWithoutAnExplanationAreRejected() throws {
+        let manifest = #"{"schemaVersion":1,"manifestVersion":1,"tested":[],"incompatibilities":[{"reason":"   "}]}"#
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: Data(manifest.utf8))
+        }
+        let cleared = try JSONDecoder().decode(CompatibilityManifest.KnownIncompatibility.self, from: Data(#"{"reason":"broken","recoveryActions":[]}"#.utf8))
+        #expect(cleared.recoveryActions == defaults)
+    }
+
+    @Test func verificationTimestampsSurviveEncoding() throws {
+        // Sub-second instants included on purpose: a real `Date()` has more precision than any
+        // ISO 8601 form carries, and rounding it must land somewhere the encoder reproduces.
+        let instants = [Date(), Date(timeIntervalSince1970: 1_800_000_000.123456)]
+            + (0..<64).map { Date(timeIntervalSince1970: 1_800_000_000 + Double($0) * 0.176_666) }
+        for instant in instants {
+            let verification = CompatibilityManifest.Verification(verifiedAt: instant, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+            let data = try JSONEncoder().encode(verification)
+            #expect(try JSONDecoder().decode(CompatibilityManifest.Verification.self, from: data) == verification)
+        }
+    }
+
+    @Test func capabilityOrderNeverDecidesWhetherARuleFires() {
+        var manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        manifest.incompatibilities = [.init(codexCLICapabilities: ["apply-patch", "remote-app-server"], reason: "this capability pair deadlocks")]
+        var observed = ObservedTuple(Fixtures.tuple())
+        observed.codexCLICapabilities = ["remote-app-server", "apply-patch"]
+        #expect(CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: []) == .incompatible(reason: "this capability pair deadlocks", recoveryActions: defaults))
+    }
+
+    @Test func negativeInstallationCountsAreNeverVerified() throws {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        let impossible = Fixtures.tuple(installations: -1)
+        let history = [try ConnectionVerificationRecord(tuple: impossible, verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .userConfirmedWorkspaceOpened)]
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(impossible), manifest: manifest, history: history) == .needsValidation(.unknownFields([.codexCLIInstallations])))
+    }
+
+    @Test func decodedRecordsAreRevalidatedIncludingTheirEvidence() throws {
+        let record = try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(timeIntervalSince1970: 1_800_000_000), evidence: .machineReadableStatus(source: "desktop-status"))
+        let json = String(decoding: try JSONEncoder().encode(record), as: UTF8.self)
+        let secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        let poisonedTuple = json.replacingOccurrences(of: #""0.50.0""#, with: #""0.50.0 \#(secret)""#)
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIVersion)) {
+            try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(poisonedTuple.utf8))
+        }
+        let poisonedEvidence = json.replacingOccurrences(of: "desktop-status", with: "desktop-status \(secret)")
+        #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
+            try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(poisonedEvidence.utf8))
+        }
+        #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
+            try ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: Date(), evidence: .machineReadableStatus(source: "status\u{1B}[31m"))
+        }
+        #expect(!CompatibilityRecordError.implausibleEvidenceSource.userMessage.isEmpty)
+    }
+
+    @Test func fullLengthPathsAreRecordableButUnboundedOnesAreNot() throws {
+        let deep = "/Users/dev/" + String(repeating: "nested/", count: 60) + "Codex.app"
+        #expect(deep.unicodeScalars.count > ConnectionVerificationRecord.maximumObservationLength)
+        var far = Fixtures.tuple()
+        far.codexDesktopPath = deep
+        far.codexCLIPath = deep + "/Contents/MacOS/codex"
+        #expect(throws: Never.self) { try ConnectionVerificationRecord(tuple: far, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened) }
+        var unbounded = Fixtures.tuple()
+        unbounded.codexCLIPath = "/" + String(repeating: "a", count: ConnectionVerificationRecord.maximumPathLength)
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIPath)) {
+            try ConnectionVerificationRecord(tuple: unbounded, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        var wordy = Fixtures.tuple()
+        wordy.codexDesktopVersion = String(repeating: "1", count: ConnectionVerificationRecord.maximumObservationLength + 1)
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexDesktopVersion)) {
+            try ConnectionVerificationRecord(tuple: wordy, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
     }
 
     @Test func invertedRangesAreRejectedWhenDecoding() {
@@ -78,8 +176,12 @@ import Testing
         let verification = CompatibilityManifest.Verification(verifiedAt: Date(timeIntervalSince1970: 1_800_000_000.25), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
         let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Fixtures.tested(verification: verification)])
         let data = try JSONEncoder().encode(manifest)
-        #expect(String(decoding: data, as: UTF8.self).contains("2027-01-15T08:00:00.250Z"))
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json.contains("2027-01-15T08:00:00Z"))
         #expect(try CompatibilityManifest.decode(from: data) == manifest)
+        // A manifest authored with fractional seconds still reads, at the same precision.
+        let fractional = json.replacingOccurrences(of: "2027-01-15T08:00:00Z", with: "2027-01-15T08:00:00.250Z")
+        #expect(try CompatibilityManifest.decode(from: Data(fractional.utf8)) == manifest)
     }
 
     @Test func aMissingCLIIsAMissingPrerequisiteNotACompetingInstallation() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -50,10 +50,52 @@ import Testing
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(beta), manifest: manifest, history: []) == .incompatible(reason: "beta desktop", recoveryActions: defaults))
     }
 
+    @Test func implausibleObservationsAreNeverRecorded() {
+        var poisoned = Fixtures.tuple()
+        poisoned.codexCLIVersion = "0.50.0 ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIVersion)) {
+            try ConnectionVerificationRecord(tuple: poisoned, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        var control = Fixtures.tuple()
+        control.guestMacOSBuild = "25F84\u{1B}[31m"
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.guestMacOSBuild)) {
+            try ConnectionVerificationRecord(tuple: control, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        var capability = Fixtures.tuple(capabilities: [String(repeating: "x", count: 300)])
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLICapabilities)) {
+            try ConnectionVerificationRecord(tuple: capability, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened)
+        }
+        capability.codexCLICapabilities = ["remote-app-server"]
+        #expect(throws: Never.self) { try ConnectionVerificationRecord(tuple: capability, verifiedAt: Date(), evidence: .userConfirmedWorkspaceOpened) }
+        let error = CompatibilityRecordError.implausibleObservation(.codexCLIVersion)
+        #expect(!error.userMessage.isEmpty && !error.recoveryActions.isEmpty)
+    }
+
+    @Test func manifestErrorsAreActionableAndVerifiedManifestsRoundTrip() throws {
+        let error = CompatibilityManifestError.unsupportedSchema(found: SchemaVersion(9), supported: .current)
+        #expect(error.recoveryActions.first == .reinstallApp)
+        #expect(error.errorDescription == error.userMessage)
+        let verification = CompatibilityManifest.Verification(verifiedAt: Date(timeIntervalSince1970: 1_800_000_000.25), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Fixtures.tested(verification: verification)])
+        let data = try JSONEncoder().encode(manifest)
+        #expect(String(decoding: data, as: UTF8.self).contains("2027-01-15T08:00:00.250Z"))
+        #expect(try CompatibilityManifest.decode(from: data) == manifest)
+    }
+
+    @Test func aMissingCLIIsAMissingPrerequisiteNotACompetingInstallation() {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        var none = ObservedTuple(Fixtures.tuple(installations: 0))
+        #expect(CompatibilityEvaluator.evaluate(observed: none, manifest: manifest, history: []) == .needsValidation(.codexCLIMissing))
+        none.codexCLIVersion = nil
+        none.codexCLIPath = nil
+        #expect(CompatibilityEvaluator.evaluate(observed: none, manifest: manifest, history: []) == .needsValidation(.codexCLIMissing))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple(installations: 2)), manifest: manifest, history: []) == .needsValidation(.competingInstallations(count: 2)))
+    }
+
     @Test func replacedDesktopBundleIsDrift() {
         let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
         let day = Date(timeIntervalSince1970: 1_800_000_000)
-        let record = ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let record = try! ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
         var moved = Fixtures.tuple()
         moved.codexDesktopPath = "/Users/dev/Applications/Codex.app"
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(moved), manifest: manifest, history: [record]) == .needsValidation(.changedSinceLastVerified([.codexDesktopPath])))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -20,7 +20,7 @@ import Testing
 
     @Test func newerManifestSchemasAreRejected() throws {
         var manifest = CompatibilityManifest(manifestVersion: 1, tested: [])
-        manifest.schemaVersion = SchemaVersion(SchemaVersion.current.rawValue + 1)
+        manifest.schemaVersion = SchemaVersion(SchemaVersion.current.rawValue + 1)!
         let data = try JSONEncoder().encode(manifest)
         #expect(throws: CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)) {
             try CompatibilityManifest.decode(from: data)
@@ -175,7 +175,7 @@ import Testing
     }
 
     @Test func manifestErrorsAreActionableAndVerifiedManifestsRoundTrip() throws {
-        let error = CompatibilityManifestError.unsupportedSchema(found: SchemaVersion(9), supported: .current)
+        let error = CompatibilityManifestError.unsupportedSchema(found: SchemaVersion(9)!, supported: .current)
         #expect(error.recoveryActions.first == .reinstallApp)
         #expect(error.errorDescription == error.userMessage)
         let verification = CompatibilityManifest.Verification(verifiedAt: Date(timeIntervalSince1970: 1_800_000_000.25), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -320,6 +320,25 @@ import Testing
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: unverifiedFirst, history: []) == .verified(recordedAt: day))
     }
 
+    @Test(arguments: [false, true])
+    func newestCoveringManifestVerificationWinsRegardlessOfOrder(reverseEntries: Bool) {
+        let day = Date(timeIntervalSince1970: 1_800_000_000)
+        let older = CompatibilityManifest.Verification(verifiedAt: day, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let newestCovering = CompatibilityManifest.Verification(verifiedAt: day.addingTimeInterval(3600), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let otherHost = CompatibilityManifest.Verification(verifiedAt: day.addingTimeInterval(7200), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F99", evidence: "docs/phase0/compat.md")
+        let otherCLI = CompatibilityManifest.Verification(verifiedAt: day.addingTimeInterval(10800), hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let entries = [
+            Fixtures.tested(),
+            Fixtures.tested(verification: older),
+            Fixtures.tested(verification: newestCovering),
+            Fixtures.tested(verification: otherHost),
+            Fixtures.tested(codexCLI: "0.40.0", verification: otherCLI),
+        ]
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: reverseEntries ? Array(entries.reversed()) : entries)
+
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: manifest, history: []) == .verified(recordedAt: Date(timeIntervalSince1970: 1_800_003_600)))
+    }
+
     @Test func negativeProtocolVersionsAreNeverVerified() throws {
         let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
         var impossible = Fixtures.tuple()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityHardeningTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct CompatibilityHardeningTests {
+    typealias Fixtures = CompatibilityEvaluatorTests
+    let defaults = CompatibilityManifest.KnownIncompatibility.defaultRecoveryActions
+
+    @Test func decodedCapabilitiesAreNormalized() throws {
+        let tuple = Fixtures.tuple(capabilities: ["b", "a"])
+        let encoded = String(decoding: try JSONEncoder().encode(tuple), as: UTF8.self)
+        #expect(encoded.contains(#"["a","b"]"#))
+        let shuffled = encoded.replacingOccurrences(of: #"["a","b"]"#, with: #"["b","a","b"]"#)
+        let decoded = try JSONDecoder().decode(CompatibilityTuple.self, from: Data(shuffled.utf8))
+        #expect(decoded == tuple)
+        #expect(decoded.codexCLICapabilities == ["a", "b"])
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: Data(shuffled.utf8))
+        #expect(observed.exact == tuple)
+    }
+
+    @Test func newerManifestSchemasAreRejected() throws {
+        var manifest = CompatibilityManifest(manifestVersion: 1, tested: [])
+        manifest.schemaVersion = SchemaVersion(SchemaVersion.current.rawValue + 1)
+        let data = try JSONEncoder().encode(manifest)
+        #expect(throws: CompatibilityManifestError.unsupportedSchema(found: manifest.schemaVersion, supported: .current)) {
+            try CompatibilityManifest.decode(from: data)
+        }
+    }
+
+    @Test func invertedRangesAreRejectedWhenDecoding() {
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(VersionRange.self, from: Data(#"{"minimum":"26.5","maximum":"26.4"}"#.utf8))
+        }
+    }
+
+    @Test func rulesCanTargetCLIIdentityCapabilitiesAndDesktopBundle() {
+        var manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        manifest.incompatibilities = [
+            .init(codexCLIVersion: "0.50.0", codexCLIPath: "/usr/local/bin/codex", reason: "bottle is broken", recoveryActions: [.repair(.tools), .cancel]),
+            .init(codexCLICapabilities: ["legacy-transport"], reason: "legacy transport"),
+            .init(codexDesktopPath: "/Applications/Codex Beta.app", reason: "beta desktop"),
+        ]
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Fixtures.tuple()), manifest: manifest, history: []) == .needsValidation(.neverConnected))
+        let broken = ObservedTuple(Fixtures.tuple(path: "/usr/local/bin/codex"))
+        #expect(CompatibilityEvaluator.evaluate(observed: broken, manifest: manifest, history: []) == .incompatible(reason: "bottle is broken", recoveryActions: [.repair(.tools), .cancel]))
+        let legacy = ObservedTuple(Fixtures.tuple(capabilities: ["legacy-transport"]))
+        #expect(CompatibilityEvaluator.evaluate(observed: legacy, manifest: manifest, history: []) == .incompatible(reason: "legacy transport", recoveryActions: defaults))
+        var beta = Fixtures.tuple()
+        beta.codexDesktopPath = "/Applications/Codex Beta.app"
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(beta), manifest: manifest, history: []) == .incompatible(reason: "beta desktop", recoveryActions: defaults))
+    }
+
+    @Test func replacedDesktopBundleIsDrift() {
+        let manifest = CompatibilityManifest(manifestVersion: 1, tested: [Fixtures.tested()])
+        let day = Date(timeIntervalSince1970: 1_800_000_000)
+        let record = ConnectionVerificationRecord(tuple: Fixtures.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        var moved = Fixtures.tuple()
+        moved.codexDesktopPath = "/Users/dev/Applications/Codex.app"
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(moved), manifest: manifest, history: [record]) == .needsValidation(.changedSinceLastVerified([.codexDesktopPath])))
+        var unknownBundle = ObservedTuple(Fixtures.tuple())
+        unknownBundle.codexDesktopPath = nil
+        #expect(CompatibilityEvaluator.evaluate(observed: unknownBundle, manifest: manifest, history: [record]) == .needsValidation(.unknownFields([.codexDesktopPath])))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -20,7 +20,9 @@ import Testing
         #expect(range.contains(try #require(SemanticVersion("26.4"))))
         #expect(range.contains(try #require(SemanticVersion("27.0"))))
         #expect(!range.contains(try #require(SemanticVersion("26.3.9"))))
-        let closed = VersionRange(minimum: try #require(SemanticVersion("26.2")), maximum: try #require(SemanticVersion("26.9")))
+        let lower = try #require(SemanticVersion("26.2"))
+        let upper = try #require(SemanticVersion("26.9"))
+        let closed = VersionRange(minimum: lower, maximum: upper)
         #expect(closed.contains(try #require(SemanticVersion("26.9"))))
         #expect(!closed.contains(try #require(SemanticVersion("26.10"))))
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -139,6 +139,14 @@ import Testing
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(hostBuild: "25F99")), manifest: manifest, history: []) == .needsValidation(.verifiedOnDifferentHost))
     }
 
+    @Test func manifestVerificationForTheExactHostBeatsUnrelatedHistory() {
+        let verification = CompatibilityManifest.Verification(verifiedAt: day, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Self.tested(verification: verification)])
+        let unrelated = ConnectionVerificationRecord(tuple: Self.tuple(codexCLI: "0.40.0"), verifiedAt: day.addingTimeInterval(-86_400), evidence: .userConfirmedWorkspaceOpened)
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [unrelated]) == .verified(recordedAt: day))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(hostBuild: "25F99")), manifest: manifest, history: [unrelated]) == .needsValidation(.changedSinceLastVerified([.hostMacOSBuild, .codexCLIVersion])))
+    }
+
     @Test func untestedCombinationsNeedValidation() {
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(codexCLI: "9.9.9")), manifest: manifest, history: []) == .needsValidation(.untestedCombination))
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.3")), manifest: manifest, history: []) == .needsValidation(.untestedCombination))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -61,7 +61,7 @@ import Testing
 
     let manifest = CompatibilityManifest(manifestVersion: 1, tested: [tested()])
     let day = Date(timeIntervalSince1970: 1_800_000_000)
-    var record: ConnectionVerificationRecord { ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened) }
+    var record: ConnectionVerificationRecord { try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened) }
 
     @Test func exactRecordedConnectionIsVerified() {
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
@@ -85,7 +85,7 @@ import Testing
 
     @Test func competingInstallationsNeedValidationEvenWithHistory() {
         let ambiguous = Self.tuple(installations: 2)
-        let history = [ConnectionVerificationRecord(tuple: ambiguous, verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)]
+        let history = [try! ConnectionVerificationRecord(tuple: ambiguous, verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)]
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(ambiguous), manifest: manifest, history: history)
         #expect(state == .needsValidation(.competingInstallations(count: 2)))
     }
@@ -142,7 +142,7 @@ import Testing
     @Test func manifestVerificationForTheExactHostBeatsUnrelatedHistory() {
         let verification = CompatibilityManifest.Verification(verifiedAt: day, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
         let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Self.tested(verification: verification)])
-        let unrelated = ConnectionVerificationRecord(tuple: Self.tuple(codexCLI: "0.40.0"), verifiedAt: day.addingTimeInterval(-86_400), evidence: .userConfirmedWorkspaceOpened)
+        let unrelated = try! ConnectionVerificationRecord(tuple: Self.tuple(codexCLI: "0.40.0"), verifiedAt: day.addingTimeInterval(-86_400), evidence: .userConfirmedWorkspaceOpened)
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [unrelated]) == .verified(recordedAt: day))
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(hostBuild: "25F99")), manifest: manifest, history: [unrelated]) == .needsValidation(.changedSinceLastVerified([.hostMacOSBuild, .codexCLIVersion])))
     }
@@ -154,7 +154,7 @@ import Testing
     }
 
     @Test func newestRecordWinsForRecordedAt() {
-        let newer = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .machineReadableStatus(source: "test"))
+        let newer = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .machineReadableStatus(source: "test"))
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record, newer])
         #expect(state == .verified(recordedAt: newer.verifiedAt))
     }
@@ -167,7 +167,7 @@ import Testing
     }
 
     @Test func stateAndRecordsRoundTrip() throws {
-        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
+        let record = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
         let data = try JSONEncoder().encode(record)
         #expect(try JSONDecoder().decode(ConnectionVerificationRecord.self, from: data) == record)
         let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -154,7 +154,7 @@ import Testing
     }
 
     @Test func newestRecordWinsForRecordedAt() {
-        let newer = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .machineReadableStatus(source: "test"))
+        let newer = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .userConfirmedWorkspaceOpened)
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record, newer])
         #expect(state == .verified(recordedAt: newer.verifiedAt))
     }
@@ -167,14 +167,16 @@ import Testing
     }
 
     @Test func stateAndRecordsRoundTrip() throws {
-        let record = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
+        let record = try! ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
         let data = try JSONEncoder().encode(record)
         #expect(try JSONDecoder().decode(ConnectionVerificationRecord.self, from: data) == record)
         let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
-        #expect(json["schemaVersion"] as? Int == SchemaVersion.current.rawValue)
-        let future = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(SchemaVersion.current.rawValue)", with: "\"schemaVersion\":99")
-        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(future.utf8)) }
-        let older = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(SchemaVersion.current.rawValue)", with: "\"schemaVersion\":0")
+        #expect(json["schemaVersion"] as? Int == ConnectionVerificationRecord.currentSchema.rawValue)
+        let future = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(ConnectionVerificationRecord.currentSchema.rawValue)", with: "\"schemaVersion\":99")
+        #expect(throws: CompatibilityRecordError.unsupportedSchema(found: SchemaVersion(99)!, supported: ConnectionVerificationRecord.currentSchema)) {
+            try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(future.utf8))
+        }
+        let older = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(ConnectionVerificationRecord.currentSchema.rawValue)", with: "\"schemaVersion\":0")
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(older.utf8)) }
         for state in [CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild])), .needsValidation(.competingInstallations(count: 3)), .needsValidation(.verifiedOnDifferentHost)] {
             let stateData = try JSONEncoder().encode(state)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct SemanticVersionTests {
+    @Test func parsesAndComparesNumerically() throws {
+        let a = try #require(SemanticVersion("26.5.2"))
+        let b = try #require(SemanticVersion("26.10"))
+        let c = try #require(SemanticVersion("26.5"))
+        #expect(a < b)
+        #expect(c < a)
+        #expect(SemanticVersion("26.5.0") == c)
+        #expect(SemanticVersion("26.5.2-beta") == nil)
+        #expect(SemanticVersion("") == nil)
+        #expect(a.description == "26.5.2")
+    }
+
+    @Test func rangeIsInclusiveAndOpenEnded() throws {
+        let range = VersionRange(minimum: try #require(SemanticVersion("26.4")))
+        #expect(range.contains(try #require(SemanticVersion("26.4"))))
+        #expect(range.contains(try #require(SemanticVersion("27.0"))))
+        #expect(!range.contains(try #require(SemanticVersion("26.3.9"))))
+        let closed = VersionRange(minimum: try #require(SemanticVersion("26.2")), maximum: try #require(SemanticVersion("26.9")))
+        #expect(closed.contains(try #require(SemanticVersion("26.9"))))
+        #expect(!closed.contains(try #require(SemanticVersion("26.10"))))
+    }
+}
+
+@Suite struct CompatibilityEvaluatorTests {
+    static func tuple(codexCLI: String = "0.50.0", host: String = "26.5.2") -> CompatibilityTuple {
+        CompatibilityTuple(
+            hostMacOSVersion: SemanticVersion(host)!,
+            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
+            runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
+            xcodeBuild: "17F113", codexCLIVersion: codexCLI, githubCLIVersion: "2.80.0",
+            provisioningScriptVersion: "1"
+        )
+    }
+
+    static func tested(codexCLI: String = "0.50.0", verifiedAt: Date? = nil) -> CompatibilityManifest.TestedTuple {
+        CompatibilityManifest.TestedTuple(
+            hostMacOS: VersionRange(minimum: SemanticVersion("26.4")!),
+            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
+            runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
+            xcodeBuild: "17F113", codexCLIVersion: codexCLI, githubCLIVersion: "2.80.0",
+            provisioningScriptVersion: "1", verifiedAt: verifiedAt
+        )
+    }
+
+    let manifest = CompatibilityManifest(manifestVersion: 1, tested: [tested()])
+    let day = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func exactRecordedConnectionIsVerified() {
+        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
+        #expect(state == .verified(recordedAt: day))
+        #expect(state.allowsHandoff)
+    }
+
+    @Test func changedComponentSinceLastConnectionNeedsValidation() {
+        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let drifted = ObservedTuple(Self.tuple(codexCLI: "0.51.0"))
+        let state = CompatibilityEvaluator.evaluate(observed: drifted, manifest: manifest, history: [record])
+        #expect(state == .needsValidation(.changedSinceLastVerified([.codexCLIVersion])))
+        #expect(!state.allowsHandoff)
+    }
+
+    @Test func unknownFieldIsNeverVerified() {
+        var observed = ObservedTuple(Self.tuple())
+        observed.codexDesktopBuild = nil
+        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let state = CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: [record])
+        #expect(state == .needsValidation(.unknownFields([.codexDesktopBuild])))
+    }
+
+    @Test func knownIncompatibilityBlocksHandoffEvenWithHistory() {
+        var manifest = manifest
+        manifest.incompatibilities = [.init(codexCLIVersion: "0.50.0", reason: "0.50.0 cannot start the remote app-server")]
+        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
+        #expect(state == .incompatible(reason: "0.50.0 cannot start the remote app-server"))
+    }
+
+    @Test func incompatibilityRuleDoesNotFireOnUnknownField() {
+        var manifest = manifest
+        manifest.incompatibilities = [.init(codexCLIVersion: "0.50.0", reason: "bad")]
+        var observed = ObservedTuple(Self.tuple())
+        observed.codexCLIVersion = nil
+        let state = CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: [])
+        #expect(state == .needsValidation(.unknownFields([.codexCLIVersion])))
+    }
+
+    @Test func testedButNeverConnectedNeedsValidation() {
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [])
+        #expect(state == .needsValidation(.neverConnected))
+    }
+
+    @Test func manifestVerifiedTupleCountsWithoutLocalHistory() {
+        let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Self.tested(verifiedAt: day)])
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [])
+        #expect(state == .verified(recordedAt: day))
+    }
+
+    @Test func untestedCombinationNeedsValidation() {
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(codexCLI: "9.9.9")), manifest: manifest, history: [])
+        #expect(state == .needsValidation(.untestedCombination))
+    }
+
+    @Test func hostVersionOutsideRangeIsUntested() {
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.3")), manifest: manifest, history: [])
+        #expect(state == .needsValidation(.untestedCombination))
+    }
+
+    @Test func newestRecordWinsForRecordedAt() {
+        let older = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        let newer = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .machineReadableStatus(source: "test"))
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [older, newer])
+        #expect(state == .verified(recordedAt: newer.verifiedAt))
+    }
+
+    @Test func stateAndRecordsRoundTrip() throws {
+        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
+        let data = try JSONEncoder().encode(record)
+        #expect(try JSONDecoder().decode(ConnectionVerificationRecord.self, from: data) == record)
+        let state = CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild]))
+        let stateData = try JSONEncoder().encode(state)
+        #expect(try JSONDecoder().decode(CompatibilityState.self, from: stateData) == state)
+    }
+}
+
+@Suite struct BundledManifestTests {
+    @Test func bundledManifestDecodesAndIsEntirelyUnverified() throws {
+        let manifest = try CompatibilityManifest.bundled()
+        #expect(manifest.schemaVersion == .current)
+        #expect(manifest.manifestVersion >= 1)
+        #expect(!manifest.tested.isEmpty)
+        #expect(manifest.tested.allSatisfy { !$0.isVerified })
+        #expect(manifest.tested.first?.tartVersion == "2.36.0")
+    }
+
+    @Test func placeholdersNeverMatchAnObservation() throws {
+        let manifest = try CompatibilityManifest.bundled()
+        let observed = ObservedTuple(CompatibilityEvaluatorTests.tuple())
+        let state = CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: [])
+        #expect(state == .needsValidation(.untestedCombination))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -174,6 +174,8 @@ import Testing
         #expect(json["schemaVersion"] as? Int == SchemaVersion.current.rawValue)
         let future = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(SchemaVersion.current.rawValue)", with: "\"schemaVersion\":99")
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(future.utf8)) }
+        let older = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(SchemaVersion.current.rawValue)", with: "\"schemaVersion\":0")
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(older.utf8)) }
         for state in [CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild])), .needsValidation(.competingInstallations(count: 3)), .needsValidation(.verifiedOnDifferentHost)] {
             let stateData = try JSONEncoder().encode(state)
             #expect(try JSONDecoder().decode(CompatibilityState.self, from: stateData) == state)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -162,6 +162,10 @@ import Testing
         let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
         let data = try JSONEncoder().encode(record)
         #expect(try JSONDecoder().decode(ConnectionVerificationRecord.self, from: data) == record)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(json["schemaVersion"] as? Int == SchemaVersion.current.rawValue)
+        let future = String(decoding: data, as: UTF8.self).replacingOccurrences(of: "\"schemaVersion\":\(SchemaVersion.current.rawValue)", with: "\"schemaVersion\":99")
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ConnectionVerificationRecord.self, from: Data(future.utf8)) }
         for state in [CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild])), .needsValidation(.competingInstallations(count: 3)), .needsValidation(.verifiedOnDifferentHost)] {
             let stateData = try JSONEncoder().encode(state)
             #expect(try JSONDecoder().decode(CompatibilityState.self, from: stateData) == state)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -40,7 +40,7 @@ import Testing
     static func tuple(codexCLI: String = "0.50.0", host: String = "26.5.2", hostBuild: String = "25F84", path: String = "/opt/homebrew/bin/codex", installations: Int = 1, capabilities: [String] = ["remote-app-server"]) -> CompatibilityTuple {
         CompatibilityTuple(
             hostMacOSVersion: SemanticVersion(host)!, hostMacOSBuild: hostBuild,
-            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
+            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234", codexDesktopPath: "/Applications/Codex.app",
             runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
             xcodeBuild: "17F113", codexCLIVersion: codexCLI, codexCLIPath: path,
             codexCLIInstallations: installations, codexCLICapabilities: capabilities,
@@ -51,7 +51,7 @@ import Testing
     static func tested(codexCLI: String = "0.50.0", verification: CompatibilityManifest.Verification? = nil) -> CompatibilityManifest.TestedTuple {
         CompatibilityManifest.TestedTuple(
             hostMacOS: VersionRange(minimum: SemanticVersion("26.4")!),
-            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
+            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234", codexDesktopPath: "/Applications/Codex.app",
             runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
             xcodeBuild: "17F113", codexCLIVersion: codexCLI, codexCLIPath: "/opt/homebrew/bin/codex",
             codexCLICapabilities: ["remote-app-server"], githubCLIVersion: "2.80.0",
@@ -102,7 +102,7 @@ import Testing
         var manifest = manifest
         manifest.incompatibilities = [.init(codexCLIVersion: "0.50.0", reason: "0.50.0 cannot start the remote app-server")]
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
-        #expect(state == .incompatible(reason: "0.50.0 cannot start the remote app-server"))
+        #expect(state == .incompatible(reason: "0.50.0 cannot start the remote app-server", recoveryActions: CompatibilityManifest.KnownIncompatibility.defaultRecoveryActions))
     }
 
     @Test func incompatibilityRulesCoverHostAndProvisioningScript() {
@@ -111,10 +111,10 @@ import Testing
             .init(hostMacOS: VersionRange(minimum: SemanticVersion("26.5")!, maximum: SemanticVersion("26.5.2")!), hostMacOSBuild: "25F84", reason: "host build breaks Screen Sharing tunnels"),
             .init(provisioningScriptVersion: "0", reason: "script 0 left password SSH enabled"),
         ]
-        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record]) == .incompatible(reason: "host build breaks Screen Sharing tunnels"))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record]) == .incompatible(reason: "host build breaks Screen Sharing tunnels", recoveryActions: CompatibilityManifest.KnownIncompatibility.defaultRecoveryActions))
         #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.6", hostBuild: "25G10")), manifest: manifest, history: []) == .needsValidation(.neverConnected))
         var badScript = Self.tuple(host: "26.6", hostBuild: "25G10"); badScript.provisioningScriptVersion = "0"
-        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(badScript), manifest: manifest, history: []) == .incompatible(reason: "script 0 left password SSH enabled"))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(badScript), manifest: manifest, history: []) == .incompatible(reason: "script 0 left password SSH enabled", recoveryActions: CompatibilityManifest.KnownIncompatibility.defaultRecoveryActions))
     }
 
     @Test func incompatibilityRuleDoesNotFireOnUnknownField() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTests.swift
@@ -11,6 +11,7 @@ import Testing
         #expect(c < a)
         #expect(SemanticVersion("26.5.0") == c)
         #expect(SemanticVersion("26.5.2-beta") == nil)
+        #expect(SemanticVersion("-1") == nil)
         #expect(SemanticVersion("") == nil)
         #expect(a.description == "26.5.2")
     }
@@ -26,70 +27,103 @@ import Testing
         #expect(closed.contains(try #require(SemanticVersion("26.9"))))
         #expect(!closed.contains(try #require(SemanticVersion("26.10"))))
     }
+
+    @Test func encodedVersionsAlwaysDecode() throws {
+        for version in [SemanticVersion([26, 4]), SemanticVersion([0]), SemanticVersion([1, 2, 3, 4])] {
+            let data = try JSONEncoder().encode(version)
+            #expect(try JSONDecoder().decode(SemanticVersion.self, from: data) == version)
+        }
+    }
 }
 
 @Suite struct CompatibilityEvaluatorTests {
-    static func tuple(codexCLI: String = "0.50.0", host: String = "26.5.2") -> CompatibilityTuple {
+    static func tuple(codexCLI: String = "0.50.0", host: String = "26.5.2", hostBuild: String = "25F84", path: String = "/opt/homebrew/bin/codex", installations: Int = 1, capabilities: [String] = ["remote-app-server"]) -> CompatibilityTuple {
         CompatibilityTuple(
-            hostMacOSVersion: SemanticVersion(host)!,
+            hostMacOSVersion: SemanticVersion(host)!, hostMacOSBuild: hostBuild,
             codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
             runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
-            xcodeBuild: "17F113", codexCLIVersion: codexCLI, githubCLIVersion: "2.80.0",
-            provisioningScriptVersion: "1"
+            xcodeBuild: "17F113", codexCLIVersion: codexCLI, codexCLIPath: path,
+            codexCLIInstallations: installations, codexCLICapabilities: capabilities,
+            githubCLIVersion: "2.80.0", provisioningScriptVersion: "1"
         )
     }
 
-    static func tested(codexCLI: String = "0.50.0", verifiedAt: Date? = nil) -> CompatibilityManifest.TestedTuple {
+    static func tested(codexCLI: String = "0.50.0", verification: CompatibilityManifest.Verification? = nil) -> CompatibilityManifest.TestedTuple {
         CompatibilityManifest.TestedTuple(
             hostMacOS: VersionRange(minimum: SemanticVersion("26.4")!),
             codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234",
             runtimeProtocolVersion: 1, tartVersion: "2.36.0", guestMacOSBuild: "25F84",
-            xcodeBuild: "17F113", codexCLIVersion: codexCLI, githubCLIVersion: "2.80.0",
-            provisioningScriptVersion: "1", verifiedAt: verifiedAt
+            xcodeBuild: "17F113", codexCLIVersion: codexCLI, codexCLIPath: "/opt/homebrew/bin/codex",
+            codexCLICapabilities: ["remote-app-server"], githubCLIVersion: "2.80.0",
+            provisioningScriptVersion: "1", verification: verification
         )
     }
 
     let manifest = CompatibilityManifest(manifestVersion: 1, tested: [tested()])
     let day = Date(timeIntervalSince1970: 1_800_000_000)
+    var record: ConnectionVerificationRecord { ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened) }
 
     @Test func exactRecordedConnectionIsVerified() {
-        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
         #expect(state == .verified(recordedAt: day))
         #expect(state.allowsHandoff)
     }
 
-    @Test func changedComponentSinceLastConnectionNeedsValidation() {
-        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
-        let drifted = ObservedTuple(Self.tuple(codexCLI: "0.51.0"))
-        let state = CompatibilityEvaluator.evaluate(observed: drifted, manifest: manifest, history: [record])
-        #expect(state == .needsValidation(.changedSinceLastVerified([.codexCLIVersion])))
-        #expect(!state.allowsHandoff)
+    @Test func anyChangedComponentSinceLastConnectionNeedsValidation() {
+        let cases: [(CompatibilityTuple, [CompatibilityField])] = [
+            (Self.tuple(codexCLI: "0.51.0"), [.codexCLIVersion]),
+            (Self.tuple(hostBuild: "25F99"), [.hostMacOSBuild]),
+            (Self.tuple(path: "/usr/local/bin/codex"), [.codexCLIPath]),
+            (Self.tuple(capabilities: []), [.codexCLICapabilities]),
+        ]
+        for (drifted, expected) in cases {
+            let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(drifted), manifest: manifest, history: [record])
+            #expect(state == .needsValidation(.changedSinceLastVerified(expected)))
+            #expect(!state.allowsHandoff)
+        }
+    }
+
+    @Test func competingInstallationsNeedValidationEvenWithHistory() {
+        let ambiguous = Self.tuple(installations: 2)
+        let history = [ConnectionVerificationRecord(tuple: ambiguous, verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)]
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(ambiguous), manifest: manifest, history: history)
+        #expect(state == .needsValidation(.competingInstallations(count: 2)))
     }
 
     @Test func unknownFieldIsNeverVerified() {
         var observed = ObservedTuple(Self.tuple())
         observed.codexDesktopBuild = nil
-        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
+        observed.codexCLIPath = nil
         let state = CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: [record])
-        #expect(state == .needsValidation(.unknownFields([.codexDesktopBuild])))
+        #expect(state == .needsValidation(.unknownFields([.codexDesktopBuild, .codexCLIPath])))
     }
 
     @Test func knownIncompatibilityBlocksHandoffEvenWithHistory() {
         var manifest = manifest
         manifest.incompatibilities = [.init(codexCLIVersion: "0.50.0", reason: "0.50.0 cannot start the remote app-server")]
-        let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
         let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record])
         #expect(state == .incompatible(reason: "0.50.0 cannot start the remote app-server"))
     }
 
+    @Test func incompatibilityRulesCoverHostAndProvisioningScript() {
+        var manifest = manifest
+        manifest.incompatibilities = [
+            .init(hostMacOS: VersionRange(minimum: SemanticVersion("26.5")!, maximum: SemanticVersion("26.5.2")!), hostMacOSBuild: "25F84", reason: "host build breaks Screen Sharing tunnels"),
+            .init(provisioningScriptVersion: "0", reason: "script 0 left password SSH enabled"),
+        ]
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record]) == .incompatible(reason: "host build breaks Screen Sharing tunnels"))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.6", hostBuild: "25G10")), manifest: manifest, history: []) == .needsValidation(.neverConnected))
+        var badScript = Self.tuple(host: "26.6", hostBuild: "25G10"); badScript.provisioningScriptVersion = "0"
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(badScript), manifest: manifest, history: []) == .incompatible(reason: "script 0 left password SSH enabled"))
+    }
+
     @Test func incompatibilityRuleDoesNotFireOnUnknownField() {
         var manifest = manifest
-        manifest.incompatibilities = [.init(codexCLIVersion: "0.50.0", reason: "bad")]
+        manifest.incompatibilities = [.init(hostMacOS: VersionRange(minimum: SemanticVersion("26")!), codexCLIVersion: "0.50.0", reason: "bad")]
         var observed = ObservedTuple(Self.tuple())
-        observed.codexCLIVersion = nil
+        observed.hostMacOSVersion = nil
         let state = CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: [])
-        #expect(state == .needsValidation(.unknownFields([.codexCLIVersion])))
+        #expect(state == .needsValidation(.unknownFields([.hostMacOSVersion])))
     }
 
     @Test func testedButNeverConnectedNeedsValidation() {
@@ -97,36 +131,41 @@ import Testing
         #expect(state == .needsValidation(.neverConnected))
     }
 
-    @Test func manifestVerifiedTupleCountsWithoutLocalHistory() {
-        let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Self.tested(verifiedAt: day)])
-        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [])
-        #expect(state == .verified(recordedAt: day))
+    @Test func manifestVerificationCountsOnlyForTheExactHost() {
+        let verification = CompatibilityManifest.Verification(verifiedAt: day, hostMacOSVersion: SemanticVersion("26.5.2")!, hostMacOSBuild: "25F84", evidence: "docs/phase0/compat.md")
+        let manifest = CompatibilityManifest(manifestVersion: 2, tested: [Self.tested(verification: verification)])
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: []) == .verified(recordedAt: day))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "27.0", hostBuild: "26A1")), manifest: manifest, history: []) == .needsValidation(.verifiedOnDifferentHost))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(hostBuild: "25F99")), manifest: manifest, history: []) == .needsValidation(.verifiedOnDifferentHost))
     }
 
-    @Test func untestedCombinationNeedsValidation() {
-        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(codexCLI: "9.9.9")), manifest: manifest, history: [])
-        #expect(state == .needsValidation(.untestedCombination))
-    }
-
-    @Test func hostVersionOutsideRangeIsUntested() {
-        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.3")), manifest: manifest, history: [])
-        #expect(state == .needsValidation(.untestedCombination))
+    @Test func untestedCombinationsNeedValidation() {
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(codexCLI: "9.9.9")), manifest: manifest, history: []) == .needsValidation(.untestedCombination))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(host: "26.3")), manifest: manifest, history: []) == .needsValidation(.untestedCombination))
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple(path: "/usr/local/bin/codex")), manifest: manifest, history: []) == .needsValidation(.untestedCombination))
     }
 
     @Test func newestRecordWinsForRecordedAt() {
-        let older = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .userConfirmedWorkspaceOpened)
         let newer = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day.addingTimeInterval(3600), evidence: .machineReadableStatus(source: "test"))
-        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [older, newer])
+        let state = CompatibilityEvaluator.evaluate(observed: ObservedTuple(Self.tuple()), manifest: manifest, history: [record, newer])
         #expect(state == .verified(recordedAt: newer.verifiedAt))
+    }
+
+    @Test func capabilitiesCompareAsSets() {
+        let a = Self.tuple(capabilities: ["b", "a"])
+        let b = Self.tuple(capabilities: ["a", "b"])
+        #expect(a == b)
+        #expect(a.differences(from: b).isEmpty)
     }
 
     @Test func stateAndRecordsRoundTrip() throws {
         let record = ConnectionVerificationRecord(tuple: Self.tuple(), verifiedAt: day, evidence: .machineReadableStatus(source: "desktop-status"))
         let data = try JSONEncoder().encode(record)
         #expect(try JSONDecoder().decode(ConnectionVerificationRecord.self, from: data) == record)
-        let state = CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild]))
-        let stateData = try JSONEncoder().encode(state)
-        #expect(try JSONDecoder().decode(CompatibilityState.self, from: stateData) == state)
+        for state in [CompatibilityState.needsValidation(.changedSinceLastVerified([.tartVersion, .xcodeBuild])), .needsValidation(.competingInstallations(count: 3)), .needsValidation(.verifiedOnDifferentHost)] {
+            let stateData = try JSONEncoder().encode(state)
+            #expect(try JSONDecoder().decode(CompatibilityState.self, from: stateData) == state)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #14 (`MVP-PLAN.md` §4 "Version and resource policy", §5 "Connect-time compatibility, not only update-time checks", §10 Phase 2 manifest fields). Stacked on #54.

- `CompatibilityTuple` / `ObservedTuple` / `CompatibilityField`: the ten components (host macOS, desktop version and build, runtime protocol, Tart, guest macOS build, Xcode build, Codex CLI, gh CLI, provisioning script). Observed fields are optional; `nil` means unknown and unknown never matches anything.
- `CompatibilityManifest`: versioned, with `TestedTuple` (host macOS as an inclusive `VersionRange`, everything else exact, optional `verifiedAt` and evidence pointer) and `KnownIncompatibility` rules that fire only when every specified field is known and equal.
- `ConnectionVerificationRecord`: can only be built from `DesktopConnectionEvidence` (user confirmed the workspace opened, or a named machine-readable status). `codex --version` has no way to produce one.
- `CompatibilityEvaluator.evaluate(observed:manifest:history:)` → `verified(recordedAt)`, `needsValidation(reason)`, or `incompatible(reason)`. Order: known incompatibility, unknown fields, exact recorded connection, drift since the last recorded connection (naming the changed fields), untested combination, tested-but-never-connected. `allowsHandoff` is true only for `verified`.
- `SemanticVersion` and `VersionRange` for numeric dotted versions.
- Bundled `compatibility-manifest.json` seeded from the plan baseline (host ≥ 26.4, Tart 2.36.0, Xcode 17F113, guest 25F84) with `TBD` placeholders for the Codex desktop, CLI, and script versions, all unverified. Gate #41 replaces it.

Tests: 15 new, covering version parsing and ranges, each evaluator outcome, rule precedence, newest-record-wins, Codable round trips, and that the bundled manifest decodes, is entirely unverified, and cannot accidentally match a real observation.

Closes #14

## Checklist

- [x] Tests cover the new logic; `swift test --package-path Packages/GuesthouseCore` passes (52 tests)
- [x] No new warnings
- [x] No new dependencies (one bundled JSON resource)
- [x] No secrets
- [x] No process launched anywhere in this change
- [x] Diff under 500 lines of logic (the rest is field plumbing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)