### PR TITLE
Core: typed runtime XPC contract (operations, messages, validation)

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -208,7 +208,10 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
         self.codexCLIVersion = codexCLIVersion
         self.codexCLIPath = codexCLIPath
         self.codexCLIInstallations = codexCLIInstallations
-        self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
+        // An observation is capped for the wire, not refused, so it canonicalizes through its
+        // own rule: the record type's `normalize` deliberately leaves an oversized list
+        // uncollapsed so a count check can refuse it.
+        self.codexCLICapabilities = codexCLICapabilities.map(ObservedTuple.canonicalCapabilities)
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -237,7 +237,7 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion)
         )
         // A decoded observation is untrusted: it came from another process or from disk.
-        self = sanitizedForWire()
+        self = boundedForDecoding()
     }
 
     public init(_ tuple: CompatibilityTuple) {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -236,6 +236,8 @@ public struct ObservedTuple: Codable, Hashable, Sendable {
             githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
             provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion)
         )
+        // A decoded observation is untrusted: it came from another process or from disk.
+        self = sanitizedForWire()
     }
 
     public init(_ tuple: CompatibilityTuple) {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -56,9 +56,25 @@ public enum RequestValidator: Sendable {
                   case .control, .format, .lineSeparator, .paragraphSeparator: true
                   default: false
                   }
-              })
+              }),
+              // The name is kept for progress and errors, where it is shown as it arrived, and
+              // nothing downstream redacts a display value again. Refusing rather than
+              // rewriting keeps the user's own file name honest: showing something other than
+              // what they picked would be worse than declining the selection.
+              !carriesCredential(handoff.displayName)
         else {
             throw .invalidDisplayName
+        }
+    }
+
+    /// Whether the redactor recognizes a credential in a file name, examined whole and by
+    /// dot-separated part. A name is a single Unicode word across its dots, so a token that
+    /// ends where an extension begins (`ghp_….app`) reaches no word boundary the patterns can
+    /// anchor on; the whole name is examined as well, so a credential that needs its dots,
+    /// such as a JWT, is still recognized.
+    static func carriesCredential(_ name: String) -> Bool {
+        ([name] + name.split(separator: ".").map(String.init)).contains {
+            GuesthouseError.sanitizeReporting($0, limit: maximumDisplayNameLength).redacted
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -48,7 +48,8 @@ public enum RequestValidator: Sendable {
             }
         }
         guard !handoff.displayName.isEmpty,
-              handoff.displayName.count <= maximumDisplayNameLength,
+              handoff.displayName.unicodeScalars.count <= maximumDisplayNameLength,
+              handoff.displayName.utf8.count <= maximumDisplayNameLength * 4,
               !handoff.displayName.contains("/"),
               !handoff.displayName.unicodeScalars.contains(where: { scalar in
                   switch scalar.properties.generalCategory {
@@ -80,13 +81,9 @@ public enum RequestValidator: Sendable {
     public static func validateContainment(of candidate: URL, within root: URL) throws(RequestValidationError) -> URL {
         guard candidate.isFileURL, root.isFileURL else { throw .invalidPath }
         guard !candidate.pathComponents.contains("..") else { throw .pathEscapesRoot }
-        // The root itself must be a real directory, not a link to one and not a dangling
-        // link: a write to the root would otherwise land wherever the link points.
-        var rootInfo = stat()
-        if lstat(root.standardizedFileURL.path, &rootInfo) == 0, (rootInfo.st_mode & S_IFMT) == S_IFLNK {
-            var target = stat()
-            guard stat(root.standardizedFileURL.path, &target) == 0 else { throw .pathEscapesRoot }
-        }
+        // The root and every one of its ancestors must resolve: a dangling link anywhere in
+        // the chain would send a later create through it, outside the allowed location.
+        guard !containsDanglingSymbolicLink(root, below: URL(fileURLWithPath: "/")) else { throw .pathEscapesRoot }
         let resolvedRoot = resolveThroughExistingAncestors(root)
         let resolvedCandidate = resolveThroughExistingAncestors(candidate)
         let rootComponents = resolvedRoot.pathComponents

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -1,8 +1,9 @@
+import Darwin
 import Foundation
 
 /// Pure checks the service applies to every message before acting on it
 /// (MVP-PLAN.md §3: "validate message sizes and paths, reject symlink escapes").
-public enum RequestValidator {
+public enum RequestValidator: Sendable {
     /// Larger than any legitimate message (a security-scoped bookmark is a few kilobytes).
     public static let maximumEncodedSize = 64 * 1024
     public static let maximumBookmarkSize = 16 * 1024
@@ -49,7 +50,12 @@ public enum RequestValidator {
         guard !handoff.displayName.isEmpty,
               handoff.displayName.count <= maximumDisplayNameLength,
               !handoff.displayName.contains("/"),
-              !handoff.displayName.unicodeScalars.contains(where: { $0.properties.generalCategory == .control })
+              !handoff.displayName.unicodeScalars.contains(where: { scalar in
+                  switch scalar.properties.generalCategory {
+                  case .control, .format, .lineSeparator, .paragraphSeparator: true
+                  default: false
+                  }
+              })
         else {
             throw .invalidDisplayName
         }
@@ -83,6 +89,12 @@ public enum RequestValidator {
         else {
             throw .pathEscapesRoot
         }
+        // A link that resolves inside the root was followed above and is fine; a dangling
+        // link is not resolvable, so it must be refused: the first write through it would
+        // create the target wherever the link points.
+        guard !containsDanglingSymbolicLink(candidate, below: root) else {
+            throw .pathEscapesRoot
+        }
         return resolvedCandidate
     }
 }
@@ -106,6 +118,22 @@ extension RequestValidator {
             resolved.append(path: component)
         }
         return resolved
+    }
+
+    /// Whether any component of `url` below `root` is a symbolic link whose target does not
+    /// exist. Each component is examined with `lstat`, so the link itself is seen rather than
+    /// what it points at; a dangling link (`root/link -> /outside/new-file`) does not exist
+    /// as a file, but the first write through it would create the target.
+    static func containsDanglingSymbolicLink(_ url: URL, below root: URL) -> Bool {
+        let rootCount = root.standardizedFileURL.pathComponents.count
+        var current = root.standardizedFileURL
+        for component in url.standardizedFileURL.pathComponents.dropFirst(rootCount) {
+            current.append(path: component)
+            var info = stat()
+            guard lstat(current.path, &info) == 0 else { return false }
+            if (info.st_mode & S_IFMT) == S_IFLNK, stat(current.path, &info) != 0 { return true }
+        }
+        return false
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -1,0 +1,131 @@
+import Foundation
+
+/// Pure checks the service applies to every message before acting on it
+/// (MVP-PLAN.md §3: "validate message sizes and paths, reject symlink escapes").
+public enum RequestValidator {
+    /// Larger than any legitimate message (a security-scoped bookmark is a few kilobytes).
+    public static let maximumEncodedSize = 64 * 1024
+    public static let maximumBookmarkSize = 16 * 1024
+    public static let maximumDisplayNameLength = 255
+    public static let maximumIPWait: Duration = .seconds(300)
+    public static let maximumGracefulStopDeadline: Duration = .seconds(600)
+
+    /// Validates the raw bytes before decoding, so an oversized message never reaches the decoder.
+    public static func validateEncodedSize(_ data: Data) throws(RequestValidationError) {
+        guard data.count <= maximumEncodedSize else {
+            throw .oversized(bytes: data.count, limit: maximumEncodedSize)
+        }
+    }
+
+    /// Validates a decoded envelope: protocol version, option bounds, handoff sizes.
+    public static func validate(_ envelope: RuntimeRequestEnvelope) throws(RequestValidationError) {
+        guard envelope.protocolVersion == .current else {
+            throw .protocolMismatch(client: envelope.protocolVersion, service: .current)
+        }
+        switch envelope.request {
+        case .runtimeVersion, .environmentStatus, .cancelOperation:
+            break
+        case .startEnvironment(_, let options):
+            guard options.ipWait >= .zero, options.ipWait <= maximumIPWait else {
+                throw .optionOutOfRange("ipWait")
+            }
+        case .stopEnvironment(_, .graceful(let deadline)):
+            guard deadline > .zero, deadline <= maximumGracefulStopDeadline else {
+                throw .optionOutOfRange("deadline")
+            }
+        case .stopEnvironment(_, .force):
+            break
+        case .importXcode(_, let handoff):
+            try validate(handoff)
+        }
+    }
+
+    public static func validate(_ handoff: FileHandoff) throws(RequestValidationError) {
+        if case .securityScopedBookmark(let data) = handoff.kind {
+            guard !data.isEmpty, data.count <= maximumBookmarkSize else {
+                throw .oversized(bytes: data.count, limit: maximumBookmarkSize)
+            }
+        }
+        guard !handoff.displayName.isEmpty,
+              handoff.displayName.count <= maximumDisplayNameLength,
+              !handoff.displayName.contains("/"),
+              !handoff.displayName.unicodeScalars.contains(where: { $0.properties.generalCategory == .control })
+        else {
+            throw .invalidDisplayName
+        }
+    }
+
+    /// App-managed VM names are exactly `guesthouse-<lowercase uuid>`; anything else could
+    /// address a VM Guesthouse does not own.
+    public static func validateVMName(_ name: String) throws(RequestValidationError) {
+        guard name.hasPrefix("guesthouse-"),
+              let uuid = UUID(uuidString: String(name.dropFirst("guesthouse-".count))),
+              name == EnvironmentID(uuid: uuid).tartVMName
+        else {
+            throw .invalidVMName
+        }
+    }
+
+    /// Resolves `candidate` and proves it lies inside `root` after following every symlink.
+    ///
+    /// Both paths are resolved with `realpath` semantics, so a symlink inside the root that
+    /// points outside is rejected, as is `..` traversal and a sibling directory whose name
+    /// merely starts with the root's name. Returns the resolved location.
+    public static func validateContainment(of candidate: URL, within root: URL) throws(RequestValidationError) -> URL {
+        guard candidate.isFileURL, root.isFileURL else { throw .invalidPath }
+        guard !candidate.pathComponents.contains("..") else { throw .pathEscapesRoot }
+        let resolvedRoot = resolveThroughExistingAncestors(root)
+        let resolvedCandidate = resolveThroughExistingAncestors(candidate)
+        let rootComponents = resolvedRoot.pathComponents
+        let candidateComponents = resolvedCandidate.pathComponents
+        guard candidateComponents.count >= rootComponents.count,
+              Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
+        else {
+            throw .pathEscapesRoot
+        }
+        return resolvedCandidate
+    }
+}
+
+extension RequestValidator {
+    /// `resolvingSymlinksInPath()` leaves a path untouched when a component does not exist,
+    /// which would let `<symlink-to-outside>/new-file` pass. This resolves the deepest existing
+    /// ancestor with real symlink resolution and re-attaches the remaining components.
+    static func resolveThroughExistingAncestors(_ url: URL) -> URL {
+        let standardized = url.standardizedFileURL
+        var existing = standardized
+        var remainder: [String] = []
+        while !FileManager.default.fileExists(atPath: existing.path) {
+            let parent = existing.deletingLastPathComponent()
+            if parent.path == existing.path { break }
+            remainder.insert(existing.lastPathComponent, at: 0)
+            existing = parent
+        }
+        var resolved = existing.resolvingSymlinksInPath()
+        for component in remainder {
+            resolved.append(path: component)
+        }
+        return resolved
+    }
+}
+
+public enum RequestValidationError: Error, Hashable, Sendable {
+    case oversized(bytes: Int, limit: Int)
+    case protocolMismatch(client: RuntimeProtocolVersion, service: RuntimeProtocolVersion)
+    case optionOutOfRange(String)
+    case invalidDisplayName
+    case invalidVMName
+    case invalidPath
+    case pathEscapesRoot
+
+    /// The user-facing error the service reports for this rejection.
+    public var guesthouseError: GuesthouseError {
+        switch self {
+        case .oversized: .invalidRequest(.oversized)
+        case .protocolMismatch(let client, let service): .protocolMismatch(client: client.rawValue, service: service.rawValue)
+        case .optionOutOfRange, .invalidDisplayName, .invalidPath: .invalidRequest(.malformed)
+        case .invalidVMName: .invalidRequest(.invalidVMName)
+        case .pathEscapesRoot: .invalidRequest(.pathEscapesAllowedRoot)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -91,8 +91,12 @@ public enum RequestValidator: Sendable {
         }
         // A link that resolves inside the root was followed above and is fine; a dangling
         // link is not resolvable, so it must be refused: the first write through it would
-        // create the target wherever the link points.
-        guard !containsDanglingSymbolicLink(candidate, below: root) else {
+        // create the target wherever the link points. Both the path as given and the path
+        // with its existing ancestors resolved are walked, so a root reached through an
+        // alias is checked where the components actually live.
+        guard !containsDanglingSymbolicLink(candidate, below: root),
+              !containsDanglingSymbolicLink(resolvedCandidate, below: resolvedRoot)
+        else {
             throw .pathEscapesRoot
         }
         return resolvedCandidate
@@ -125,9 +129,15 @@ extension RequestValidator {
     /// what it points at; a dangling link (`root/link -> /outside/new-file`) does not exist
     /// as a file, but the first write through it would create the target.
     static func containsDanglingSymbolicLink(_ url: URL, below root: URL) -> Bool {
-        let rootCount = root.standardizedFileURL.pathComponents.count
+        let rootComponents = root.standardizedFileURL.pathComponents
+        let components = url.standardizedFileURL.pathComponents
+        // Only a path that lexically continues the root can be walked from it; anything else
+        // is already refused by the containment check above.
+        guard components.count >= rootComponents.count,
+              Array(components.prefix(rootComponents.count)) == rootComponents
+        else { return false }
         var current = root.standardizedFileURL
-        for component in url.standardizedFileURL.pathComponents.dropFirst(rootCount) {
+        for component in components.dropFirst(rootComponents.count) {
             current.append(path: component)
             var info = stat()
             guard lstat(current.path, &info) == 0 else { return false }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -80,6 +80,13 @@ public enum RequestValidator: Sendable {
     public static func validateContainment(of candidate: URL, within root: URL) throws(RequestValidationError) -> URL {
         guard candidate.isFileURL, root.isFileURL else { throw .invalidPath }
         guard !candidate.pathComponents.contains("..") else { throw .pathEscapesRoot }
+        // The root itself must be a real directory, not a link to one and not a dangling
+        // link: a write to the root would otherwise land wherever the link points.
+        var rootInfo = stat()
+        if lstat(root.standardizedFileURL.path, &rootInfo) == 0, (rootInfo.st_mode & S_IFMT) == S_IFLNK {
+            var target = stat()
+            guard stat(root.standardizedFileURL.path, &target) == 0 else { throw .pathEscapesRoot }
+        }
         let resolvedRoot = resolveThroughExistingAncestors(root)
         let resolvedCandidate = resolveThroughExistingAncestors(candidate)
         let rootComponents = resolvedRoot.pathComponents

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -119,8 +119,11 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
         case stopped
         case running
         /// Ownership could not be established (for example a PID that no longer matches).
-        /// Start is refused until a person or a repair resolves it.
-        case uncertain(reason: String)
+        /// Start is refused until a person or a repair resolves it. The reason is formed from
+        /// runtime and process-identity diagnostics, which quote CLI text: `SanitizedText`
+        /// bounds and redacts it at construction and again when decoded, so it reaches GUI
+        /// status under the same rules as an observation or an error.
+        case uncertain(reason: SanitizedText)
     }
 
     public enum Readiness: Codable, Hashable, Sendable {
@@ -163,20 +166,38 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
 extension ObservedTuple {
     /// Every string bounded and redacted; capabilities capped in number and length.
     public func sanitizedForWire() -> ObservedTuple {
-        func clean(_ value: String?) -> String? { value.map { Self.bounded($0, limit: 256) } }
+        mapped(string: { Self.bounded($0, limit: 256) }, capabilities: Self.boundedCapabilities)
+    }
+
+    /// The same bounds for an observation that has already crossed the wire: the sender is
+    /// another process, so every string is redacted and bounded again. No identity is derived
+    /// here, and a generated `[exact:…]` suffix is left as it arrived rather than read as
+    /// forged marker text, so a status the sender sanitized is evaluated by the receiver under
+    /// the identity it was sent with. A peer that invents a suffix gains nothing: it supplies
+    /// every other field of the observation as well.
+    func boundedForDecoding() -> ObservedTuple {
+        mapped(
+            string: { GuesthouseError.sanitize($0, limit: 256) },
+            capabilities: { values in
+                CompatibilityTuple.normalize(values.prefix(Self.maximumCapabilities).map { GuesthouseError.sanitize($0, limit: 128) })
+            }
+        )
+    }
+
+    private func mapped(string clean: (String) -> String, capabilities: ([String]) -> [String]) -> ObservedTuple {
         var copy = self
-        copy.hostMacOSBuild = clean(hostMacOSBuild)
-        copy.codexDesktopVersion = clean(codexDesktopVersion)
-        copy.codexDesktopBuild = clean(codexDesktopBuild)
-        copy.codexDesktopPath = clean(codexDesktopPath)
-        copy.tartVersion = clean(tartVersion)
-        copy.guestMacOSBuild = clean(guestMacOSBuild)
-        copy.xcodeBuild = clean(xcodeBuild)
-        copy.codexCLIVersion = clean(codexCLIVersion)
-        copy.codexCLIPath = clean(codexCLIPath)
-        copy.codexCLICapabilities = codexCLICapabilities.map { Self.boundedCapabilities($0) }
-        copy.githubCLIVersion = clean(githubCLIVersion)
-        copy.provisioningScriptVersion = clean(provisioningScriptVersion)
+        copy.hostMacOSBuild = hostMacOSBuild.map(clean)
+        copy.codexDesktopVersion = codexDesktopVersion.map(clean)
+        copy.codexDesktopBuild = codexDesktopBuild.map(clean)
+        copy.codexDesktopPath = codexDesktopPath.map(clean)
+        copy.tartVersion = tartVersion.map(clean)
+        copy.guestMacOSBuild = guestMacOSBuild.map(clean)
+        copy.xcodeBuild = xcodeBuild.map(clean)
+        copy.codexCLIVersion = codexCLIVersion.map(clean)
+        copy.codexCLIPath = codexCLIPath.map(clean)
+        copy.codexCLICapabilities = codexCLICapabilities.map(capabilities)
+        copy.githubCLIVersion = githubCLIVersion.map(clean)
+        copy.provisioningScriptVersion = provisioningScriptVersion.map(clean)
         return copy
     }
 
@@ -185,9 +206,13 @@ extension ObservedTuple {
     /// carries a digest of the exact observation, so two different observations never
     /// collapse into one verified compatibility tuple.
     static func bounded(_ value: String, limit: Int) -> String {
-        // A value that already contains the identity marker is neutralized first, so untrusted
-        // text cannot forge the suffix this function appends and impersonate another value.
-        let value = value.replacingOccurrences(of: identityMarker, with: "[exact\u{FFFD}:")
+        // Untrusted text must not be able to forge the suffix this function appends. Escaping
+        // the escape before the marker keeps that neutralization injective: were the marker
+        // alone rewritten, `foo[exact:` and `foo[exact\u{FFFD}:` would both arrive at the
+        // latter and two different observations would share one identity.
+        let value = value
+            .replacingOccurrences(of: identityEscape, with: identityEscape + identityEscape)
+            .replacingOccurrences(of: identityMarker, with: "[exact\(identityEscape):")
         let (sanitized, wasRedacted) = GuesthouseError.sanitizeReporting(value, limit: limit)
         // A redacted value stands for a secret: it gets no digest, since that would let a
         // guess be confirmed. Whether redaction happened comes from the sanitizer itself, not
@@ -195,22 +220,37 @@ extension ObservedTuple {
         // normalized carries a digest, counted against the same limit.
         guard sanitized != value, !wasRedacted else { return sanitized }
         let room = max(16, limit - identitySuffixLength)
-        return "\(GuesthouseError.sanitize(value, limit: room)) \(identityMarker)\(digest(of: value))]"
+        return "\(GuesthouseError.sanitize(value, limit: room)) \(identityMarker)\(digest(of: inspected(value, limit: limit)))]"
     }
 
     /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
     static let identitySuffixLength = 22
     static let identityMarker = "[exact:"
+    static let identityEscape = "\u{FFFD}"
     static let maximumCapabilities = 64
 
+    /// The prefix the sanitizer actually reads: the bound plus the lookahead that catches a
+    /// credential starting inside it. Only this much may be hashed, because a secret that
+    /// begins past it is never inspected, leaves `wasRedacted` false, and would otherwise be
+    /// published as a digest that confirms a guess offline.
+    static func inspected(_ value: String, limit: Int) -> String {
+        String(String.UnicodeScalarView(value.unicodeScalars.prefix(limit + GuesthouseError.sanitizeLookahead)))
+    }
+
     /// The first `maximumCapabilities` entries, each bounded; when entries are dropped, one
-    /// final entry names how many and carries a digest of the whole list, so two capability
-    /// sets that share a prefix keep different identities.
+    /// further entry names how many and carries a digest of the whole list, so two capability
+    /// sets that share a prefix keep different identities. That entry wears the same identity
+    /// marker as a bounded value, so a literal capability shaped like it is neutralized and
+    /// cannot pass a different capability set off as a capped one. The list is canonical, so
+    /// it survives the normalization a receiver applies. The digest is over the bounded
+    /// entries: an entry past the cap is never inspected, and hashing it raw would publish a
+    /// digest of whatever secret it holds.
     static func boundedCapabilities(_ values: [String]) -> [String] {
-        guard values.count > maximumCapabilities else { return values.map { bounded($0, limit: 128) } }
-        let kept = values.prefix(maximumCapabilities - 1).map { bounded($0, limit: 128) }
+        let entries = values.map { bounded($0, limit: 128) }
+        guard values.count > maximumCapabilities else { return CompatibilityTuple.normalize(entries) }
+        let kept = Array(entries.prefix(maximumCapabilities - 1))
         let omitted = values.count - kept.count
-        return kept + ["[\(omitted) more; exact:\(digest(ofList: values))]"]
+        return CompatibilityTuple.normalize(kept + ["\(omitted) more \(identityMarker)\(digest(ofList: entries))]"])
     }
 
     /// A digest over a length-prefixed encoding, so no two different lists can produce the

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -172,7 +172,7 @@ extension ObservedTuple {
         copy.xcodeBuild = clean(xcodeBuild)
         copy.codexCLIVersion = clean(codexCLIVersion)
         copy.codexCLIPath = clean(codexCLIPath)
-        copy.codexCLICapabilities = codexCLICapabilities.map { Array($0.prefix(64)).map { Self.bounded($0, limit: 128) } }
+        copy.codexCLICapabilities = codexCLICapabilities.map { Self.boundedCapabilities($0) }
         copy.githubCLIVersion = clean(githubCLIVersion)
         copy.provisioningScriptVersion = clean(provisioningScriptVersion)
         return copy
@@ -183,17 +183,29 @@ extension ObservedTuple {
     /// carries a digest of the exact observation, so two different observations never
     /// collapse into one verified compatibility tuple.
     static func bounded(_ value: String, limit: Int) -> String {
-        let sanitized = GuesthouseError.sanitize(value, limit: limit)
+        let (sanitized, wasRedacted) = GuesthouseError.sanitizeReporting(value, limit: limit)
         // A redacted value stands for a secret: it gets no digest, since that would let a
-        // guess be confirmed. Only a value that was merely bounded or normalized carries one,
-        // and the suffix is counted against the same limit.
-        guard sanitized != value, !sanitized.contains("[redacted") else { return sanitized }
+        // guess be confirmed. Whether redaction happened comes from the sanitizer itself, not
+        // from marker text the value could contain. Only a value that was merely bounded or
+        // normalized carries a digest, counted against the same limit.
+        guard sanitized != value, !wasRedacted else { return sanitized }
         let room = max(16, limit - identitySuffixLength)
         return "\(GuesthouseError.sanitize(value, limit: room)) [exact:\(digest(of: value))]"
     }
 
     /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
     static let identitySuffixLength = 22
+    static let maximumCapabilities = 64
+
+    /// The first `maximumCapabilities` entries, each bounded; when entries are dropped, one
+    /// final entry names how many and carries a digest of the whole list, so two capability
+    /// sets that share a prefix keep different identities.
+    static func boundedCapabilities(_ values: [String]) -> [String] {
+        guard values.count > maximumCapabilities else { return values.map { bounded($0, limit: 128) } }
+        let kept = values.prefix(maximumCapabilities - 1).map { bounded($0, limit: 128) }
+        let omitted = values.count - kept.count
+        return kept + ["[\(omitted) more; exact:\(digest(of: values.joined(separator: "\u{0}")))]"]
+    }
 
     static func digest(of value: String) -> String {
         SHA256.hash(data: Data(value.utf8)).prefix(6).map { String(format: "%02x", $0) }.joined()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -73,10 +73,25 @@ public struct ProgressPhase: Codable, Hashable, Sendable {
     /// False for phases that must not be interrupted (for example a rename after a copy).
     public var cancelable: Bool
 
+    /// A fraction that is not finite or not within `0...1` is dropped, so a backend that
+    /// divides by zero yields an indeterminate phase rather than an event that cannot be
+    /// encoded.
     public init(kind: Kind, fraction: Double? = nil, cancelable: Bool = true) {
         self.kind = kind
-        self.fraction = fraction
+        self.fraction = Self.valid(fraction)
         self.cancelable = cancelable
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind, fraction, cancelable }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(kind: try c.decode(Kind.self, forKey: .kind), fraction: try c.decodeIfPresent(Double.self, forKey: .fraction), cancelable: try c.decodeIfPresent(Bool.self, forKey: .cancelable) ?? true)
+    }
+
+    static func valid(_ fraction: Double?) -> Double? {
+        guard let fraction, fraction.isFinite, (0...1).contains(fraction) else { return nil }
+        return fraction
     }
 }
 
@@ -119,7 +134,31 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
         self.vm = vm
         self.readiness = readiness
         self.inFlightOperation = inFlightOperation
-        self.observed = observed
+        // Observations come from guest and CLI probes: every string is bounded and redacted
+        // before it crosses XPC, at construction and again when decoded.
+        self.observed = observed.sanitizedForWire()
         self.reconciledAt = reconciledAt
+    }
+}
+
+
+extension ObservedTuple {
+    /// Every string bounded and redacted; capabilities capped in number and length.
+    public func sanitizedForWire() -> ObservedTuple {
+        func clean(_ value: String?) -> String? { value.map { GuesthouseError.sanitize($0, limit: 256) } }
+        var copy = self
+        copy.hostMacOSBuild = clean(hostMacOSBuild)
+        copy.codexDesktopVersion = clean(codexDesktopVersion)
+        copy.codexDesktopBuild = clean(codexDesktopBuild)
+        copy.codexDesktopPath = clean(codexDesktopPath)
+        copy.tartVersion = clean(tartVersion)
+        copy.guestMacOSBuild = clean(guestMacOSBuild)
+        copy.xcodeBuild = clean(xcodeBuild)
+        copy.codexCLIVersion = clean(codexCLIVersion)
+        copy.codexCLIPath = clean(codexCLIPath)
+        copy.codexCLICapabilities = codexCLICapabilities.map { Array($0.prefix(64)).map { GuesthouseError.sanitize($0, limit: 128) } }
+        copy.githubCLIVersion = clean(githubCLIVersion)
+        copy.provisioningScriptVersion = clean(provisioningScriptVersion)
+        return copy
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -265,7 +265,11 @@ extension ObservedTuple {
         // redact a run the first pass retained, so its provenance is a separate gate too.
         let display = GuesthouseError.sanitizeReporting(escaped, limit: room)
         guard !display.redacted else { return nil }
-        return "\(display.value) \(identityMarker)\(digest(of: escaped))]"
+        // A display cut can manufacture a credential-shaped boundary (for example shortening
+        // a long identifier to ABCD-EFGH). The sender must not emit an identity its own wire
+        // decoder would change; such a value is unknown at both ends.
+        let identity = "\(display.value) \(identityMarker)\(digest(of: escaped))]"
+        return decodedIdentity(identity, limit: limit)
     }
 
     /// `" [exact:" + 64 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -135,7 +135,9 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
     public var readiness: Readiness
     public var inFlightOperation: OperationID?
     /// Versions observed on the host and guest, with unknowns left `nil`.
-    public var observed: ObservedTuple
+    /// Only this type sets it, and only through `sanitizedForWire()`: a raw probe value can
+    /// never be assigned into a status and encoded unchanged.
+    public private(set) var observed: ObservedTuple
     public var reconciledAt: Date?
 
     public init(
@@ -183,6 +185,9 @@ extension ObservedTuple {
     /// carries a digest of the exact observation, so two different observations never
     /// collapse into one verified compatibility tuple.
     static func bounded(_ value: String, limit: Int) -> String {
+        // A value that already contains the identity marker is neutralized first, so untrusted
+        // text cannot forge the suffix this function appends and impersonate another value.
+        let value = value.replacingOccurrences(of: identityMarker, with: "[exact\u{FFFD}:")
         let (sanitized, wasRedacted) = GuesthouseError.sanitizeReporting(value, limit: limit)
         // A redacted value stands for a secret: it gets no digest, since that would let a
         // guess be confirmed. Whether redaction happened comes from the sanitizer itself, not
@@ -190,11 +195,12 @@ extension ObservedTuple {
         // normalized carries a digest, counted against the same limit.
         guard sanitized != value, !wasRedacted else { return sanitized }
         let room = max(16, limit - identitySuffixLength)
-        return "\(GuesthouseError.sanitize(value, limit: room)) [exact:\(digest(of: value))]"
+        return "\(GuesthouseError.sanitize(value, limit: room)) \(identityMarker)\(digest(of: value))]"
     }
 
     /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
     static let identitySuffixLength = 22
+    static let identityMarker = "[exact:"
     static let maximumCapabilities = 64
 
     /// The first `maximumCapabilities` entries, each bounded; when entries are dropped, one
@@ -204,7 +210,19 @@ extension ObservedTuple {
         guard values.count > maximumCapabilities else { return values.map { bounded($0, limit: 128) } }
         let kept = values.prefix(maximumCapabilities - 1).map { bounded($0, limit: 128) }
         let omitted = values.count - kept.count
-        return kept + ["[\(omitted) more; exact:\(digest(of: values.joined(separator: "\u{0}")))]"]
+        return kept + ["[\(omitted) more; exact:\(digest(ofList: values))]"]
+    }
+
+    /// A digest over a length-prefixed encoding, so no two different lists can produce the
+    /// same input: a value containing the separator cannot be mistaken for two values.
+    static func digest(ofList values: [String]) -> String {
+        var data = Data()
+        for value in values {
+            let bytes = Data(value.utf8)
+            withUnsafeBytes(of: UInt64(bytes.count).bigEndian) { data.append(contentsOf: $0) }
+            data.append(bytes)
+        }
+        return SHA256.hash(data: data).prefix(6).map { String(format: "%02x", $0) }.joined()
     }
 
     static func digest(of value: String) -> String {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -246,7 +246,11 @@ extension ObservedTuple {
         // normalized carries a digest of the inspected text, counted against the same limit.
         guard sanitized != escaped else { return sanitized }
         let room = max(16, limit - identitySuffixLength)
-        return "\(GuesthouseError.sanitize(escaped, limit: room)) \(identityMarker)\(digest(of: escaped))]"
+        // Making room for the suffix narrows the inspection window. That second pass can
+        // redact a run the first pass retained, so its provenance is a separate gate too.
+        let display = GuesthouseError.sanitizeReporting(escaped, limit: room)
+        guard !display.redacted else { return nil }
+        return "\(display.value) \(identityMarker)\(digest(of: escaped))]"
     }
 
     /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -179,11 +179,25 @@ extension ObservedTuple {
     /// every other field of the observation as well.
     func boundedForDecoding() -> ObservedTuple {
         mapped(
-            string: { GuesthouseError.sanitize($0, limit: 256) },
+            string: { Self.decodedIdentity($0, limit: 256) },
             capabilities: { values in
-                Self.canonicalCapabilities(values.prefix(Self.maximumCapabilities).map { GuesthouseError.sanitize($0, limit: 128) })
+                guard values.count <= Self.maximumCapabilities else { return nil }
+                let entries = values.compactMap { Self.decodedIdentity($0, limit: 128) }
+                guard entries.count == values.count else { return nil }
+                return Self.canonicalCapabilities(entries)
             }
         )
+    }
+
+    /// A wire identity must already be bounded and sanitized by its sender. Deriving a
+    /// different identity while decoding could collapse distinct raw paths or credentials
+    /// into the same value. Existing generated suffixes survive verbatim; raw unsafe or
+    /// lossy values become unknown instead of acquiring a new digest here.
+    private static func decodedIdentity(_ value: String, limit: Int) -> String? {
+        guard value.unicodeScalars.prefix(limit + 1).count <= limit else { return nil }
+        let result = GuesthouseError.sanitizeReporting(value, limit: limit)
+        guard !result.redacted, result.value == value else { return nil }
+        return value
     }
 
     /// `clean` returns `nil` for an observation that cannot serve as an identity, and the field
@@ -245,7 +259,8 @@ extension ObservedTuple {
         // A value the sanitizer left alone is its own identity. One it merely bounded or
         // normalized carries a digest of the inspected text, counted against the same limit.
         guard sanitized != escaped else { return sanitized }
-        let room = max(16, limit - identitySuffixLength)
+        let room = limit - identitySuffixLength
+        guard room > 0 else { return nil }
         // Making room for the suffix narrows the inspection window. That second pass can
         // redact a run the first pass retained, so its provenance is a separate gate too.
         let display = GuesthouseError.sanitizeReporting(escaped, limit: room)
@@ -253,8 +268,8 @@ extension ObservedTuple {
         return "\(display.value) \(identityMarker)\(digest(of: escaped))]"
     }
 
-    /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
-    static let identitySuffixLength = 22
+    /// `" [exact:" + 64 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
+    static let identitySuffixLength = 74
     static let identityMarker = "[exact:"
     static let identityEscape = "\u{FFFD}"
     static let maximumCapabilities = 64
@@ -321,10 +336,10 @@ extension ObservedTuple {
             withUnsafeBytes(of: UInt64(bytes.count).bigEndian) { data.append(contentsOf: $0) }
             data.append(bytes)
         }
-        return SHA256.hash(data: data).prefix(6).map { String(format: "%02x", $0) }.joined()
+        return SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
     }
 
     static func digest(of value: String) -> String {
-        SHA256.hash(data: Data(value.utf8)).prefix(6).map { String(format: "%02x", $0) }.joined()
+        SHA256.hash(data: Data(value.utf8)).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Everything the runtime service streams back to the GUI.
@@ -41,13 +42,22 @@ public struct RuntimeVersionInfo: Codable, Hashable, Sendable {
     }
 
     public struct TartRuntimeInfo: Codable, Hashable, Sendable {
-        public var version: String
+        /// Parsed from the runtime's own `--version` output: redacted and bounded before it
+        /// is stored, so CLI text cannot reach the GUI or diagnostics unchanged.
+        public private(set) var version: String
         /// Signature and digest checks passed against the pinned expectations.
         public var verified: Bool
 
         public init(version: String, verified: Bool) {
-            self.version = version
+            self.version = GuesthouseError.sanitize(version, limit: 64)
             self.verified = verified
+        }
+
+        private enum CodingKeys: String, CodingKey { case version, verified }
+
+        public init(from decoder: any Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            self.init(version: try c.decode(String.self, forKey: .version), verified: try c.decode(Bool.self, forKey: .verified))
         }
     }
 }
@@ -68,8 +78,9 @@ public struct ProgressPhase: Codable, Hashable, Sendable {
     }
 
     public var kind: Kind
-    /// 0...1 when the phase can measure itself; `nil` for indeterminate phases.
-    public var fraction: Double?
+    /// 0...1 when the phase can measure itself; `nil` for indeterminate phases. Only this
+    /// type sets it, so a value that cannot be encoded never reaches an event.
+    public private(set) var fraction: Double?
     /// False for phases that must not be interrupted (for example a rename after a copy).
     public var cancelable: Bool
 
@@ -87,6 +98,11 @@ public struct ProgressPhase: Codable, Hashable, Sendable {
     public init(from decoder: any Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         self.init(kind: try c.decode(Kind.self, forKey: .kind), fraction: try c.decodeIfPresent(Double.self, forKey: .fraction), cancelable: try c.decodeIfPresent(Bool.self, forKey: .cancelable) ?? true)
+    }
+
+    /// A copy of the phase measured at `fraction`, normalized the same way.
+    public func measured(_ fraction: Double?) -> ProgressPhase {
+        ProgressPhase(kind: kind, fraction: fraction, cancelable: cancelable)
     }
 
     static func valid(_ fraction: Double?) -> Double? {
@@ -145,7 +161,7 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
 extension ObservedTuple {
     /// Every string bounded and redacted; capabilities capped in number and length.
     public func sanitizedForWire() -> ObservedTuple {
-        func clean(_ value: String?) -> String? { value.map { GuesthouseError.sanitize($0, limit: 256) } }
+        func clean(_ value: String?) -> String? { value.map { Self.bounded($0, limit: 256) } }
         var copy = self
         copy.hostMacOSBuild = clean(hostMacOSBuild)
         copy.codexDesktopVersion = clean(codexDesktopVersion)
@@ -156,9 +172,30 @@ extension ObservedTuple {
         copy.xcodeBuild = clean(xcodeBuild)
         copy.codexCLIVersion = clean(codexCLIVersion)
         copy.codexCLIPath = clean(codexCLIPath)
-        copy.codexCLICapabilities = codexCLICapabilities.map { Array($0.prefix(64)).map { GuesthouseError.sanitize($0, limit: 128) } }
+        copy.codexCLICapabilities = codexCLICapabilities.map { Array($0.prefix(64)).map { Self.bounded($0, limit: 128) } }
         copy.githubCLIVersion = clean(githubCLIVersion)
         copy.provisioningScriptVersion = clean(provisioningScriptVersion)
         return copy
+    }
+
+    /// Sanitizing is lossy, and these values are also an identity: a long path and a
+    /// decomposed one can bound to the same text. A value the sanitizer changed therefore
+    /// carries a digest of the exact observation, so two different observations never
+    /// collapse into one verified compatibility tuple.
+    static func bounded(_ value: String, limit: Int) -> String {
+        let sanitized = GuesthouseError.sanitize(value, limit: limit)
+        // A redacted value stands for a secret: it gets no digest, since that would let a
+        // guess be confirmed. Only a value that was merely bounded or normalized carries one,
+        // and the suffix is counted against the same limit.
+        guard sanitized != value, !sanitized.contains("[redacted") else { return sanitized }
+        let room = max(16, limit - identitySuffixLength)
+        return "\(GuesthouseError.sanitize(value, limit: room)) [exact:\(digest(of: value))]"
+    }
+
+    /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
+    static let identitySuffixLength = 22
+
+    static func digest(of value: String) -> String {
+        SHA256.hash(data: Data(value.utf8)).prefix(6).map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -164,7 +164,9 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
 
 
 extension ObservedTuple {
-    /// Every string bounded and redacted; capabilities capped in number and length.
+    /// Every string bounded and redacted; capabilities capped in number and length. A value
+    /// that cannot survive as an identity — one a secret was removed from, or one longer than
+    /// the sanitizer ever reads — becomes unknown instead.
     public func sanitizedForWire() -> ObservedTuple {
         mapped(string: { Self.bounded($0, limit: 256) }, capabilities: Self.boundedCapabilities)
     }
@@ -179,48 +181,72 @@ extension ObservedTuple {
         mapped(
             string: { GuesthouseError.sanitize($0, limit: 256) },
             capabilities: { values in
-                CompatibilityTuple.normalize(values.prefix(Self.maximumCapabilities).map { GuesthouseError.sanitize($0, limit: 128) })
+                Self.canonicalCapabilities(values.prefix(Self.maximumCapabilities).map { GuesthouseError.sanitize($0, limit: 128) })
             }
         )
     }
 
-    private func mapped(string clean: (String) -> String, capabilities: ([String]) -> [String]) -> ObservedTuple {
+    /// `clean` returns `nil` for an observation that cannot serve as an identity, and the field
+    /// becomes unknown rather than being kept as a value two different observations could share.
+    private func mapped(string clean: (String) -> String?, capabilities: ([String]) -> [String]?) -> ObservedTuple {
         var copy = self
-        copy.hostMacOSBuild = hostMacOSBuild.map(clean)
-        copy.codexDesktopVersion = codexDesktopVersion.map(clean)
-        copy.codexDesktopBuild = codexDesktopBuild.map(clean)
-        copy.codexDesktopPath = codexDesktopPath.map(clean)
-        copy.tartVersion = tartVersion.map(clean)
-        copy.guestMacOSBuild = guestMacOSBuild.map(clean)
-        copy.xcodeBuild = xcodeBuild.map(clean)
-        copy.codexCLIVersion = codexCLIVersion.map(clean)
-        copy.codexCLIPath = codexCLIPath.map(clean)
-        copy.codexCLICapabilities = codexCLICapabilities.map(capabilities)
-        copy.githubCLIVersion = githubCLIVersion.map(clean)
-        copy.provisioningScriptVersion = provisioningScriptVersion.map(clean)
+        copy.hostMacOSBuild = hostMacOSBuild.flatMap(clean)
+        copy.codexDesktopVersion = codexDesktopVersion.flatMap(clean)
+        copy.codexDesktopBuild = codexDesktopBuild.flatMap(clean)
+        copy.codexDesktopPath = codexDesktopPath.flatMap(clean)
+        copy.tartVersion = tartVersion.flatMap(clean)
+        copy.guestMacOSBuild = guestMacOSBuild.flatMap(clean)
+        copy.xcodeBuild = xcodeBuild.flatMap(clean)
+        copy.codexCLIVersion = codexCLIVersion.flatMap(clean)
+        copy.codexCLIPath = codexCLIPath.flatMap(clean)
+        copy.codexCLICapabilities = codexCLICapabilities.flatMap(capabilities)
+        copy.githubCLIVersion = githubCLIVersion.flatMap(clean)
+        copy.provisioningScriptVersion = provisioningScriptVersion.flatMap(clean)
         return copy
     }
 
     /// Sanitizing is lossy, and these values are also an identity: a long path and a
     /// decomposed one can bound to the same text. A value the sanitizer changed therefore
     /// carries a digest of the exact observation, so two different observations never
-    /// collapse into one verified compatibility tuple.
-    static func bounded(_ value: String, limit: Int) -> String {
+    /// collapse into one verified compatibility tuple. `nil` means the observation cannot be
+    /// an identity at all, and the field is reported unknown rather than as a value another
+    /// observation could match (MVP-PLAN.md §5: report unknown rather than guess).
+    static func bounded(_ value: String, limit: Int) -> String? {
+        let scalars = value.unicodeScalars
+        let inspectable = limit + GuesthouseError.sanitizeLookahead
+        // Text past the window is never read: it is not redacted and no digest covers it, so
+        // two values that share the window are indistinguishable here. Reporting one of them
+        // as an exact observation would let a changed executable match the connection record
+        // of the one before it. The window is measured, and everything below works on it, so
+        // arbitrarily long CLI output is never copied or scanned in full either.
+        let window = scalars.prefix(inspectable + 1)
+        guard window.count <= inspectable else { return nil }
         // Untrusted text must not be able to forge the suffix this function appends. Escaping
         // the escape before the marker keeps that neutralization injective: were the marker
         // alone rewritten, `foo[exact:` and `foo[exact\u{FFFD}:` would both arrive at the
         // latter and two different observations would share one identity.
-        let value = value
+        let escaped = String(String.UnicodeScalarView(window))
             .replacingOccurrences(of: identityEscape, with: identityEscape + identityEscape)
             .replacingOccurrences(of: identityMarker, with: "[exact\(identityEscape):")
-        let (sanitized, wasRedacted) = GuesthouseError.sanitizeReporting(value, limit: limit)
-        // A redacted value stands for a secret: it gets no digest, since that would let a
-        // guess be confirmed. Whether redaction happened comes from the sanitizer itself, not
-        // from marker text the value could contain. Only a value that was merely bounded or
-        // normalized carries a digest, counted against the same limit.
-        guard sanitized != value, !wasRedacted else { return sanitized }
+        // Escaping grows the text — every escape scalar becomes two — so the string that
+        // reaches the sanitizer can stand outside the window the raw value was measured
+        // against. The window is what makes both answers below honest: past it nothing is
+        // redacted and the digest would cover a tail nobody inspected, publishing a verifier
+        // for whatever credential was placed there. A value that no longer fits is unknown,
+        // for the same reason one that never fit is.
+        guard escaped.unicodeScalars.count <= inspectable else { return nil }
+        let (sanitized, wasRedacted) = GuesthouseError.sanitizeReporting(escaped, limit: limit)
+        // A redacted value stands for a secret. It gets no digest, since that would let a guess
+        // be confirmed, and it is not an identity either: two paths that differ only in the
+        // credential they contain redact to the same text, and calling that an exact value
+        // would reuse one path's verification record for the other. Whether redaction happened
+        // comes from the sanitizer itself, not from marker text the value could contain.
+        guard !wasRedacted else { return nil }
+        // A value the sanitizer left alone is its own identity. One it merely bounded or
+        // normalized carries a digest of the inspected text, counted against the same limit.
+        guard sanitized != escaped else { return sanitized }
         let room = max(16, limit - identitySuffixLength)
-        return "\(GuesthouseError.sanitize(value, limit: room)) \(identityMarker)\(digest(of: inspected(value, limit: limit)))]"
+        return "\(GuesthouseError.sanitize(escaped, limit: room)) \(identityMarker)\(digest(of: escaped))]"
     }
 
     /// `" [exact:" + 12 hex + "]"`, plus the one scalar the sanitizer adds when it truncates.
@@ -228,29 +254,58 @@ extension ObservedTuple {
     static let identityMarker = "[exact:"
     static let identityEscape = "\u{FFFD}"
     static let maximumCapabilities = 64
+    /// The most raw entries a probe may report before the answer stops being a capability list.
+    /// Bounding and redacting an entry is real work, and the canonical list is built and sorted
+    /// before `maximumCapabilities` applies, so without this the cost of constructing a status
+    /// would follow whatever the guest printed rather than the bounded shape that goes over the
+    /// wire. Far above any real CLI's capability list, and far below a size worth inspecting.
+    static let maximumReportedCapabilities = 1024
 
-    /// The prefix the sanitizer actually reads: the bound plus the lookahead that catches a
-    /// credential starting inside it. Only this much may be hashed, because a secret that
-    /// begins past it is never inspected, leaves `wasRedacted` false, and would otherwise be
-    /// published as a digest that confirms a guess offline.
-    static func inspected(_ value: String, limit: Int) -> String {
-        String(String.UnicodeScalarView(value.unicodeScalars.prefix(limit + GuesthouseError.sanitizeLookahead)))
+    /// The canonical form of a reported capability list: duplicates collapsed, and the order
+    /// the guest happened to use removed. Bounded by `maximumReportedCapabilities` rather than
+    /// by the wire cap, because the cap is applied *after* this: the identity below is derived
+    /// from the canonical form, and capping before the sort would make it depend on the order
+    /// the probe reported in. `CompatibilityTuple.normalize` refuses to canonicalize a list
+    /// over the wire cap on purpose — a persisted record's count check must still see a flood
+    /// of duplicates rather than the one entry they collapse to — and an observation on the
+    /// wire is capped rather than refused, so it canonicalizes here instead.
+    static func canonicalCapabilities(_ values: [String]) -> [String] {
+        guard values.count <= maximumReportedCapabilities else {
+            return Array(values.prefix(maximumReportedCapabilities + 1))
+        }
+        return Array(Set(values)).sorted()
     }
 
-    /// The first `maximumCapabilities` entries, each bounded; when entries are dropped, one
-    /// further entry names how many and carries a digest of the whole list, so two capability
-    /// sets that share a prefix keep different identities. That entry wears the same identity
-    /// marker as a bounded value, so a literal capability shaped like it is neutralized and
-    /// cannot pass a different capability set off as a capped one. The list is canonical, so
-    /// it survives the normalization a receiver applies. The digest is over the bounded
-    /// entries: an entry past the cap is never inspected, and hashing it raw would publish a
-    /// digest of whatever secret it holds.
-    static func boundedCapabilities(_ values: [String]) -> [String] {
-        let entries = values.map { bounded($0, limit: 128) }
-        guard values.count > maximumCapabilities else { return CompatibilityTuple.normalize(entries) }
-        let kept = Array(entries.prefix(maximumCapabilities - 1))
-        let omitted = values.count - kept.count
-        return CompatibilityTuple.normalize(kept + ["\(omitted) more \(identityMarker)\(digest(ofList: entries))]"])
+    /// The first `maximumCapabilities` entries of the canonical list, each bounded; when entries
+    /// are dropped, one further entry names how many and carries a digest of the whole list, so
+    /// two capability sets that share a prefix keep different identities. That entry wears the
+    /// same identity marker as a bounded value, so a literal capability shaped like it is
+    /// neutralized and cannot pass a different capability set off as a capped one. The digest is
+    /// over the bounded entries: an entry past the cap is never inspected, and hashing it raw
+    /// would publish a digest of whatever secret it holds.
+    ///
+    /// The list is made canonical before it is capped and hashed, not after. A probe may report
+    /// the same capabilities in any order, or twice; which entries the cap keeps and what the
+    /// digest covers must not depend on that, or one capability set would produce two
+    /// identities and revalidate a connection that never changed.
+    ///
+    /// `nil` when any entry is not an identity: dropping just that entry would let two
+    /// different capability sets collapse into one. `nil` too when there are more raw entries
+    /// than `maximumReportedCapabilities`, which is checked before any of them is read: keeping
+    /// a prefix of such a list is not open either, because the digest below would then cover
+    /// the prefix and two different lists that share one would arrive at a single identity.
+    static func boundedCapabilities(_ values: [String]) -> [String]? {
+        guard values.count <= maximumReportedCapabilities else { return nil }
+        var entries: [String] = []
+        for value in values {
+            guard let entry = bounded(value, limit: 128) else { return nil }
+            entries.append(entry)
+        }
+        let canonical = Self.canonicalCapabilities(entries)
+        guard canonical.count > maximumCapabilities else { return canonical }
+        let kept = Array(canonical.prefix(maximumCapabilities - 1))
+        let omitted = canonical.count - kept.count
+        return Self.canonicalCapabilities(kept + ["\(omitted) more \(identityMarker)\(digest(ofList: canonical))]"])
     }
 
     /// A digest over a length-prefixed encoding, so no two different lists can produce the

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+/// Everything the runtime service streams back to the GUI.
+public enum RuntimeEvent: Codable, Hashable, Sendable {
+    /// The reply to `runtimeVersion`.
+    case runtimeVersion(RuntimeVersionInfo)
+    /// The request was journaled and is now in flight.
+    case accepted(OperationID)
+    case progress(OperationID, ProgressPhase)
+    /// A redacted line of output. Never raw process output.
+    case log(OperationID?, RedactedLine)
+    case status(EnvironmentStatus)
+    case completed(OperationID)
+    case failed(OperationID, GuesthouseError)
+
+    public var caseName: String {
+        switch self {
+        case .runtimeVersion: "runtimeVersion"
+        case .accepted: "accepted"
+        case .progress: "progress"
+        case .log: "log"
+        case .status: "status"
+        case .completed: "completed"
+        case .failed: "failed"
+        }
+    }
+}
+
+public struct RuntimeVersionInfo: Codable, Hashable, Sendable {
+    public var serviceVersion: String
+    public var serviceBuild: String
+    public var protocolVersion: RuntimeProtocolVersion
+    /// `nil` until the service has located a runtime bundle.
+    public var tart: TartRuntimeInfo?
+
+    public init(serviceVersion: String, serviceBuild: String, protocolVersion: RuntimeProtocolVersion = .current, tart: TartRuntimeInfo? = nil) {
+        self.serviceVersion = serviceVersion
+        self.serviceBuild = serviceBuild
+        self.protocolVersion = protocolVersion
+        self.tart = tart
+    }
+
+    public struct TartRuntimeInfo: Codable, Hashable, Sendable {
+        public var version: String
+        /// Signature and digest checks passed against the pinned expectations.
+        public var verified: Bool
+
+        public init(version: String, verified: Bool) {
+            self.version = version
+            self.verified = verified
+        }
+    }
+}
+
+/// A named step of an operation, shown as real progress instead of one indefinite spinner
+/// (MVP-PLAN.md §2, step 2).
+public struct ProgressPhase: Codable, Hashable, Sendable {
+    public enum Kind: String, Codable, Hashable, Sendable {
+        case inspectingState
+        case verifyingRuntime
+        case startingVM
+        case waitingForNetwork
+        case stoppingVM
+        case forceStoppingVM
+        case validatingSelection
+        case copying
+        case verifyingCopy
+    }
+
+    public var kind: Kind
+    /// 0...1 when the phase can measure itself; `nil` for indeterminate phases.
+    public var fraction: Double?
+    /// False for phases that must not be interrupted (for example a rename after a copy).
+    public var cancelable: Bool
+
+    public init(kind: Kind, fraction: Double? = nil, cancelable: Bool = true) {
+        self.kind = kind
+        self.fraction = fraction
+        self.cancelable = cancelable
+    }
+}
+
+/// What the service knows about one environment right now. Produced by reconciling the
+/// VM inventory, the process-identity verdict, and the journal; never read from a cache.
+public struct EnvironmentStatus: Codable, Hashable, Sendable {
+    public enum VMState: Codable, Hashable, Sendable {
+        case notFound
+        case stopped
+        case running
+        /// Ownership could not be established (for example a PID that no longer matches).
+        /// Start is refused until a person or a repair resolves it.
+        case uncertain(reason: String)
+    }
+
+    public enum Readiness: Codable, Hashable, Sendable {
+        /// Reconciliation has not finished. The GUI shows "Checking environment".
+        case checking
+        case ready
+        case needsAttention(GuesthouseError)
+    }
+
+    public var environmentID: EnvironmentID
+    public var vm: VMState
+    public var readiness: Readiness
+    public var inFlightOperation: OperationID?
+    /// Versions observed on the host and guest, with unknowns left `nil`.
+    public var observed: ObservedTuple
+    public var reconciledAt: Date?
+
+    public init(
+        environmentID: EnvironmentID,
+        vm: VMState,
+        readiness: Readiness,
+        inFlightOperation: OperationID? = nil,
+        observed: ObservedTuple = ObservedTuple(),
+        reconciledAt: Date? = nil
+    ) {
+        self.environmentID = environmentID
+        self.vm = vm
+        self.readiness = readiness
+        self.inFlightOperation = inFlightOperation
+        self.observed = observed
+        self.reconciledAt = reconciledAt
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
@@ -1,0 +1,48 @@
+/// The versioned service-to-GUI event contract for the XPC boundary (MVP-PLAN.md §3).
+///
+/// Transports must encode and decode this envelope, not a bare `RuntimeEvent`, to reject
+/// incompatible service replies before interpreting their version-specific payloads.
+public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
+    public var protocolVersion: RuntimeProtocolVersion
+    public var event: RuntimeEvent
+
+    public init(protocolVersion: RuntimeProtocolVersion = .current, event: RuntimeEvent) {
+        self.protocolVersion = protocolVersion
+        self.event = event
+    }
+
+    private enum CodingKeys: String, CodingKey { case protocolVersion, event }
+
+    /// The outer header is authoritative and required, even for a runtime-version reply.
+    /// A foreign header yields `ProtocolMismatch` before the event is decoded. A supported
+    /// header with contradictory nested version information is malformed, not a mismatch.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion)
+        guard version == .current else { throw ProtocolMismatch(service: version) }
+
+        let decodedEvent = try container.decode(RuntimeEvent.self, forKey: .event)
+        if case .runtimeVersion(let info) = decodedEvent, info.protocolVersion != version {
+            throw DecodingError.dataCorruptedError(
+                forKey: .event,
+                in: container,
+                debugDescription: "The runtime-version payload contradicts its envelope header."
+            )
+        }
+        protocolVersion = version
+        event = decodedEvent
+    }
+
+    /// Thrown before a foreign service's payload is decoded.
+    public struct ProtocolMismatch: Error, Hashable, Sendable {
+        public let service: RuntimeProtocolVersion
+
+        public init(service: RuntimeProtocolVersion) {
+            self.service = service
+        }
+
+        public var error: GuesthouseError {
+            .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: service.rawValue)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -1,0 +1,30 @@
+/// Version of the message contract between the GUI and the GuesthouseRuntime XPC service.
+///
+/// Bump on any change a peer from the previous version could misread. Both sides send it in
+/// every envelope, and the service refuses a mismatch with `GuesthouseError.protocolMismatch`.
+public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
+    public let rawValue: Int
+
+    public init(_ rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let current = RuntimeProtocolVersion(1)
+
+    public static func < (lhs: RuntimeProtocolVersion, rhs: RuntimeProtocolVersion) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+
+    public var description: String { "protocol \(rawValue)" }
+}
+
+extension RuntimeProtocolVersion: Codable {
+    public init(from decoder: any Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(Int.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -34,6 +34,25 @@ public struct RuntimeRequestEnvelope: Codable, Hashable, Sendable {
         self.protocolVersion = protocolVersion
         self.request = request
     }
+
+    private enum CodingKeys: String, CodingKey { case protocolVersion, request }
+
+    /// The version header is read first; a peer on another protocol is reported as
+    /// `ProtocolMismatch` before its version-specific payload is decoded, so a request case
+    /// this build does not know yields the actionable mismatch, never a malformed request.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion)
+        guard version == .current else { throw ProtocolMismatch(client: version) }
+        protocolVersion = version
+        request = try container.decode(RuntimeRequest.self, forKey: .request)
+    }
+
+    /// Thrown by `init(from:)` before the payload is decoded.
+    public struct ProtocolMismatch: Error, Hashable, Sendable {
+        public let client: RuntimeProtocolVersion
+        public var error: GuesthouseError { .protocolMismatch(client: client.rawValue, service: RuntimeProtocolVersion.current.rawValue) }
+    }
 }
 
 public struct StartOptions: Codable, Hashable, Sendable {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Everything the GUI may ask the runtime service to do.
+///
+/// Requests name environments and operations and carry validated options. They never carry a
+/// path to execute, an executable, or a Tart flag: the service chooses those itself
+/// (MVP-PLAN.md §3, "Sandbox and XPC boundary").
+public enum RuntimeRequest: Codable, Hashable, Sendable {
+    case runtimeVersion
+    case environmentStatus(EnvironmentID)
+    case startEnvironment(EnvironmentID, StartOptions)
+    case stopEnvironment(EnvironmentID, StopMode)
+    case importXcode(EnvironmentID, FileHandoff)
+    case cancelOperation(OperationID)
+
+    public var caseName: String {
+        switch self {
+        case .runtimeVersion: "runtimeVersion"
+        case .environmentStatus: "environmentStatus"
+        case .startEnvironment: "startEnvironment"
+        case .stopEnvironment: "stopEnvironment"
+        case .importXcode: "importXcode"
+        case .cancelOperation: "cancelOperation"
+        }
+    }
+}
+
+/// Every message from the GUI carries the protocol version it speaks.
+public struct RuntimeRequestEnvelope: Codable, Hashable, Sendable {
+    public var protocolVersion: RuntimeProtocolVersion
+    public var request: RuntimeRequest
+
+    public init(protocolVersion: RuntimeProtocolVersion = .current, request: RuntimeRequest) {
+        self.protocolVersion = protocolVersion
+        self.request = request
+    }
+}
+
+public struct StartOptions: Codable, Hashable, Sendable {
+    /// Which console the VM gets. The service maps this to its own Tart arguments.
+    public enum ConsoleMode: String, Codable, Hashable, Sendable {
+        /// Normal daily operation; the guest is reached over SSH and Screen Sharing.
+        case headless
+        /// Tart's native window, for first boot and recovery only (MVP-PLAN.md §4).
+        case native
+    }
+
+    public var console: ConsoleMode
+    /// How long the service may wait for the guest to obtain an IP address before reporting
+    /// `guestNotReachable`. Bounded by `RequestValidator.maximumIPWait`.
+    public var ipWait: Duration
+
+    public init(console: ConsoleMode = .headless, ipWait: Duration = .seconds(90)) {
+        self.console = console
+        self.ipWait = ipWait
+    }
+}
+
+public enum StopMode: Codable, Hashable, Sendable {
+    /// Ask the guest to shut down and wait up to `deadline`.
+    case graceful(deadline: Duration)
+    /// Kill the VM process. Only after the GUI has shown the explicit force-stop warning
+    /// (MVP-PLAN.md §2).
+    case force
+}
+
+/// A user-selected file or bundle handed from the sandboxed GUI to the service.
+///
+/// The authority to read is the bookmark or the out-of-band file descriptor, never the
+/// display name (MVP-PLAN.md §3: "A path string alone is not a transferable sandbox
+/// permission"). The service re-validates what it receives; the caller's claims are hints.
+public struct FileHandoff: Codable, Hashable, Sendable {
+    public enum Kind: Codable, Hashable, Sendable {
+        /// A security-scoped bookmark created by the GUI from an `NSOpenPanel` selection.
+        case securityScopedBookmark(Data)
+        /// A descriptor sent alongside the message, identified by this token.
+        case fileDescriptor(token: UUID)
+    }
+
+    public var kind: Kind
+    /// Shown in progress and errors, for example `Xcode.app`. Not used to open anything.
+    public var displayName: String
+    /// What the GUI believes it selected; the service verifies the bundle itself.
+    public var expectedBundleIdentifier: String?
+
+    public init(kind: Kind, displayName: String, expectedBundleIdentifier: String? = nil) {
+        self.kind = kind
+        self.displayName = displayName
+        self.expectedBundleIdentifier = expectedBundleIdentifier
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -245,6 +245,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
                 true
             }
         }))
+        var truncationRedacted = false
         if truncated {
             // Normalization drops scalars, so a window full of raw input can normalize to far
             // less: a run of combining marks between a device code's first and last character
@@ -261,6 +262,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             // recognized in both the spellings the redactor's own userinfo rule accepts, since a
             // URL that reached a log through JSON keeps that encoding's escaped slashes, and is
             // put back exactly as it came in.
+            let opened = normalized
             normalized = normalized.replacing(#/(:(?:\\?\/){2})[^\s\/]*$/#) { match in "\(match.1)\(Redactor.marker("userinfo"))" }
             // A JWT whose payload is longer than the window loses the second `.` the redactor
             // matches on, so a token that began inside the visible prefix would be emitted in
@@ -273,9 +275,12 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
                 guard let start = Redactor.joseHeaderStart(match.1) else { return String(match.0) }
                 return match.1[..<start] + Redactor.marker("jwt")
             }
+            truncationRedacted = normalized != opened
         }
         let redacted = Redactor().redact(fieldValue: normalized)
-        let wasRedacted = redacted != normalized
+        // The truncation-time replacement counts as redaction: a caller must not treat the
+        // result as merely bounded and attach an identity digest of the credential.
+        let wasRedacted = truncationRedacted || redacted != normalized
         let scalars = redacted.unicodeScalars
         guard scalars.count > limit else { return (redacted, wasRedacted) }
         return (String(String.UnicodeScalarView(scalars.prefix(limit))) + "…", wasRedacted)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -209,6 +209,13 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     static let sanitizeLookahead = 512
 
     public static func sanitize(_ value: String, limit: Int = 80) -> String {
+        sanitizeReporting(value, limit: limit).value
+    }
+
+    /// The sanitized text, and whether the redactor actually replaced something. Callers that
+    /// need to tell "a secret was removed" from "the text merely happens to contain the
+    /// marker" use this rather than searching the result for marker text.
+    public static func sanitizeReporting(_ value: String, limit: Int = 80) -> (value: String, redacted: Bool) {
         // This is public API, so the bound is clamped rather than trusted: an extreme limit
         // would otherwise overflow the window arithmetic and a negative one would hand
         // `prefix` an invalid length, trapping instead of returning sanitized text.
@@ -268,9 +275,10 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             }
         }
         let redacted = Redactor().redact(fieldValue: normalized)
+        let wasRedacted = redacted != normalized
         let scalars = redacted.unicodeScalars
-        guard scalars.count > limit else { return redacted }
-        return String(String.UnicodeScalarView(scalars.prefix(limit))) + "…"
+        guard scalars.count > limit else { return (redacted, wasRedacted) }
+        return (String(String.UnicodeScalarView(scalars.prefix(limit))) + "…", wasRedacted)
     }
 
     static func list(_ components: MissingComponents) -> String {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -231,7 +231,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         // with it, because stripping it would silently repair a credential into something the
         // patterns below no longer recognize. Combining marks go too: a mark inside a token
         // would otherwise split it out of the redactor's reach.
-        let stripped = Redactor.stripTerminalEscapes(Redactor.redactEscapeSplicedRuns(bounded))
+        let spliced = Redactor.redactEscapeSplicedRuns(bounded)
+        let stripped = Redactor.stripTerminalEscapes(spliced)
         var normalized = String(String.UnicodeScalarView(stripped.unicodeScalars.filter { scalar in
             switch scalar.properties.generalCategory {
             case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned,
@@ -278,9 +279,10 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             truncationRedacted = normalized != opened
         }
         let redacted = Redactor().redact(fieldValue: normalized)
-        // The truncation-time replacement counts as redaction: a caller must not treat the
-        // result as merely bounded and attach an identity digest of the credential.
-        let wasRedacted = truncationRedacted || redacted != normalized
+        // The truncation-time replacement counts as redaction, and so does the escape-spliced
+        // run dropped before normalization: both remove credential text, and a caller must not
+        // treat what is left as merely bounded and attach an identity digest of the original.
+        let wasRedacted = spliced != bounded || truncationRedacted || redacted != normalized
         let scalars = redacted.unicodeScalars
         guard scalars.count > limit else { return (redacted, wasRedacted) }
         return (String(String.UnicodeScalarView(scalars.prefix(limit))) + "…", wasRedacted)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -233,6 +233,11 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         // would otherwise split it out of the redactor's reach.
         let spliced = Redactor.redactEscapeSplicedRuns(bounded)
         let stripped = Redactor.stripTerminalEscapes(spliced)
+        // OSC/DCS/APC/PM/SOS discard arbitrary payload, not just styling. Even an edge
+        // sequence can hide a credential whose digest must not become an identity. Keep
+        // ordinary SGR/charset normalization distinct: those carry no arbitrary payload.
+        let controlPayloadRemoved = stripped != spliced
+            && spliced.contains(#/\u{1B}[\]P_^X]|[\u{9D}\u{90}\u{9F}\u{9E}\u{98}]/#)
         var normalized = String(String.UnicodeScalarView(stripped.unicodeScalars.filter { scalar in
             switch scalar.properties.generalCategory {
             case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned,
@@ -248,6 +253,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         }))
         var truncationRedacted = false
         if truncated {
+            let opened = normalized
             // Normalization drops scalars, so a window full of raw input can normalize to far
             // less: a run of combining marks between a device code's first and last character
             // pushes that last character out of the window and leaves `AB12-CD3`, which no
@@ -263,7 +269,6 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             // recognized in both the spellings the redactor's own userinfo rule accepts, since a
             // URL that reached a log through JSON keeps that encoding's escaped slashes, and is
             // put back exactly as it came in.
-            let opened = normalized
             normalized = normalized.replacing(#/(:(?:\\?\/){2})[^\s\/]*$/#) { match in "\(match.1)\(Redactor.marker("userinfo"))" }
             // A JWT whose payload is longer than the window loses the second `.` the redactor
             // matches on, so a token that began inside the visible prefix would be emitted in
@@ -280,9 +285,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         }
         let redacted = Redactor().redact(fieldValue: normalized)
         // The truncation-time replacement counts as redaction, and so does the escape-spliced
-        // run dropped before normalization: both remove credential text, and a caller must not
-        // treat what is left as merely bounded and attach an identity digest of the original.
-        let wasRedacted = spliced != bounded || truncationRedacted || redacted != normalized
+        // run or control payload dropped before normalization: all can remove credential text,
+        // and a caller must not attach an identity digest of that original text.
+        let wasRedacted = spliced != bounded || controlPayloadRemoved || truncationRedacted || redacted != normalized
         let scalars = redacted.unicodeScalars
         guard scalars.count > limit else { return (redacted, wasRedacted) }
         return (String(String.UnicodeScalarView(scalars.prefix(limit))) + "…", wasRedacted)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationIdentityReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationIdentityReviewTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct ObservationIdentityReviewTests {
+    @Test(arguments: ["password: sampleOne", "password: sampleTwo",
+                      "\u{1B}]AB12-CD34\u{07}"])
+    func decodedSecretObservationsAreUnknown(input: String) throws {
+        var raw = ObservedTuple(RuntimeContractHardeningTests.knownTuple)
+        raw.codexCLIPath = input
+        raw.codexCLICapabilities = ["normal", input]
+        let decoded = try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(raw))
+        #expect(decoded.codexCLIPath == nil)
+        #expect(decoded.codexCLICapabilities == nil)
+        #expect(decoded.exact == nil)
+        #expect(decoded.unknownFields.contains(.codexCLIPath))
+        #expect(decoded.unknownFields.contains(.codexCLICapabilities))
+    }
+
+    @Test func identitiesRetainTheFullSHA256Digest() {
+        #expect(ObservedTuple.digest(of: "abc")
+            == "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        #expect(ObservedTuple.digest(ofList: ["one", "two"]).count == 64)
+        let value = String(repeating: "a", count: 400)
+        let bounded = ObservedTuple.bounded(value, limit: 256)
+        #expect(bounded?.hasSuffix("[exact:\(ObservedTuple.digest(of: value))]") == true)
+        #expect((bounded?.unicodeScalars.count ?? 0) <= 256)
+        #expect(ObservedTuple.identitySuffixLength == " [exact:".count + 64 + "]…".count)
+    }
+
+    @Test(arguments: ["0.50.0\u{1B}[31m", String(repeating: "a", count: 257)])
+    func decodingDoesNotSilentlyChangeAnObservationIdentity(input: String) throws {
+        let raw = ObservedTuple(codexCLIVersion: input)
+        let decoded = try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(raw))
+        #expect(decoded.codexCLIVersion == nil)
+        let sanitized = raw.sanitizedForWire()
+        let roundTrip = try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(sanitized))
+        #expect(roundTrip == sanitized, "the sender's safe exact identity survives unchanged")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationIdentityReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationIdentityReviewTests.swift
@@ -37,4 +37,15 @@ struct ObservationIdentityReviewTests {
         let roundTrip = try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(sanitized))
         #expect(roundTrip == sanitized, "the sender's safe exact identity survives unchanged")
     }
+
+    @Test func aDisplayCutCannotCreateASecretShapedWireIdentity() throws {
+        let capability = String(repeating: "a", count: 44) + " ABCD-EFGH" + String(repeating: "Z", count: 100)
+        let path = String(repeating: "a", count: 172) + " ABCD-EFGH" + String(repeating: "Z", count: 100)
+        let raw = ObservedTuple(codexCLIPath: path, codexCLICapabilities: [capability])
+        let sent = raw.sanitizedForWire()
+        #expect(sent.codexCLIPath == nil)
+        #expect(sent.codexCLICapabilities == nil)
+        let received = try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(sent))
+        #expect(received == sent)
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationRedactionProvenanceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationRedactionProvenanceTests.swift
@@ -1,0 +1,55 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct ObservationRedactionProvenanceTests {
+    @Test func initialTruncationReplacementReportsRedaction() {
+        let input = "AB12-CD34" + String(repeating: "\u{301}", count: 800)
+        let result = GuesthouseError.sanitizeReporting(input, limit: 256)
+        #expect(result.value == "[redacted:truncated]")
+        #expect(result.redacted)
+        // The observation's independent raw-window guard also rejects this input.
+        #expect(ObservedTuple(codexCLIVersion: input).sanitizedForWire().codexCLIVersion == nil)
+    }
+
+    @Test(arguments: [
+        "\u{1B}]AB12-CD34\u{07}", "\u{9D}AB12-CD34\u{9C}",
+        "\u{1B}PAB12-CD34\u{1B}\\", "\u{90}AB12-CD34\u{9C}",
+        "\u{1B}_AB12-CD34\u{1B}\\", "\u{9F}AB12-CD34\u{9C}",
+        "\u{1B}^AB12-CD34\u{1B}\\", "\u{9E}AB12-CD34\u{9C}",
+        "\u{1B}XAB12-CD34\u{1B}\\", "\u{98}AB12-CD34\u{9C}",
+        "\u{1B}]AB12-CD34", "\u{1B}PAB12-CD34"
+    ])
+    func discardedControlPayloadCannotBecomeAnIdentity(sequence: String) throws {
+        let input = "0.50.0 " + sequence
+        let sanitized = GuesthouseError.sanitizeReporting(input, limit: 256)
+        #expect(sanitized.redacted)
+        #expect(!sanitized.value.contains("AB12-CD34"))
+        var observation = ObservedTuple(codexCLIVersion: input)
+        observation.codexCLICapabilities = ["normal", input]
+        let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped,
+                                       readiness: .checking, observed: observation)
+        #expect(status.observed.codexCLIVersion == nil)
+        #expect(status.observed.codexCLICapabilities == nil)
+        let wire = String(decoding: try JSONEncoder().encode(status), as: UTF8.self)
+        #expect(!wire.contains("AB12-CD34"))
+        #expect(!wire.contains(ObservedTuple.digest(of: input)))
+    }
+
+    @Test(arguments: ["\u{1B}[31m", "\u{9B}0m", "\u{1B}(B"])
+    func ordinaryTerminalStylingRetainsExactObservationIdentity(sequence: String) {
+        let input = "0.50.0" + sequence
+        let result = GuesthouseError.sanitizeReporting(input, limit: 256)
+        #expect(result.value == "0.50.0")
+        #expect(!result.redacted)
+        #expect(ObservedTuple(codexCLIVersion: input).sanitizedForWire()
+            .codexCLIVersion == "0.50.0 [exact:\(ObservedTuple.digest(of: input))]")
+    }
+
+    @Test func tighterIdentityDisplayBoundAlsoHonorsRedactionProvenance() {
+        let input = String(repeating: "a", count: 400) + String(repeating: "\u{301}", count: 350)
+        #expect(!GuesthouseError.sanitizeReporting(input, limit: 256).redacted)
+        #expect(GuesthouseError.sanitizeReporting(input, limit: 234).redacted)
+        #expect(ObservedTuple.bounded(input, limit: 256) == nil)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationRedactionProvenanceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/ObservationRedactionProvenanceTests.swift
@@ -49,7 +49,7 @@ struct ObservationRedactionProvenanceTests {
     @Test func tighterIdentityDisplayBoundAlsoHonorsRedactionProvenance() {
         let input = String(repeating: "a", count: 400) + String(repeating: "\u{301}", count: 350)
         #expect(!GuesthouseError.sanitizeReporting(input, limit: 256).redacted)
-        #expect(GuesthouseError.sanitizeReporting(input, limit: 234).redacted)
+        #expect(GuesthouseError.sanitizeReporting(input, limit: 256 - ObservedTuple.identitySuffixLength).redacted)
         #expect(ObservedTuple.bounded(input, limit: 256) == nil)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeContractHardeningTests {
+    let root = FileManager.default.temporaryDirectory.appending(path: "Containment-\(UUID().uuidString)")
+
+    @Test func danglingLinksAndEscapesAreRefusedWhileInsideLinksResolve() throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: root.appending(path: "dangling"), withDestinationURL: URL(fileURLWithPath: "/nonexistent/outside/new-file"))
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "dangling"), within: root) }
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "dangling/child"), within: root) }
+        try FileManager.default.createDirectory(at: root.appending(path: "real"), withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: root.appending(path: "link"), withDestinationURL: root.appending(path: "real"))
+        #expect(throws: Never.self) { try RequestValidator.validateContainment(of: root.appending(path: "link/file"), within: root) }
+        #expect(throws: Never.self) { try RequestValidator.validateContainment(of: root.appending(path: "real/new-file"), within: root) }
+        try FileManager.default.createSymbolicLink(at: root.appending(path: "escape"), withDestinationURL: URL(fileURLWithPath: "/tmp"))
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "escape/file"), within: root) }
+    }
+
+    @Test func lineSeparatorsAreNotDisplayNames() {
+        for bad in ["Xcode\u{2028}.app", "Xcode\u{2029}.app", "Xcode\u{202E}.app"] {
+            #expect(throws: RequestValidationError.invalidDisplayName) {
+                try RequestValidator.validate(FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: bad))
+            }
+        }
+    }
+
+    @Test func theVersionHeaderIsCheckedBeforeThePayload() throws {
+        let foreign = #"{"protocolVersion":99,"request":{"somethingNewer":{}}}"#
+        let error = #expect(throws: RuntimeRequestEnvelope.ProtocolMismatch.self) { try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: Data(foreign.utf8)) }
+        #expect(error?.client == RuntimeProtocolVersion(99))
+        #expect(error?.error == .protocolMismatch(client: 99, service: RuntimeProtocolVersion.current.rawValue))
+        let current = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .runtimeVersion))
+        #expect(try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: current).request == .runtimeVersion)
+    }
+
+    @Test func progressFractionsOutsideTheContractAreDropped() throws {
+        #expect(ProgressPhase(kind: .copying, fraction: .nan).fraction == nil)
+        #expect(ProgressPhase(kind: .copying, fraction: .infinity).fraction == nil)
+        #expect(ProgressPhase(kind: .copying, fraction: 1.5).fraction == nil)
+        #expect(ProgressPhase(kind: .copying, fraction: -0.1).fraction == nil)
+        #expect(ProgressPhase(kind: .copying, fraction: 0.5).fraction == 0.5)
+        let decoded = try JSONDecoder().decode(ProgressPhase.self, from: Data(#"{"kind":"copying","fraction":7,"cancelable":true}"#.utf8))
+        #expect(decoded.fraction == nil)
+        _ = try JSONEncoder().encode(RuntimeEvent.progress(OperationID(), ProgressPhase(kind: .copying, fraction: .nan)))
+    }
+
+    @Test func observedValuesAreBoundedAndRedactedOnTheWire() throws {
+        let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        let observed = ObservedTuple(codexCLIVersion: "0.50.0 \(token)", codexCLIPath: String(repeating: "x", count: 5_000), codexCLICapabilities: (0..<200).map { "cap\($0)\u{1B}[31m" })
+        let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .ready, observed: observed)
+        #expect(status.observed.codexCLIVersion?.contains(token) == false)
+        #expect(status.observed.codexCLIVersion?.contains("[redacted:github-token]") == true)
+        #expect((status.observed.codexCLIPath?.unicodeScalars.count ?? 0) <= 257)
+        #expect(status.observed.codexCLICapabilities?.count == 64)
+        #expect(status.observed.codexCLICapabilities?.allSatisfy { !$0.contains("\u{1B}") } == true)
+        let decoded = try JSONDecoder().decode(ObservedTuple.self, from: Data(#"{"tartVersion":"\#(token)"}"#.utf8))
+        #expect(decoded.tartVersion == "[redacted:github-token]")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -18,6 +18,44 @@ import Testing
         #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "escape/file"), within: root) }
     }
 
+    @Test func aRootReachedThroughAnAliasStillRefusesDanglingLinks() throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let alias = FileManager.default.temporaryDirectory.appending(path: "Alias-\(UUID().uuidString)")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: root)
+        try FileManager.default.createSymbolicLink(at: root.appending(path: "dangling"), withDestinationURL: URL(fileURLWithPath: "/nonexistent/outside/new-file"))
+        #expect(throws: RequestValidationError.pathEscapesRoot) {
+            try RequestValidator.validateContainment(of: alias.appending(path: "dangling"), within: alias)
+        }
+    }
+
+    @Test func observationsThatBoundToTheSameTextKeepTheirIdentity() {
+        let long = String(repeating: "a", count: 400)
+        let other = String(repeating: "a", count: 401)
+        let first = ObservedTuple(codexCLIPath: long).sanitizedForWire()
+        let second = ObservedTuple(codexCLIPath: other).sanitizedForWire()
+        #expect(first.codexCLIPath != second.codexCLIPath, "two different observations never collapse into one verified value")
+        #expect(first.codexCLIPath?.hasPrefix(String(repeating: "a", count: 100)) == true)
+        #expect((first.codexCLIPath?.unicodeScalars.count ?? 0) <= 256, "the identity suffix counts against the same bound")
+        let short = ObservedTuple(codexCLIPath: "/usr/local/bin/codex").sanitizedForWire()
+        #expect(short.codexCLIPath == "/usr/local/bin/codex", "a value the sanitizer leaves alone is unchanged")
+    }
+
+    @Test func theTartVersionIsSanitizedOnTheWire() throws {
+        let info = RuntimeVersionInfo(serviceVersion: "1.0", serviceBuild: "1", tart: .init(version: "2.36.0\u{1B}[31m evil", verified: true))
+        #expect(info.tart?.version.contains("\u{1B}") == false)
+        let json = #"{"serviceVersion":"1.0","serviceBuild":"1","protocolVersion":1,"tart":{"version":"2.36.0\u001b[31m","verified":true}}"#
+        let decoded = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(json.utf8))
+        #expect(decoded.tart?.version.contains("\u{1B}") == false)
+    }
+
+    @Test func aPhaseFractionIsAlwaysEncodable() throws {
+        let phase = ProgressPhase(kind: .copying, fraction: 0.5)
+        #expect(phase.measured(.nan).fraction == nil)
+        #expect(phase.measured(2).fraction == nil)
+        #expect(phase.measured(0.25).fraction == 0.25)
+        #expect(throws: Never.self) { try JSONEncoder().encode(phase.measured(.infinity)) }
+    }
+
     @Test func lineSeparatorsAreNotDisplayNames() {
         for bad in ["Xcode\u{2028}.app", "Xcode\u{2029}.app", "Xcode\u{202E}.app"] {
             #expect(throws: RequestValidationError.invalidDisplayName) {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -164,15 +164,110 @@ import Testing
         #expect(Set(forged) != Set(capped), "a literal capability cannot pass a different set off as a capped one")
     }
 
-    @Test func textBeyondTheInspectedWindowIsNeverHashed() {
-        // The sanitizer reads the bound plus its lookahead and nothing more, so a secret that
-        // begins past that window is not redacted; a digest over it would confirm a guess.
+    /// The sanitizer reads the bound plus its lookahead and nothing more. A value longer than
+    /// that has a tail nothing inspected: it is neither redacted nor covered by a digest, so two
+    /// such values used to bound to one identical value that still counted as an exact
+    /// observation, and a replaced executable could match the record of the one before it.
+    @Test func anObservationLongerThanTheInspectedWindowIsUnknown() {
         let unseen = String(repeating: "a", count: 800)
-        let first = ObservedTuple(codexCLIPath: unseen + "device-code-one").sanitizedForWire().codexCLIPath
-        let second = ObservedTuple(codexCLIPath: unseen + "device-code-two").sanitizedForWire().codexCLIPath
-        #expect(first == second, "values differing only outside the inspected window carry no distinguishing digest")
-        #expect(first?.contains("[exact:") == true)
+        let first = ObservedTuple(codexCLIPath: unseen + "device-code-one").sanitizedForWire()
+        let second = ObservedTuple(codexCLIPath: unseen + "device-code-two").sanitizedForWire()
+        #expect(first.codexCLIPath == nil)
+        #expect(second.codexCLIPath == nil)
+        #expect(first.unknownFields.contains(.codexCLIPath))
+        // Everything the sanitizer does read keeps its identity; the window is the bound plus
+        // the lookahead, and the first scalar past it is what makes the value unknown.
+        let window = 256 + GuesthouseError.sanitizeLookahead
+        #expect(ObservedTuple(codexCLIPath: String(repeating: "a", count: window)).sanitizedForWire().codexCLIPath?.contains("[exact:") == true)
+        #expect(ObservedTuple(codexCLIPath: String(repeating: "a", count: window + 1)).sanitizedForWire().codexCLIPath == nil)
+        // Nothing past the window is escaped or copied on the way to that answer: the marker
+        // neutralization now runs on the window, not on arbitrarily long CLI output.
+        #expect(ObservedTuple(codexCLIPath: String(repeating: "/opt [exact:0123456789ab] ", count: 100_000)).sanitizedForWire().codexCLIPath == nil)
+        // Escaping doubles every escape scalar, so a value inside the window when it was
+        // measured can leave it before the sanitizer reads it. The tail is then neither
+        // redacted nor visible, and the digest would still cover the credential in it.
+        let token = " ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        let grown = String(repeating: "\u{FFFD}", count: window - token.unicodeScalars.count) + token
+        #expect(grown.unicodeScalars.count == window)
+        #expect(ObservedTuple(codexCLIPath: grown).sanitizedForWire().codexCLIPath == nil)
     }
+
+    /// Two paths that differ only in a credential redact to the same text. Reporting that text
+    /// as an exact observation reused one executable's connection-verification record for
+    /// another (MVP-PLAN.md §5), so a value a secret was removed from is unknown instead.
+    @Test func anObservationASecretWasRemovedFromIsNotAnIdentity() {
+        let first = ObservedTuple(codexCLIPath: "/opt/ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab/codex").sanitizedForWire()
+        let second = ObservedTuple(codexCLIPath: "/opt/ghp_ZYXWVUTSRQPONMLKJIHGFEDCBA9876543210ba/codex").sanitizedForWire()
+        #expect(first.codexCLIPath == nil)
+        #expect(second.codexCLIPath == nil)
+        #expect(first.unknownFields.contains(.codexCLIPath))
+        // A fully known observation stops being exact when one of its values is redacted, so
+        // nothing can be verified against a record that named a different executable.
+        var complete = ObservedTuple(Self.knownTuple)
+        #expect(complete.sanitizedForWire().exact != nil)
+        complete.codexCLIPath = "/opt/ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab/codex"
+        #expect(complete.sanitizedForWire().exact == nil)
+    }
+
+    /// A credential split by a parameterless escape sequence is removed before the redactor
+    /// runs, so the sanitizer used to report the result as merely normalized and an identity
+    /// digest of the original credential was published alongside it.
+    @Test func aCredentialSplicedByAnEscapeCountsAsRedaction() {
+        let spliced = "ghp_ABCDEFGHIJ\u{1B}[KLMNOPQRSTUVWXYZ0123456789ab"
+        let (text, redacted) = GuesthouseError.sanitizeReporting(spliced, limit: 256)
+        #expect(text.contains("[redacted:spliced-escape]"))
+        #expect(redacted, "dropping the spliced run removes a credential; that is redaction, not normalization")
+        let observed = ObservedTuple(codexCLIPath: "/opt/" + spliced).sanitizedForWire()
+        #expect(observed.codexCLIPath == nil, "no digest of the removed credential, and no identity either")
+    }
+
+    /// Every entry is redacted and bounded and the canonical list is built before the 64-entry
+    /// cap applies, so the raw count is what has to be bounded first: otherwise a guest that
+    /// answers a capability probe with its whole output decides how much work a status costs.
+    @Test func aCapabilityListLongerThanAProbeCouldReportIsUnknown() {
+        var reported = ObservedTuple()
+        reported.codexCLICapabilities = (0...ObservedTuple.maximumReportedCapabilities).map { "cap\($0)" }
+        #expect(reported.sanitizedForWire().codexCLICapabilities == nil, "reported unknown rather than inspected in full")
+        var atTheBound = ObservedTuple()
+        atTheBound.codexCLICapabilities = (0..<ObservedTuple.maximumReportedCapabilities).map { "cap\($0)" }
+        #expect(atTheBound.sanitizedForWire().codexCLICapabilities?.count == ObservedTuple.maximumCapabilities)
+    }
+
+    /// A probe may report the same capabilities in any order, or twice. Which entries the cap
+    /// keeps and what the digest covers must not depend on that, or one capability set would
+    /// produce two identities and revalidate a connection that never changed.
+    @Test func aCappedCapabilityListDoesNotDependOnTheOrderItWasReported() {
+        let many = (0..<200).map { "cap\($0)" }
+        // Assigned rather than passed to the initializer, which normalizes on the way in.
+        var reported = ObservedTuple()
+        reported.codexCLICapabilities = many
+        var shuffled = ObservedTuple()
+        shuffled.codexCLICapabilities = many.reversed() + ["cap7", "cap7"]
+        let canonical = reported.sanitizedForWire().codexCLICapabilities
+        #expect(canonical?.count == 64)
+        #expect(canonical == shuffled.sanitizedForWire().codexCLICapabilities, "one capability set has one identity, however it is ordered or repeated")
+        var changed = ObservedTuple()
+        changed.codexCLICapabilities = Array(many.dropLast()) + ["different"]
+        #expect(changed.sanitizedForWire().codexCLICapabilities != canonical, "a set that really differs still does")
+    }
+
+    static let knownTuple = CompatibilityTuple(
+        hostMacOSVersion: SemanticVersion([26, 4]),
+        hostMacOSBuild: "25E200",
+        codexDesktopVersion: "1.2.0",
+        codexDesktopBuild: "120",
+        codexDesktopPath: "/Applications/Codex.app",
+        runtimeProtocolVersion: 1,
+        tartVersion: "2.36.0",
+        guestMacOSBuild: "25E200",
+        xcodeBuild: "17A100",
+        codexCLIVersion: "0.50.0",
+        codexCLIPath: "/usr/local/bin/codex",
+        codexCLIInstallations: 1,
+        codexCLICapabilities: ["apply-patch"],
+        githubCLIVersion: "2.60.0",
+        provisioningScriptVersion: "1.0.0"
+    )
 
     @Test func aSanitizedStatusSurvivesTheWireUnchanged() throws {
         let observed = ObservedTuple(
@@ -214,9 +309,14 @@ import Testing
         let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
         let observed = ObservedTuple(codexCLIVersion: "0.50.0 \(token)", codexCLIPath: String(repeating: "x", count: 5_000), codexCLICapabilities: (0..<200).map { "cap\($0)\u{1B}[31m" })
         let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .ready, observed: observed)
-        #expect(status.observed.codexCLIVersion?.contains(token) == false)
-        #expect(status.observed.codexCLIVersion?.contains("[redacted:github-token]") == true)
-        #expect((status.observed.codexCLIPath?.unicodeScalars.count ?? 0) <= 257)
+        // A value the redactor emptied of a secret, and one longer than the sanitizer reads,
+        // are both unknown: neither can serve as the identity the tuple is compared by.
+        #expect(status.observed.codexCLIVersion == nil)
+        #expect(status.observed.codexCLIPath == nil)
+        #expect(status.observed.unknownFields.contains(.codexCLIVersion))
+        #expect(status.observed.unknownFields.contains(.codexCLIPath))
+        // A value the sanitizer merely normalized keeps its place, and its identity.
+        #expect(ObservedTuple(codexCLIVersion: "0.50.0\u{1B}[31m").sanitizedForWire().codexCLIVersion?.hasPrefix("0.50.0 [exact:") == true)
         #expect(status.observed.codexCLICapabilities?.count == 64)
         #expect(status.observed.codexCLICapabilities?.allSatisfy { !$0.contains("\u{1B}") } == true)
         let decoded = try JSONDecoder().decode(ObservedTuple.self, from: Data(#"{"tartVersion":"\#(token)"}"#.utf8))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -108,7 +108,7 @@ import Testing
         let second = ObservedTuple(codexCLICapabilities: other).sanitizedForWire().codexCLICapabilities
         #expect(first?.count == 64)
         #expect(first != second, "two lists that share their first entries keep different identities")
-        #expect(first?.last?.contains("137 more") == true)
+        #expect(first?.contains { $0.contains("137 more") } == true)
         let few = ObservedTuple(codexCLICapabilities: ["a", "b"]).sanitizedForWire().codexCLICapabilities
         #expect(few == ["a", "b"], "a list under the cap is untouched")
     }
@@ -148,6 +148,66 @@ import Testing
         let decoded = try JSONDecoder().decode(ProgressPhase.self, from: Data(#"{"kind":"copying","fraction":7,"cancelable":true}"#.utf8))
         #expect(decoded.fraction == nil)
         _ = try JSONEncoder().encode(RuntimeEvent.progress(OperationID(), ProgressPhase(kind: .copying, fraction: .nan)))
+    }
+
+    @Test func neutralizingAnIdentityMarkerIsInjective() {
+        let plain = ObservedTuple(codexCLIPath: "/opt/tool [exact:0123456789ab]").sanitizedForWire().codexCLIPath
+        let alreadyEscaped = ObservedTuple(codexCLIPath: "/opt/tool [exact\u{FFFD}:0123456789ab]").sanitizedForWire().codexCLIPath
+        #expect(plain != alreadyEscaped, "neutralizing a marker never maps two reported values onto one identity")
+    }
+
+    @Test func aLiteralCapabilityCannotImpersonateACappedList() {
+        let capped = ObservedTuple(codexCLICapabilities: (0..<200).map { "cap\($0)" }).sanitizedForWire().codexCLICapabilities ?? []
+        // A probe reporting the capped list verbatim stays under the cap, so its entries are
+        // taken literally; the omitted-count entry must not survive that as an identity.
+        let forged = ObservedTuple(codexCLICapabilities: capped).sanitizedForWire().codexCLICapabilities ?? []
+        #expect(Set(forged) != Set(capped), "a literal capability cannot pass a different set off as a capped one")
+    }
+
+    @Test func textBeyondTheInspectedWindowIsNeverHashed() {
+        // The sanitizer reads the bound plus its lookahead and nothing more, so a secret that
+        // begins past that window is not redacted; a digest over it would confirm a guess.
+        let unseen = String(repeating: "a", count: 800)
+        let first = ObservedTuple(codexCLIPath: unseen + "device-code-one").sanitizedForWire().codexCLIPath
+        let second = ObservedTuple(codexCLIPath: unseen + "device-code-two").sanitizedForWire().codexCLIPath
+        #expect(first == second, "values differing only outside the inspected window carry no distinguishing digest")
+        #expect(first?.contains("[exact:") == true)
+    }
+
+    @Test func aSanitizedStatusSurvivesTheWireUnchanged() throws {
+        let observed = ObservedTuple(
+            codexDesktopPath: String(repeating: "a", count: 400),
+            codexCLICapabilities: (0..<200).map { "cap\($0)" }
+        )
+        let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .ready, observed: observed)
+        #expect(status.observed.codexDesktopPath?.contains("[exact:") == true)
+        let decoded = try JSONDecoder().decode(EnvironmentStatus.self, from: JSONEncoder().encode(status))
+        #expect(decoded == status, "the receiver evaluates the identity the sender computed, not a re-escaped one")
+    }
+
+    @Test func credentialShapedDisplayNamesAreRefused() {
+        // The bundle name ends where the extension begins, which is no word boundary at all.
+        for bad in ["ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab.app", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sig"] {
+            #expect(throws: RequestValidationError.invalidDisplayName, "\(bad)") {
+                try RequestValidator.validate(FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: bad))
+            }
+        }
+        // A decomposed name is ordinary on this filesystem; only a credential is refused.
+        for good in ["Xcode.app", "Cafe\u{301}.app"] {
+            #expect(throws: Never.self, "\(good)") {
+                try RequestValidator.validate(FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: good))
+            }
+        }
+    }
+
+    @Test func anUncertainReasonIsBoundedAndRedacted() throws {
+        let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        let state = EnvironmentStatus.VMState.uncertain(reason: SanitizedText("pid 42 \u{1B}[31mheld \(token)"))
+        guard case .uncertain(let reason) = state else { Issue.record("not uncertain"); return }
+        #expect(!reason.value.contains(token))
+        #expect(!reason.value.contains("\u{1B}"))
+        let decoded = try JSONDecoder().decode(EnvironmentStatus.VMState.self, from: Data(#"{"uncertain":{"reason":"\#(token)"}}"#.utf8))
+        #expect(decoded == .uncertain(reason: "[redacted:github-token]"))
     }
 
     @Test func observedValuesAreBoundedAndRedactedOnTheWire() throws {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -65,6 +65,42 @@ import Testing
         #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: dangling.appending(path: "x"), within: dangling) }
     }
 
+    @Test func aDanglingAncestorOfTheRootIsRefused() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "Ancestor-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: base.appending(path: "link"), withDestinationURL: URL(fileURLWithPath: "/nonexistent/outside"))
+        let root = base.appending(path: "link/subroot")
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root, within: root) }
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "Xcode.app"), within: root) }
+    }
+
+    @Test func aForgedIdentityMarkerCannotImpersonateAnotherValue() {
+        let long = String(repeating: "a", count: 400)
+        let shortened = ObservedTuple(codexCLIPath: long).sanitizedForWire().codexCLIPath ?? ""
+        // A CLI that reports the shortened text verbatim must not produce the same value.
+        let forged = ObservedTuple(codexCLIPath: shortened).sanitizedForWire().codexCLIPath
+        #expect(forged != shortened, "the shortened text of one observation is not the identity of another")
+        // A short value that carries the marker literally keeps it neutralized and unchanged
+        // otherwise, so it can never be read as an identity this type produced.
+        let literal = ObservedTuple(codexCLIPath: "/opt/tool [exact:0123456789ab]").sanitizedForWire().codexCLIPath
+        #expect(literal == "/opt/tool [exact\u{FFFD}:0123456789ab]")
+    }
+
+    @Test func capabilityDigestsDistinguishSeparatorPlacement() {
+        let base = (0..<63).map { "cap\($0)" }
+        let first = ObservedTuple(codexCLICapabilities: base + ["a", "b\u{0}c"]).sanitizedForWire().codexCLICapabilities
+        let second = ObservedTuple(codexCLICapabilities: base + ["a\u{0}b", "c"]).sanitizedForWire().codexCLICapabilities
+        #expect(first != second, "the digest is over a length-prefixed encoding, so the separator cannot move")
+    }
+
+    @Test func aDisplayNameIsBoundedByScalarsNotCharacters() {
+        let oneCharacter = "👩" + String(repeating: "\u{1F3FB}", count: 5_000)
+        #expect(oneCharacter.count == 1)
+        #expect(throws: RequestValidationError.invalidDisplayName) {
+            try RequestValidator.validate(FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: oneCharacter))
+        }
+    }
+
     @Test func aCappedCapabilityListKeepsItsIdentity() {
         let many = (0..<200).map { "cap\($0)" }
         var other = many; other[199] = "different"

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -320,6 +320,7 @@ import Testing
         #expect(status.observed.codexCLICapabilities?.count == 64)
         #expect(status.observed.codexCLICapabilities?.allSatisfy { !$0.contains("\u{1B}") } == true)
         let decoded = try JSONDecoder().decode(ObservedTuple.self, from: Data(#"{"tartVersion":"\#(token)"}"#.utf8))
-        #expect(decoded.tartVersion == "[redacted:github-token]")
+        #expect(decoded.tartVersion == nil)
+        #expect(decoded.unknownFields.contains(.tartVersion))
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractHardeningTests.swift
@@ -56,6 +56,36 @@ import Testing
         #expect(throws: Never.self) { try JSONEncoder().encode(phase.measured(.infinity)) }
     }
 
+    @Test func aDanglingRootIsRefused() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "Root-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let dangling = base.appending(path: "import")
+        try FileManager.default.createSymbolicLink(at: dangling, withDestinationURL: URL(fileURLWithPath: "/nonexistent/outside/new-file"))
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: dangling, within: dangling) }
+        #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: dangling.appending(path: "x"), within: dangling) }
+    }
+
+    @Test func aCappedCapabilityListKeepsItsIdentity() {
+        let many = (0..<200).map { "cap\($0)" }
+        var other = many; other[199] = "different"
+        let first = ObservedTuple(codexCLICapabilities: many).sanitizedForWire().codexCLICapabilities
+        let second = ObservedTuple(codexCLICapabilities: other).sanitizedForWire().codexCLICapabilities
+        #expect(first?.count == 64)
+        #expect(first != second, "two lists that share their first entries keep different identities")
+        #expect(first?.last?.contains("137 more") == true)
+        let few = ObservedTuple(codexCLICapabilities: ["a", "b"]).sanitizedForWire().codexCLICapabilities
+        #expect(few == ["a", "b"], "a list under the cap is untouched")
+    }
+
+    @Test func aForgedRedactionMarkerDoesNotSuppressTheIdentity() {
+        let a = "/opt/[redacted:token]/" + String(repeating: "a", count: 400)
+        let b = "/opt/[redacted:token]/" + String(repeating: "a", count: 401)
+        let first = ObservedTuple(codexCLIPath: a).sanitizedForWire().codexCLIPath
+        let second = ObservedTuple(codexCLIPath: b).sanitizedForWire().codexCLIPath
+        #expect(first != second, "marker text in the value is not evidence that a secret was removed")
+        #expect(first?.contains("[exact:") == true)
+    }
+
     @Test func lineSeparatorsAreNotDisplayNames() {
         for bad in ["Xcode\u{2028}.app", "Xcode\u{2029}.app", "Xcode\u{202E}.app"] {
             #expect(throws: RequestValidationError.invalidDisplayName) {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeContractTests {
+    static let environment = EnvironmentID()
+    static let operation = OperationID()
+
+    static let requests: [RuntimeRequest] = [
+        .runtimeVersion,
+        .environmentStatus(environment),
+        .startEnvironment(environment, StartOptions()),
+        .startEnvironment(environment, StartOptions(console: .native, ipWait: .seconds(120))),
+        .stopEnvironment(environment, .graceful(deadline: .seconds(60))),
+        .stopEnvironment(environment, .force),
+        .importXcode(environment, FileHandoff(kind: .securityScopedBookmark(Data(repeating: 7, count: 512)), displayName: "Xcode.app", expectedBundleIdentifier: "com.apple.dt.Xcode")),
+        .importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")),
+        .cancelOperation(operation),
+    ]
+
+    static let events: [RuntimeEvent] = [
+        .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12", tart: .init(version: "2.36.0", verified: true))),
+        .accepted(operation),
+        .progress(operation, ProgressPhase(kind: .waitingForNetwork, fraction: 0.5)),
+        .progress(operation, ProgressPhase(kind: .copying, fraction: nil, cancelable: false)),
+        .log(operation, RedactedLine(literal: "Started")),
+        .log(nil, RedactedLine(literal: "Service launched")),
+        .status(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: operation, observed: ObservedTuple(tartVersion: "2.36.0"), reconciledAt: Date(timeIntervalSince1970: 1_800_000_000))),
+        .status(EnvironmentStatus(environmentID: environment, vm: .uncertain(reason: "pid reused"), readiness: .needsAttention(.operationOutcomeUnknown(operation)))),
+        .completed(operation),
+        .failed(operation, .guestNotReachable(environment)),
+    ]
+
+    @Test(arguments: requests)
+    func requestsRoundTrip(request: RuntimeRequest) throws {
+        let envelope = RuntimeRequestEnvelope(request: request)
+        let data = try JSONEncoder().encode(envelope)
+        #expect(try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data) == envelope)
+        try RequestValidator.validateEncodedSize(data)
+        try RequestValidator.validate(envelope)
+    }
+
+    @Test(arguments: events)
+    func eventsRoundTrip(event: RuntimeEvent) throws {
+        let data = try JSONEncoder().encode(event)
+        #expect(try JSONDecoder().decode(RuntimeEvent.self, from: data) == event)
+    }
+
+    @Test func noRequestCarriesAnExecutableOrFlag() throws {
+        for request in Self.requests {
+            let data = try JSONEncoder().encode(request)
+            let json = String(decoding: data, as: UTF8.self).lowercased()
+            for forbidden in ["executable", "argument", "command", "shell", "flag", "--", "/bin/", "/usr/"] {
+                #expect(!json.contains(forbidden), "\(request.caseName) contains \(forbidden)")
+            }
+        }
+    }
+
+    @Test func wrongProtocolVersionIsRejected() {
+        let envelope = RuntimeRequestEnvelope(protocolVersion: RuntimeProtocolVersion(99), request: .runtimeVersion)
+        #expect(throws: RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(99), service: .current)) {
+            try RequestValidator.validate(envelope)
+        }
+        #expect(RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(99), service: .current).guesthouseError
+            == .protocolMismatch(client: 99, service: RuntimeProtocolVersion.current.rawValue))
+    }
+
+    @Test func oversizedMessagesAreRejectedBeforeDecoding() {
+        let big = Data(repeating: 0x20, count: RequestValidator.maximumEncodedSize + 1)
+        #expect(throws: RequestValidationError.oversized(bytes: big.count, limit: RequestValidator.maximumEncodedSize)) {
+            try RequestValidator.validateEncodedSize(big)
+        }
+        let bigBookmark = FileHandoff(kind: .securityScopedBookmark(Data(repeating: 1, count: RequestValidator.maximumBookmarkSize + 1)), displayName: "Xcode.app")
+        #expect(throws: RequestValidationError.self) {
+            try RequestValidator.validate(RuntimeRequestEnvelope(request: .importXcode(Self.environment, bigBookmark)))
+        }
+        let emptyBookmark = FileHandoff(kind: .securityScopedBookmark(Data()), displayName: "Xcode.app")
+        #expect(throws: RequestValidationError.self) {
+            try RequestValidator.validate(emptyBookmark)
+        }
+    }
+
+    @Test func optionBoundsAreEnforced() {
+        #expect(throws: RequestValidationError.optionOutOfRange("ipWait")) {
+            try RequestValidator.validate(RuntimeRequestEnvelope(request: .startEnvironment(Self.environment, StartOptions(ipWait: .seconds(301)))))
+        }
+        #expect(throws: RequestValidationError.optionOutOfRange("deadline")) {
+            try RequestValidator.validate(RuntimeRequestEnvelope(request: .stopEnvironment(Self.environment, .graceful(deadline: .zero))))
+        }
+    }
+
+    @Test func displayNamesCannotBePaths() {
+        for bad in ["", "../Xcode.app", "Applications/Xcode.app", "Xcode\n.app", String(repeating: "x", count: 256)] {
+            #expect(throws: RequestValidationError.invalidDisplayName) {
+                try RequestValidator.validate(FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: bad))
+            }
+        }
+    }
+
+    @Test func vmNamesMustBeAppManaged() throws {
+        try RequestValidator.validateVMName(EnvironmentID().tartVMName)
+        for bad in ["guesthouse-1a2b3c4d", "GUESTHOUSE-\(UUID().uuidString.lowercased())", "guesthouse-\(UUID().uuidString)", "../\(EnvironmentID().tartVMName)", "ubuntu", ""] {
+            #expect(throws: RequestValidationError.invalidVMName, "\(bad)") {
+                try RequestValidator.validateVMName(bad)
+            }
+        }
+    }
+
+    @Test func containmentFollowsSymlinksAndRejectsEscapes() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "containment-\(UUID().uuidString)")
+        let root = base.appending(path: "root")
+        let sibling = base.appending(path: "root-sibling")
+        let outside = base.appending(path: "outside")
+        for dir in [root, sibling, outside] {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+        let inside = root.appending(path: "Xcode.app")
+        try FileManager.default.createDirectory(at: inside, withIntermediateDirectories: true)
+        let escapeLink = root.appending(path: "escape")
+        try FileManager.default.createSymbolicLink(at: escapeLink, withDestinationURL: outside)
+        let innerLink = root.appending(path: "alias")
+        try FileManager.default.createSymbolicLink(at: innerLink, withDestinationURL: inside)
+
+        #expect(try RequestValidator.validateContainment(of: inside, within: root).lastPathComponent == "Xcode.app")
+        #expect(try RequestValidator.validateContainment(of: innerLink, within: root).lastPathComponent == "Xcode.app")
+        #expect(throws: RequestValidationError.pathEscapesRoot) {
+            try RequestValidator.validateContainment(of: escapeLink, within: root)
+        }
+        #expect(throws: RequestValidationError.pathEscapesRoot) {
+            try RequestValidator.validateContainment(of: escapeLink.appending(path: "file"), within: root)
+        }
+        #expect(throws: RequestValidationError.pathEscapesRoot) {
+            try RequestValidator.validateContainment(of: root.appending(path: "../outside"), within: root)
+        }
+        #expect(throws: RequestValidationError.pathEscapesRoot) {
+            try RequestValidator.validateContainment(of: sibling, within: root)
+        }
+        #expect(throws: RequestValidationError.invalidPath) {
+            try RequestValidator.validateContainment(of: URL(string: "https://example.com")!, within: root)
+        }
+    }
+
+    @Test func validationErrorsMapToUserFacingErrors() {
+        #expect(RequestValidationError.pathEscapesRoot.guesthouseError == .invalidRequest(.pathEscapesAllowedRoot))
+        #expect(RequestValidationError.invalidVMName.guesthouseError == .invalidRequest(.invalidVMName))
+        #expect(RequestValidationError.oversized(bytes: 1, limit: 0).guesthouseError == .invalidRequest(.oversized))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventEnvelopeTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventEnvelopeTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct RuntimeEventEnvelopeTests {
+    @Test(arguments: [
+        RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12")),
+        .accepted(OperationID()),
+        .progress(OperationID(), ProgressPhase(kind: .copying, fraction: 0.5)),
+        .log(OperationID(), RedactedLine(literal: "Started")),
+        .log(nil, RedactedLine(literal: "Service launched")),
+        .status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .running, readiness: .ready)),
+        .completed(OperationID()),
+        .failed(OperationID(), .guestNotReachable(EnvironmentID()))
+    ])
+    func eventCasesRoundTrip(event: RuntimeEvent) throws {
+        let envelope = RuntimeEventEnvelope(event: event)
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+
+        #expect(decoded == envelope)
+        #expect(decoded.protocolVersion == .current)
+    }
+
+    @Test
+    func wireKeysKeepVersionOutsideEvent() throws {
+        let data = try JSONEncoder().encode(RuntimeEventEnvelope(event: .completed(OperationID())))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == ["protocolVersion", "event"])
+        #expect(object["protocolVersion"] as? Int == RuntimeProtocolVersion.current.rawValue)
+        #expect(object["event"] is [String: Any])
+    }
+
+    @Test(arguments: [0, 99])
+    func foreignVersionRejectsUnknownEventBeforePayload(serviceVersion: Int) throws {
+        // Put the event first in the encoded object: JSON key order must not affect validation.
+        let json = #"{"event":{"futureReply":{}},"protocolVersion":\#(serviceVersion)}"#
+        let mismatch = try #require(#expect(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: Data(json.utf8))
+        })
+
+        #expect(mismatch.service == RuntimeProtocolVersion(serviceVersion))
+        #expect(mismatch.error == .protocolMismatch(
+            client: RuntimeProtocolVersion.current.rawValue,
+            service: serviceVersion
+        ))
+    }
+
+    @Test
+    func currentVersionUnknownEventIsMalformed() throws {
+        let json = #"{"protocolVersion":\#(RuntimeProtocolVersion.current.rawValue),"event":{"futureReply":{}}}"#
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: Data(json.utf8))
+        })
+
+        guard case .typeMismatch = error else {
+            Issue.record("An unknown current-version event must be a malformed payload: \(error)")
+            return
+        }
+    }
+
+    @Test
+    func missingVersionRefusesOtherwiseValidEvent() throws {
+        let data = try JSONEncoder().encode(RuntimeEventEnvelope(event: .completed(OperationID())))
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "protocolVersion")
+
+        try expectMissingVersion(try JSONSerialization.data(withJSONObject: object))
+    }
+
+    @Test
+    func bareEventHasNoUnversionedFallback() throws {
+        try expectMissingVersion(try JSONEncoder().encode(RuntimeEvent.completed(OperationID())))
+    }
+
+    @Test
+    func foreignHeaderWinsOverSupportedNestedVersion() throws {
+        let envelope = RuntimeEventEnvelope(
+            protocolVersion: RuntimeProtocolVersion(99),
+            event: .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12"))
+        )
+        let data = try JSONEncoder().encode(envelope)
+
+        #expect(throws: RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        }
+    }
+
+    @Test
+    func currentHeaderWithContradictoryNestedVersionIsMalformed() throws {
+        let envelope = RuntimeEventEnvelope(event: .runtimeVersion(RuntimeVersionInfo(
+            serviceVersion: "0.1.0",
+            serviceBuild: "12",
+            protocolVersion: RuntimeProtocolVersion(99)
+        )))
+        let data = try JSONEncoder().encode(envelope)
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        })
+
+        guard case .dataCorrupted(let context) = error else {
+            Issue.record("Contradictory nested version information must be malformed: \(error)")
+            return
+        }
+        #expect(context.codingPath.map(\.stringValue) == ["event"])
+    }
+
+    private func expectMissingVersion(_ data: Data) throws {
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        })
+        guard case .keyNotFound(let key, _) = error else {
+            Issue.record("An unversioned reply must fail at its missing header: \(error)")
+            return
+        }
+        #expect(key.stringValue == "protocolVersion")
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Closed reference — retained scope is merged through replacements. Do not merge this historical stack.**
>
> The [September 9 retained-scope audit](https://github.com/PicoMLX/Guesthouse/pull/58#issuecomment-5613838005) maps the Core contract to merged #139/#140/#143–#147 and native integration through #148–#160. ADR 0003 explicitly supersedes the old sanitize/hash/display-identity mechanism; its source and regressions remain preserved here.
>
> The decomposition finding is [addressed through merged slices](https://github.com/PicoMLX/Guesthouse/pull/58#discussion_r3975960408), not a waiver of this old diff's size. #9 is closed. Remaining signed-GUI, unsigned-client procedure, downstream audit, mutation/recovery and GUI/export obligations stay with their own issues; closing this reference does not mark them complete.
>
> Branch, code, tests and review history are retained. Follow [issue #48](https://github.com/PicoMLX/Guesthouse/issues/48) for the active queue. The original description below is historical and unchanged.

---

## Summary

Implements #9 (`MVP-PLAN.md` §3 "Sandbox and XPC boundary": named operations with environment IDs and validated configuration; authenticate callers, validate message sizes and paths, reject symlink escapes; the service, never the client, chooses executable paths and arguments). Stacked on #57. Transport is #19; this PR is only the messages and the checks.

- `RuntimeProtocolVersion` and `RuntimeRequestEnvelope`: every message carries the version; a mismatch is rejected.
- `RuntimeRequest`: `runtimeVersion`, `environmentStatus`, `startEnvironment(StartOptions)`, `stopEnvironment(StopMode)`, `importXcode(FileHandoff)`, `cancelOperation`. `StartOptions` has a console mode and a bounded IP wait; `StopMode` is `graceful(deadline:)` or `force`.
- `RuntimeEvent`: `runtimeVersion(info)`, `accepted`, `progress(ProgressPhase)`, `log(RedactedLine)`, `status(EnvironmentStatus)`, `completed`, `failed(GuesthouseError)`. `EnvironmentStatus` carries VM state (including `uncertain`), readiness (including `checking`), the in-flight operation, and an `ObservedTuple` of versions.
- `FileHandoff`: a security-scoped bookmark or an out-of-band descriptor token, plus a display name that is never used to open anything.
- `RequestValidator`: encoded-size cap before decoding, bookmark-size cap, option ranges, display-name rules, the exact `guesthouse-<uuid>` VM-name form, and `validateContainment(of:within:)`, which resolves symlinks through the deepest existing ancestor so `<symlink-to-outside>/new-file` cannot pass. `RequestValidationError` maps to `GuesthouseError`.

Tests (10, several parameterized): round trips for every request and event, a check that no request JSON contains executables, arguments, flags, or shell paths, protocol mismatch, oversized messages and bookmarks, option bounds, display names that are paths, VM-name form, and containment with real temp directories (symlink inside root to outside, nonexistent child of that symlink, `..`, and a sibling directory sharing the root's name prefix).

Closes #9

## Checklist

- [x] Tests cover the new logic; all 334 Core tests pass with warnings-as-errors at f03f2bc
- [x] No new warnings
- [x] No new dependencies
- [x] No secrets
- [x] No process launched anywhere in this change
- [ ] Full base-relative diff is over the roughly 500-line limit; contract and regression decomposition remains outstanding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Overnight review follow-up (2026-09-05)

Current head: f03f2bc. All 334 Core tests pass with warnings-as-errors, and both exact-head Xcode Cloud checks passed. Codex review is pending. Regressions reproduced discarded-control payload identity hashing, decode-time credential identity collapse, and a display-cut sender/decoder mismatch before their respective fixes.

- Preserve redaction provenance across initial truncation, arbitrary control-string removal, and the narrower second display pass. Ordinary non-secret terminal styling keeps the existing identity behavior.
- Retain all 256 SHA-256 digest bits and count the entire suffix in the 128/256-scalar bounds. Decode only already-bounded, unchanged sanitized identities; an unsafe field or capability set becomes unknown. Previously saved short-digest identities for bounded values require re-verification.
- Add RuntimeEventEnvelope and version-first decoding tests for every current event case, foreign/unknown payloads, missing headers, and contradictory nested runtime-version metadata. This is the initial Core contract; the native-XPC boundary is implemented in later stack layers.

Four identity/provenance findings have evidence-backed replies and are resolved. The event-envelope finding remains open until #67 and later reply/push/client/UI sites adopt the wrapper and preserve actionable mismatch errors without clearing unknown mutation outcomes. Descendant protocol-version changes must be reconciled during integration. CI is not a substitute for approval or unresolved-finding checks.

The full base-relative diff is 1458 lines; its roughly 500-line decomposition remains explicitly unfinished, not waived as Codable plumbing. Base remains #57. No merges, force pushes, or hardware/VM operations performed.
