### PR TITLE
Core: RuntimeBackend protocol and FakeRuntimeBackend for previews and tests

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -48,6 +48,9 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
+    /// Consumer cancellations a reservation kept out of `receivedRequests`. They are replayed
+    /// if that reserved request turns out never to have taken effect.
+    private var suppressedCancellations: Set<OperationID> = []
 
     private var servingTicket: UInt64 = 0
     private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
@@ -162,6 +165,9 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         }
 
         let id = binding.seededOperationID ?? OperationID()
+        // `accepted` means journaled and in flight, so the environment's stored status names
+        // the operation from here until its terminal event, whether or not a caller seeded it.
+        markInFlight(id, for: request)
         continuation.yield(.accepted(id))
         advanceTurn()
 
@@ -176,7 +182,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             // terminal event, so a status query never sees an idle environment mid-stream.
             guard !cancelled(id, continuation) else { return }
             if let status {
-                statuses[status.environmentID] = status
+                // The scripted status is stored with the operation still in flight, since it
+                // does not end until `completed`: a status query during the pause below must
+                // not see an idle environment.
+                var stored = status
+                stored.inFlightOperation = status.inFlightOperation ?? id
+                statuses[status.environmentID] = stored
                 continuation.yield(.status(status))
                 await pause()
                 guard !cancelled(id, continuation) else { return }
@@ -210,6 +221,10 @@ public actor FakeRuntimeBackend: RuntimeBackend {
                 guard await progress(id, phase, continuation) else { return }
             }
             await pause()
+            // A consumer that went away during the pause cancelled the operation, exactly as
+            // in the other branches: it is recorded and ends as canceled rather than leaving
+            // a seeded operation in flight behind a connection loss nobody is listening for.
+            guard !cancelled(id, continuation) else { return }
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }
     }
@@ -235,13 +250,32 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     }
 
     /// Undoes the reservation `send` made for a cancellation request that did not succeed.
-    private nonisolated func releaseReservation(of id: OperationID) {
+    ///
+    /// A consumer cancellation the reservation suppressed meanwhile is recorded now: the
+    /// request that stood in for it never took effect, so the consumer's own cancellation is
+    /// the only one that happened and `receivedRequests` must show it.
+    private func releaseReservation(of id: OperationID) {
         configuration.withLock { _ = $0.explicitCancellations.remove(id) }
+        guard suppressedCancellations.remove(id) != nil else { return }
+        canceledOperations.insert(id)
+        let ticket = nextTicket()
+        Task { await self.appendCancellation(of: id, ticket: ticket) }
     }
 
     private func clearInFlight(_ id: OperationID) {
         for (environment, status) in statuses where status.inFlightOperation == id {
             statuses[environment]?.inFlightOperation = nil
+        }
+    }
+
+    /// Names the operation in the environment's stored status, when one is stored. A fake with
+    /// no status for that environment stays silent rather than inventing VM and readiness state.
+    private func markInFlight(_ id: OperationID, for request: RuntimeRequest) {
+        switch request {
+        case .startEnvironment(let environment, _), .stopEnvironment(let environment, _), .importXcode(let environment, _):
+            statuses[environment]?.inFlightOperation = id
+        case .runtimeVersion, .environmentStatus, .cancelOperation:
+            break
         }
     }
 
@@ -254,13 +288,23 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// that was made before the consumer went away.
     private func recordImplicitCancellation(of id: OperationID) {
         let explicit = configuration.withLock { $0.explicitCancellations.contains(id) }
-        guard Task.isCancelled, !canceledOperations.contains(id), !explicit else { return }
+        guard Task.isCancelled, !canceledOperations.contains(id) else { return }
+        // The reserved request may still fail, so what it suppressed is remembered rather
+        // than dropped: releasing the reservation replays it.
+        if explicit {
+            suppressedCancellations.insert(id)
+            return
+        }
         canceledOperations.insert(id)
-        let ticket = configuration.withLock { configuration -> UInt64 in
+        let ticket = nextTicket()
+        Task { await self.appendCancellation(of: id, ticket: ticket) }
+    }
+
+    private nonisolated func nextTicket() -> UInt64 {
+        configuration.withLock { configuration -> UInt64 in
             defer { configuration.nextTicket += 1 }
             return configuration.nextTicket
         }
-        Task { await self.appendCancellation(of: id, ticket: ticket) }
     }
 
     private func appendCancellation(of id: OperationID, ticket: UInt64) async {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -30,6 +30,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
+    private var pendingOperationIDs: [String: OperationID] = [:]
 
     private nonisolated let ticketCounter = Mutex<UInt64>(0)
     private var servingTicket: UInt64 = 0
@@ -58,6 +59,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     public func status(of id: EnvironmentID) -> EnvironmentStatus? {
         statuses[id]
+    }
+
+    /// Makes the next request with this case name use `id` as its operation id, so a preview
+    /// or test can correlate a pre-seeded `EnvironmentStatus.inFlightOperation` with the events.
+    public func useOperationID(_ id: OperationID, forNext caseName: String) {
+        pendingOperationIDs[caseName] = id
     }
 
     // MARK: - RuntimeBackend
@@ -102,16 +109,28 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             return
 
         case .cancelOperation(let id):
-            canceledOperations.insert(id)
             advanceTurn()
-            continuation.finish()
+            await pause()
+            switch scenario {
+            case .disconnect:
+                continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
+            case .fail(_, let error):
+                continuation.yield(.failed(id, error))
+                continuation.finish()
+            case .hang:
+                while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(5)) }
+                continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
+            case .succeed:
+                canceledOperations.insert(id)
+                continuation.finish()
+            }
             return
 
         case .startEnvironment, .stopEnvironment, .importXcode:
             break
         }
 
-        let id = OperationID()
+        let id = pendingOperationIDs.removeValue(forKey: request.caseName) ?? OperationID()
         continuation.yield(.accepted(id))
         advanceTurn()
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -33,6 +33,9 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         var scenarios: [String: Scenario] = [:]
         var pendingOperationIDs: [String: OperationID] = [:]
         var nextTicket: UInt64 = 0
+        /// Cancellations reserved by `send` before any producer can run, so an explicit
+        /// request is never mistaken for a consumer that merely stopped listening.
+        var explicitCancellations: Set<OperationID> = []
     }
 
     /// What one `send` bound when it was called.
@@ -87,6 +90,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         // the seeded id intended for the earlier one.
         let (ticket, binding) = configuration.withLock { configuration in
             defer { configuration.nextTicket += 1 }
+            if case .cancelOperation(let id) = request { configuration.explicitCancellations.insert(id) }
             return (configuration.nextTicket, Binding(
                 scenario: configuration.scenarios[request.caseName] ?? .succeed(),
                 seededOperationID: configuration.pendingOperationIDs.removeValue(forKey: request.caseName)
@@ -161,9 +165,14 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             for phase in phases {
                 guard await progress(id, phase, continuation) else { return }
             }
+            // The operation has ended: it is no longer in flight for any environment, with or
+            // without a scripted replacement status.
+            clearInFlight(id)
+            await pause()
             if let status {
                 statuses[status.environmentID] = status
                 continuation.yield(.status(status))
+                await pause()
             }
             continuation.yield(.completed(id))
             continuation.finish()
@@ -174,6 +183,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             }
             // A failed operation is no longer in flight for any environment.
             clearInFlight(id)
+            await pause()
             continuation.yield(.failed(id, error))
             continuation.finish()
 
@@ -190,6 +200,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             for phase in phases {
                 guard await progress(id, phase, continuation) else { return }
             }
+            await pause()
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }
     }
@@ -199,6 +210,8 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         await pause()
         if Task.isCancelled || canceledOperations.contains(id) {
             recordImplicitCancellation(of: id)
+            // A cancelled operation is no longer in flight either, however it was cancelled.
+            clearInFlight(id)
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
             return false
@@ -215,8 +228,11 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     /// A consumer that stops listening counts as one cancel request, unless the operation was
     /// already canceled explicitly: `receivedRequests` then still mirrors real `send` calls.
+    /// The explicit request reserves the id in `send`, before any producer can run, so the
+    /// two never race.
     private func recordImplicitCancellation(of id: OperationID) {
-        guard Task.isCancelled, !canceledOperations.contains(id) else { return }
+        let explicit = configuration.withLock { $0.explicitCancellations.contains(id) }
+        guard Task.isCancelled, !canceledOperations.contains(id), !explicit else { return }
         canceledOperations.insert(id)
         receivedRequests.append(.cancelOperation(id))
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// A scripted `RuntimeBackend` for SwiftUI previews and tests. Performs no I/O.
+///
+/// Scenarios are keyed by request case name. Each `send` records the request, so tests can
+/// assert what the GUI asked for, including the `cancelOperation` the fake records when a
+/// consumer stops reading a hanging operation.
+public actor FakeRuntimeBackend: RuntimeBackend {
+    public enum Scenario: Sendable {
+        /// `accepted`, the given phases, an optional status, then `completed`.
+        case succeed(phases: [ProgressPhase] = [], status: EnvironmentStatus? = nil)
+        /// `accepted`, the given phases, then `failed(error)`.
+        case fail(after: [ProgressPhase] = [], error: GuesthouseError)
+        /// `accepted`, then nothing until the consumer cancels; the fake then records
+        /// `cancelOperation` and ends with `failed(.canceled)`.
+        case hang
+        /// `accepted`, the given phases, then the stream throws `RuntimeConnectionInterrupted`.
+        case disconnect(after: [ProgressPhase] = [])
+    }
+
+    /// Pause between events, so previews can show progress.
+    public var delay: Duration
+    public private(set) var receivedRequests: [RuntimeRequest] = []
+
+    private var scenarios: [String: Scenario] = [:]
+    private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
+    private var versionInfo: RuntimeVersionInfo
+
+    public init(delay: Duration = .zero, versionInfo: RuntimeVersionInfo = RuntimeVersionInfo(serviceVersion: "0.0.0", serviceBuild: "fake", tart: .init(version: "2.36.0", verified: true))) {
+        self.delay = delay
+        self.versionInfo = versionInfo
+    }
+
+    // MARK: - Scripting
+
+    /// Sets the scenario for every request whose `caseName` matches, for example `"startEnvironment"`.
+    public func script(_ caseName: String, _ scenario: Scenario) {
+        scenarios[caseName] = scenario
+    }
+
+    /// The status returned for `environmentStatus(id)`.
+    public func setStatus(_ status: EnvironmentStatus) {
+        statuses[status.environmentID] = status
+    }
+
+    public func setVersionInfo(_ info: RuntimeVersionInfo) {
+        versionInfo = info
+    }
+
+    public func status(of id: EnvironmentID) -> EnvironmentStatus? {
+        statuses[id]
+    }
+
+    // MARK: - RuntimeBackend
+
+    public nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { await self.run(request, continuation) }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func run(_ request: RuntimeRequest, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
+        receivedRequests.append(request)
+
+        switch request {
+        case .runtimeVersion:
+            await pause()
+            continuation.yield(.runtimeVersion(versionInfo))
+            continuation.finish()
+            return
+        case .environmentStatus(let id):
+            await pause()
+            continuation.yield(.status(statuses[id] ?? EnvironmentStatus(environmentID: id, vm: .notFound, readiness: .checking)))
+            continuation.finish()
+            return
+        case .cancelOperation:
+            continuation.finish()
+            return
+        case .startEnvironment, .stopEnvironment, .importXcode:
+            break
+        }
+
+        let id = OperationID()
+        let scenario = scenarios[request.caseName] ?? .succeed()
+        continuation.yield(.accepted(id))
+
+        switch scenario {
+        case .succeed(let phases, let status):
+            for phase in phases {
+                guard await progress(id, phase, continuation) else { return }
+            }
+            if let status {
+                statuses[status.environmentID] = status
+                continuation.yield(.status(status))
+            }
+            continuation.yield(.completed(id))
+            continuation.finish()
+
+        case .fail(let phases, let error):
+            for phase in phases {
+                guard await progress(id, phase, continuation) else { return }
+            }
+            continuation.yield(.failed(id, error))
+            continuation.finish()
+
+        case .hang:
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .milliseconds(5))
+            }
+            receivedRequests.append(.cancelOperation(id))
+            continuation.yield(.failed(id, .canceled))
+            continuation.finish()
+
+        case .disconnect(let phases):
+            for phase in phases {
+                guard await progress(id, phase, continuation) else { return }
+            }
+            continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
+        }
+    }
+
+    /// Emits one phase. Returns false if the consumer canceled meanwhile.
+    private func progress(_ id: OperationID, _ phase: ProgressPhase, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async -> Bool {
+        await pause()
+        if Task.isCancelled {
+            receivedRequests.append(.cancelOperation(id))
+            continuation.yield(.failed(id, .canceled))
+            continuation.finish()
+            return false
+        }
+        continuation.yield(.progress(id, phase))
+        return true
+    }
+
+    private func pause() async {
+        guard delay > .zero else { return }
+        try? await Task.sleep(for: delay)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -236,7 +236,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     /// Undoes the reservation `send` made for a cancellation request that did not succeed.
     private nonisolated func releaseReservation(of id: OperationID) {
-        configuration.withLock { $0.explicitCancellations.remove(id) }
+        configuration.withLock { _ = $0.explicitCancellations.remove(id) }
     }
 
     private func clearInFlight(_ id: OperationID) {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -32,6 +32,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private struct Configuration: Sendable {
         var scenarios: [String: Scenario] = [:]
         var pendingOperationIDs: [String: OperationID] = [:]
+        var nextTicket: UInt64 = 0
     }
 
     /// What one `send` bound when it was called.
@@ -45,7 +46,6 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
 
-    private nonisolated let ticketCounter = Mutex<UInt64>(0)
     private var servingTicket: UInt64 = 0
     private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
 
@@ -83,15 +83,14 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     // MARK: - RuntimeBackend
 
     public nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
-        let ticket = ticketCounter.withLock { counter in
-            defer { counter += 1 }
-            return counter
-        }
-        let binding = configuration.withLock { configuration in
-            Binding(
+        // Ticket and binding are taken under one lock, so two concurrent sends cannot swap
+        // the seeded id intended for the earlier one.
+        let (ticket, binding) = configuration.withLock { configuration in
+            defer { configuration.nextTicket += 1 }
+            return (configuration.nextTicket, Binding(
                 scenario: configuration.scenarios[request.caseName] ?? .succeed(),
                 seededOperationID: configuration.pendingOperationIDs.removeValue(forKey: request.caseName)
-            )
+            ))
         }
         return AsyncThrowingStream { continuation in
             let task = Task { await self.run(request, ticket: ticket, binding: binding, continuation) }
@@ -139,8 +138,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             case .hang:
                 while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(5)) }
                 continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
-            case .succeed:
+            case .succeed(_, let status):
                 canceledOperations.insert(id)
+                // The canceled operation is no longer in flight for any environment, and a
+                // scripted post-cancellation status is applied.
+                clearInFlight(id)
+                if let status { statuses[status.environmentID] = status }
                 continuation.finish()
             }
             return
@@ -177,6 +180,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
                 try? await Task.sleep(for: .milliseconds(5))
             }
             recordImplicitCancellation(of: id)
+            clearInFlight(id)
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
 
@@ -199,6 +203,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         }
         continuation.yield(.progress(id, phase))
         return true
+    }
+
+    private func clearInFlight(_ id: OperationID) {
+        for (environment, status) in statuses where status.inFlightOperation == id {
+            statuses[environment]?.inFlightOperation = nil
+        }
     }
 
     /// A consumer that stops listening counts as one cancel request, unless the operation was

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -5,8 +5,10 @@ import Synchronization
 ///
 /// Scenarios are keyed by request case name and apply to queries as well as operations.
 /// Requests are recorded in the order `send` was called, not in scheduler order. Each `send`
-/// records the request and emits `accepted` under a turn ticket; the rest of the scenario
-/// runs concurrently so a hanging operation never blocks the `cancelOperation` that ends it.
+/// binds its scenario and any seeded operation id at the moment it is called, so a later
+/// `script` or `useOperationID` cannot change a request already sent. It records the request
+/// and emits `accepted` under a turn ticket; the rest of the scenario runs concurrently so a
+/// hanging operation never blocks the `cancelOperation` that ends it.
 public actor FakeRuntimeBackend: RuntimeBackend {
     public enum Scenario: Sendable {
         /// `accepted`, the given phases, an optional status, then `completed`. For queries, the
@@ -26,11 +28,22 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     public var delay: Duration
     public private(set) var receivedRequests: [RuntimeRequest] = []
 
-    private var scenarios: [String: Scenario] = [:]
+    /// Read synchronously by `send`, so configuration and requests keep their call order.
+    private struct Configuration: Sendable {
+        var scenarios: [String: Scenario] = [:]
+        var pendingOperationIDs: [String: OperationID] = [:]
+    }
+
+    /// What one `send` bound when it was called.
+    private struct Binding: Sendable {
+        let scenario: Scenario
+        let seededOperationID: OperationID?
+    }
+
+    private nonisolated let configuration = Mutex(Configuration())
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
-    private var pendingOperationIDs: [String: OperationID] = [:]
 
     private nonisolated let ticketCounter = Mutex<UInt64>(0)
     private var servingTicket: UInt64 = 0
@@ -45,7 +58,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     /// Sets the scenario for every request whose `caseName` matches, for example `"startEnvironment"`.
     public func script(_ caseName: String, _ scenario: Scenario) {
-        scenarios[caseName] = scenario
+        configuration.withLock { $0.scenarios[caseName] = scenario }
     }
 
     /// The status returned for `environmentStatus(id)`.
@@ -64,7 +77,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// Makes the next request with this case name use `id` as its operation id, so a preview
     /// or test can correlate a pre-seeded `EnvironmentStatus.inFlightOperation` with the events.
     public func useOperationID(_ id: OperationID, forNext caseName: String) {
-        pendingOperationIDs[caseName] = id
+        configuration.withLock { $0.pendingOperationIDs[caseName] = id }
     }
 
     // MARK: - RuntimeBackend
@@ -74,16 +87,22 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             defer { counter += 1 }
             return counter
         }
+        let binding = configuration.withLock { configuration in
+            Binding(
+                scenario: configuration.scenarios[request.caseName] ?? .succeed(),
+                seededOperationID: configuration.pendingOperationIDs.removeValue(forKey: request.caseName)
+            )
+        }
         return AsyncThrowingStream { continuation in
-            let task = Task { await self.run(request, ticket: ticket, continuation) }
+            let task = Task { await self.run(request, ticket: ticket, binding: binding, continuation) }
             continuation.onTermination = { _ in task.cancel() }
         }
     }
 
-    private func run(_ request: RuntimeRequest, ticket: UInt64, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
+    private func run(_ request: RuntimeRequest, ticket: UInt64, binding: Binding, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
         await waitForTurn(ticket)
         receivedRequests.append(request)
-        let scenario = scenarios[request.caseName] ?? .succeed()
+        let scenario = binding.scenario
 
         switch request {
         case .runtimeVersion, .environmentStatus:
@@ -130,7 +149,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             break
         }
 
-        let id = pendingOperationIDs.removeValue(forKey: request.caseName) ?? OperationID()
+        let id = binding.seededOperationID ?? OperationID()
         continuation.yield(.accepted(id))
         advanceTurn()
 
@@ -157,7 +176,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             while !Task.isCancelled, !canceledOperations.contains(id) {
                 try? await Task.sleep(for: .milliseconds(5))
             }
-            if Task.isCancelled { receivedRequests.append(.cancelOperation(id)) }
+            recordImplicitCancellation(of: id)
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
 
@@ -173,13 +192,21 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private func progress(_ id: OperationID, _ phase: ProgressPhase, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async -> Bool {
         await pause()
         if Task.isCancelled || canceledOperations.contains(id) {
-            if Task.isCancelled { receivedRequests.append(.cancelOperation(id)) }
+            recordImplicitCancellation(of: id)
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
             return false
         }
         continuation.yield(.progress(id, phase))
         return true
+    }
+
+    /// A consumer that stops listening counts as one cancel request, unless the operation was
+    /// already canceled explicitly: `receivedRequests` then still mirrors real `send` calls.
+    private func recordImplicitCancellation(of id: OperationID) {
+        guard Task.isCancelled, !canceledOperations.contains(id) else { return }
+        canceledOperations.insert(id)
+        receivedRequests.append(.cancelOperation(id))
     }
 
     private func waitForTurn(_ ticket: UInt64) async {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -340,8 +340,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// The synthetic request takes a ticket like any other, so it cannot overtake a `send`
     /// that was made before the consumer went away.
     private func recordImplicitCancellation(of id: OperationID) {
-        let explicit = configuration.withLock { $0.explicitCancellations[id] != nil }
         guard Task.isCancelled, !canceledOperations.contains(id) else { return }
+        // One snapshot gives the suppression a position relative to concurrent sends. Taking
+        // the reservation and ticket separately could move it behind a send between those reads.
+        let reservation = configuration.withLock {
+            (isExplicit: $0.explicitCancellations[id] != nil, nextTicket: $0.nextTicket)
+        }
         // The reserved request may still fail, so what it suppressed is remembered rather
         // than dropped: releasing the reservation replays it, in the slot reserved here. The
         // slot is read from the ticket counter rather than taken from it — a ticket has to be
@@ -349,11 +353,11 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         // reservation would stall every later request — so it names the moment before the next
         // request is sent and after every request that has already taken its ticket, whether or
         // not that request has reached the log yet.
-        if explicit {
+        if reservation.isExplicit {
             guard suppressedCancellations[id] == nil else { return }
             defer { nextSuppression += 1 }
             suppressedCancellations[id] = LogKey(
-                ticket: 2 * configuration.withLock { $0.nextTicket },
+                ticket: 2 * reservation.nextTicket,
                 suppression: nextSuppression
             )
             return

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -1,20 +1,24 @@
 import Foundation
+import Synchronization
 
 /// A scripted `RuntimeBackend` for SwiftUI previews and tests. Performs no I/O.
 ///
-/// Scenarios are keyed by request case name. Each `send` records the request, so tests can
-/// assert what the GUI asked for, including the `cancelOperation` the fake records when a
-/// consumer stops reading a hanging operation.
+/// Scenarios are keyed by request case name and apply to queries as well as operations.
+/// Requests are recorded in the order `send` was called, not in scheduler order. Each `send`
+/// records the request and emits `accepted` under a turn ticket; the rest of the scenario
+/// runs concurrently so a hanging operation never blocks the `cancelOperation` that ends it.
 public actor FakeRuntimeBackend: RuntimeBackend {
     public enum Scenario: Sendable {
-        /// `accepted`, the given phases, an optional status, then `completed`.
+        /// `accepted`, the given phases, an optional status, then `completed`. For queries, the
+        /// normal reply.
         case succeed(phases: [ProgressPhase] = [], status: EnvironmentStatus? = nil)
-        /// `accepted`, the given phases, then `failed(error)`.
+        /// `accepted`, the given phases, then `failed(error)`. For queries, `failed` with a fresh id.
         case fail(after: [ProgressPhase] = [], error: GuesthouseError)
-        /// `accepted`, then nothing until the consumer cancels; the fake then records
-        /// `cancelOperation` and ends with `failed(.canceled)`.
+        /// `accepted`, then nothing until the consumer cancels or sends `cancelOperation` for
+        /// the id; the fake then ends with `failed(.canceled)`.
         case hang
         /// `accepted`, the given phases, then the stream throws `RuntimeConnectionInterrupted`.
+        /// For queries, the stream throws immediately.
         case disconnect(after: [ProgressPhase] = [])
     }
 
@@ -25,6 +29,11 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private var scenarios: [String: Scenario] = [:]
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private var versionInfo: RuntimeVersionInfo
+    private var canceledOperations: Set<OperationID> = []
+
+    private nonisolated let ticketCounter = Mutex<UInt64>(0)
+    private var servingTicket: UInt64 = 0
+    private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
 
     public init(delay: Duration = .zero, versionInfo: RuntimeVersionInfo = RuntimeVersionInfo(serviceVersion: "0.0.0", serviceBuild: "fake", tart: .init(version: "2.36.0", verified: true))) {
         self.delay = delay
@@ -54,36 +63,57 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     // MARK: - RuntimeBackend
 
     public nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
-        AsyncThrowingStream { continuation in
-            let task = Task { await self.run(request, continuation) }
+        let ticket = ticketCounter.withLock { counter in
+            defer { counter += 1 }
+            return counter
+        }
+        return AsyncThrowingStream { continuation in
+            let task = Task { await self.run(request, ticket: ticket, continuation) }
             continuation.onTermination = { _ in task.cancel() }
         }
     }
 
-    private func run(_ request: RuntimeRequest, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
+    private func run(_ request: RuntimeRequest, ticket: UInt64, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
+        await waitForTurn(ticket)
         receivedRequests.append(request)
+        let scenario = scenarios[request.caseName] ?? .succeed()
 
         switch request {
-        case .runtimeVersion:
+        case .runtimeVersion, .environmentStatus:
+            advanceTurn()
             await pause()
-            continuation.yield(.runtimeVersion(versionInfo))
+            switch scenario {
+            case .disconnect:
+                continuation.finish(throwing: RuntimeConnectionInterrupted())
+            case .fail(_, let error):
+                continuation.yield(.failed(OperationID(), error))
+                continuation.finish()
+            case .hang:
+                while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(5)) }
+                continuation.finish(throwing: RuntimeConnectionInterrupted())
+            case .succeed:
+                if case .environmentStatus(let id) = request {
+                    continuation.yield(.status(statuses[id] ?? EnvironmentStatus(environmentID: id, vm: .notFound, readiness: .checking)))
+                } else {
+                    continuation.yield(.runtimeVersion(versionInfo))
+                }
+                continuation.finish()
+            }
+            return
+
+        case .cancelOperation(let id):
+            canceledOperations.insert(id)
+            advanceTurn()
             continuation.finish()
             return
-        case .environmentStatus(let id):
-            await pause()
-            continuation.yield(.status(statuses[id] ?? EnvironmentStatus(environmentID: id, vm: .notFound, readiness: .checking)))
-            continuation.finish()
-            return
-        case .cancelOperation:
-            continuation.finish()
-            return
+
         case .startEnvironment, .stopEnvironment, .importXcode:
             break
         }
 
         let id = OperationID()
-        let scenario = scenarios[request.caseName] ?? .succeed()
         continuation.yield(.accepted(id))
+        advanceTurn()
 
         switch scenario {
         case .succeed(let phases, let status):
@@ -105,10 +135,10 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             continuation.finish()
 
         case .hang:
-            while !Task.isCancelled {
+            while !Task.isCancelled, !canceledOperations.contains(id) {
                 try? await Task.sleep(for: .milliseconds(5))
             }
-            receivedRequests.append(.cancelOperation(id))
+            if Task.isCancelled { receivedRequests.append(.cancelOperation(id)) }
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
 
@@ -120,17 +150,33 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         }
     }
 
-    /// Emits one phase. Returns false if the consumer canceled meanwhile.
+    /// Emits one phase. Returns false if the consumer or a `cancelOperation` canceled meanwhile.
     private func progress(_ id: OperationID, _ phase: ProgressPhase, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async -> Bool {
         await pause()
-        if Task.isCancelled {
-            receivedRequests.append(.cancelOperation(id))
+        if Task.isCancelled || canceledOperations.contains(id) {
+            if Task.isCancelled { receivedRequests.append(.cancelOperation(id)) }
             continuation.yield(.failed(id, .canceled))
             continuation.finish()
             return false
         }
         continuation.yield(.progress(id, phase))
         return true
+    }
+
+    private func waitForTurn(_ ticket: UInt64) async {
+        while servingTicket != ticket {
+            await withCheckedContinuation { continuation in
+                waiters[ticket] = continuation
+                if servingTicket == ticket, let waiter = waiters.removeValue(forKey: ticket) {
+                    waiter.resume()
+                }
+            }
+        }
+    }
+
+    private func advanceTurn() {
+        servingTicket += 1
+        waiters.removeValue(forKey: servingTicket)?.resume()
     }
 
     private func pause() async {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -172,6 +172,8 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             for phase in phases {
                 guard await progress(id, phase, continuation) else { return }
             }
+            // A failed operation is no longer in flight for any environment.
+            clearInFlight(id)
             continuation.yield(.failed(id, error))
             continuation.finish()
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -135,12 +135,17 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             await pause()
             switch scenario {
             case .disconnect:
+                // The request never took effect: the reservation is released, so a later
+                // consumer-driven cancellation is recorded as the request it is.
+                releaseReservation(of: id)
                 continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
             case .fail(_, let error):
+                releaseReservation(of: id)
                 continuation.yield(.failed(id, error))
                 continuation.finish()
             case .hang:
                 while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(5)) }
+                releaseReservation(of: id)
                 continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
             case .succeed(_, let status):
                 canceledOperations.insert(id)
@@ -165,15 +170,18 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             for phase in phases {
                 guard await progress(id, phase, continuation) else { return }
             }
-            // The operation has ended: it is no longer in flight for any environment, with or
-            // without a scripted replacement status.
-            clearInFlight(id)
             await pause()
+            // Cancellation is re-checked after the pause: an operation cancelled while the
+            // fake was waiting must not report success, and it stays in flight until its own
+            // terminal event, so a status query never sees an idle environment mid-stream.
+            guard !cancelled(id, continuation) else { return }
             if let status {
                 statuses[status.environmentID] = status
                 continuation.yield(.status(status))
                 await pause()
+                guard !cancelled(id, continuation) else { return }
             }
+            clearInFlight(id)
             continuation.yield(.completed(id))
             continuation.finish()
 
@@ -181,9 +189,10 @@ public actor FakeRuntimeBackend: RuntimeBackend {
             for phase in phases {
                 guard await progress(id, phase, continuation) else { return }
             }
+            await pause()
+            guard !cancelled(id, continuation) else { return }
             // A failed operation is no longer in flight for any environment.
             clearInFlight(id)
-            await pause()
             continuation.yield(.failed(id, error))
             continuation.finish()
 
@@ -208,16 +217,26 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// Emits one phase. Returns false if the consumer or a `cancelOperation` canceled meanwhile.
     private func progress(_ id: OperationID, _ phase: ProgressPhase, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async -> Bool {
         await pause()
-        if Task.isCancelled || canceledOperations.contains(id) {
-            recordImplicitCancellation(of: id)
-            // A cancelled operation is no longer in flight either, however it was cancelled.
-            clearInFlight(id)
-            continuation.yield(.failed(id, .canceled))
-            continuation.finish()
-            return false
-        }
+        guard !cancelled(id, continuation) else { return false }
         continuation.yield(.progress(id, phase))
         return true
+    }
+
+    /// Whether the operation was cancelled, by the consumer or by a `cancelOperation`. Ends
+    /// the stream with `canceled` when it was, so every suspension point answers the same way.
+    private func cancelled(_ id: OperationID, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) -> Bool {
+        guard Task.isCancelled || canceledOperations.contains(id) else { return false }
+        recordImplicitCancellation(of: id)
+        // A cancelled operation is no longer in flight either, however it was cancelled.
+        clearInFlight(id)
+        continuation.yield(.failed(id, .canceled))
+        continuation.finish()
+        return true
+    }
+
+    /// Undoes the reservation `send` made for a cancellation request that did not succeed.
+    private nonisolated func releaseReservation(of id: OperationID) {
+        configuration.withLock { $0.explicitCancellations.remove(id) }
     }
 
     private func clearInFlight(_ id: OperationID) {
@@ -229,12 +248,25 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// A consumer that stops listening counts as one cancel request, unless the operation was
     /// already canceled explicitly: `receivedRequests` then still mirrors real `send` calls.
     /// The explicit request reserves the id in `send`, before any producer can run, so the
-    /// two never race.
+    /// two never race, and the reservation is released again if that request fails.
+    ///
+    /// The synthetic request takes a ticket like any other, so it cannot overtake a `send`
+    /// that was made before the consumer went away.
     private func recordImplicitCancellation(of id: OperationID) {
         let explicit = configuration.withLock { $0.explicitCancellations.contains(id) }
         guard Task.isCancelled, !canceledOperations.contains(id), !explicit else { return }
         canceledOperations.insert(id)
+        let ticket = configuration.withLock { configuration -> UInt64 in
+            defer { configuration.nextTicket += 1 }
+            return configuration.nextTicket
+        }
+        Task { await self.appendCancellation(of: id, ticket: ticket) }
+    }
+
+    private func appendCancellation(of id: OperationID, ticket: UInt64) async {
+        await waitForTurn(ticket)
         receivedRequests.append(.cancelOperation(id))
+        advanceTurn()
     }
 
     private func waitForTurn(_ ticket: UInt64) async {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -318,12 +318,15 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         }
     }
 
-    /// Names the operation in the environment's stored status, when one is stored. A fake with
-    /// no status for that environment stays silent rather than inventing VM and readiness state.
+    /// Records every accepted operation, including when no status was scripted. Its baseline
+    /// remains uncertain/checking until an observation establishes the VM's actual state.
     private func markInFlight(_ id: OperationID, for request: RuntimeRequest) {
         switch request {
         case .startEnvironment(let environment, _), .stopEnvironment(let environment, _), .importXcode(let environment, _):
-            statuses[environment]?.inFlightOperation = id
+            statuses[environment, default: EnvironmentStatus(
+                environmentID: environment,
+                vm: .uncertain(reason: "No status has been observed."), readiness: .checking
+            )].inFlightOperation = id
         case .runtimeVersion, .environmentStatus, .cancelOperation:
             break
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -34,8 +34,10 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         var pendingOperationIDs: [String: OperationID] = [:]
         var nextTicket: UInt64 = 0
         /// Cancellations reserved by `send` before any producer can run, so an explicit
-        /// request is never mistaken for a consumer that merely stopped listening.
-        var explicitCancellations: Set<OperationID> = []
+        /// request is never mistaken for a consumer that merely stopped listening. Counted
+        /// per id: overlapping requests for one operation each hold their own reservation,
+        /// so releasing one does not speak for the others.
+        var explicitCancellations: [OperationID: Int] = [:]
     }
 
     /// What one `send` bound when it was called.
@@ -48,9 +50,34 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
-    /// Consumer cancellations a reservation kept out of `receivedRequests`. They are replayed
-    /// if that reserved request turns out never to have taken effect.
-    private var suppressedCancellations: Set<OperationID> = []
+    /// Where a recorded request falls in the order the requests were *made*, which is the order
+    /// their turn tickets were taken in rather than the order they reached `receivedRequests`.
+    ///
+    /// A consumer cancellation a reservation suppresses is given a key in the same space at the
+    /// moment it happens, and replaying it later inserts it by that key. An index into the log
+    /// is not enough: a request that took an earlier ticket may still be waiting for its turn,
+    /// so it is not in the log yet, and the cancellation would be replayed in front of a request
+    /// that was really sent before it. The doubling makes room for the suppressed ones — a
+    /// request's key is odd, a suppression's is even — so a cancellation seen while ticket `t`
+    /// was still unissued sorts ahead of the request that goes on to take it, and `suppression`
+    /// keeps two seen between the same pair of requests in the order they were seen.
+    private struct LogKey: Comparable {
+        let ticket: UInt64
+        let suppression: UInt64
+
+        static func < (a: LogKey, b: LogKey) -> Bool {
+            (a.ticket, a.suppression) < (b.ticket, b.suppression)
+        }
+
+        static func request(_ ticket: UInt64) -> LogKey { LogKey(ticket: 2 * ticket + 1, suppression: 0) }
+    }
+
+    private var receivedKeys: [LogKey] = []
+    private var nextSuppression: UInt64 = 0
+    /// Consumer cancellations a reservation kept out of `receivedRequests`, each with the log
+    /// slot it reserved when it happened. They are replayed in that slot if the reserved request
+    /// turns out never to have taken effect.
+    private var suppressedCancellations: [OperationID: LogKey] = [:]
 
     private var servingTicket: UInt64 = 0
     private var waiters: [UInt64: CheckedContinuation<Void, Never>] = [:]
@@ -93,7 +120,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         // the seeded id intended for the earlier one.
         let (ticket, binding) = configuration.withLock { configuration in
             defer { configuration.nextTicket += 1 }
-            if case .cancelOperation(let id) = request { configuration.explicitCancellations.insert(id) }
+            if case .cancelOperation(let id) = request { configuration.explicitCancellations[id, default: 0] += 1 }
             return (configuration.nextTicket, Binding(
                 scenario: configuration.scenarios[request.caseName] ?? .succeed(),
                 seededOperationID: configuration.pendingOperationIDs.removeValue(forKey: request.caseName)
@@ -107,7 +134,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     private func run(_ request: RuntimeRequest, ticket: UInt64, binding: Binding, _ continuation: AsyncThrowingStream<RuntimeEvent, any Error>.Continuation) async {
         await waitForTurn(ticket)
-        receivedRequests.append(request)
+        record(request, at: .request(ticket))
         let scenario = binding.scenario
 
         switch request {
@@ -152,10 +179,14 @@ public actor FakeRuntimeBackend: RuntimeBackend {
                 continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
             case .succeed(_, let status):
                 canceledOperations.insert(id)
-                // The canceled operation is no longer in flight for any environment, and a
-                // scripted post-cancellation status is applied.
-                clearInFlight(id)
+                // This request took effect, so a consumer cancellation its reservation
+                // suppressed stays suppressed even if another reserved request later fails.
+                suppressedCancellations.removeValue(forKey: id)
+                // A scripted post-cancellation status is applied first: the canceled
+                // operation is no longer in flight for any environment, including one the
+                // scripted status still names.
                 if let status { statuses[status.environmentID] = status }
+                clearInFlight(id)
                 continuation.finish()
             }
             return
@@ -188,7 +219,9 @@ public actor FakeRuntimeBackend: RuntimeBackend {
                 var stored = status
                 stored.inFlightOperation = status.inFlightOperation ?? id
                 statuses[status.environmentID] = stored
-                continuation.yield(.status(status))
+                // The stored copy is what is emitted, so a consumer applying stream events
+                // and a status query agree about the operation still being in flight.
+                continuation.yield(.status(stored))
                 await pause()
                 guard !cancelled(id, continuation) else { return }
             }
@@ -255,11 +288,28 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// request that stood in for it never took effect, so the consumer's own cancellation is
     /// the only one that happened and `receivedRequests` must show it.
     private func releaseReservation(of id: OperationID) {
-        configuration.withLock { _ = $0.explicitCancellations.remove(id) }
-        guard suppressedCancellations.remove(id) != nil else { return }
+        let outstanding = configuration.withLock { configuration -> Int in
+            guard let held = configuration.explicitCancellations[id] else { return 0 }
+            configuration.explicitCancellations[id] = held > 1 ? held - 1 : nil
+            return held - 1
+        }
+        // Another reserved request for the same id is still pending: that one, not the
+        // consumer, stands in for the cancellation until it too fails to take effect.
+        guard outstanding <= 0 else { return }
+        guard let slot = suppressedCancellations.removeValue(forKey: id) else { return }
         canceledOperations.insert(id)
-        let ticket = nextTicket()
-        Task { await self.appendCancellation(of: id, ticket: ticket) }
+        // Replayed in the slot it reserved rather than appended here: the reservation can be
+        // released long after the consumer went away, and appending would show the cancellation
+        // behind every request that was really sent after it.
+        record(.cancelOperation(id), at: slot)
+    }
+
+    /// Puts a request in the log in the order it was made, which for everything but a replayed
+    /// cancellation is simply the end.
+    private func record(_ request: RuntimeRequest, at key: LogKey) {
+        let index = receivedKeys.firstIndex { key < $0 } ?? receivedRequests.count
+        receivedRequests.insert(request, at: index)
+        receivedKeys.insert(key, at: index)
     }
 
     private func clearInFlight(_ id: OperationID) {
@@ -287,12 +337,22 @@ public actor FakeRuntimeBackend: RuntimeBackend {
     /// The synthetic request takes a ticket like any other, so it cannot overtake a `send`
     /// that was made before the consumer went away.
     private func recordImplicitCancellation(of id: OperationID) {
-        let explicit = configuration.withLock { $0.explicitCancellations.contains(id) }
+        let explicit = configuration.withLock { $0.explicitCancellations[id] != nil }
         guard Task.isCancelled, !canceledOperations.contains(id) else { return }
         // The reserved request may still fail, so what it suppressed is remembered rather
-        // than dropped: releasing the reservation replays it.
+        // than dropped: releasing the reservation replays it, in the slot reserved here. The
+        // slot is read from the ticket counter rather than taken from it — a ticket has to be
+        // served for the queue to advance, and one held for the lifetime of a hanging
+        // reservation would stall every later request — so it names the moment before the next
+        // request is sent and after every request that has already taken its ticket, whether or
+        // not that request has reached the log yet.
         if explicit {
-            suppressedCancellations.insert(id)
+            guard suppressedCancellations[id] == nil else { return }
+            defer { nextSuppression += 1 }
+            suppressedCancellations[id] = LogKey(
+                ticket: 2 * configuration.withLock { $0.nextTicket },
+                suppression: nextSuppression
+            )
             return
         }
         canceledOperations.insert(id)
@@ -309,7 +369,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     private func appendCancellation(of id: OperationID, ticket: UInt64) async {
         await waitForTurn(ticket)
-        receivedRequests.append(.cancelOperation(id))
+        record(.cancelOperation(id), at: .request(ticket))
         advanceTurn()
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
@@ -7,15 +7,19 @@ public struct PreviewScenario: Sendable {
     public let snapshot: EnvironmentsSnapshot
     /// A fake backend scripted to match.
     public let backend: FakeRuntimeBackend
+    /// A request the preview should send on appear so an in-flight operation is really in
+    /// flight; `nil` when the scenario starts idle.
+    public let initialRequest: RuntimeRequest?
 
-    public init(name: String, snapshot: EnvironmentsSnapshot, backend: FakeRuntimeBackend) {
+    public init(name: String, snapshot: EnvironmentsSnapshot, backend: FakeRuntimeBackend, initialRequest: RuntimeRequest? = nil) {
         self.name = name
         self.snapshot = snapshot
         self.backend = backend
+        self.initialRequest = initialRequest
     }
 }
 
-public enum PreviewScenarios {
+public enum PreviewScenarios: Sendable {
     public static let all: [@Sendable () async -> PreviewScenario] = [
         { await freshMac() }, { await oneRunningEnvironment() }, { await environmentNeedingRepair() },
         { await bothSlotsFull() }, { await operationInProgress() },
@@ -36,7 +40,7 @@ public enum PreviewScenarios {
             observed: ObservedTuple(hostMacOSVersion: SemanticVersion("26.5.2"), tartVersion: "2.36.0", guestMacOSBuild: "25F84", xcodeBuild: "17F113"),
             reconciledAt: date
         ))
-        await backend.script("stopEnvironment", .succeed(phases: [ProgressPhase(kind: .stoppingVM)]))
+        await backend.script("stopEnvironment", .succeed(phases: [ProgressPhase(kind: .stoppingVM)], status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, reconciledAt: date)))
         return PreviewScenario(name: "One running environment", snapshot: snapshot, backend: backend)
     }
 
@@ -65,16 +69,19 @@ public enum PreviewScenarios {
         return PreviewScenario(name: "Both slots full", snapshot: snapshot, backend: backend)
     }
 
-    /// A start operation that keeps reporting progress, for progress UI.
+    /// A start operation that keeps reporting progress, for progress UI. The status already
+    /// names an in-flight operation, and `initialRequest` is the start the preview should send so
+    /// the progress events actually flow.
     public static func operationInProgress() async -> PreviewScenario {
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
         let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .ready, status: .completed(Checkpoint(stage: .ready, reachedAt: date)))])
         let backend = FakeRuntimeBackend(delay: .milliseconds(800))
-        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, reconciledAt: date))
+        let inFlight = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: inFlight, reconciledAt: date))
         await backend.script("startEnvironment", .succeed(phases: [
             ProgressPhase(kind: .verifyingRuntime), ProgressPhase(kind: .startingVM), ProgressPhase(kind: .waitingForNetwork, fraction: 0.3), ProgressPhase(kind: .waitingForNetwork, fraction: 0.9),
         ], status: EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready, reconciledAt: date)))
-        return PreviewScenario(name: "Operation in progress", snapshot: snapshot, backend: backend)
+        return PreviewScenario(name: "Operation in progress", snapshot: snapshot, backend: backend, initialRequest: .startEnvironment(environment.id, StartOptions()))
     }
 
     private static let date = Date(timeIntervalSince1970: 1_800_000_000)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
@@ -78,6 +78,7 @@ public enum PreviewScenarios: Sendable {
         let backend = FakeRuntimeBackend(delay: .milliseconds(800))
         let inFlight = OperationID()
         await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: inFlight, reconciledAt: date))
+        await backend.useOperationID(inFlight, forNext: "startEnvironment")
         await backend.script("startEnvironment", .succeed(phases: [
             ProgressPhase(kind: .verifyingRuntime), ProgressPhase(kind: .startingVM), ProgressPhase(kind: .waitingForNetwork, fraction: 0.3), ProgressPhase(kind: .waitingForNetwork, fraction: 0.9),
         ], status: EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready, reconciledAt: date)))

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Ready-made app states for SwiftUI previews and view-model tests. No I/O.
+public struct PreviewScenario: Sendable {
+    public let name: String
+    /// What the state store would hold.
+    public let snapshot: EnvironmentsSnapshot
+    /// A fake backend scripted to match.
+    public let backend: FakeRuntimeBackend
+
+    public init(name: String, snapshot: EnvironmentsSnapshot, backend: FakeRuntimeBackend) {
+        self.name = name
+        self.snapshot = snapshot
+        self.backend = backend
+    }
+}
+
+public enum PreviewScenarios {
+    public static let all: [@Sendable () async -> PreviewScenario] = [
+        { await freshMac() }, { await oneRunningEnvironment() }, { await environmentNeedingRepair() },
+        { await bothSlotsFull() }, { await operationInProgress() },
+    ]
+
+    /// First launch: nothing exists yet.
+    public static func freshMac() async -> PreviewScenario {
+        PreviewScenario(name: "Fresh Mac", snapshot: .empty, backend: FakeRuntimeBackend())
+    }
+
+    /// One environment, running and ready, with known tool versions.
+    public static func oneRunningEnvironment() async -> PreviewScenario {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
+        let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .ready, status: .completed(Checkpoint(stage: .ready, reachedAt: date)))])
+        let backend = FakeRuntimeBackend()
+        await backend.setStatus(EnvironmentStatus(
+            environmentID: environment.id, vm: .running, readiness: .ready,
+            observed: ObservedTuple(hostMacOSVersion: SemanticVersion("26.5.2"), tartVersion: "2.36.0", guestMacOSBuild: "25F84", xcodeBuild: "17F113"),
+            reconciledAt: date
+        ))
+        await backend.script("stopEnvironment", .succeed(phases: [ProgressPhase(kind: .stoppingVM)]))
+        return PreviewScenario(name: "One running environment", snapshot: snapshot, backend: backend)
+    }
+
+    /// A stopped environment whose SSH identity changed; Start is refused until repaired.
+    public static func environmentNeedingRepair() async -> PreviewScenario {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
+        let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .sshPaired, status: .recoverableFailure(.hostKeyChanged(environment.id)))])
+        let backend = FakeRuntimeBackend()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .needsAttention(.hostKeyChanged(environment.id)), reconciledAt: date))
+        await backend.script("startEnvironment", .fail(error: .hostKeyChanged(environment.id)))
+        return PreviewScenario(name: "Environment needing repair", snapshot: snapshot, backend: backend)
+    }
+
+    /// Two environments, one preserved after a failed repair, so no slot is free.
+    public static func bothSlotsFull() async -> PreviewScenario {
+        let active = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
+        let preserved = DevelopmentEnvironment(name: "Old Dev Mac", createdAt: date.addingTimeInterval(-86_400 * 30))
+        var snapshot = try! snapshot(for: [active, preserved], provisioning: [
+            active.id: ProvisioningState(stage: .ready, status: .completed(Checkpoint(stage: .ready, reachedAt: date))),
+            preserved.id: ProvisioningState(stage: .guestSecured, status: .recoverableFailure(.guestNotReachable(preserved.id))),
+        ])
+        try! snapshot.slots.markPreserved(preserved.id)
+        let backend = FakeRuntimeBackend()
+        await backend.setStatus(EnvironmentStatus(environmentID: active.id, vm: .stopped, readiness: .ready, reconciledAt: date))
+        await backend.setStatus(EnvironmentStatus(environmentID: preserved.id, vm: .stopped, readiness: .needsAttention(.guestNotReachable(preserved.id)), reconciledAt: date))
+        return PreviewScenario(name: "Both slots full", snapshot: snapshot, backend: backend)
+    }
+
+    /// A start operation that keeps reporting progress, for progress UI.
+    public static func operationInProgress() async -> PreviewScenario {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
+        let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .ready, status: .completed(Checkpoint(stage: .ready, reachedAt: date)))])
+        let backend = FakeRuntimeBackend(delay: .milliseconds(800))
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, reconciledAt: date))
+        await backend.script("startEnvironment", .succeed(phases: [
+            ProgressPhase(kind: .verifyingRuntime), ProgressPhase(kind: .startingVM), ProgressPhase(kind: .waitingForNetwork, fraction: 0.3), ProgressPhase(kind: .waitingForNetwork, fraction: 0.9),
+        ], status: EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready, reconciledAt: date)))
+        return PreviewScenario(name: "Operation in progress", snapshot: snapshot, backend: backend)
+    }
+
+    private static let date = Date(timeIntervalSince1970: 1_800_000_000)
+
+    private static func snapshot(for environments: [DevelopmentEnvironment], provisioning: [EnvironmentID: ProvisioningState]) throws -> EnvironmentsSnapshot {
+        var slots = VMSlotInventory()
+        for environment in environments {
+            try slots.reserve(environment.id)
+        }
+        return EnvironmentsSnapshot(environments: environments, slots: slots, provisioning: provisioning)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/PreviewScenarios.swift
@@ -47,7 +47,7 @@ public enum PreviewScenarios: Sendable {
     /// A stopped environment whose SSH identity changed; Start is refused until repaired.
     public static func environmentNeedingRepair() async -> PreviewScenario {
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: date)
-        let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .sshPaired, status: .recoverableFailure(.hostKeyChanged(environment.id)))])
+        let snapshot = try! snapshot(for: [environment], provisioning: [environment.id: ProvisioningState(stage: .sshPaired, status: .recoverableFailure(.hostKeyChanged(environment.id), interrupted: nil))])
         let backend = FakeRuntimeBackend()
         await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .needsAttention(.hostKeyChanged(environment.id)), reconciledAt: date))
         await backend.script("startEnvironment", .fail(error: .hostKeyChanged(environment.id)))
@@ -60,7 +60,7 @@ public enum PreviewScenarios: Sendable {
         let preserved = DevelopmentEnvironment(name: "Old Dev Mac", createdAt: date.addingTimeInterval(-86_400 * 30))
         var snapshot = try! snapshot(for: [active, preserved], provisioning: [
             active.id: ProvisioningState(stage: .ready, status: .completed(Checkpoint(stage: .ready, reachedAt: date))),
-            preserved.id: ProvisioningState(stage: .guestSecured, status: .recoverableFailure(.guestNotReachable(preserved.id))),
+            preserved.id: ProvisioningState(stage: .guestSecured, status: .recoverableFailure(.guestNotReachable(preserved.id), interrupted: nil)),
         ])
         try! snapshot.slots.markPreserved(preserved.id)
         let backend = FakeRuntimeBackend()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
@@ -1,0 +1,22 @@
+/// The one seam between the GUI and whatever executes host operations.
+///
+/// The real implementation is the XPC `RuntimeClient` (issue #19); the fake below drives
+/// previews and tests. Keep this small: MVP-PLAN.md §3 warns against a plugin system before
+/// a second backend exists.
+public protocol RuntimeBackend: Sendable {
+    /// Sends one request and streams the service's events for it.
+    ///
+    /// The stream ends after `completed` or `failed` for operations, after the reply for
+    /// queries, or by throwing when the connection to the service is lost. A thrown error
+    /// means the outcome is unknown; the caller must inspect actual state before retrying.
+    func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error>
+}
+
+/// Thrown by a backend when the connection dropped before the operation reported a result.
+public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable {
+    public let operationID: OperationID?
+
+    public init(operationID: OperationID? = nil) {
+        self.operationID = operationID
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
@@ -9,15 +9,18 @@ public protocol RuntimeBackend: Sendable {
     /// Sends one request and streams the service's events for it.
     ///
     /// The stream ends after `completed` or `failed` for operations, after the reply for
-    /// queries, or by throwing when the connection to the service is lost. A thrown error
-    /// means the outcome is unknown; the caller must inspect actual state before retrying.
+    /// queries, or by throwing when the connection to the service is lost. A throw after an
+    /// operation was accepted means its outcome is unknown; the caller must inspect actual
+    /// state before retrying.
     func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error>
 }
 
-/// Thrown by a backend when the connection dropped before the operation reported a result.
+/// Thrown by a backend when the connection dropped before the request reported a result.
 ///
-/// Carries the same presentation contract as `GuesthouseError`: the user is told the outcome
-/// is unknown and offered an inspection, never a blind retry (MVP-PLAN.md §3).
+/// Carries the same presentation contract as `GuesthouseError`: when an operation was in
+/// flight the user is told the outcome is unknown and offered an inspection, never a blind
+/// retry (MVP-PLAN.md §3). A read-only query names no operation, changed nothing, and is
+/// offered the retry that its own failure calls for.
 public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable, LocalizedError {
     public let operationID: OperationID?
 
@@ -26,14 +29,20 @@ public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable, Localized
     }
 
     public var userMessage: String {
-        "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+        operationID == nil
+            ? "Guesthouse lost contact with its runtime service before it answered."
+            : "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
     }
 
     public var recoveryMessage: String {
-        "Check the environment before doing anything else."
+        operationID == nil
+            ? "Ask again once the service is back."
+            : "Check the environment before doing anything else."
     }
 
-    public var recoveryActions: [RecoveryAction] { [.inspectState, .cancel] }
+    public var recoveryActions: [RecoveryAction] {
+        operationID == nil ? [.retry] : [.inspectState, .cancel]
+    }
 
     public var errorDescription: String? { userMessage }
     public var recoverySuggestion: String? { recoveryMessage }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
@@ -9,39 +9,50 @@ public protocol RuntimeBackend: Sendable {
     /// Sends one request and streams the service's events for it.
     ///
     /// The stream ends after `completed` or `failed` for operations, after the reply for
-    /// queries, or by throwing when the connection to the service is lost. A throw after an
-    /// operation was accepted means its outcome is unknown; the caller must inspect actual
-    /// state before retrying.
+    /// queries, or by throwing when the connection to the service is lost. A mutating request
+    /// may have reached the service even before its acceptance reply arrives; the backend
+    /// must report that uncertainty so the caller inspects actual state before retrying.
     func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error>
 }
 
 /// Thrown by a backend when the connection dropped before the request reported a result.
 ///
-/// Carries the same presentation contract as `GuesthouseError`: when an operation was in
-/// flight the user is told the outcome is unknown and offered an inspection, never a blind
-/// retry (MVP-PLAN.md §3). A read-only query names no operation, changed nothing, and is
-/// offered the retry that its own failure calls for.
+/// Carries the same presentation contract as `GuesthouseError`: when host state may have
+/// changed the user is told the outcome is unknown and offered an inspection, never a blind
+/// retry (MVP-PLAN.md §3). That covers an operation that was in flight and a mutating request
+/// that may have reached the service before it was accepted. A read-only query names no
+/// operation, changed nothing, and is offered the retry that its own failure calls for.
 public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable, LocalizedError {
     public let operationID: OperationID?
+    /// Whether a request that changes the host may already have reached the service.
+    ///
+    /// A request interrupted before its `accepted` reply has no operation id, but the service
+    /// may still have received it and started or journaled the mutation. Such a request has an
+    /// unknown outcome just as an accepted one does, so it is never offered a blind retry.
+    public let mayHaveMutated: Bool
 
-    public init(operationID: OperationID? = nil) {
+    public init(operationID: OperationID? = nil, mayHaveMutated: Bool = false) {
         self.operationID = operationID
+        self.mayHaveMutated = mayHaveMutated
     }
 
+    /// Whether host state may have changed, so it has to be inspected before anything else.
+    private var outcomeUnknown: Bool { operationID != nil || mayHaveMutated }
+
     public var userMessage: String {
-        operationID == nil
-            ? "Guesthouse lost contact with its runtime service before it answered."
-            : "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+        outcomeUnknown
+            ? "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+            : "Guesthouse lost contact with its runtime service before it answered."
     }
 
     public var recoveryMessage: String {
-        operationID == nil
-            ? "Ask again once the service is back."
-            : "Check the environment before doing anything else."
+        outcomeUnknown
+            ? "Check the environment before doing anything else."
+            : "Ask again once the service is back."
     }
 
     public var recoveryActions: [RecoveryAction] {
-        operationID == nil ? [.retry] : [.inspectState, .cancel]
+        outcomeUnknown ? [.inspectState, .cancel] : [.retry]
     }
 
     public var errorDescription: String? { userMessage }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// The one seam between the GUI and whatever executes host operations.
 ///
 /// The real implementation is the XPC `RuntimeClient` (issue #19); the fake below drives
@@ -13,10 +15,31 @@ public protocol RuntimeBackend: Sendable {
 }
 
 /// Thrown by a backend when the connection dropped before the operation reported a result.
-public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable {
+///
+/// Carries the same presentation contract as `GuesthouseError`: the user is told the outcome
+/// is unknown and offered an inspection, never a blind retry (MVP-PLAN.md §3).
+public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable, LocalizedError {
     public let operationID: OperationID?
 
     public init(operationID: OperationID? = nil) {
         self.operationID = operationID
+    }
+
+    public var userMessage: String {
+        "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+    }
+
+    public var recoveryMessage: String {
+        "Check the environment before doing anything else."
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.inspectState, .cancel] }
+
+    public var errorDescription: String? { userMessage }
+    public var recoverySuggestion: String? { recoveryMessage }
+
+    /// The equivalent structured error when the interrupted operation is known.
+    public var guesthouseError: GuesthouseError? {
+        operationID.map { .operationOutcomeUnknown($0) }
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendAcceptanceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendAcceptanceTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct FakeRuntimeBackendAcceptanceTests {
+    enum Mutation: Sendable {
+        case start, stop, importXcode
+
+        func request(for environment: EnvironmentID) -> RuntimeRequest {
+            switch self {
+            case .start: .startEnvironment(environment, StartOptions())
+            case .stop: .stopEnvironment(environment, .force)
+            case .importXcode:
+                .importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app"))
+            }
+        }
+    }
+
+    @Test(arguments: [Mutation.start, .stop, .importXcode])
+    func acceptedOperationsAreVisibleWithoutASeededStatus(_ mutation: Mutation) async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let operation = OperationID()
+        let request = mutation.request(for: environment)
+        await backend.script(request.caseName, .hang)
+        await backend.useOperationID(operation, forNext: request.caseName)
+
+        let stream = backend.send(request)
+        var iterator = stream.makeAsyncIterator()
+        try #require(try await iterator.next() == .accepted(operation))
+
+        let inFlight = EnvironmentStatus(
+            environmentID: environment, vm: .uncertain(reason: "No status has been observed."), readiness: .checking,
+            inFlightOperation: operation
+        )
+        #expect(await backend.status(of: environment) == inFlight)
+        var query = backend.send(.environmentStatus(environment)).makeAsyncIterator()
+        #expect(try await query.next() == .status(inFlight))
+        #expect(try await query.next() == nil)
+
+        for try await _ in backend.send(.cancelOperation(operation)) {}
+        #expect(try await iterator.next() == .failed(operation, .canceled))
+        #expect(try await iterator.next() == nil)
+        #expect(await backend.status(of: environment) == EnvironmentStatus(
+            environmentID: environment, vm: .uncertain(reason: "No status has been observed."), readiness: .checking
+        ))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -212,6 +212,153 @@ import Testing
         #expect(cancels.count == 2, "a request that never took effect swallowed the consumer's own cancellation")
     }
 
+    /// The replay has to land where the cancellation happened. A reservation can be released
+    /// long after the consumer went away, and a coordinator test reading `receivedRequests`
+    /// would otherwise see the requests it sent in between ahead of a cancellation that
+    /// preceded them.
+    @Test func aSuppressedCancellationIsReplayedWhereItHappened() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .hang)
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        let cancelStream = backend.send(.cancelOperation(id))
+        let canceller = Task { for try await _ in cancelStream {} }
+        while await backend.receivedRequests.count < 2 { try await Task.sleep(for: .milliseconds(2)) }
+        consumer.cancel()
+        for _ in 0..<400 where await backend.status(of: environment)?.inFlightOperation != nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        // Sent after the consumer went away, so it must stay behind that cancellation.
+        for try await _ in backend.send(.environmentStatus(environment)) {}
+        canceller.cancel()
+        _ = try? await canceller.value
+        for _ in 0..<400 where await backend.receivedRequests.filter({ $0 == .cancelOperation(id) }).count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let requests = await backend.receivedRequests
+        let replay = requests.lastIndex(of: .cancelOperation(id))
+        let query = requests.firstIndex(of: .environmentStatus(environment))
+        #expect(requests.filter { $0 == .cancelOperation(id) }.count == 2)
+        #expect(replay != nil && query != nil && replay! < query!, "\(requests)")
+    }
+
+    /// Two suppressed cancellations reserve two slots, so replaying them puts them back in the
+    /// order they happened whatever order their reservations are released in. Keying them on the
+    /// length of the log instead made the second replay land in front of the first.
+    @Test func twoSuppressedCancellationsKeepTheOrderTheyHappenedIn() async throws {
+        let backend = FakeRuntimeBackend()
+        let first = EnvironmentID()
+        let second = EnvironmentID()
+        let one = OperationID()
+        let two = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: first, vm: .running, readiness: .ready, inFlightOperation: one))
+        await backend.setStatus(EnvironmentStatus(environmentID: second, vm: .running, readiness: .ready, inFlightOperation: two))
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .hang)
+
+        await backend.useOperationID(one, forNext: "startEnvironment")
+        let firstStream = backend.send(.startEnvironment(first, StartOptions()))
+        let firstConsumer = Task { for try await _ in firstStream {} }
+        while await backend.receivedRequests.count < 1 { try await Task.sleep(for: .milliseconds(2)) }
+        await backend.useOperationID(two, forNext: "startEnvironment")
+        let secondStream = backend.send(.startEnvironment(second, StartOptions()))
+        let secondConsumer = Task { for try await _ in secondStream {} }
+        while await backend.receivedRequests.count < 2 { try await Task.sleep(for: .milliseconds(2)) }
+        let firstCancel = backend.send(.cancelOperation(one))
+        let firstCanceller = Task { for try await _ in firstCancel {} }
+        while await backend.receivedRequests.count < 3 { try await Task.sleep(for: .milliseconds(2)) }
+        let secondCancel = backend.send(.cancelOperation(two))
+        let secondCanceller = Task { for try await _ in secondCancel {} }
+        while await backend.receivedRequests.count < 4 { try await Task.sleep(for: .milliseconds(2)) }
+
+        // The consumer of `one` goes away first, so its cancellation happened first.
+        firstConsumer.cancel()
+        for _ in 0..<400 where await backend.status(of: first)?.inFlightOperation != nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        secondConsumer.cancel()
+        for _ in 0..<400 where await backend.status(of: second)?.inFlightOperation != nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        // Released in the same order, which is the order that used to invert the replays.
+        firstCanceller.cancel()
+        _ = try? await firstCanceller.value
+        for _ in 0..<400 where await backend.receivedRequests.filter({ $0 == .cancelOperation(one) }).count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        secondCanceller.cancel()
+        _ = try? await secondCanceller.value
+        for _ in 0..<400 where await backend.receivedRequests.filter({ $0 == .cancelOperation(two) }).count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        let requests = await backend.receivedRequests
+        #expect(requests.suffix(2) == [.cancelOperation(one), .cancelOperation(two)], "\(requests)")
+    }
+
+    @Test func theEmittedScriptedStatusNamesTheOperationStillInFlight() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .succeed(status: EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready)))
+        var emitted: EnvironmentStatus?
+        for try await event in backend.send(.startEnvironment(environment, StartOptions())) {
+            if case .status(let status) = event { emitted = status }
+        }
+        #expect(emitted?.inFlightOperation == id, "a consumer applying the status event must not see an idle environment while the operation runs")
+    }
+
+    @Test func aScriptedPostCancellationStatusDoesNotRestoreTheCanceledOperation() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: id))
+        await backend.script("cancelOperation", .succeed(status: EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: id)))
+        for try await _ in backend.send(.cancelOperation(id)) {}
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "a scripted status must not put the canceled operation back in flight")
+    }
+
+    @Test func releasingOneReservationLeavesAnOverlappingRequestSpeakingForTheConsumer() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .hang)
+        let consumer = Task { for try await _ in backend.send(.startEnvironment(environment, StartOptions())) {} }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        // The first request reserves the id and then hangs, so its reservation still stands
+        // while the second one is sent, released, and the consumer goes away.
+        let pending = backend.send(.cancelOperation(id))
+        let canceller = Task { for try await _ in pending {} }
+        while await backend.receivedRequests.count < 2 { try await Task.sleep(for: .milliseconds(2)) }
+        await backend.script("cancelOperation", .disconnect())
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await _ in backend.send(.cancelOperation(id)) {}
+        }
+        consumer.cancel()
+        for _ in 0..<400 where await backend.status(of: environment)?.inFlightOperation != nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "the consumer's cancellation ended the operation")
+        // A later ticket cannot be served until every earlier one has been, so a synthetic
+        // cancellation taken before this query is recorded by the time it replies.
+        for try await _ in backend.send(.environmentStatus(environment)) {}
+        let cancels = await backend.receivedRequests.filter { $0 == .cancelOperation(id) }
+        #expect(cancels.count == 2, "the released request spoke for a reservation another request still holds")
+        canceller.cancel()
+        _ = try? await canceller.value
+    }
+
     @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
         let backend = FakeRuntimeBackend()
         let id = OperationID()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct FakeRuntimeBackendBindingTests {
+    func acceptedID(_ stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> OperationID? {
+        var accepted: OperationID?
+        for try await event in stream {
+            if case .accepted(let id) = event { accepted = id }
+        }
+        return accepted
+    }
+
+    @Test func seededIDsBindToTheSendThatFollowsThem() async throws {
+        let backend = FakeRuntimeBackend()
+        let first = OperationID()
+        let second = OperationID()
+        await backend.useOperationID(first, forNext: "startEnvironment")
+        let one = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        await backend.useOperationID(second, forNext: "startEnvironment")
+        let two = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let three = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        #expect(try await acceptedID(one) == first)
+        #expect(try await acceptedID(two) == second)
+        let unseeded = try await acceptedID(three)
+        #expect(unseeded != nil && unseeded != first && unseeded != second)
+    }
+
+    @Test func scriptChangesAfterSendDoNotAffectTheSentRequest() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("startEnvironment", .fail(error: .canceled))
+        let stream = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        await backend.script("startEnvironment", .succeed())
+        var names: [String] = []
+        for try await event in stream { names.append(event.caseName) }
+        #expect(names == ["accepted", "failed"])
+    }
+
+    @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
+        let backend = FakeRuntimeBackend()
+        let id = OperationID()
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        let stream = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let consumer = Task {
+            var names: [String] = []
+            for try await event in stream { names.append(event.caseName) }
+            return names
+        }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        for try await _ in backend.send(.cancelOperation(id)) {}
+        consumer.cancel()
+        _ = try? await consumer.value
+        let cancels = await backend.receivedRequests.filter { $0 == .cancelOperation(id) }
+        #expect(cancels.count == 1)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -36,6 +36,38 @@ import Testing
         #expect(names == ["accepted", "failed"])
     }
 
+    @Test func cancellationClearsTheSeededInFlightOperationAndAppliesAScriptedStatus() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        for try await _ in backend.send(.cancelOperation(id)) {}
+        try await consumer.value
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+        let other = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: other))
+        await backend.script("cancelOperation", .succeed(status: EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready)))
+        for try await _ in backend.send(.cancelOperation(other)) {}
+        #expect(await backend.status(of: environment)?.vm == .stopped)
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+    }
+
+    @Test func concurrentSendsKeepTheirSeededIDs() async throws {
+        let backend = FakeRuntimeBackend()
+        let ids = (0..<8).map { _ in OperationID() }
+        var accepted: [OperationID?] = []
+        for id in ids {
+            await backend.useOperationID(id, forNext: "startEnvironment")
+            accepted.append(try await acceptedID(backend.send(.startEnvironment(EnvironmentID(), StartOptions()))))
+        }
+        #expect(accepted == ids.map { Optional($0) })
+    }
+
     @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
         let backend = FakeRuntimeBackend()
         let id = OperationID()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -57,6 +57,17 @@ import Testing
         #expect(await backend.status(of: environment)?.inFlightOperation == nil)
     }
 
+    @Test func aScriptedFailureClearsTheSeededInFlightOperation() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .fail(error: .guestNotReachable(environment)))
+        for try await _ in backend.send(.startEnvironment(environment, StartOptions())) {}
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+    }
+
     @Test func concurrentSendsKeepTheirSeededIDs() async throws {
         let backend = FakeRuntimeBackend()
         let ids = (0..<8).map { _ in OperationID() }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -79,6 +79,31 @@ import Testing
         #expect(accepted == ids.map { Optional($0) })
     }
 
+    @Test func aCompletedOperationIsNoLongerInFlightWithoutAScriptedStatus() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let operation = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: operation))
+        await backend.useOperationID(operation, forNext: "startEnvironment")
+        for try await _ in backend.send(.startEnvironment(environment, StartOptions())) {}
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "a completed operation is not still in flight")
+    }
+
+    @Test func aConsumerCancelledDuringAProgressPhaseClearsTheInFlightOperation() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(30))
+        let environment = EnvironmentID()
+        let operation = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: operation))
+        await backend.useOperationID(operation, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .succeed(phases: [ProgressPhase(kind: .startingVM), ProgressPhase(kind: .waitingForNetwork)]))
+        let consumer = Task { for try await _ in backend.send(.startEnvironment(environment, StartOptions())) { break } }
+        _ = try? await consumer.value
+        for _ in 0..<200 where await backend.status(of: environment)?.inFlightOperation != nil {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "a cancelled operation is not still in flight")
+    }
+
     @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
         let backend = FakeRuntimeBackend()
         let id = OperationID()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -137,6 +137,81 @@ import Testing
         #expect(cancels.count == 2, "the failed request did not suppress the consumer's own cancellation")
     }
 
+    @Test func anAcceptedOperationIsInFlightForItsEnvironment() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(30))
+        let environment = EnvironmentID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready))
+        let stream = backend.send(.stopEnvironment(environment, .force))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id) = try await iterator.next() else { Issue.record("no accepted"); return }
+        #expect(await backend.status(of: environment)?.inFlightOperation == id, "an accepted operation is in flight even when no caller seeded its id")
+        #expect(try await iterator.next() == .completed(id))
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+    }
+
+    @Test func aScriptedStatusLeavesTheOperationInFlightUntilItCompletes() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(30))
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .succeed(status: EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready)))
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(id))
+        guard case .status = try await iterator.next() else { Issue.record("no status"); return }
+        #expect(await backend.status(of: environment)?.vm == .running)
+        #expect(await backend.status(of: environment)?.inFlightOperation == id, "the operation is still in flight until its own terminal event")
+        #expect(try await iterator.next() == .completed(id))
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+    }
+
+    @Test func aConsumerCancelledBeforeAScriptedDisconnectionEndsAsCancelled() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(30))
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .disconnect())
+        let consumer = Task { for try await _ in backend.send(.startEnvironment(environment, StartOptions())) { break } }
+        _ = try? await consumer.value
+        for _ in 0..<200 where await backend.receivedRequests.filter({ $0 == .cancelOperation(id) }).isEmpty {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await backend.receivedRequests.contains(.cancelOperation(id)), "the cancellation before a scripted disconnection was not recorded")
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "a cancelled operation is not left in flight by a scripted disconnection")
+    }
+
+    @Test func aConsumerCancellationSuppressedByAReservationIsRecordedWhenThatRequestFails() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .hang)
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        // The request reserves the id in `send` and then hangs, so the consumer's own
+        // cancellation arrives while that reservation still stands.
+        let cancelStream = backend.send(.cancelOperation(id))
+        let canceller = Task { for try await _ in cancelStream {} }
+        while await backend.receivedRequests.count < 2 { try await Task.sleep(for: .milliseconds(2)) }
+        consumer.cancel()
+        for _ in 0..<400 where await backend.status(of: environment)?.inFlightOperation != nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil, "the consumer's cancellation ended the operation")
+        canceller.cancel()
+        _ = try? await canceller.value
+        for _ in 0..<400 where await backend.receivedRequests.filter({ $0 == .cancelOperation(id) }).count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let cancels = await backend.receivedRequests.filter { $0 == .cancelOperation(id) }
+        #expect(cancels.count == 2, "a request that never took effect swallowed the consumer's own cancellation")
+    }
+
     @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
         let backend = FakeRuntimeBackend()
         let id = OperationID()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendBindingTests.swift
@@ -104,6 +104,39 @@ import Testing
         #expect(await backend.status(of: environment)?.inFlightOperation == nil, "a cancelled operation is not still in flight")
     }
 
+    @Test func anOperationCancelledDuringItsTerminalPauseReportsCancellation() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(60))
+        let environment = EnvironmentID()
+        let id = OperationID()
+        await backend.setStatus(EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready, inFlightOperation: id))
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        let collector = Task { try await acceptedID(stream) }
+        try await Task.sleep(for: .milliseconds(30))
+        for try await _ in backend.send(.cancelOperation(id)) {}
+        _ = try? await collector.value
+        #expect(await backend.status(of: environment)?.inFlightOperation == nil)
+    }
+
+    @Test func aFailedCancellationRequestReleasesItsReservation() async throws {
+        let backend = FakeRuntimeBackend()
+        let id = OperationID()
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .fail(error: .invalidRequest(.unsupportedOperation)))
+        let stream = backend.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        while await backend.receivedRequests.isEmpty { try await Task.sleep(for: .milliseconds(2)) }
+        for try await _ in backend.send(.cancelOperation(id)) {}
+        consumer.cancel()
+        _ = try? await consumer.value
+        for _ in 0..<200 where await backend.receivedRequests.filter({ $0 == .cancelOperation(id) }).count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let cancels = await backend.receivedRequests.filter { $0 == .cancelOperation(id) }
+        #expect(cancels.count == 2, "the failed request did not suppress the consumer's own cancellation")
+    }
+
     @Test func explicitCancellationIsRecordedOnceEvenWhenTheConsumerAlsoStops() async throws {
         let backend = FakeRuntimeBackend()
         let id = OperationID()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -73,6 +73,48 @@ import Testing
         guard case .cancelOperation = requests[1] else { Issue.record("no cancelOperation recorded: \(requests)"); return }
     }
 
+    @Test func cancelOperationRequestEndsAHangingOperation() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("startEnvironment", .hang)
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id) = try await iterator.next() else { Issue.record("no accepted"); return }
+        _ = try await collect(backend.send(.cancelOperation(id)))
+        let last = try await iterator.next()
+        #expect(last == .failed(id, .canceled))
+        #expect(try await iterator.next() == nil)
+        #expect(await backend.receivedRequests == [.startEnvironment(environment, StartOptions()), .cancelOperation(id)])
+    }
+
+    @Test func scriptedFailuresApplyToQueries() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("environmentStatus", .disconnect())
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await _ in backend.send(.environmentStatus(environment)) {}
+        }
+        await backend.script("runtimeVersion", .fail(error: .unauthorizedCaller))
+        let events = try await collect(backend.send(.runtimeVersion))
+        guard case .failed(_, let error) = events.first! else { Issue.record("expected failed"); return }
+        #expect(error == .unauthorizedCaller)
+    }
+
+    @Test func requestsAreRecordedInSendOrder() async throws {
+        let backend = FakeRuntimeBackend()
+        var streams: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        let requests: [RuntimeRequest] = (0..<20).map { $0.isMultiple(of: 2) ? .startEnvironment(environment, StartOptions()) : .stopEnvironment(environment, .force) }
+        for request in requests { streams.append(backend.send(request)) }
+        for stream in streams { _ = try await collect(stream) }
+        #expect(await backend.receivedRequests == requests)
+    }
+
+    @Test func interruptionCarriesRecoveryGuidance() {
+        let error = RuntimeConnectionInterrupted(operationID: OperationID())
+        #expect(error.recoveryActions.first == .inspectState)
+        #expect(error.errorDescription?.isEmpty == false)
+        #expect(error.guesthouseError?.caseName == "operationOutcomeUnknown")
+        #expect(RuntimeConnectionInterrupted().guesthouseError == nil)
+    }
+
     @Test func queriesReplyWithoutOperationIDs() async throws {
         let backend = FakeRuntimeBackend()
         let status = EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready)
@@ -106,6 +148,14 @@ import Testing
         }
         let full = await PreviewScenarios.bothSlotsFull()
         #expect(full.snapshot.slots.isFull)
+        let running = await PreviewScenarios.oneRunningEnvironment()
+        let runningID = running.snapshot.environments[0].id
+        _ = try await collect(running.backend.send(.stopEnvironment(runningID, .graceful(deadline: .seconds(30)))))
+        #expect(await running.backend.status(of: runningID)?.vm == .stopped)
+        let inProgress = await PreviewScenarios.operationInProgress()
+        let progressID = inProgress.snapshot.environments[0].id
+        #expect(await inProgress.backend.status(of: progressID)?.inFlightOperation != nil)
+        #expect(inProgress.initialRequest == .startEnvironment(progressID, StartOptions()))
         let repair = await PreviewScenarios.environmentNeedingRepair()
         let id = repair.snapshot.environments[0].id
         let events = try await collect(repair.backend.send(.startEnvironment(id, StartOptions())))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -143,6 +143,16 @@ import Testing
         #expect(RuntimeConnectionInterrupted().guesthouseError == nil)
     }
 
+    @Test func aPreAcceptanceMutationRequiresInspectionWithoutInventingAnOperationID() {
+        let error = RuntimeConnectionInterrupted(mayHaveMutated: true)
+        #expect(error.operationID == nil)
+        #expect(error.mayHaveMutated)
+        #expect(error.recoveryActions == [.inspectState, .cancel])
+        #expect(error.userMessage.contains("may or may not have completed"))
+        #expect(error.recoveryMessage == "Check the environment before doing anything else.")
+        #expect(error.guesthouseError == nil)
+    }
+
     @Test func aQueryInterruptionOffersRetryRatherThanAnUnknownOutcome() async throws {
         let backend = FakeRuntimeBackend()
         await backend.script("runtimeVersion", .disconnect())
@@ -151,6 +161,7 @@ import Testing
             Issue.record("expected an interruption")
         } catch let error as RuntimeConnectionInterrupted {
             #expect(error.operationID == nil)
+            #expect(!error.mayHaveMutated)
             #expect(error.recoveryActions == [.retry], "a read-only query has nothing to inspect or cancel")
             #expect(!error.userMessage.contains("may or may not"))
             #expect(error.recoveryMessage.isEmpty == false)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -86,6 +86,32 @@ import Testing
         #expect(await backend.receivedRequests == [.startEnvironment(environment, StartOptions()), .cancelOperation(id)])
     }
 
+    @Test func cancelRequestsHonorScenarios() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("startEnvironment", .hang)
+        await backend.script("cancelOperation", .disconnect())
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id) = try await iterator.next() else { Issue.record("no accepted"); return }
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await _ in backend.send(.cancelOperation(id)) {}
+        }
+        await backend.script("cancelOperation", .fail(error: .unauthorizedCaller))
+        let events = try await collect(backend.send(.cancelOperation(id)))
+        #expect(events == [.failed(id, .unauthorizedCaller)])
+        #expect(await backend.receivedRequests.count == 3)
+    }
+
+    @Test func seededOperationIDIsReusedByTheNextRequest() async throws {
+        let backend = FakeRuntimeBackend()
+        let id = OperationID()
+        await backend.useOperationID(id, forNext: "startEnvironment")
+        let events = try await collect(backend.send(.startEnvironment(environment, StartOptions())))
+        #expect(events.first == .accepted(id))
+        let again = try await collect(backend.send(.startEnvironment(environment, StartOptions())))
+        #expect(again.first != .accepted(id), "the seeded id is used once")
+    }
+
     @Test func scriptedFailuresApplyToQueries() async throws {
         let backend = FakeRuntimeBackend()
         await backend.script("environmentStatus", .disconnect())
@@ -154,8 +180,10 @@ import Testing
         #expect(await running.backend.status(of: runningID)?.vm == .stopped)
         let inProgress = await PreviewScenarios.operationInProgress()
         let progressID = inProgress.snapshot.environments[0].id
-        #expect(await inProgress.backend.status(of: progressID)?.inFlightOperation != nil)
+        let seeded = try #require(await inProgress.backend.status(of: progressID)?.inFlightOperation)
         #expect(inProgress.initialRequest == .startEnvironment(progressID, StartOptions()))
+        let first = try await inProgress.backend.send(inProgress.initialRequest!).first { _ in true }
+        #expect(first == .accepted(seeded), "preview progress events carry the seeded operation id")
         let repair = await PreviewScenarios.environmentNeedingRepair()
         let id = repair.snapshot.environments[0].id
         let events = try await collect(repair.backend.send(.startEnvironment(id, StartOptions())))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -141,6 +141,21 @@ import Testing
         #expect(RuntimeConnectionInterrupted().guesthouseError == nil)
     }
 
+    @Test func aQueryInterruptionOffersRetryRatherThanAnUnknownOutcome() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("runtimeVersion", .disconnect())
+        do {
+            for try await _ in backend.send(.runtimeVersion) {}
+            Issue.record("expected an interruption")
+        } catch let error as RuntimeConnectionInterrupted {
+            #expect(error.operationID == nil)
+            #expect(error.recoveryActions == [.retry], "a read-only query has nothing to inspect or cancel")
+            #expect(!error.userMessage.contains("may or may not"))
+            #expect(error.recoveryMessage.isEmpty == false)
+        }
+        #expect(RuntimeConnectionInterrupted(operationID: OperationID()).recoveryActions == [.inspectState, .cancel])
+    }
+
     @Test func queriesReplyWithoutOperationIDs() async throws {
         let backend = FakeRuntimeBackend()
         let status = EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct FakeRuntimeBackendTests {
+    let environment = EnvironmentID()
+
+    func collect(_ stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> [RuntimeEvent] {
+        var events: [RuntimeEvent] = []
+        for try await event in stream { events.append(event) }
+        return events
+    }
+
+    @Test func successScenarioEmitsStagedProgressThenCompleted() async throws {
+        let backend = FakeRuntimeBackend()
+        let phases = [ProgressPhase(kind: .startingVM), ProgressPhase(kind: .waitingForNetwork, fraction: 0.5)]
+        let status = EnvironmentStatus(environmentID: environment, vm: .running, readiness: .ready)
+        await backend.script("startEnvironment", .succeed(phases: phases, status: status))
+
+        let events = try await collect(backend.send(.startEnvironment(environment, StartOptions())))
+        #expect(events.map(\.caseName) == ["accepted", "progress", "progress", "status", "completed"])
+        guard case .accepted(let id) = events[0] else { Issue.record("no accepted"); return }
+        #expect(events[1] == .progress(id, phases[0]))
+        #expect(events[3] == .status(status))
+        #expect(events[4] == .completed(id))
+        #expect(await backend.status(of: environment) == status)
+        #expect(await backend.receivedRequests == [.startEnvironment(environment, StartOptions())])
+    }
+
+    @Test func failureScenarioEndsWithTheGivenError() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("stopEnvironment", .fail(after: [ProgressPhase(kind: .stoppingVM)], error: .guestNotReachable(environment)))
+        let events = try await collect(backend.send(.stopEnvironment(environment, .force)))
+        #expect(events.map(\.caseName) == ["accepted", "progress", "failed"])
+        guard case .failed(_, let error) = events.last! else { Issue.record("no failed"); return }
+        #expect(error == .guestNotReachable(environment))
+    }
+
+    @Test func disconnectScenarioThrowsInterruptionSoOutcomeIsUnknown() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("importXcode", .disconnect(after: [ProgressPhase(kind: .copying)]))
+        let handoff = FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")
+        var seen: [String] = []
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await event in backend.send(.importXcode(environment, handoff)) {
+                seen.append(event.caseName)
+            }
+        }
+        #expect(seen == ["accepted", "progress"])
+    }
+
+    @Test func cancellingTheConsumerStopsAHangingOperationAndRecordsCancel() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("startEnvironment", .hang)
+        let stream = backend.send(.startEnvironment(environment, StartOptions()))
+        let consumer = Task {
+            var events: [RuntimeEvent] = []
+            do {
+                for try await event in stream { events.append(event) }
+            } catch {}
+            return events
+        }
+        while await backend.receivedRequests.isEmpty {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        consumer.cancel()
+        _ = await consumer.value
+        for _ in 0..<200 where await backend.receivedRequests.count < 2 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let requests = await backend.receivedRequests
+        #expect(requests.count == 2)
+        guard case .cancelOperation = requests[1] else { Issue.record("no cancelOperation recorded: \(requests)"); return }
+    }
+
+    @Test func queriesReplyWithoutOperationIDs() async throws {
+        let backend = FakeRuntimeBackend()
+        let status = EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready)
+        await backend.setStatus(status)
+        #expect(try await collect(backend.send(.environmentStatus(environment))) == [.status(status)])
+        let unknown = EnvironmentID()
+        #expect(try await collect(backend.send(.environmentStatus(unknown))) == [.status(EnvironmentStatus(environmentID: unknown, vm: .notFound, readiness: .checking))])
+        let version = try await collect(backend.send(.runtimeVersion))
+        guard case .runtimeVersion(let info) = version.first! else { Issue.record("no version"); return }
+        #expect(info.tart?.verified == true)
+        #expect(await backend.receivedRequests.count == 3)
+    }
+
+    @Test func defaultScenarioSucceedsWithoutPhases() async throws {
+        let backend = FakeRuntimeBackend()
+        let events = try await collect(backend.send(.stopEnvironment(environment, .graceful(deadline: .seconds(30)))))
+        #expect(events.map(\.caseName) == ["accepted", "completed"])
+    }
+
+    @Test func previewScenariosBuildWithoutIOAndAnswerStatusQueries() async throws {
+        for make in PreviewScenarios.all {
+            let scenario = await make()
+            #expect(!scenario.name.isEmpty)
+            for environment in scenario.snapshot.environments {
+                let events = try await collect(scenario.backend.send(.environmentStatus(environment.id)))
+                guard case .status(let status) = events.first! else { Issue.record("\(scenario.name): no status"); continue }
+                #expect(status.environmentID == environment.id, Comment(rawValue: scenario.name))
+                #expect(status.vm != .notFound, Comment(rawValue: scenario.name))
+            }
+            #expect(scenario.snapshot.slots.occupiedSlots == scenario.snapshot.environments.count, Comment(rawValue: scenario.name))
+        }
+        let full = await PreviewScenarios.bothSlotsFull()
+        #expect(full.snapshot.slots.isFull)
+        let repair = await PreviewScenarios.environmentNeedingRepair()
+        let id = repair.snapshot.environments[0].id
+        let events = try await collect(repair.backend.send(.startEnvironment(id, StartOptions())))
+        #expect(events.last?.caseName == "failed")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -21,7 +21,9 @@ import Testing
         #expect(events.map(\.caseName) == ["accepted", "progress", "progress", "status", "completed"])
         guard case .accepted(let id) = events[0] else { Issue.record("no accepted"); return }
         #expect(events[1] == .progress(id, phases[0]))
-        #expect(events[3] == .status(status))
+        var inFlight = status
+        inFlight.inFlightOperation = id
+        #expect(events[3] == .status(inFlight), "the emitted status names the operation that has not completed yet")
         #expect(events[4] == .completed(id))
         #expect(await backend.status(of: environment) == status)
         #expect(await backend.receivedRequests == [.startEnvironment(environment, StartOptions())])


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration complete; closed without merging.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: reusable backend/preflight/workspace/identity contracts (#10, #12, #15, #17, #18). Adapt useful implementation/tests to current Core. A historical Tart ancestor does not make shared functionality obsolete.
>
> September 20 closure: owner-merged #198 completes the retained preview factories after #160/#180/#181/#182. Final #10 acceptance mapping and the [six-file/37-thread scope audit](https://github.com/PicoMLX/Guesthouse/pull/60#issuecomment-5619347196) account for the entire retained scope. #198 af251f92 has recorded exact-head Cloud SUCCESS/check106099249153, completed matching Codex and original thumbs-up/no findings. Closing this superseded draft without merging; preserve its branch, code, tests, original description and review history. Synthetic previews are not hardware evidence.
>
> Branch, code, tests and review history remain preserved. This closure does not merge or delete the historical stack. The original description follows unchanged.

---

The fake backend provides deterministic previews and tests through the same typed `RuntimeBackend.send(_:)` stream used by the GUI. It binds scripts and operation IDs when requests are sent, preserves request ordering through cancellation, and models success, failure, hanging work, and disconnection. Suppressed cancellations capture reservation state and the ordering ticket atomically, so a concurrent send cannot change their recorded position.

Accepted start, stop, and Xcode-import operations appear in environment status even when the test did not seed a status. Their baseline remains uncertain/checking until an observation is supplied; terminal cleanup clears the running operation ID. Existing scripted VM/readiness values are preserved.

`RuntimeConnectionInterrupted` carries the defaulted `mayHaveMutated` flag already used by the downstream XPC client. A lost acceptance reply can therefore require inspection without inventing an operation ID, while a read-only query interruption still offers retry.

Implements `MVP-PLAN.md` §3, “Application components” and the interruption/inspection contract, and §10 Phase 0's fake-backend preview boundary. Closes #10. Stacked on #58 (`issue-9-runtime-contract`).

## Validation

- Head `14b75ff9e033c564bcd56fe8e05c384f17890860`: all 353 Core tests in 22 suites pass locally, with no compiler warnings.
- The accepted-status regression fails on the preceding implementation and passes for start, stop, and import after the fix.
- Existing request-order, overlapping cancellation, terminal cleanup, preview, and query recovery tests also pass.
- The five review threads addressed during this update have code/test evidence or an explicit contract-based rejection and are resolved.
- Fresh Xcode Cloud and Codex review are running on this head; their final outcome remains pending.

The complete PR is 1,213 changed lines against #58, above the repository's approximate 500-line target. Review-size decomposition remains outstanding for the broader stack organization; this update does not claim that requirement is satisfied. This update consists of a 91-addition/18-deletion fix across four files, followed by the narrow 7-addition/3-deletion cancellation fix.

No process execution, new dependency, VM operation, or provider migration is added.
