### PR TITLE
Core: host preflight checks (architecture, macOS version, disk, memory, Codex desktop)

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -28,8 +28,11 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     public enum UnsupportedHostReason: Codable, Hashable, Sendable {
         case notAppleSilicon
         /// The Mac's processor is not the one the configured policy requires. `notAppleSilicon`
-        /// is the default-policy spelling of this; this case carries both sides.
-        case wrongArchitecture(found: SanitizedText, required: String)
+        /// is the default-policy spelling of this; this case carries both sides. Both are
+        /// `SanitizedText`, so what a decoded payload put in either is bounded and redacted
+        /// where the value is built rather than where it is shown, and re-encoding the error
+        /// cannot carry the original through.
+        case wrongArchitecture(found: SanitizedText, required: SanitizedText)
         case macOSTooOld(found: SanitizedText, minimum: SanitizedText)
         /// The processor architecture could not be determined; the check can be run again.
         case architectureUnknown
@@ -76,7 +79,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     public var userMessage: String {
         switch self {
         case .unsupportedHost(.wrongArchitecture(let found, let required)):
-            "This Mac has \(found.value); Guesthouse needs \(GuesthouseError.sanitize(required, limit: 40)). Development Macs cannot run here."
+            "This Mac has \(found.value); Guesthouse needs \(required.value). Development Macs cannot run here."
         case .unsupportedHost(.notAppleSilicon):
             "This Mac has an Intel processor. Guesthouse needs an Apple silicon Mac to run a macOS virtual machine."
         case .unsupportedHost(.architectureUnknown):
@@ -317,12 +320,17 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         return "This step needs \(requiredText) free on \(sanitize(volume)), but only \(availableText) is available, \(shortfallText) short."
     }
 
+    /// `ByteCountFormatter` takes an `Int64`, so an amount above that range would be shown as
+    /// half of itself. An amount that large is named exactly instead, so a requirement no
+    /// disk could satisfy is not reported as a plausible one.
     private static func formatBytes(_ bytes: UInt64) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: .file)
+        guard let representable = Int64(exactly: bytes) else { return "\(bytes.formatted()) bytes" }
+        return ByteCountFormatter.string(fromByteCount: representable, countStyle: .file)
     }
 
     private static func formatMemory(_ bytes: UInt64) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: .memory)
+        guard let representable = Int64(exactly: bytes) else { return "\(bytes.formatted()) bytes" }
+        return ByteCountFormatter.string(fromByteCount: representable, countStyle: .memory)
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -28,6 +28,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     public enum UnsupportedHostReason: Codable, Hashable, Sendable {
         case notAppleSilicon
         case macOSTooOld(found: SanitizedText, minimum: SanitizedText)
+        /// The processor architecture could not be determined; the check can be run again.
+        case architectureUnknown
         case insufficientMemory(foundBytes: UInt64, minimumBytes: UInt64)
     }
 
@@ -72,6 +74,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         switch self {
         case .unsupportedHost(.notAppleSilicon):
             "This Mac has an Intel processor. Guesthouse needs an Apple silicon Mac to run a macOS virtual machine."
+        case .unsupportedHost(.architectureUnknown):
+            "Guesthouse could not determine this Mac's processor type. Check this Mac again; if it keeps failing, export diagnostics."
         case .unsupportedHost(.macOSTooOld(let found, let minimum)):
             "This Mac runs macOS \(found.value). Guesthouse needs macOS \(minimum.value) or later."
         case .unsupportedHost(.insufficientMemory(let found, let minimum)):
@@ -117,6 +121,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     public var recoveryActions: [RecoveryAction] {
         switch self {
         case .unsupportedHost(.macOSTooOld): [.openSettings, .cancel]
+        case .unsupportedHost(.architectureUnknown): [.retry, .cancel]
         case .unsupportedHost: [.cancel]
         case .insufficientDisk: [.freeDiskSpace, .retry, .openSettings, .cancel]
         case .downloadVerificationFailed: [.retry, .cancel]

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -27,6 +27,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
 
     public enum UnsupportedHostReason: Codable, Hashable, Sendable {
         case notAppleSilicon
+        /// The Mac's processor is not the one the configured policy requires. `notAppleSilicon`
+        /// is the default-policy spelling of this; this case carries both sides.
+        case wrongArchitecture(found: SanitizedText, required: String)
         case macOSTooOld(found: SanitizedText, minimum: SanitizedText)
         /// The processor architecture could not be determined; the check can be run again.
         case architectureUnknown
@@ -72,6 +75,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     /// what it means; the recovery actions say what to do.
     public var userMessage: String {
         switch self {
+        case .unsupportedHost(.wrongArchitecture(let found, let required)):
+            "This Mac has \(found.value); Guesthouse needs \(GuesthouseError.sanitize(required, limit: 40)). Development Macs cannot run here."
         case .unsupportedHost(.notAppleSilicon):
             "This Mac has an Intel processor. Guesthouse needs an Apple silicon Mac to run a macOS virtual machine."
         case .unsupportedHost(.architectureUnknown):

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -130,6 +130,13 @@ public struct SystemHostProbe: HostProbe {
         guard stat(existing.path, &found) == 0, (found.st_mode & S_IFMT) == S_IFDIR else {
             throw HostProbeError.notADirectory(path: existing.path)
         }
+        // Capacity on a directory this user cannot write is not space a development Mac can
+        // use: the VM directory could never be created there, whether the folder's
+        // permissions changed or the volume is mounted read-only. Asked before the capacity,
+        // so an unusable destination is never reported as free space.
+        guard access(existing.path, W_OK) == 0 else {
+            throw HostProbeError.destinationNotWritable(path: existing.path)
+        }
         let values = try existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
         guard let capacity = values.volumeAvailableCapacityForImportantUsage else {
             throw CocoaError(.fileReadUnknown)
@@ -155,6 +162,8 @@ public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
     case volumeUnavailable(path: String)
     /// Something that is not a directory occupies the destination path.
     case notADirectory(path: String)
+    /// The destination is a directory this user cannot write, so nothing can be created in it.
+    case destinationNotWritable(path: String)
 
     public var userMessage: String {
         switch self {
@@ -162,6 +171,8 @@ public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
             "The volume that holds \(GuesthouseError.sanitize(path, limit: 200)) is not available, so Guesthouse cannot tell how much space it has. Connect the volume, or choose a storage location on this Mac."
         case .notADirectory(let path):
             "\(GuesthouseError.sanitize(path, limit: 200)) is not a folder, so Guesthouse cannot store a development Mac there. Choose another storage location."
+        case .destinationNotWritable(let path):
+            "Guesthouse cannot write to \(GuesthouseError.sanitize(path, limit: 200)), so it cannot create a development Mac there. Choose another storage location, or give yourself write access to that folder."
         }
     }
 
@@ -170,6 +181,7 @@ public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
         switch self {
         case .volumeUnavailable: [.retry, .openSettings, .cancel]
         case .notADirectory: [.openSettings, .cancel]
+        case .destinationNotWritable: [.openSettings, .retry, .cancel]
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -70,9 +70,9 @@ public struct SystemHostProbe: HostProbe {
     public var operatingSystemBuild: String? {
         var size = 0
         guard sysctlbyname("kern.osversion", nil, &size, nil, 0) == 0, size > 0 else { return nil }
-        var buffer = [CChar](repeating: 0, count: size)
+        var buffer = [UInt8](repeating: 0, count: size)
         guard sysctlbyname("kern.osversion", &buffer, &size, nil, 0) == 0 else { return nil }
-        return String(cString: buffer)
+        return String(decoding: buffer.prefix { $0 != 0 }, as: UTF8.self)
     }
 
     public var physicalMemoryBytes: UInt64 {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -1,3 +1,4 @@
+import Darwin
 import AppKit
 import Foundation
 import IOKit.ps
@@ -44,6 +45,14 @@ public protocol HostProbe: Sendable {
 public struct SystemHostProbe: HostProbe {
     /// Where macOS mounts volumes other than the startup volume.
     static let mountContainerPath = "/Volumes"
+
+    /// Whether `url` is that directory, compared by filesystem identity rather than by
+    /// spelling: on a case-insensitive volume `/volumes` names the same directory.
+    static func isMountContainer(_ url: URL) -> Bool {
+        var candidate = stat(), container = stat()
+        guard stat(url.path, &candidate) == 0, stat(mountContainerPath, &container) == 0 else { return false }
+        return candidate.st_dev == container.st_dev && candidate.st_ino == container.st_ino
+    }
 
     public init() {}
 
@@ -104,7 +113,7 @@ public struct SystemHostProbe: HostProbe {
         while !FileManager.default.fileExists(atPath: existing.path) {
             let parent = existing.deletingLastPathComponent()
             if parent.path == existing.path { break }
-            if parent.path == Self.mountContainerPath {
+            if Self.isMountContainer(parent) {
                 throw HostProbeError.volumeUnavailable(path: existing.path)
             }
             existing = parent

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -90,8 +90,16 @@ public struct SystemHostProbe: HostProbe {
         }
     }
 
+    /// The destination usually does not exist yet on first launch; the nearest existing
+    /// ancestor tells which volume it will land on.
     public func freeBytes(at url: URL) throws -> UInt64 {
-        let values = try url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        var existing = url.standardizedFileURL
+        while !FileManager.default.fileExists(atPath: existing.path) {
+            let parent = existing.deletingLastPathComponent()
+            if parent.path == existing.path { break }
+            existing = parent
+        }
+        let values = try existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
         guard let capacity = values.volumeAvailableCapacityForImportantUsage else {
             throw CocoaError(.fileReadUnknown)
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -1,0 +1,110 @@
+import AppKit
+import Foundation
+import IOKit.ps
+
+public enum CPUArchitecture: String, Codable, Hashable, Sendable {
+    case appleSilicon
+    case intel
+    case unknown
+}
+
+public enum PowerSource: String, Codable, Hashable, Sendable {
+    case externalPower
+    case battery
+    case unknown
+}
+
+public struct InstalledApplication: Codable, Hashable, Sendable {
+    public var url: URL
+    public var version: String?
+    public var build: String?
+
+    public init(url: URL, version: String?, build: String?) {
+        self.url = url
+        self.version = version
+        self.build = build
+    }
+}
+
+/// Everything the preflight needs to know about this Mac, behind a protocol so checks can be
+/// tested with a stub (MVP-PLAN.md §2, step 1).
+public protocol HostProbe: Sendable {
+    var cpuArchitecture: CPUArchitecture { get }
+    var operatingSystemVersion: SemanticVersion { get }
+    var operatingSystemBuild: String? { get }
+    var physicalMemoryBytes: UInt64 { get }
+    var powerSource: PowerSource { get }
+    /// Free space usable for important data on the volume containing `url`.
+    func freeBytes(at url: URL) throws -> UInt64
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication?
+}
+
+/// The real thing. Not unit-tested beyond a smoke test; every decision that matters is made
+/// by `PreflightCheck` from values that tests supply through a stub.
+public struct SystemHostProbe: HostProbe {
+    public init() {}
+
+    public var cpuArchitecture: CPUArchitecture {
+        var value: Int32 = 0
+        var size = MemoryLayout<Int32>.size
+        if sysctlbyname("hw.optional.arm64", &value, &size, nil, 0) == 0, value == 1 {
+            return .appleSilicon
+        }
+        var translated: Int32 = 0
+        size = MemoryLayout<Int32>.size
+        if sysctlbyname("sysctl.proc_translated", &translated, &size, nil, 0) == 0, translated == 1 {
+            return .appleSilicon
+        }
+        #if arch(x86_64)
+        return .intel
+        #else
+        return .unknown
+        #endif
+    }
+
+    public var operatingSystemVersion: SemanticVersion {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return SemanticVersion([v.majorVersion, v.minorVersion, v.patchVersion])
+    }
+
+    public var operatingSystemBuild: String? {
+        var size = 0
+        guard sysctlbyname("kern.osversion", nil, &size, nil, 0) == 0, size > 0 else { return nil }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("kern.osversion", &buffer, &size, nil, 0) == 0 else { return nil }
+        return String(cString: buffer)
+    }
+
+    public var physicalMemoryBytes: UInt64 {
+        ProcessInfo.processInfo.physicalMemory
+    }
+
+    public var powerSource: PowerSource {
+        guard let info = IOPSCopyPowerSourcesInfo()?.takeRetainedValue(),
+              let type = IOPSGetProvidingPowerSourceType(info)?.takeUnretainedValue() as String?
+        else { return .unknown }
+        switch type {
+        case kIOPMACPowerKey: return .externalPower
+        case kIOPMBatteryPowerKey, kIOPMUPSPowerKey: return .battery
+        default: return .unknown
+        }
+    }
+
+    public func freeBytes(at url: URL) throws -> UInt64 {
+        let values = try url.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        guard let capacity = values.volumeAvailableCapacityForImportantUsage else {
+            throw CocoaError(.fileReadUnknown)
+        }
+        return UInt64(max(0, capacity))
+    }
+
+    public func installedApplication(bundleIdentifier: String) -> InstalledApplication? {
+        guard let url = NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) else { return nil }
+        let info = Bundle(url: url)?.infoDictionary
+        return InstalledApplication(
+            url: url,
+            version: info?["CFBundleShortVersionString"] as? String,
+            build: info?["CFBundleVersion"] as? String
+        )
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -111,12 +111,24 @@ public struct SystemHostProbe: HostProbe {
     public func freeBytes(at url: URL) throws -> UInt64 {
         var existing = url.standardizedFileURL
         while !FileManager.default.fileExists(atPath: existing.path) {
+            // A component that exists as a link but does not resolve names a destination on a
+            // volume that is not there; walking past it would measure the wrong disk.
+            var info = stat()
+            if lstat(existing.path, &info) == 0 {
+                throw HostProbeError.volumeUnavailable(path: existing.path)
+            }
             let parent = existing.deletingLastPathComponent()
             if parent.path == existing.path { break }
             if Self.isMountContainer(parent) {
                 throw HostProbeError.volumeUnavailable(path: existing.path)
             }
             existing = parent
+        }
+        // The destination has to be a directory: a regular file where a folder is expected is
+        // not a place a development Mac can be created.
+        var found = stat()
+        guard stat(existing.path, &found) == 0, (found.st_mode & S_IFMT) == S_IFDIR else {
+            throw HostProbeError.notADirectory(path: existing.path)
         }
         let values = try existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
         guard let capacity = values.volumeAvailableCapacityForImportantUsage else {
@@ -141,11 +153,23 @@ public struct SystemHostProbe: HostProbe {
 public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
     /// The destination's volume is not mounted, so its free space is unknowable.
     case volumeUnavailable(path: String)
+    /// Something that is not a directory occupies the destination path.
+    case notADirectory(path: String)
 
     public var userMessage: String {
         switch self {
         case .volumeUnavailable(let path):
             "The volume that holds \(GuesthouseError.sanitize(path, limit: 200)) is not available, so Guesthouse cannot tell how much space it has. Connect the volume, or choose a storage location on this Mac."
+        case .notADirectory(let path):
+            "\(GuesthouseError.sanitize(path, limit: 200)) is not a folder, so Guesthouse cannot store a development Mac there. Choose another storage location."
+        }
+    }
+
+    /// What the user can do about it, so every presentation path has a way forward.
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .volumeUnavailable: [.retry, .openSettings, .cancel]
+        case .notADirectory: [.openSettings, .cancel]
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -48,10 +48,48 @@ public struct SystemHostProbe: HostProbe {
 
     /// Whether `url` is that directory, compared by filesystem identity rather than by
     /// spelling: on a case-insensitive volume `/volumes` names the same directory.
-    static func isMountContainer(_ url: URL) -> Bool {
-        var candidate = stat(), container = stat()
-        guard stat(url.path, &candidate) == 0, stat(mountContainerPath, &container) == 0 else { return false }
-        return candidate.st_dev == container.st_dev && candidate.st_ino == container.st_ino
+    static func isMountContainer(_ url: URL, container: String = mountContainerPath) -> Bool {
+        var candidate = stat(), holder = stat()
+        guard stat(url.path, &candidate) == 0, stat(container, &holder) == 0 else { return false }
+        return candidate.st_dev == holder.st_dev && candidate.st_ino == holder.st_ino
+    }
+
+    /// The folder on `url`'s path where a volume mounts, `/Volumes/External` for
+    /// `/Volumes/External/Guesthouse`, or `nil` for a path that names no mount point.
+    ///
+    /// A mount point is always one component below the folder that holds them, so the walk
+    /// is a fixed depth rather than a climb to the root: `deletingLastPathComponent` answers
+    /// `/..` for the root and would never end.
+    static func volumeMountPoint(of url: URL, container: String = mountContainerPath) -> URL? {
+        let depth = URL(fileURLWithPath: container).standardizedFileURL.pathComponents.count
+        var candidate = url.standardizedFileURL
+        guard candidate.pathComponents.count > depth else { return nil }
+        while candidate.pathComponents.count > depth + 1 {
+            candidate = candidate.deletingLastPathComponent()
+        }
+        guard isMountContainer(candidate.deletingLastPathComponent(), container: container) else { return nil }
+        return candidate
+    }
+
+    /// Whether that mount point is a leftover folder rather than a mounted volume: a real
+    /// directory on the same filesystem as the folder that holds mount points is where a
+    /// volume *would* mount, so its capacity is the startup disk's and not the selected
+    /// volume's. A link is left alone; it names a location that resolves on its own.
+    static func isUnmountedVolumePoint(_ url: URL, container: String = mountContainerPath) -> Bool {
+        var point = stat(), holder = stat()
+        guard lstat(url.path, &point) == 0, (point.st_mode & S_IFMT) == S_IFDIR else { return false }
+        guard stat(container, &holder) == 0 else { return false }
+        return point.st_dev == holder.st_dev
+    }
+
+    /// Whether a failed `access` check rules the destination out.
+    ///
+    /// `access` answers for the calling process. The sandboxed app is refused with `EPERM`
+    /// for a folder the runtime service — the process that actually creates the VM — can
+    /// write, so that denial says nothing about the destination. A filesystem permission
+    /// denial and a read-only volume do rule it out, whatever process asks.
+    static func rulesOutDestination(_ denial: Int32) -> Bool {
+        denial == EACCES || denial == EROFS
     }
 
     public init() {}
@@ -109,6 +147,12 @@ public struct SystemHostProbe: HostProbe {
     /// that holds mount points: an unmounted external volume must not be answered with the
     /// startup disk's free space.
     public func freeBytes(at url: URL) throws -> UInt64 {
+        try freeBytes(at: url, mountContainer: Self.mountContainerPath)
+    }
+
+    /// The folder that holds mount points is a parameter so a test can stand one up; the
+    /// product always asks about `/Volumes`.
+    func freeBytes(at url: URL, mountContainer: String) throws -> UInt64 {
         var existing = url.standardizedFileURL
         while !FileManager.default.fileExists(atPath: existing.path) {
             // A component that exists as a link but does not resolve names a destination on a
@@ -119,10 +163,28 @@ public struct SystemHostProbe: HostProbe {
             }
             let parent = existing.deletingLastPathComponent()
             if parent.path == existing.path { break }
-            if Self.isMountContainer(parent) {
+            if Self.isMountContainer(parent, container: mountContainer) {
                 throw HostProbeError.volumeUnavailable(path: existing.path)
             }
             existing = parent
+        }
+        // A destination under a mount point that holds no mounted volume is a leftover folder
+        // on the startup disk: its capacity would answer a question about a volume that is
+        // not there, which is exactly what the walk above refuses to do.
+        if let mountPoint = Self.volumeMountPoint(of: existing, container: mountContainer),
+           Self.isUnmountedVolumePoint(mountPoint, container: mountContainer) {
+            throw HostProbeError.volumeUnavailable(path: mountPoint.path)
+        }
+        // The same question asked of where the destination really leads. A link outside the
+        // folder that holds mount points may point inside one — `~/Development Macs` at
+        // `/Volumes/External` — and the spelled path then names no mount point at all, while
+        // everything below follows the link and reads the leftover folder's startup-disk
+        // capacity. The container is resolved too, so the mount point is counted at the same
+        // depth in both paths.
+        let resolvedContainer = URL(fileURLWithPath: mountContainer).resolvingSymlinksInPath().path
+        if let mountPoint = Self.volumeMountPoint(of: existing.resolvingSymlinksInPath(), container: resolvedContainer),
+           Self.isUnmountedVolumePoint(mountPoint, container: resolvedContainer) {
+            throw HostProbeError.volumeUnavailable(path: mountPoint.path)
         }
         // The destination has to be a directory: a regular file where a folder is expected is
         // not a place a development Mac can be created.
@@ -130,11 +192,11 @@ public struct SystemHostProbe: HostProbe {
         guard stat(existing.path, &found) == 0, (found.st_mode & S_IFMT) == S_IFDIR else {
             throw HostProbeError.notADirectory(path: existing.path)
         }
-        // Capacity on a directory this user cannot write is not space a development Mac can
-        // use: the VM directory could never be created there, whether the folder's
-        // permissions changed or the volume is mounted read-only. Asked before the capacity,
-        // so an unusable destination is never reported as free space.
-        guard access(existing.path, W_OK) == 0 else {
+        // Capacity in a directory nothing can be created in is not space a development Mac
+        // can use: creating the VM folder needs write *and* search permission, whether the
+        // folder's permissions changed or the volume is mounted read-only. Asked before the
+        // capacity, so an unusable destination is never reported as free space.
+        if access(existing.path, W_OK | X_OK) != 0, Self.rulesOutDestination(errno) {
             throw HostProbeError.destinationNotWritable(path: existing.path)
         }
         let values = try existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -42,6 +42,9 @@ public protocol HostProbe: Sendable {
 /// The real thing. Not unit-tested beyond a smoke test; every decision that matters is made
 /// by `PreflightCheck` from values that tests supply through a stub.
 public struct SystemHostProbe: HostProbe {
+    /// Where macOS mounts volumes other than the startup volume.
+    static let mountContainerPath = "/Volumes"
+
     public init() {}
 
     public var cpuArchitecture: CPUArchitecture {
@@ -92,11 +95,18 @@ public struct SystemHostProbe: HostProbe {
 
     /// The destination usually does not exist yet on first launch; the nearest existing
     /// ancestor tells which volume it will land on.
+    /// The capacity of the volume that will hold `url`. A destination that does not exist yet
+    /// is measured on its nearest existing ancestor, but the walk never crosses the directory
+    /// that holds mount points: an unmounted external volume must not be answered with the
+    /// startup disk's free space.
     public func freeBytes(at url: URL) throws -> UInt64 {
         var existing = url.standardizedFileURL
         while !FileManager.default.fileExists(atPath: existing.path) {
             let parent = existing.deletingLastPathComponent()
             if parent.path == existing.path { break }
+            if parent.path == Self.mountContainerPath {
+                throw HostProbeError.volumeUnavailable(path: existing.path)
+            }
             existing = parent
         }
         let values = try existing.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
@@ -115,4 +125,20 @@ public struct SystemHostProbe: HostProbe {
             build: info?["CFBundleVersion"] as? String
         )
     }
+}
+
+/// What the host probe could not answer. Each leaves a preflight check undetermined rather
+/// than answered from the wrong disk.
+public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
+    /// The destination's volume is not mounted, so its free space is unknowable.
+    case volumeUnavailable(path: String)
+
+    public var userMessage: String {
+        switch self {
+        case .volumeUnavailable(let path):
+            "The volume that holds \(GuesthouseError.sanitize(path, limit: 200)) is not available, so Guesthouse cannot tell how much space it has. Connect the volume, or choose a storage location on this Mac."
+        }
+    }
+
+    public var errorDescription: String? { userMessage }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -13,6 +13,9 @@ public struct PreflightResult: Codable, Hashable, Sendable {
         case pass(detail: String)
         /// Setup may continue; the detail says what the user should know.
         case warn(detail: String, recovery: [RecoveryAction])
+        /// The check could not be made at all. Setup does not continue on a guess: an
+        /// unanswerable question is not the same as a satisfied requirement.
+        case undetermined(detail: String, recovery: [RecoveryAction])
         /// Setup cannot continue. The error carries the message and recovery actions.
         case fail(GuesthouseError)
     }
@@ -28,6 +31,14 @@ public struct PreflightResult: Codable, Hashable, Sendable {
     public var isFailure: Bool {
         if case .fail = outcome { return true }
         return false
+    }
+
+    /// Whether this result stops setup: a failure, or a check that could not be made.
+    public var isBlocking: Bool {
+        switch outcome {
+        case .fail, .undetermined: true
+        case .pass, .warn: false
+        }
     }
 }
 
@@ -61,8 +72,8 @@ public struct PreflightReport: Codable, Hashable, Sendable {
         self.checkedAt = checkedAt
     }
 
-    /// True when no check failed. Warnings do not block.
-    public var canProceed: Bool { !results.contains(where: \.isFailure) }
+    /// True when no check failed and every check could be made. Warnings do not block.
+    public var canProceed: Bool { !results.contains(where: \.isBlocking) }
 
     public func result(_ kind: PreflightCheckKind) -> PreflightResult? {
         results.first { $0.kind == kind }
@@ -70,7 +81,7 @@ public struct PreflightReport: Codable, Hashable, Sendable {
 }
 
 /// The "Check this Mac" step. Pure given a probe; every threshold comes from `ResourcePolicy`.
-public enum PreflightCheck {
+public enum PreflightCheck: Sendable {
     public static func run(
         probe: any HostProbe,
         policy: ResourcePolicy = .standard,
@@ -82,11 +93,12 @@ public enum PreflightCheck {
 
         let architecture = probe.cpuArchitecture
         // An architecture nobody could determine is never a pass, whatever the policy asks
-        // for: the unknown case is answered before the policy is consulted.
+        // for: the unknown case is answered before the policy is consulted. The text names
+        // what was found and what is required, so a non-default policy still reads correctly.
         let architectureOutcome: PreflightResult.Outcome = switch architecture {
         case .unknown: .fail(.unsupportedHost(.architectureUnknown))
-        case policy.requiredArchitecture: .pass(detail: "Apple silicon")
-        default: .fail(.unsupportedHost(.notAppleSilicon))
+        case policy.requiredArchitecture: .pass(detail: Self.name(of: architecture))
+        default: .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText(Self.name(of: architecture)), required: Self.name(of: policy.requiredArchitecture))))
         }
         results.append(PreflightResult(kind: .architecture, outcome: architectureOutcome))
 
@@ -123,8 +135,12 @@ public enum PreflightCheck {
             } else {
                 diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
             }
+        } catch HostProbeError.volumeUnavailable(let path) {
+            // The destination's volume is not mounted: not a transient lookup failure, and
+            // never a warning, since there is no disk to check.
+            diskOutcome = .undetermined(detail: HostProbeError.volumeUnavailable(path: path).userMessage, recovery: [.retry, .openSettings])
         } catch {
-            diskOutcome = .warn(detail: "Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined.", recovery: [.retry])
+            diskOutcome = .undetermined(detail: "Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read.", recovery: [.retry, .openSettings])
         }
         results.append(PreflightResult(kind: .freeDisk, outcome: diskOutcome))
 
@@ -146,6 +162,14 @@ public enum PreflightCheck {
         return PreflightReport(results: results, storage: storage, powerSource: probe.powerSource, checkedAt: now)
     }
 
+    static func name(of architecture: CPUArchitecture) -> String {
+        switch architecture {
+        case .appleSilicon: "Apple silicon"
+        case .intel: "Intel"
+        case .unknown: "an unrecognized processor"
+        }
+    }
+
     private static func format(_ bytes: UInt64, memory: Bool = false) -> String {
         ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: memory ? .memory : .file)
     }
@@ -153,7 +177,7 @@ public enum PreflightCheck {
 
 /// Free-space check before every download, import, or clone, not only at first launch
 /// (MVP-PLAN.md §4: "Check free space before each large operation").
-public enum LargeOperationPreflight {
+public enum LargeOperationPreflight: Sendable {
     public static func check(
         freeBytes: UInt64,
         requiredBytes: UInt64,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -61,18 +61,42 @@ public struct PreflightResult: Codable, Hashable, Sendable {
 
 /// "What will be downloaded and where the VM will live" (MVP-PLAN.md §2, step 1).
 public struct StorageSummary: Codable, Hashable, Sendable {
-    public var storageRootPath: String
+    /// Display text only, never authority to access a storage location. Construction,
+    /// assignment, and decoding all enforce the same boundary as other report details.
+    public var storageRootPath: String {
+        didSet { storageRootPath = Self.sanitizedPath(storageRootPath) }
+    }
     public var runtimeDownloadEstimateBytes: UInt64
     public var restoreImageEstimateBytes: UInt64
     public var guestDiskBytes: UInt64
     public var firstSetupAllowanceBytes: UInt64
 
     public init(storageRootPath: String, runtimeDownloadEstimateBytes: UInt64, restoreImageEstimateBytes: UInt64, guestDiskBytes: UInt64, firstSetupAllowanceBytes: UInt64) {
-        self.storageRootPath = storageRootPath
+        self.storageRootPath = Self.sanitizedPath(storageRootPath)
         self.runtimeDownloadEstimateBytes = runtimeDownloadEstimateBytes
         self.restoreImageEstimateBytes = restoreImageEstimateBytes
         self.guestDiskBytes = guestDiskBytes
         self.firstSetupAllowanceBytes = firstSetupAllowanceBytes
+    }
+
+    private static func sanitizedPath(_ path: String) -> String {
+        GuesthouseError.sanitize(path, limit: 400)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case storageRootPath, runtimeDownloadEstimateBytes, restoreImageEstimateBytes
+        case guestDiskBytes, firstSetupAllowanceBytes
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(
+            storageRootPath: try container.decode(String.self, forKey: .storageRootPath),
+            runtimeDownloadEstimateBytes: try container.decode(UInt64.self, forKey: .runtimeDownloadEstimateBytes),
+            restoreImageEstimateBytes: try container.decode(UInt64.self, forKey: .restoreImageEstimateBytes),
+            guestDiskBytes: try container.decode(UInt64.self, forKey: .guestDiskBytes),
+            firstSetupAllowanceBytes: try container.decode(UInt64.self, forKey: .firstSetupAllowanceBytes)
+        )
     }
 }
 
@@ -180,7 +204,7 @@ public enum PreflightCheck: Sendable {
         } ?? .warn(detail: PreflightResult.detail("Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex."), recovery: [])))
 
         let storage = StorageSummary(
-            storageRootPath: GuesthouseError.sanitize(storageRoot.path, limit: 400),
+            storageRootPath: storageRoot.path,
             runtimeDownloadEstimateBytes: policy.runtimeDownloadEstimateBytes,
             restoreImageEstimateBytes: policy.restoreImageEstimateBytes,
             guestDiskBytes: preset.diskBytes,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -9,15 +9,32 @@ public enum PreflightCheckKind: String, Codable, Hashable, Sendable, CaseIterabl
 }
 
 public struct PreflightResult: Codable, Hashable, Sendable {
+    /// A check's own words about the host: what was found, what is recommended, why an answer
+    /// could not be had.
+    ///
+    /// `SanitizedText` rather than `String`, like every other value that can come from outside
+    /// the app: a detail names the operating system build, the storage path, and the Codex
+    /// bundle path, and `run` is not the only way a result comes into being. A report decoded
+    /// from a diagnostics file or received over the wire would otherwise carry whatever control
+    /// characters, unbounded text, or credential-shaped values the sender put there, straight
+    /// into the GUI and back out through `encode(to:)`.
     public enum Outcome: Codable, Hashable, Sendable {
-        case pass(detail: String)
+        case pass(detail: SanitizedText)
         /// Setup may continue; the detail says what the user should know.
-        case warn(detail: String, recovery: [RecoveryAction])
+        case warn(detail: SanitizedText, recovery: [RecoveryAction])
         /// The check could not be made at all. Setup does not continue on a guess: an
         /// unanswerable question is not the same as a satisfied requirement.
-        case undetermined(detail: String, recovery: [RecoveryAction])
+        case undetermined(detail: SanitizedText, recovery: [RecoveryAction])
         /// Setup cannot continue. The error carries the message and recovery actions.
         case fail(GuesthouseError)
+    }
+
+    /// A detail bounded at the sanitizer's maximum rather than its 80-scalar default: these are
+    /// sentences, not identifiers, and the memory and storage advice runs well past 80 scalars.
+    /// `SanitizedText`'s decoder bounds at the same maximum, so a result survives a round trip
+    /// unchanged. A string literal still builds one directly, which is what the tests use.
+    public static func detail(_ text: String) -> SanitizedText {
+        SanitizedText(text, limit: SanitizedText.maximumLimit)
     }
 
     public let kind: PreflightCheckKind
@@ -101,31 +118,37 @@ public enum PreflightCheck: Sendable {
         // what was found and what is required, so a non-default policy still reads correctly.
         let architectureOutcome: PreflightResult.Outcome = switch architecture {
         case .unknown: .fail(.unsupportedHost(.architectureUnknown))
-        case policy.requiredArchitecture: .pass(detail: Self.name(of: architecture))
-        default: .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText(Self.name(of: architecture)), required: Self.name(of: policy.requiredArchitecture))))
+        case policy.requiredArchitecture: .pass(detail: PreflightResult.detail(Self.name(of: architecture)))
+        default: .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText(Self.name(of: architecture)), required: SanitizedText(Self.name(of: policy.requiredArchitecture)))))
         }
         results.append(PreflightResult(kind: .architecture, outcome: architectureOutcome))
 
         let version = probe.operatingSystemVersion
-        let build = probe.operatingSystemBuild.map { " (\($0))" } ?? ""
+        // The build string comes from the host through the probe protocol, like application
+        // metadata and storage paths: bounded and normalized before it becomes result text.
+        let build = probe.operatingSystemBuild.map { " (\(GuesthouseError.sanitize($0, limit: 40)))" } ?? ""
         results.append(PreflightResult(kind: .macOSVersion, outcome: version >= policy.minimumMacOS
-            ? .pass(detail: "macOS \(version)\(build)")
+            ? .pass(detail: PreflightResult.detail("macOS \(version)\(build)"))
             : .fail(.unsupportedHost(.macOSTooOld(found: SanitizedText(version.description), minimum: SanitizedText(policy.minimumMacOS.description))))))
 
         let memory = probe.physicalMemoryBytes
         let memoryOutcome: PreflightResult.Outcome
         // The guest's allocation plus the host's headroom is the real floor; the policy minimum
         // applies on top of it.
-        // A guest allocation plus headroom that cannot be represented cannot be satisfied.
+        // A guest allocation plus headroom that cannot be represented cannot be satisfied, and
+        // that is decided on the overflow itself rather than on a `UInt64.max` floor no Mac was
+        // expected to reach: a probe that answers `UInt64.max` compares equal to that floor, not
+        // below it, and the report would then allow setup for an allocation that cannot exist
+        // (MVP-PLAN.md §4, host headroom).
         let (required, requiredOverflows) = preset.memoryBytes.addingReportingOverflow(policy.hostMemoryHeadroomBytes)
         let floor = requiredOverflows ? UInt64.max : max(policy.minimumMemoryBytes, required)
-        if memory < floor {
+        if requiredOverflows || memory < floor {
             memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: floor)))
         } else if memory >= policy.recommendedMemoryBytes {
-            memoryOutcome = .pass(detail: "\(format(memory, memory: true)) of memory")
+            memoryOutcome = .pass(detail: PreflightResult.detail("\(format(memory, memory: true)) of memory"))
         } else {
             memoryOutcome = .warn(
-                detail: "\(format(memory, memory: true)) of memory. \(format(policy.recommendedMemoryBytes, memory: true)) is recommended; with less, run one development Mac at a time and expect memory pressure during large builds.",
+                detail: PreflightResult.detail("\(format(memory, memory: true)) of memory. \(format(policy.recommendedMemoryBytes, memory: true)) is recommended; with less, run one development Mac at a time and expect memory pressure during large builds."),
                 recovery: []
             )
         }
@@ -135,16 +158,16 @@ public enum PreflightCheck: Sendable {
         do {
             let free = try probe.freeBytes(at: storageRoot)
             if free >= policy.firstSetupAllowanceBytes {
-                diskOutcome = .pass(detail: "\(format(free)) free on the volume that will hold the development Mac")
+                diskOutcome = .pass(detail: PreflightResult.detail("\(format(free)) free on the volume that will hold the development Mac"))
             } else {
                 diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
             }
         } catch let error as HostProbeError {
             // The destination is unusable or its volume is not there: not a transient lookup
             // failure, and never a warning, since there is no disk to check.
-            diskOutcome = .undetermined(detail: error.userMessage, recovery: error.recoveryActions)
+            diskOutcome = .undetermined(detail: PreflightResult.detail(error.userMessage), recovery: error.recoveryActions)
         } catch {
-            diskOutcome = .undetermined(detail: "Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read.", recovery: [.retry, .openSettings])
+            diskOutcome = .undetermined(detail: PreflightResult.detail("Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read."), recovery: [.retry, .openSettings])
         }
         results.append(PreflightResult(kind: .freeDisk, outcome: diskOutcome))
 
@@ -153,8 +176,8 @@ public enum PreflightCheck: Sendable {
             // Bundle metadata and paths come from another app on disk: normalize and bound them
             // before they become UI text, as every externally sourced value is.
             let version = [app.version.map { GuesthouseError.sanitize($0) }, app.build.map { "(\(GuesthouseError.sanitize($0)))" }].compactMap { $0 }.joined(separator: " ")
-            return .pass(detail: "Codex desktop \(version.isEmpty ? "found" : version) at \(GuesthouseError.sanitize(app.url.path, limit: 200))")
-        } ?? .warn(detail: "Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex.", recovery: [])))
+            return .pass(detail: PreflightResult.detail("Codex desktop \(version.isEmpty ? "found" : version) at \(GuesthouseError.sanitize(app.url.path, limit: 200))"))
+        } ?? .warn(detail: PreflightResult.detail("Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex."), recovery: [])))
 
         let storage = StorageSummary(
             storageRootPath: GuesthouseError.sanitize(storageRoot.path, limit: 400),

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -81,9 +81,11 @@ public enum PreflightCheck {
         var results: [PreflightResult] = []
 
         let architecture = probe.cpuArchitecture
+        // An architecture nobody could determine is never a pass, whatever the policy asks
+        // for: the unknown case is answered before the policy is consulted.
         let architectureOutcome: PreflightResult.Outcome = switch architecture {
-        case policy.requiredArchitecture: .pass(detail: "Apple silicon")
         case .unknown: .fail(.unsupportedHost(.architectureUnknown))
+        case policy.requiredArchitecture: .pass(detail: "Apple silicon")
         default: .fail(.unsupportedHost(.notAppleSilicon))
         }
         results.append(PreflightResult(kind: .architecture, outcome: architectureOutcome))
@@ -98,7 +100,9 @@ public enum PreflightCheck {
         let memoryOutcome: PreflightResult.Outcome
         // The guest's allocation plus the host's headroom is the real floor; the policy minimum
         // applies on top of it.
-        let floor = max(policy.minimumMemoryBytes, preset.memoryBytes.addingReportingOverflow(policy.hostMemoryHeadroomBytes).partialValue)
+        // A guest allocation plus headroom that cannot be represented cannot be satisfied.
+        let (required, requiredOverflows) = preset.memoryBytes.addingReportingOverflow(policy.hostMemoryHeadroomBytes)
+        let floor = requiredOverflows ? UInt64.max : max(policy.minimumMemoryBytes, required)
         if memory < floor {
             memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: floor)))
         } else if memory >= policy.recommendedMemoryBytes {
@@ -156,8 +160,10 @@ public enum LargeOperationPreflight {
         volumePath: String,
         policy: ResourcePolicy = .standard
     ) throws(GuesthouseError) {
-        // A requirement that cannot be represented cannot be satisfied.
-        let (needed, overflow) = requiredBytes.addingReportingOverflow(policy.largeOperationMarginBytes)
+        // A requirement that cannot be represented cannot be satisfied, and the reported
+        // requirement is the unrepresentable one rather than the wrapped remainder.
+        let (sum, overflow) = requiredBytes.addingReportingOverflow(policy.largeOperationMarginBytes)
+        let needed = overflow ? UInt64.max : sum
         guard !overflow, freeBytes >= needed else {
             throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes, volumePath: SanitizedText(volumePath))
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -1,0 +1,156 @@
+import Foundation
+
+public enum PreflightCheckKind: String, Codable, Hashable, Sendable, CaseIterable {
+    case architecture
+    case macOSVersion
+    case memory
+    case freeDisk
+    case codexDesktop
+}
+
+public struct PreflightResult: Codable, Hashable, Sendable {
+    public enum Outcome: Codable, Hashable, Sendable {
+        case pass(detail: String)
+        /// Setup may continue; the detail says what the user should know.
+        case warn(detail: String, recovery: [RecoveryAction])
+        /// Setup cannot continue. The error carries the message and recovery actions.
+        case fail(GuesthouseError)
+    }
+
+    public let kind: PreflightCheckKind
+    public let outcome: Outcome
+
+    public init(kind: PreflightCheckKind, outcome: Outcome) {
+        self.kind = kind
+        self.outcome = outcome
+    }
+
+    public var isFailure: Bool {
+        if case .fail = outcome { return true }
+        return false
+    }
+}
+
+/// "What will be downloaded and where the VM will live" (MVP-PLAN.md §2, step 1).
+public struct StorageSummary: Codable, Hashable, Sendable {
+    public var storageRootPath: String
+    public var runtimeDownloadEstimateBytes: UInt64
+    public var restoreImageEstimateBytes: UInt64
+    public var guestDiskBytes: UInt64
+    public var firstSetupAllowanceBytes: UInt64
+
+    public init(storageRootPath: String, runtimeDownloadEstimateBytes: UInt64, restoreImageEstimateBytes: UInt64, guestDiskBytes: UInt64, firstSetupAllowanceBytes: UInt64) {
+        self.storageRootPath = storageRootPath
+        self.runtimeDownloadEstimateBytes = runtimeDownloadEstimateBytes
+        self.restoreImageEstimateBytes = restoreImageEstimateBytes
+        self.guestDiskBytes = guestDiskBytes
+        self.firstSetupAllowanceBytes = firstSetupAllowanceBytes
+    }
+}
+
+public struct PreflightReport: Codable, Hashable, Sendable {
+    public var results: [PreflightResult]
+    public var storage: StorageSummary
+    public var powerSource: PowerSource
+    public var checkedAt: Date
+
+    public init(results: [PreflightResult], storage: StorageSummary, powerSource: PowerSource, checkedAt: Date) {
+        self.results = results
+        self.storage = storage
+        self.powerSource = powerSource
+        self.checkedAt = checkedAt
+    }
+
+    /// True when no check failed. Warnings do not block.
+    public var canProceed: Bool { !results.contains(where: \.isFailure) }
+
+    public func result(_ kind: PreflightCheckKind) -> PreflightResult? {
+        results.first { $0.kind == kind }
+    }
+}
+
+/// The "Check this Mac" step. Pure given a probe; every threshold comes from `ResourcePolicy`.
+public enum PreflightCheck {
+    public static func run(
+        probe: any HostProbe,
+        policy: ResourcePolicy = .standard,
+        storageRoot: URL,
+        preset: ResourcePreset = .recommended,
+        now: Date = Date()
+    ) -> PreflightReport {
+        var results: [PreflightResult] = []
+
+        let architecture = probe.cpuArchitecture
+        results.append(PreflightResult(kind: .architecture, outcome: architecture == policy.requiredArchitecture
+            ? .pass(detail: "Apple silicon")
+            : .fail(.unsupportedHost(.notAppleSilicon))))
+
+        let version = probe.operatingSystemVersion
+        let build = probe.operatingSystemBuild.map { " (\($0))" } ?? ""
+        results.append(PreflightResult(kind: .macOSVersion, outcome: version >= policy.minimumMacOS
+            ? .pass(detail: "macOS \(version)\(build)")
+            : .fail(.unsupportedHost(.macOSTooOld(found: version.description, minimum: policy.minimumMacOS.description)))))
+
+        let memory = probe.physicalMemoryBytes
+        let memoryOutcome: PreflightResult.Outcome
+        if memory >= policy.recommendedMemoryBytes {
+            memoryOutcome = .pass(detail: "\(format(memory, memory: true)) of memory")
+        } else if memory >= policy.minimumMemoryBytes {
+            memoryOutcome = .warn(
+                detail: "\(format(memory, memory: true)) of memory. \(format(policy.recommendedMemoryBytes, memory: true)) is recommended; with less, run one development Mac at a time and expect memory pressure during large builds.",
+                recovery: []
+            )
+        } else {
+            memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: policy.minimumMemoryBytes)))
+        }
+        results.append(PreflightResult(kind: .memory, outcome: memoryOutcome))
+
+        let diskOutcome: PreflightResult.Outcome
+        do {
+            let free = try probe.freeBytes(at: storageRoot)
+            if free >= policy.firstSetupAllowanceBytes {
+                diskOutcome = .pass(detail: "\(format(free)) free on the volume that will hold the development Mac")
+            } else {
+                diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: storageRoot.path))
+            }
+        } catch {
+            diskOutcome = .warn(detail: "Free space on \(storageRoot.path) could not be determined.", recovery: [.retry])
+        }
+        results.append(PreflightResult(kind: .freeDisk, outcome: diskOutcome))
+
+        let codex = policy.codexDesktopBundleIdentifiers.lazy.compactMap(probe.installedApplication(bundleIdentifier:)).first
+        results.append(PreflightResult(kind: .codexDesktop, outcome: codex.map { app in
+            let version = [app.version, app.build.map { "(\($0))" }].compactMap { $0 }.joined(separator: " ")
+            return .pass(detail: "Codex desktop \(version.isEmpty ? "found" : version) at \(app.url.path)")
+        } ?? .warn(detail: "Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex.", recovery: [])))
+
+        let storage = StorageSummary(
+            storageRootPath: storageRoot.path,
+            runtimeDownloadEstimateBytes: policy.runtimeDownloadEstimateBytes,
+            restoreImageEstimateBytes: policy.restoreImageEstimateBytes,
+            guestDiskBytes: preset.diskBytes,
+            firstSetupAllowanceBytes: policy.firstSetupAllowanceBytes
+        )
+        return PreflightReport(results: results, storage: storage, powerSource: probe.powerSource, checkedAt: now)
+    }
+
+    private static func format(_ bytes: UInt64, memory: Bool = false) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(clamping: bytes), countStyle: memory ? .memory : .file)
+    }
+}
+
+/// Free-space check before every download, import, or clone, not only at first launch
+/// (MVP-PLAN.md §4: "Check free space before each large operation").
+public enum LargeOperationPreflight {
+    public static func check(
+        freeBytes: UInt64,
+        requiredBytes: UInt64,
+        volumePath: String,
+        policy: ResourcePolicy = .standard
+    ) throws(GuesthouseError) {
+        let needed = requiredBytes &+ policy.largeOperationMarginBytes
+        guard freeBytes >= needed else {
+            throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes, volumePath: volumePath)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -89,19 +89,19 @@ public enum PreflightCheck {
         let build = probe.operatingSystemBuild.map { " (\($0))" } ?? ""
         results.append(PreflightResult(kind: .macOSVersion, outcome: version >= policy.minimumMacOS
             ? .pass(detail: "macOS \(version)\(build)")
-            : .fail(.unsupportedHost(.macOSTooOld(found: version.description, minimum: policy.minimumMacOS.description)))))
+            : .fail(.unsupportedHost(.macOSTooOld(found: SanitizedText(version.description), minimum: policy.minimumMacOS.description)))))
 
         let memory = probe.physicalMemoryBytes
         let memoryOutcome: PreflightResult.Outcome
-        if memory >= policy.recommendedMemoryBytes {
+        if memory < policy.minimumMemoryBytes {
+            memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: policy.minimumMemoryBytes)))
+        } else if memory >= policy.recommendedMemoryBytes {
             memoryOutcome = .pass(detail: "\(format(memory, memory: true)) of memory")
-        } else if memory >= policy.minimumMemoryBytes {
+        } else {
             memoryOutcome = .warn(
                 detail: "\(format(memory, memory: true)) of memory. \(format(policy.recommendedMemoryBytes, memory: true)) is recommended; with less, run one development Mac at a time and expect memory pressure during large builds.",
                 recovery: []
             )
-        } else {
-            memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: policy.minimumMemoryBytes)))
         }
         results.append(PreflightResult(kind: .memory, outcome: memoryOutcome))
 
@@ -111,7 +111,7 @@ public enum PreflightCheck {
             if free >= policy.firstSetupAllowanceBytes {
                 diskOutcome = .pass(detail: "\(format(free)) free on the volume that will hold the development Mac")
             } else {
-                diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: storageRoot.path))
+                diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
             }
         } catch {
             diskOutcome = .warn(detail: "Free space on \(storageRoot.path) could not be determined.", recovery: [.retry])
@@ -120,8 +120,10 @@ public enum PreflightCheck {
 
         let codex = policy.codexDesktopBundleIdentifiers.lazy.compactMap(probe.installedApplication(bundleIdentifier:)).first
         results.append(PreflightResult(kind: .codexDesktop, outcome: codex.map { app in
-            let version = [app.version, app.build.map { "(\($0))" }].compactMap { $0 }.joined(separator: " ")
-            return .pass(detail: "Codex desktop \(version.isEmpty ? "found" : version) at \(app.url.path)")
+            // Bundle metadata and paths come from another app on disk: normalize and bound them
+            // before they become UI text, as every externally sourced value is.
+            let version = [app.version.map { GuesthouseError.sanitize($0) }, app.build.map { "(\(GuesthouseError.sanitize($0)))" }].compactMap { $0 }.joined(separator: " ")
+            return .pass(detail: "Codex desktop \(version.isEmpty ? "found" : version) at \(GuesthouseError.sanitize(app.url.path, limit: 200))")
         } ?? .warn(detail: "Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex.", recovery: [])))
 
         let storage = StorageSummary(
@@ -150,7 +152,7 @@ public enum LargeOperationPreflight {
     ) throws(GuesthouseError) {
         let needed = requiredBytes &+ policy.largeOperationMarginBytes
         guard freeBytes >= needed else {
-            throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes, volumePath: volumePath)
+            throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes, volumePath: SanitizedText(volumePath))
         }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -81,20 +81,26 @@ public enum PreflightCheck {
         var results: [PreflightResult] = []
 
         let architecture = probe.cpuArchitecture
-        results.append(PreflightResult(kind: .architecture, outcome: architecture == policy.requiredArchitecture
-            ? .pass(detail: "Apple silicon")
-            : .fail(.unsupportedHost(.notAppleSilicon))))
+        let architectureOutcome: PreflightResult.Outcome = switch architecture {
+        case policy.requiredArchitecture: .pass(detail: "Apple silicon")
+        case .unknown: .fail(.unsupportedHost(.architectureUnknown))
+        default: .fail(.unsupportedHost(.notAppleSilicon))
+        }
+        results.append(PreflightResult(kind: .architecture, outcome: architectureOutcome))
 
         let version = probe.operatingSystemVersion
         let build = probe.operatingSystemBuild.map { " (\($0))" } ?? ""
         results.append(PreflightResult(kind: .macOSVersion, outcome: version >= policy.minimumMacOS
             ? .pass(detail: "macOS \(version)\(build)")
-            : .fail(.unsupportedHost(.macOSTooOld(found: SanitizedText(version.description), minimum: policy.minimumMacOS.description)))))
+            : .fail(.unsupportedHost(.macOSTooOld(found: SanitizedText(version.description), minimum: SanitizedText(policy.minimumMacOS.description))))))
 
         let memory = probe.physicalMemoryBytes
         let memoryOutcome: PreflightResult.Outcome
-        if memory < policy.minimumMemoryBytes {
-            memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: policy.minimumMemoryBytes)))
+        // The guest's allocation plus the host's headroom is the real floor; the policy minimum
+        // applies on top of it.
+        let floor = max(policy.minimumMemoryBytes, preset.memoryBytes.addingReportingOverflow(policy.hostMemoryHeadroomBytes).partialValue)
+        if memory < floor {
+            memoryOutcome = .fail(.unsupportedHost(.insufficientMemory(foundBytes: memory, minimumBytes: floor)))
         } else if memory >= policy.recommendedMemoryBytes {
             memoryOutcome = .pass(detail: "\(format(memory, memory: true)) of memory")
         } else {
@@ -114,7 +120,7 @@ public enum PreflightCheck {
                 diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
             }
         } catch {
-            diskOutcome = .warn(detail: "Free space on \(storageRoot.path) could not be determined.", recovery: [.retry])
+            diskOutcome = .warn(detail: "Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined.", recovery: [.retry])
         }
         results.append(PreflightResult(kind: .freeDisk, outcome: diskOutcome))
 
@@ -127,7 +133,7 @@ public enum PreflightCheck {
         } ?? .warn(detail: "Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex.", recovery: [])))
 
         let storage = StorageSummary(
-            storageRootPath: storageRoot.path,
+            storageRootPath: GuesthouseError.sanitize(storageRoot.path, limit: 400),
             runtimeDownloadEstimateBytes: policy.runtimeDownloadEstimateBytes,
             restoreImageEstimateBytes: policy.restoreImageEstimateBytes,
             guestDiskBytes: preset.diskBytes,
@@ -150,8 +156,9 @@ public enum LargeOperationPreflight {
         volumePath: String,
         policy: ResourcePolicy = .standard
     ) throws(GuesthouseError) {
-        let needed = requiredBytes &+ policy.largeOperationMarginBytes
-        guard freeBytes >= needed else {
+        // A requirement that cannot be represented cannot be satisfied.
+        let (needed, overflow) = requiredBytes.addingReportingOverflow(policy.largeOperationMarginBytes)
+        guard !overflow, freeBytes >= needed else {
             throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes, volumePath: SanitizedText(volumePath))
         }
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -72,8 +72,12 @@ public struct PreflightReport: Codable, Hashable, Sendable {
         self.checkedAt = checkedAt
     }
 
-    /// True when no check failed and every check could be made. Warnings do not block.
-    public var canProceed: Bool { !results.contains(where: \.isBlocking) }
+    /// True when every check was made and none of them blocks. A report missing a check is
+    /// not a passing report: warnings do not block, an absent answer does.
+    public var canProceed: Bool {
+        guard PreflightCheckKind.allCases.allSatisfy({ kind in results.contains { $0.kind == kind } }) else { return false }
+        return !results.contains(where: \.isBlocking)
+    }
 
     public func result(_ kind: PreflightCheckKind) -> PreflightResult? {
         results.first { $0.kind == kind }
@@ -135,10 +139,10 @@ public enum PreflightCheck: Sendable {
             } else {
                 diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
             }
-        } catch HostProbeError.volumeUnavailable(let path) {
-            // The destination's volume is not mounted: not a transient lookup failure, and
-            // never a warning, since there is no disk to check.
-            diskOutcome = .undetermined(detail: HostProbeError.volumeUnavailable(path: path).userMessage, recovery: [.retry, .openSettings])
+        } catch let error as HostProbeError {
+            // The destination is unusable or its volume is not there: not a transient lookup
+            // failure, and never a warning, since there is no disk to check.
+            diskOutcome = .undetermined(detail: error.userMessage, recovery: error.recoveryActions)
         } catch {
             diskOutcome = .undetermined(detail: "Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read.", recovery: [.retry, .openSettings])
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
@@ -27,6 +27,11 @@ public struct ResourcePolicy: Hashable, Sendable {
     public init() {}
 
     public static let standard = ResourcePolicy()
+
+    /// A policy whose blocking minimum exceeds its recommendation is contradictory; the
+    /// preflight evaluates the minimum first regardless, and this check makes the mistake
+    /// visible in tests.
+    public var isWellFormed: Bool { minimumMemoryBytes <= recommendedMemoryBytes }
 }
 
 extension ResourcePreset {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
@@ -9,6 +9,9 @@ public struct ResourcePolicy: Hashable, Sendable {
     public var minimumMacOS = SemanticVersion([26, 4])
     /// Below this the host cannot run a development Mac alongside anything else.
     public var minimumMemoryBytes: UInt64 = 16 * ResourcePreset.gibibyte
+    /// What the host keeps for itself beside the guest's allocation. A Mac whose memory is
+    /// below the guest allocation plus this headroom is blocked, not warned (MVP-PLAN.md §4).
+    public var hostMemoryHeadroomBytes: UInt64 = 8 * ResourcePreset.gibibyte
     /// Below this the preflight warns; the reference Mac has 32 GB.
     public var recommendedMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
     /// Free space needed for the first setup: runtime, restore image, temporary extraction,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
@@ -1,0 +1,34 @@
+/// Every threshold the preflight and the large-operation checks use, in one place.
+///
+/// Numbers come from MVP-PLAN.md §4 ("Version and resource policy") and are planning
+/// estimates until phase 0 records measured peaks. Change them here, nowhere else.
+public struct ResourcePolicy: Hashable, Sendable {
+    public var requiredArchitecture: CPUArchitecture = .appleSilicon
+    /// The app's deployment target; older hosts cannot run it anyway, but a preflight that
+    /// somehow runs on one must say so plainly.
+    public var minimumMacOS = SemanticVersion([26, 4])
+    /// Below this the host cannot run a development Mac alongside anything else.
+    public var minimumMemoryBytes: UInt64 = 16 * ResourcePreset.gibibyte
+    /// Below this the preflight warns; the reference Mac has 32 GB.
+    public var recommendedMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    /// Free space needed for the first setup: runtime, restore image, temporary extraction,
+    /// and the sparse guest disk's early growth (§4: "roughly 200 GB").
+    public var firstSetupAllowanceBytes: UInt64 = 200 * ResourcePreset.gigabyte
+    /// Headroom added to every large operation's own requirement.
+    public var largeOperationMarginBytes: UInt64 = 10 * ResourcePreset.gigabyte
+    /// Download estimates shown before the first setup starts. Estimates, not measurements.
+    public var runtimeDownloadEstimateBytes: UInt64 = 50 * ResourcePreset.megabyte
+    public var restoreImageEstimateBytes: UInt64 = 16 * ResourcePreset.gigabyte
+    /// Bundle identifiers that count as the Codex desktop app, in preference order. The plan
+    /// calls the host application "Codex desktop"; current OpenAI documentation places the
+    /// connection UI in the ChatGPT desktop app. Gate #41 confirms the identifier.
+    public var codexDesktopBundleIdentifiers: [String] = ["com.openai.chat", "com.openai.codex"]
+
+    public init() {}
+
+    public static let standard = ResourcePolicy()
+}
+
+extension ResourcePreset {
+    public static let megabyte: UInt64 = 1_000_000
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct StubProbe: HostProbe {
+    var cpuArchitecture: CPUArchitecture = .appleSilicon
+    var operatingSystemVersion = SemanticVersion([26, 5, 2])
+    var operatingSystemBuild: String? = "25F84"
+    var physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    var powerSource: PowerSource = .externalPower
+    var free: Result<UInt64, any Error> = .success(500 * ResourcePreset.gigabyte)
+    var applications: [String: InstalledApplication] = [:]
+
+    func freeBytes(at url: URL) throws -> UInt64 { try free.get() }
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication? { applications[bundleIdentifier] }
+}
+
+@Suite struct PreflightCheckTests {
+    let root = URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse")
+    struct ProbeFailure: Error {}
+
+    func run(_ probe: StubProbe) -> PreflightReport {
+        PreflightCheck.run(probe: probe, storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000))
+    }
+
+    @Test func healthyHostPassesEverythingExceptMissingCodexWhichWarns() {
+        var probe = StubProbe()
+        probe.applications["com.openai.chat"] = InstalledApplication(url: URL(fileURLWithPath: "/Applications/ChatGPT.app"), version: "1.2.3", build: "456")
+        let report = run(probe)
+        #expect(report.canProceed)
+        for kind in PreflightCheckKind.allCases {
+            guard case .pass(let detail) = report.result(kind)!.outcome else { Issue.record("\(kind) not pass"); continue }
+            #expect(!detail.isEmpty)
+        }
+        #expect(report.result(.macOSVersion)!.outcome == .pass(detail: "macOS 26.5.2 (25F84)"))
+        #expect(report.result(.codexDesktop)!.outcome == .pass(detail: "Codex desktop 1.2.3 (456) at /Applications/ChatGPT.app"))
+        #expect(report.storage.storageRootPath == root.path)
+        #expect(report.storage.guestDiskBytes == ResourcePreset.recommended.diskBytes)
+        #expect(report.powerSource == .externalPower)
+
+        let missing = run(StubProbe())
+        #expect(missing.canProceed)
+        guard case .warn(let detail, _) = missing.result(.codexDesktop)!.outcome else { Issue.record("expected warn"); return }
+        #expect(detail.contains("not installed"))
+    }
+
+    @Test func intelHostFails() {
+        var probe = StubProbe(); probe.cpuArchitecture = .intel
+        let report = run(probe)
+        #expect(!report.canProceed)
+        #expect(report.result(.architecture)!.outcome == .fail(.unsupportedHost(.notAppleSilicon)))
+    }
+
+    @Test func oldMacOSFails() {
+        var probe = StubProbe(); probe.operatingSystemVersion = SemanticVersion([26, 3, 9])
+        let report = run(probe)
+        #expect(report.result(.macOSVersion)!.outcome == .fail(.unsupportedHost(.macOSTooOld(found: "26.3.9", minimum: "26.4"))))
+    }
+
+    @Test func memoryTiersPassWarnFail() {
+        var probe = StubProbe()
+        probe.physicalMemoryBytes = 24 * ResourcePreset.gibibyte
+        guard case .warn(let detail, _) = run(probe).result(.memory)!.outcome else { Issue.record("expected warn"); return }
+        #expect(detail.contains("32 GB is recommended"))
+        #expect(run(probe).canProceed)
+
+        probe.physicalMemoryBytes = 8 * ResourcePreset.gibibyte
+        #expect(run(probe).result(.memory)!.outcome == .fail(.unsupportedHost(.insufficientMemory(foundBytes: 8 * ResourcePreset.gibibyte, minimumBytes: 16 * ResourcePreset.gibibyte))))
+        #expect(!run(probe).canProceed)
+    }
+
+    @Test func lowDiskFailsWithPreciseNumbersAndUnknownDiskWarns() {
+        var probe = StubProbe()
+        probe.free = .success(50 * ResourcePreset.gigabyte)
+        #expect(run(probe).result(.freeDisk)!.outcome == .fail(.insufficientDisk(requiredBytes: 200 * ResourcePreset.gigabyte, availableBytes: 50 * ResourcePreset.gigabyte, volumePath: root.path)))
+
+        probe.free = .failure(ProbeFailure())
+        guard case .warn(_, let recovery) = run(probe).result(.freeDisk)!.outcome else { Issue.record("expected warn"); return }
+        #expect(recovery == [.retry])
+        #expect(run(probe).canProceed)
+    }
+
+    @Test func everyFailureCarriesARecoveryAction() {
+        var probe = StubProbe()
+        probe.cpuArchitecture = .intel
+        probe.operatingSystemVersion = SemanticVersion([15, 0])
+        probe.physicalMemoryBytes = 4 * ResourcePreset.gibibyte
+        probe.free = .success(1)
+        for result in run(probe).results {
+            if case .fail(let error) = result.outcome {
+                #expect(!error.recoveryActions.isEmpty, Comment(rawValue: result.kind.rawValue))
+                #expect(!error.userMessage.isEmpty)
+            }
+        }
+    }
+
+    @Test func largeOperationAddsMarginAndReportsTheRealRequirement() throws {
+        try LargeOperationPreflight.check(freeBytes: 60 * ResourcePreset.gigabyte, requiredBytes: 40 * ResourcePreset.gigabyte, volumePath: "/")
+        #expect(throws: GuesthouseError.insufficientDisk(requiredBytes: 50 * ResourcePreset.gigabyte, availableBytes: 45 * ResourcePreset.gigabyte, volumePath: "/")) {
+            try LargeOperationPreflight.check(freeBytes: 45 * ResourcePreset.gigabyte, requiredBytes: 40 * ResourcePreset.gigabyte, volumePath: "/")
+        }
+    }
+
+    @Test func reportRoundTripsThroughJSON() throws {
+        let report = run(StubProbe())
+        let data = try JSONEncoder().encode(report)
+        #expect(try JSONDecoder().decode(PreflightReport.self, from: data) == report)
+    }
+
+    @Test func systemProbeReturnsPlausibleValuesOnThisMac() throws {
+        let probe = SystemHostProbe()
+        #expect(probe.physicalMemoryBytes > 0)
+        #expect(probe.operatingSystemVersion >= SemanticVersion([14]))
+        #expect(try probe.freeBytes(at: FileManager.default.temporaryDirectory) > 0)
+        #expect(probe.installedApplication(bundleIdentifier: "com.apple.finder")?.url.lastPathComponent == "Finder.app")
+        #expect(probe.installedApplication(bundleIdentifier: "com.example.does.not.exist") == nil)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -65,8 +65,43 @@ struct StubProbe: HostProbe {
         #expect(run(probe).canProceed)
 
         probe.physicalMemoryBytes = 8 * ResourcePreset.gibibyte
-        #expect(run(probe).result(.memory)!.outcome == .fail(.unsupportedHost(.insufficientMemory(foundBytes: 8 * ResourcePreset.gibibyte, minimumBytes: 16 * ResourcePreset.gibibyte))))
+        #expect(run(probe).result(.memory)!.outcome == .fail(.unsupportedHost(.insufficientMemory(foundBytes: 8 * ResourcePreset.gibibyte, minimumBytes: 24 * ResourcePreset.gibibyte))))
         #expect(!run(probe).canProceed)
+
+        // Exactly the guest allocation leaves nothing for the host: blocked, not warned.
+        probe.physicalMemoryBytes = 16 * ResourcePreset.gibibyte
+        #expect(run(probe).result(.memory)!.isFailure)
+        probe.physicalMemoryBytes = 24 * ResourcePreset.gibibyte
+        #expect(!run(probe).result(.memory)!.isFailure)
+    }
+
+    @Test func unknownArchitectureIsNamedAndRetryable() {
+        var probe = StubProbe(); probe.cpuArchitecture = .unknown
+        let report = run(probe)
+        #expect(report.result(.architecture)!.outcome == .fail(.unsupportedHost(.architectureUnknown)))
+        #expect(GuesthouseError.unsupportedHost(.architectureUnknown).recoveryActions.first == .retry)
+    }
+
+    @Test func storagePathsAreSanitizedInWarningsAndTheSummary() {
+        var probe = StubProbe(); probe.free = .failure(ProbeFailure())
+        let hostile = URL(fileURLWithPath: "/Volumes/Ext\u{202E}gnol/Guesthouse")
+        let report = PreflightCheck.run(probe: probe, storageRoot: hostile, now: Date(timeIntervalSince1970: 1_800_000_000))
+        guard case .warn(let detail, _) = report.result(.freeDisk)!.outcome else { Issue.record("expected warn"); return }
+        #expect(!detail.contains("\u{202E}"))
+        #expect(!report.storage.storageRootPath.contains("\u{202E}"))
+    }
+
+    @Test func largeOperationRequirementsThatOverflowAreInsufficient() {
+        let probe = StubProbe()
+        _ = probe
+        #expect(throws: GuesthouseError.self) {
+            try LargeOperationPreflight.check(freeBytes: 500 * ResourcePreset.gigabyte, requiredBytes: UInt64.max - 1, volumePath: "/")
+        }
+    }
+
+    @Test func freeSpaceIsReadFromTheNearestExistingAncestor() throws {
+        let missing = FileManager.default.temporaryDirectory.appending(path: "does-not-exist-\(UUID().uuidString)/nested/Guesthouse")
+        #expect(try SystemHostProbe().freeBytes(at: missing) > 0)
     }
 
     @Test func blockingMinimumIsEvaluatedBeforeTheRecommendation() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -214,6 +214,27 @@ struct StubProbe: HostProbe {
         }
     }
 
+    @Test func anUnwritableDestinationIsNotReportedAsUsableSpace() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "Unwritable-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: base.path) }
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: base.path)
+        // Permission bits do not restrain root, so only an ordinary user can prove this.
+        if getuid() != 0 {
+            let probe = SystemHostProbe()
+            #expect(throws: HostProbeError.destinationNotWritable(path: base.path)) { try probe.freeBytes(at: base) }
+            #expect(throws: HostProbeError.destinationNotWritable(path: base.path)) { try probe.freeBytes(at: base.appending(path: "Guesthouse")) }
+        }
+
+        var stub = StubProbe()
+        stub.free = .failure(HostProbeError.destinationNotWritable(path: root.path))
+        let report = run(stub)
+        guard case .undetermined(let detail, let recovery) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
+        #expect(detail.contains("cannot write"))
+        #expect(recovery.contains(.openSettings))
+        #expect(!report.canProceed, "a destination that cannot be written is not a satisfied storage check")
+    }
+
     @Test func everyFailureCarriesARecoveryAction() {
         var probe = StubProbe()
         probe.cpuArchitecture = .intel

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -48,7 +48,7 @@ struct StubProbe: HostProbe {
         var probe = StubProbe(); probe.cpuArchitecture = .intel
         let report = run(probe)
         #expect(!report.canProceed)
-        #expect(report.result(.architecture)!.outcome == .fail(.unsupportedHost(.notAppleSilicon)))
+        #expect(report.result(.architecture)!.outcome == .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText("Intel"), required: "Apple silicon"))))
     }
 
     @Test func oldMacOSFails() {
@@ -86,7 +86,7 @@ struct StubProbe: HostProbe {
         var probe = StubProbe(); probe.free = .failure(ProbeFailure())
         let hostile = URL(fileURLWithPath: "/Volumes/Ext\u{202E}gnol/Guesthouse")
         let report = PreflightCheck.run(probe: probe, storageRoot: hostile, now: Date(timeIntervalSince1970: 1_800_000_000))
-        guard case .warn(let detail, _) = report.result(.freeDisk)!.outcome else { Issue.record("expected warn"); return }
+        guard case .undetermined(let detail, _) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
         #expect(!detail.contains("\u{202E}"))
         #expect(!report.storage.storageRootPath.contains("\u{202E}"))
     }
@@ -123,15 +123,15 @@ struct StubProbe: HostProbe {
         #expect(!detail.contains(String(repeating: "9", count: 100)))
     }
 
-    @Test func lowDiskFailsWithPreciseNumbersAndUnknownDiskWarns() {
+    @Test func lowDiskFailsWithPreciseNumbersAndUnknownDiskBlocks() {
         var probe = StubProbe()
         probe.free = .success(50 * ResourcePreset.gigabyte)
         #expect(run(probe).result(.freeDisk)!.outcome == .fail(.insufficientDisk(requiredBytes: 200 * ResourcePreset.gigabyte, availableBytes: 50 * ResourcePreset.gigabyte, volumePath: SanitizedText(root.path))))
 
         probe.free = .failure(ProbeFailure())
-        guard case .warn(_, let recovery) = run(probe).result(.freeDisk)!.outcome else { Issue.record("expected warn"); return }
-        #expect(recovery == [.retry])
-        #expect(run(probe).canProceed)
+        guard case .undetermined(_, let recovery) = run(probe).result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
+        #expect(recovery == [.retry, .openSettings])
+        #expect(!run(probe).canProceed, "a check that could not be made never counts as satisfied")
     }
 
     @Test func anUnknownArchitectureFailsEvenWhenThePolicyAsksForOne() {
@@ -144,7 +144,7 @@ struct StubProbe: HostProbe {
 
     @Test func anImpossibleMemoryFloorIsNeverSatisfied() {
         var policy = ResourcePolicy(); policy.hostMemoryHeadroomBytes = UInt64.max - 1
-        var preset = ResourcePreset.recommended; preset.memoryBytes = 16 * ResourcePreset.gibibyte
+        let preset = ResourcePreset(name: "Test", memoryBytes: 16 * ResourcePreset.gibibyte, cpuCount: ResourcePreset.recommended.cpuCount, diskBytes: ResourcePreset.recommended.diskBytes, verification: .planBaseline)!
         let report = PreflightCheck.run(probe: StubProbe(), policy: policy, storageRoot: root, preset: preset, now: Date(timeIntervalSince1970: 1_800_000_000))
         #expect(report.result(.memory)!.isFailure, "a requirement that overflows can never be met")
     }
@@ -156,6 +156,36 @@ struct StubProbe: HostProbe {
         guard case .insufficientDisk(let required, let available, _)? = error else { Issue.record("expected insufficientDisk"); return }
         #expect(required == UInt64.max, "the reported requirement is not the wrapped remainder")
         #expect(available == 500 * ResourcePreset.gigabyte)
+    }
+
+    @Test func anUnavailableVolumeBlocksSetup() {
+        struct UnmountedProbe: HostProbe {
+            var cpuArchitecture: CPUArchitecture = .appleSilicon
+            var operatingSystemVersion = SemanticVersion([26, 5, 2])
+            var operatingSystemBuild: String? = "25F84"
+            var physicalMemoryBytes: UInt64 = 64 * ResourcePreset.gibibyte
+            var powerSource: PowerSource = .externalPower
+            func freeBytes(at url: URL) throws -> UInt64 { throw HostProbeError.volumeUnavailable(path: "/Volumes/External/Guesthouse") }
+            func installedApplication(bundleIdentifier: String) -> InstalledApplication? { nil }
+        }
+        let report = PreflightCheck.run(probe: UnmountedProbe(), storageRoot: URL(fileURLWithPath: "/Volumes/External/Guesthouse"), now: Date(timeIntervalSince1970: 1_800_000_000))
+        guard case .undetermined(let detail, let recovery) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
+        #expect(detail.contains("not available"))
+        #expect(recovery.first == .retry)
+        #expect(!report.canProceed, "there is no disk to check, so setup does not continue")
+    }
+
+    @Test func theArchitectureTextFollowsTheConfiguredPolicy() {
+        var policy = ResourcePolicy(); policy.requiredArchitecture = .intel
+        var probe = StubProbe(); probe.cpuArchitecture = .intel
+        guard case .pass(let detail) = PreflightCheck.run(probe: probe, policy: policy, storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000)).result(.architecture)!.outcome else { Issue.record("expected pass"); return }
+        #expect(detail == "Intel")
+        probe.cpuArchitecture = .appleSilicon
+        let failure = PreflightCheck.run(probe: probe, policy: policy, storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000)).result(.architecture)!.outcome
+        #expect(failure == .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText("Apple silicon"), required: "Intel"))))
+        if case .fail(let error) = failure {
+            #expect(error.userMessage.contains("Apple silicon") && error.userMessage.contains("Intel"))
+        }
     }
 
     @Test func everyFailureCarriesARecoveryAction() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -30,7 +30,7 @@ struct StubProbe: HostProbe {
         #expect(report.canProceed)
         for kind in PreflightCheckKind.allCases {
             guard case .pass(let detail) = report.result(kind)!.outcome else { Issue.record("\(kind) not pass"); continue }
-            #expect(!detail.isEmpty)
+            #expect(!detail.value.isEmpty)
         }
         #expect(report.result(.macOSVersion)!.outcome == .pass(detail: "macOS 26.5.2 (25F84)"))
         #expect(report.result(.codexDesktop)!.outcome == .pass(detail: "Codex desktop 1.2.3 (456) at /Applications/ChatGPT.app"))
@@ -41,7 +41,7 @@ struct StubProbe: HostProbe {
         let missing = run(StubProbe())
         #expect(missing.canProceed)
         guard case .warn(let detail, _) = missing.result(.codexDesktop)!.outcome else { Issue.record("expected warn"); return }
-        #expect(detail.contains("not installed"))
+        #expect(detail.value.contains("not installed"))
     }
 
     @Test func intelHostFails() {
@@ -61,7 +61,7 @@ struct StubProbe: HostProbe {
         var probe = StubProbe()
         probe.physicalMemoryBytes = 24 * ResourcePreset.gibibyte
         guard case .warn(let detail, _) = run(probe).result(.memory)!.outcome else { Issue.record("expected warn"); return }
-        #expect(detail.contains("32 GB is recommended"))
+        #expect(detail.value.contains("32 GB is recommended"))
         #expect(run(probe).canProceed)
 
         probe.physicalMemoryBytes = 8 * ResourcePreset.gibibyte
@@ -87,7 +87,7 @@ struct StubProbe: HostProbe {
         let hostile = URL(fileURLWithPath: "/Volumes/Ext\u{202E}gnol/Guesthouse")
         let report = PreflightCheck.run(probe: probe, storageRoot: hostile, now: Date(timeIntervalSince1970: 1_800_000_000))
         guard case .undetermined(let detail, _) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
-        #expect(!detail.contains("\u{202E}"))
+        #expect(!detail.value.contains("\u{202E}"))
         #expect(!report.storage.storageRootPath.contains("\u{202E}"))
     }
 
@@ -118,9 +118,9 @@ struct StubProbe: HostProbe {
         var probe = StubProbe()
         probe.applications["com.openai.chat"] = InstalledApplication(url: URL(fileURLWithPath: "/Applications/Chat\u{202E}GPT.app"), version: "1.2\n.3", build: String(repeating: "9", count: 300))
         guard case .pass(let detail) = run(probe).result(.codexDesktop)!.outcome else { Issue.record("expected pass"); return }
-        #expect(!detail.contains("\u{202E}"))
-        #expect(!detail.contains("\n"))
-        #expect(!detail.contains(String(repeating: "9", count: 100)))
+        #expect(!detail.value.contains("\u{202E}"))
+        #expect(!detail.value.contains("\n"))
+        #expect(!detail.value.contains(String(repeating: "9", count: 100)))
     }
 
     @Test func lowDiskFailsWithPreciseNumbersAndUnknownDiskBlocks() {
@@ -170,7 +170,7 @@ struct StubProbe: HostProbe {
         }
         let report = PreflightCheck.run(probe: UnmountedProbe(), storageRoot: URL(fileURLWithPath: "/Volumes/External/Guesthouse"), now: Date(timeIntervalSince1970: 1_800_000_000))
         guard case .undetermined(let detail, let recovery) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
-        #expect(detail.contains("not available"))
+        #expect(detail.value.contains("not available"))
         #expect(recovery.first == .retry)
         #expect(!report.canProceed, "there is no disk to check, so setup does not continue")
     }
@@ -186,6 +186,19 @@ struct StubProbe: HostProbe {
         if case .fail(let error) = failure {
             #expect(error.userMessage.contains("Apple silicon") && error.userMessage.contains("Intel"))
         }
+    }
+
+    /// Both sides of the mismatch are sanitized where the value is built, not where it is shown,
+    /// so what a decoded payload put in either is bounded and redacted in the encoded form too.
+    @Test func theRequiredArchitectureIsSanitizedInTheEncodedPayloadToo() throws {
+        let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+        let error = GuesthouseError.unsupportedHost(.wrongArchitecture(found: "Intel", required: SanitizedText("Apple silicon \(token)")))
+        #expect(!error.userMessage.contains(token))
+        let json = String(decoding: try JSONEncoder().encode(error), as: UTF8.self)
+        #expect(!json.contains(token))
+        #expect(json.contains("[redacted:github-token]"))
+        let restored = try JSONDecoder().decode(GuesthouseError.self, from: Data(json.utf8))
+        #expect(restored == error)
     }
 
     @Test func aReportMissingACheckNeverProceeds() {
@@ -230,9 +243,83 @@ struct StubProbe: HostProbe {
         stub.free = .failure(HostProbeError.destinationNotWritable(path: root.path))
         let report = run(stub)
         guard case .undetermined(let detail, let recovery) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
-        #expect(detail.contains("cannot write"))
+        #expect(detail.value.contains("cannot write"))
         #expect(recovery.contains(.openSettings))
         #expect(!report.canProceed, "a destination that cannot be written is not a satisfied storage check")
+    }
+
+    @Test func theOperatingSystemBuildIsSanitizedBeforeItReachesTheResult() {
+        var probe = StubProbe()
+        probe.operatingSystemBuild = "25F84\u{202E}\n" + String(repeating: "9", count: 300)
+        guard case .pass(let detail) = run(probe).result(.macOSVersion)!.outcome else { Issue.record("expected pass"); return }
+        #expect(!detail.value.contains("\u{202E}"))
+        #expect(!detail.value.contains("\n"))
+        #expect(!detail.value.contains(String(repeating: "9", count: 100)))
+    }
+
+    @Test func anUnrepresentableRequirementIsNamedAtFullSize() {
+        let error = GuesthouseError.insufficientDisk(requiredBytes: .max, availableBytes: 512, volumePath: SanitizedText("/Volumes/Work"))
+        #expect(error.userMessage.contains(UInt64.max.formatted()), "a requirement above Int64 must not be presented as half of itself")
+    }
+
+    @Test func aDestinationThatCannotBeTraversedIsNotUsableSpace() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "Unsearchable-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: base.path) }
+        // Writable but not searchable: nothing can be created in it, so its capacity is not
+        // space a development Mac can use.
+        try FileManager.default.setAttributes([.posixPermissions: 0o200], ofItemAtPath: base.path)
+        // Permission bits do not restrain root, so only an ordinary user can prove this.
+        if getuid() != 0 {
+            #expect(throws: HostProbeError.destinationNotWritable(path: base.path)) { try SystemHostProbe().freeBytes(at: base) }
+        }
+    }
+
+    @Test func onlyAFilesystemDenialRulesOutTheDestination() {
+        #expect(SystemHostProbe.rulesOutDestination(EACCES))
+        #expect(SystemHostProbe.rulesOutDestination(EROFS), "a read-only volume cannot be written by any process")
+        #expect(!SystemHostProbe.rulesOutDestination(EPERM), "the sandboxed app's own refusal says nothing about a folder the runtime service writes")
+    }
+
+    @Test func aLeftoverMountPointIsNeverMeasuredOnTheStartupDisk() throws {
+        let container = FileManager.default.temporaryDirectory.appending(path: "Volumes-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: container, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: container) }
+        let leftover = container.appending(path: "External")
+        try FileManager.default.createDirectory(at: leftover, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let probe = SystemHostProbe()
+        #expect(throws: HostProbeError.volumeUnavailable(path: leftover.path)) {
+            try probe.freeBytes(at: leftover.appending(path: "Guesthouse"), mountContainer: container.path)
+        }
+        #expect(throws: HostProbeError.volumeUnavailable(path: leftover.path)) {
+            try probe.freeBytes(at: leftover, mountContainer: container.path)
+        }
+        // A destination that names no mount point is still measured normally.
+        #expect(throws: Never.self) { _ = try probe.freeBytes(at: leftover.appending(path: "Guesthouse")) }
+    }
+
+    /// A link outside the folder that holds mount points can lead inside one. The spelled path
+    /// names no mount point, so the leftover-folder check used to be skipped while the capacity
+    /// lookup followed the link and answered with the startup disk's space for a volume that is
+    /// not mounted.
+    @Test func aLinkIntoALeftoverMountPointIsNotMeasuredEither() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "LinkedVolume-\(UUID().uuidString)")
+        let container = base.appending(path: "Volumes")
+        try FileManager.default.createDirectory(at: container, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: base) }
+        let leftover = container.appending(path: "External")
+        try FileManager.default.createDirectory(at: leftover, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        let link = base.appending(path: "Development Macs")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: leftover)
+        #expect(SystemHostProbe.volumeMountPoint(of: link, container: container.path) == nil, "the path as spelled names no mount point")
+        let probe = SystemHostProbe()
+        let unmounted = leftover.resolvingSymlinksInPath().path
+        #expect(throws: HostProbeError.volumeUnavailable(path: unmounted)) {
+            try probe.freeBytes(at: link, mountContainer: container.path)
+        }
+        #expect(throws: HostProbeError.volumeUnavailable(path: unmounted)) {
+            try probe.freeBytes(at: link.appending(path: "Guesthouse"), mountContainer: container.path)
+        }
     }
 
     @Test func everyFailureCarriesARecoveryAction() {
@@ -269,5 +356,40 @@ struct StubProbe: HostProbe {
         #expect(try probe.freeBytes(at: FileManager.default.temporaryDirectory) > 0)
         #expect(probe.installedApplication(bundleIdentifier: "com.apple.finder")?.url.lastPathComponent == "Finder.app")
         #expect(probe.installedApplication(bundleIdentifier: "com.example.does.not.exist") == nil)
+    }
+
+    /// A guest allocation plus host headroom that cannot be represented is a failure in its own
+    /// right. Deciding it with a `UInt64.max` floor let a probe that answers `UInt64.max` past
+    /// it: `.max < .max` is false, so the check recorded a pass for an allocation no Mac has.
+    @Test func anUnrepresentableMemoryFloorAlwaysFails() throws {
+        var policy = ResourcePolicy()
+        policy.hostMemoryHeadroomBytes = .max
+        let preset = try #require(ResourcePreset(name: "huge", memoryBytes: 1, cpuCount: 4, diskBytes: 1, verification: .experimental))
+        var probe = StubProbe()
+        probe.physicalMemoryBytes = .max
+        let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: root, preset: preset, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(report.result(.memory)!.outcome == .fail(.unsupportedHost(.insufficientMemory(foundBytes: .max, minimumBytes: .max))))
+        #expect(!report.canProceed)
+    }
+
+    /// A result does not only come from `run`. One decoded from a diagnostics file or received
+    /// over the wire carries whatever the sender put in it, and `detail` is presented and
+    /// re-encoded, so it is bounded and redacted by its own type rather than by its author.
+    @Test func aDecodedDetailIsSanitizedLikeEveryOtherOutsideValue() throws {
+        let hostile = "one-time code is AB12-CD34 \u{202E}reversed\nsecond line " + String(repeating: "9", count: 2_000)
+        let json = try JSONEncoder().encode(["pass": ["detail": hostile]])
+        let outcome = try JSONDecoder().decode(PreflightResult.Outcome.self, from: json)
+        guard case .pass(let detail) = outcome else { Issue.record("expected pass"); return }
+        #expect(!detail.value.contains("AB12-CD34"))
+        #expect(!detail.value.contains("\u{202E}"))
+        #expect(!detail.value.contains("\n"))
+        #expect(detail.value.unicodeScalars.count <= SanitizedText.maximumLimit + 1)
+        // What `encode(to:)` writes is the sanitized text, not what came in.
+        let reencoded = String(decoding: try JSONEncoder().encode(outcome), as: UTF8.self)
+        #expect(!reencoded.contains("AB12-CD34"))
+        // A detail built by `run` is a sentence, and survives the round trip whole.
+        let advice = PreflightResult.detail(String(repeating: "a", count: 300))
+        #expect(advice.value.unicodeScalars.count == 300)
+        #expect(try JSONDecoder().decode(SanitizedText.self, from: JSONEncoder().encode(advice)) == advice)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -134,6 +134,30 @@ struct StubProbe: HostProbe {
         #expect(run(probe).canProceed)
     }
 
+    @Test func anUnknownArchitectureFailsEvenWhenThePolicyAsksForOne() {
+        var probe = StubProbe(); probe.cpuArchitecture = .unknown
+        var policy = ResourcePolicy(); policy.requiredArchitecture = .unknown
+        let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(report.result(.architecture)!.outcome == .fail(.unsupportedHost(.architectureUnknown)))
+        #expect(!report.canProceed)
+    }
+
+    @Test func anImpossibleMemoryFloorIsNeverSatisfied() {
+        var policy = ResourcePolicy(); policy.hostMemoryHeadroomBytes = UInt64.max - 1
+        var preset = ResourcePreset.recommended; preset.memoryBytes = 16 * ResourcePreset.gibibyte
+        let report = PreflightCheck.run(probe: StubProbe(), policy: policy, storageRoot: root, preset: preset, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(report.result(.memory)!.isFailure, "a requirement that overflows can never be met")
+    }
+
+    @Test func anUnrepresentableRequirementReportsItselfAsSuch() {
+        let error = #expect(throws: GuesthouseError.self) {
+            try LargeOperationPreflight.check(freeBytes: 500 * ResourcePreset.gigabyte, requiredBytes: UInt64.max - 1, volumePath: "/x")
+        }
+        guard case .insufficientDisk(let required, let available, _)? = error else { Issue.record("expected insufficientDisk"); return }
+        #expect(required == UInt64.max, "the reported requirement is not the wrapped remainder")
+        #expect(available == 500 * ResourcePreset.gigabyte)
+    }
+
     @Test func everyFailureCarriesARecoveryAction() {
         var probe = StubProbe()
         probe.cpuArchitecture = .intel

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -69,10 +69,29 @@ struct StubProbe: HostProbe {
         #expect(!run(probe).canProceed)
     }
 
+    @Test func blockingMinimumIsEvaluatedBeforeTheRecommendation() {
+        var policy = ResourcePolicy()
+        policy.minimumMemoryBytes = 48 * ResourcePreset.gibibyte
+        policy.recommendedMemoryBytes = 32 * ResourcePreset.gibibyte
+        #expect(!policy.isWellFormed)
+        #expect(ResourcePolicy.standard.isWellFormed)
+        let report = PreflightCheck.run(probe: StubProbe(), policy: policy, storageRoot: root)
+        #expect(report.result(.memory)!.isFailure, "32 GB is above the recommendation but below the contradictory minimum")
+    }
+
+    @Test func applicationMetadataIsSanitizedBeforePresentation() {
+        var probe = StubProbe()
+        probe.applications["com.openai.chat"] = InstalledApplication(url: URL(fileURLWithPath: "/Applications/Chat\u{202E}GPT.app"), version: "1.2\n.3", build: String(repeating: "9", count: 300))
+        guard case .pass(let detail) = run(probe).result(.codexDesktop)!.outcome else { Issue.record("expected pass"); return }
+        #expect(!detail.contains("\u{202E}"))
+        #expect(!detail.contains("\n"))
+        #expect(!detail.contains(String(repeating: "9", count: 100)))
+    }
+
     @Test func lowDiskFailsWithPreciseNumbersAndUnknownDiskWarns() {
         var probe = StubProbe()
         probe.free = .success(50 * ResourcePreset.gigabyte)
-        #expect(run(probe).result(.freeDisk)!.outcome == .fail(.insufficientDisk(requiredBytes: 200 * ResourcePreset.gigabyte, availableBytes: 50 * ResourcePreset.gigabyte, volumePath: root.path)))
+        #expect(run(probe).result(.freeDisk)!.outcome == .fail(.insufficientDisk(requiredBytes: 200 * ResourcePreset.gigabyte, availableBytes: 50 * ResourcePreset.gigabyte, volumePath: SanitizedText(root.path))))
 
         probe.free = .failure(ProbeFailure())
         guard case .warn(_, let recovery) = run(probe).result(.freeDisk)!.outcome else { Issue.record("expected warn"); return }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -144,7 +144,7 @@ struct StubProbe: HostProbe {
 
     @Test func anImpossibleMemoryFloorIsNeverSatisfied() {
         var policy = ResourcePolicy(); policy.hostMemoryHeadroomBytes = UInt64.max - 1
-        let preset = ResourcePreset(name: "Test", memoryBytes: 16 * ResourcePreset.gibibyte, cpuCount: ResourcePreset.recommended.cpuCount, diskBytes: ResourcePreset.recommended.diskBytes, verification: .planBaseline)!
+        let preset = ResourcePreset(name: "Test", memoryBytes: 16 * ResourcePreset.gibibyte, cpuCount: 4, diskBytes: ResourcePreset.recommended.diskBytes, verification: .experimental)!
         let report = PreflightCheck.run(probe: StubProbe(), policy: policy, storageRoot: root, preset: preset, now: Date(timeIntervalSince1970: 1_800_000_000))
         #expect(report.result(.memory)!.isFailure, "a requirement that overflows can never be met")
     }
@@ -185,6 +185,32 @@ struct StubProbe: HostProbe {
         #expect(failure == .fail(.unsupportedHost(.wrongArchitecture(found: SanitizedText("Apple silicon"), required: "Intel"))))
         if case .fail(let error) = failure {
             #expect(error.userMessage.contains("Apple silicon") && error.userMessage.contains("Intel"))
+        }
+    }
+
+    @Test func aReportMissingACheckNeverProceeds() {
+        let full = PreflightCheck.run(probe: StubProbe(), storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(full.canProceed)
+        let partial = PreflightReport(results: Array(full.results.dropLast()), storage: full.storage, powerSource: full.powerSource, checkedAt: full.checkedAt)
+        #expect(!partial.canProceed, "a report that answers only some checks is not a passing report")
+        let empty = PreflightReport(results: [], storage: full.storage, powerSource: full.powerSource, checkedAt: full.checkedAt)
+        #expect(!empty.canProceed)
+    }
+
+    @Test func aDanglingOrFileDestinationIsNeverMeasuredOnAnotherDisk() throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "Destination-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+        let probe = SystemHostProbe()
+        let dangling = base.appending(path: "external")
+        try FileManager.default.createSymbolicLink(at: dangling, withDestinationURL: URL(fileURLWithPath: "/Volumes/NotMounted/Guesthouse"))
+        #expect(throws: HostProbeError.self) { try probe.freeBytes(at: dangling.appending(path: "store")) }
+        let file = base.appending(path: "file")
+        try Data("x".utf8).write(to: file)
+        #expect(throws: HostProbeError.notADirectory(path: file.path)) { try probe.freeBytes(at: file.appending(path: "store")) }
+        #expect(throws: Never.self) { _ = try probe.freeBytes(at: base.appending(path: "fresh/store")) }
+        for error in [HostProbeError.volumeUnavailable(path: "/x"), .notADirectory(path: "/x")] {
+            #expect(!error.recoveryActions.isEmpty)
+            #expect(!error.userMessage.isEmpty)
         }
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/StorageSummarySafetyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/StorageSummarySafetyTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct StorageSummarySafetyTests {
+    private func summary(path: String) -> StorageSummary {
+        StorageSummary(storageRootPath: path, runtimeDownloadEstimateBytes: 1,
+                       restoreImageEstimateBytes: 2, guestDiskBytes: 3, firstSetupAllowanceBytes: 4)
+    }
+
+    private static let hostilePaths = [
+        "/Volumes/ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab/Guesthouse",
+        "/Volumes/AB12-CD34/Guesthouse",
+        "/Volumes/Work\u{202E}\n\u{1B}[31m/Guesthouse",
+        "/Volumes/" + String(repeating: "a", count: 2_000),
+    ]
+
+    private func expectSafe(_ path: String) {
+        #expect(!path.contains("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"))
+        #expect(!path.contains("AB12-CD34"))
+        #expect(!path.contains("\u{202E}"))
+        #expect(!path.contains("\n"))
+        #expect(!path.contains("\u{1B}"))
+        #expect(path.unicodeScalars.count <= 401)
+    }
+
+    @Test(arguments: hostilePaths)
+    func constructionSanitizesThePathBeforeEncoding(_ path: String) throws {
+        let value = summary(path: path)
+        let expected = GuesthouseError.sanitize(path, limit: 400)
+        #expect(value.storageRootPath == expected)
+        expectSafe(value.storageRootPath)
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value)) as? [String: Any]
+        #expect(json?["storageRootPath"] as? String == expected)
+    }
+
+    @Test(arguments: hostilePaths)
+    func assignmentCannotBypassThePathBoundary(_ path: String) throws {
+        var value = summary(path: "/Volumes/Work/Guesthouse")
+        value.storageRootPath = path
+        #expect(value.storageRootPath == GuesthouseError.sanitize(path, limit: 400))
+        expectSafe(value.storageRootPath)
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value)) as? [String: Any]
+        #expect(json?["storageRootPath"] as? String == value.storageRootPath)
+    }
+
+    @Test(arguments: hostilePaths)
+    func decodingSanitizesUntrustedPathStrings(_ path: String) throws {
+        let data = try JSONSerialization.data(withJSONObject: [
+            "storageRootPath": path, "runtimeDownloadEstimateBytes": 1,
+            "restoreImageEstimateBytes": 2, "guestDiskBytes": 3, "firstSetupAllowanceBytes": 4,
+        ])
+        let value = try JSONDecoder().decode(StorageSummary.self, from: data)
+        #expect(value.storageRootPath == GuesthouseError.sanitize(path, limit: 400))
+        expectSafe(value.storageRootPath)
+        let encoded = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value)) as? [String: Any]
+        #expect(encoded?["storageRootPath"] as? String == value.storageRootPath)
+        #expect(value.runtimeDownloadEstimateBytes == 1)
+        #expect(value.restoreImageEstimateBytes == 2)
+        #expect(value.guestDiskBytes == 3)
+        #expect(value.firstSetupAllowanceBytes == 4)
+    }
+
+    @Test func inPlaceStringMutationsCannotBypassTheBoundary() throws {
+        var value = summary(path: "/Volumes/Work/")
+        value.storageRootPath.append("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab")
+        expectSafe(value.storageRootPath)
+        #expect(value.storageRootPath.contains("[redacted:github-token]"))
+
+        value.storageRootPath = "/Volumes/Work/Guesthouse"
+        let range = try #require(value.storageRootPath.range(of: "Work"))
+        value.storageRootPath.replaceSubrange(range, with: "AB12-CD34")
+        expectSafe(value.storageRootPath)
+        #expect(value.storageRootPath.contains("[redacted:device-code]"))
+        let json = try JSONSerialization.jsonObject(with: JSONEncoder().encode(value)) as? [String: Any]
+        #expect(json?["storageRootPath"] as? String == value.storageRootPath)
+    }
+
+    @Test func ordinaryPathsAndJSONShapeRemainCompatible() throws {
+        let path = "/Users/dev/Library/Application Support/Guesthouse"
+        let value = summary(path: path)
+        #expect(value.storageRootPath == path)
+        let data = try JSONEncoder().encode(value)
+        #expect(try JSONDecoder().decode(StorageSummary.self, from: data) == value)
+        let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(Set(json.keys) == ["storageRootPath", "runtimeDownloadEstimateBytes", "restoreImageEstimateBytes", "guestDiskBytes", "firstSetupAllowanceBytes"])
+        #expect(json["storageRootPath"] as? String == path)
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Draft reference — do not merge this historical stack.** Shared preflight replacements #170–#174 are merged; #175 is CI-green and awaiting review of its corrected commit. Native query, retained storage binding and wizard integration remain unfinished. Follow [issue #12's current status](https://github.com/PicoMLX/Guesthouse/issues/12) and [issue #48's queue](https://github.com/PicoMLX/Guesthouse/issues/48).
>
> Keep this branch, original description, tests and review history. Historical probe/volume-identity findings are not resolved by helper-only migration. No new review or CI run is requested on this reference.

<details>
<summary>Historical migration notes — old heads and unpublished states are superseded</summary>

> **Bounded worker preparation — September 10, 2026:** A bounded read-only worker is prepared on `mvp/runtime-readonly-worker` at `a8d03d4ccd168a86ef3c1749cebe879eaf10847f`, above the existing reply-accounting branch: two files/334 additions and nine authored tests. Its process-wide four-slot bound retains canceled jobs until actual queue drain/OS return; reserve performs only in-memory work under the authenticated gate, start schedules outside it, and refusal settles replies once outside worker locks. This worker is not yet wired to native queries. Source/diff and seven shell-only hook checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. Typed deferred registration is now prepared at `d196891d6bfd41c2b5f3489c7226e9be5dea9e88` on `mvp/runtime-deferred-registration`: three files/103 additions/7 deletions above the worker, with four new Core tests and one worker regression. RuntimeSessionGate returns an in-process registered value or refusal; the existing event-returning commit delegates to the same lock boundary. Worker fixtures use real tickets instead of synthetic wire events. Prior/later refusal, registered nil, throwing registration, counted-reply ownership and no reservation after refusal are covered in authored tests. The combined worker/registration batch is four files/434 changed lines and 14 test functions. Source/diff and seven shell-only hook checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. Native deferred reply wiring is prepared at `20a5ed738301fa484908130f3dd065517762bf83` on `mvp/native-deferred-replies`, above typed registration: two files/235 additions/16 deletions and seven new test functions/nine cases. Native ingress reserves under the existing authenticated gate and schedules outside it; original reply contexts survive callback return, terminal/encoding/send refusals settle queued siblings once, and canceled slots drain without probing. Immediate replies and the public runtimeVersion-only policy remain; no host-preflight query or mutation is enabled. Tests extend the existing anonymous-XPC fixture with a manually advanced worker, cross-session capacity, refusal, one-way and failure-drain cases. Added captured-owner regressions verify release after rejection/unlock/reply handoff, and retention until actual queue drain for both normal and refused work; deinit safely rereads the gate to detect locked destruction. Source/diff and seven shell-only hook checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. Retained-volume persistence, production query activation and wizard freshness still remain.

> **Publication update — September 10, 2026:** [PR #170](https://github.com/PicoMLX/Guesthouse/pull/170) publishes both prepared pure preflight slices together against main at `f20f0a3e785b104b9a7a9dd22f75b63b2917373a` (six files/375 additions; 21 test functions/52 cases). Exact-head Xcode Cloud passed at 14:09:51 UTC; matching Codex review completed at 14:09:30 UTC and the original-message bot thumbs-up arrived at 14:09:33 UTC, with no findings. #170 is merge-ready on main. No local Swift/Xcode build or test pass is claimed. The preparation notes below are historical. This draft remains the retained reference: the report/evaluator, RuntimeKit-owned probe, authenticated query, saved-volume identity and wizard integration are still outstanding, including the open concrete-probe P1. Do not close this reference when only #170 lands.

> **Reply accounting preparation — September 10, 2026:** Reply accounting is prepared on `mvp/runtime-reply-obligation` at `5486cff1c16df50d7df50c32960ec4148df780b7`, above the existing composition head. Three files/203 additions/8 deletions add an internal exactly-once obligation and adapt the existing native handler without changing its synchronous runtimeVersion-only surface. Every counted path explicitly settles through the existing reply/send-failure logic before gate accounting/cancel; callbacks execute outside the helper/gate mutexes and settled objects release their captures. Seven focused tests cover duplicate/reentrant/concurrent completion, reply-before-cancel, draining siblings and capture lifetime. Source/diff and seven shell-only hook checks pass; **this head is unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. It does not implement worker admission, cancellation of host I/O, a named query, retained-volume persistence or wizard freshness. The composition/accounting batch totals five files/399 changed lines; keep it unpublished until its dependencies settle.

> **Runtime composition preparation — September 10, 2026:** Runtime-only probe composition is prepared on `mvp/runtime-preflight-composition`, head `d00442cd3f00e4ab11d3c101a3e86dec5a58bbd3`, above the existing storage-probe head. Two files/188 additions add RuntimeHostPreflight and eight test functions/16 cases. Construction performs no I/O; each check rereads basic facts, selected-volume capacity and Codex discovery, then runs the existing evaluator with the service-owned policy/preset and a completion timestamp. Dedicated disk/app results replace any partial snapshot placeholders; no selected UUID is recaptured or storage created. **This head is unpublished, uncompiled, test-unexecuted and Cloud-unvalidated.** Full source/diff checks and seven shell-only CI-hook scenarios pass. Named host-preflight wire/client routing and its one-shot client are prepared on `mvp/host-preflight-wire` at `12e9b4fdc2f4b00773a37f536616eb87ed5ab220`, above native ownership 20a5ed73: 20 files/466 changed lines, 19 new test functions plus expanded existing cases. Epoch 13 adds a parameterless request/report, validates five distinct checks independently of readiness, and accepts only complete owning replies. Both transport and router classify it as read-only; unsolicited/mismatched reports fail closed and cannot settle operations. The one-shot helper uses one ten-second deadline, cancellation without replay and awaited connection cleanup, including failed/late replies and complete blocked reports. Source/diff and seven shell-only hook checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. Normal merges carried #171's Cloud-validated one-line assertion fix through all seven existing prepared branches; each ancestor's remaining source is unchanged. Production native construction still refuses hostPreflight. The read-only saved-state prerequisite is prepared separately on `mvp/state-store-readonly` at `fb064b41d1e11a22fcec662c18cc4e0a9ef4df74`, above persistence-recovery 109289df: five files/285 changed lines, 13 tests/30 cases. It reuses the existing store's anchored/locked access with verify-only protection and a 4-MiB read budget; missing storage is not created and drift is not repaired. Source/diff and seven shell-only checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. The retained-record follow-up is now prepared at `d0592d2d06056be85c799b4cba33a2e60bd55680` on `mvp/retained-storage-selection`: 14 files/305 changed lines, 13 new tests/20 cases plus seven added cases in existing suites. Snapshot format 3 retains a nonzero host-volume UUID in the existing store; ordinary saves cannot erase/replace it or infer it for existing environment/journal evidence. Older format-2 state is preserved without an invented upgrade, and failed durability barriers still fail while retaining visible evidence. Source/diff and seven shell-only checks pass; **unpublished, uncompiled, test-unexecuted and Cloud-unvalidated**. No second store. Next: actual service-owned initial capture and persisted-identity loading/composition, then native query activation and wizard stale-result fencing; no identity recapture on refresh or GUI authority. Retain the concrete-probe P1 and this original reference until the complete integration lands.

> **Runtime storage preparation — September 10, 2026:** Runtime storage probing is prepared on `mvp/runtime-storage-probe`, head `0874d5f1ebd687d3f9f24a31340e1c15bdd5c817`, above the existing runtime-discovery head: four files/439 additions, 26 test functions/110 cases. An existing-directory descriptor supplies the volume UUID and actual nonprivileged free bytes in one fixed 48-byte Darwin attribute read. This is deliberately conservative available space, not an estimate including purgeable data. Unsupported/malformed attributes, absent/zero UUID and negative capacity fail closed. The runtime-only observer requires a separately retained expected volume UUID. Initial identity capture accepts only an existing service-chosen directory; refresh never selects a replacement identity. Missing first-launch suffixes may measure an ancestor only on that selected volume. Wrong UUID, final/dangling links, files, permission failures including EPERM, changed directory bindings and newly appeared suffixes are refused. Descriptor-based search/write access has no GUI-sandbox bypass. Runtime paths/UUIDs/buffers do not enter the public report or diagnostics. Source/staged/final diff checks and seven shell-only CI-hook scenarios pass. **0874d5f1 is unpublished, uncompiled, test-unexecuted and Cloud-unvalidated.** No native, filesystem-fixture or volume-replacement test has run; the latter still needs real hardware evidence where required. Source tests include bounded ABI decoding, Foundation/native UUID agreement, borrowed-FD lifetime, missing-root noncreation, supplied UUID mismatch, permissions, links and deterministic namespace changes in isolated fixtures. No host mount, storage preparation, persistence or production query is activated. Retain the original concrete-probe P1 until service-owned selection/persistence, authenticated query composition and wizard integration land.

> **Runtime probe publication — September 10, 2026, 18:35 UTC:** Published the basic host-facts and Codex-discovery slices together as [PR #172](https://github.com/PicoMLX/Guesthouse/pull/172), head `2f9b1e7e89666af66f083cb797d01387e04ee880`, on `mvp/runtime-codex-discovery`, stacked on #171. Four files/494 additions, 26 Swift Testing functions/75 cases. A normal merge incorporates #171's explicit-predicate assertion fix without rewriting history. Full source/test diff and seven shell-only hook scenarios pass. No local Swift/Xcode build or new cache was created; compilation and test execution are delegated to Xcode Cloud and remain pending. Matching Codex review completed at 18:38:28 UTC and the original-message bot thumbs-up arrived at 18:38:34 UTC, with no inline or standalone findings and complete pagination. Xcode Cloud suite 93503138549 is queued for this exact head; no completed check exists. Subscription remains verified. This is not merge-ready: #170 and #171 must land first, then retarget/settle #172 on main and recheck its own exact-head gates. The owner alone merges; never merge a child into its feature-branch base. Only this completed focused batch was published under the owner's renewed origin/Cloud request; the larger integration stack remains local. The runtime-only probes return typed architecture, macOS, memory, power and application observations. Codex discovery preserves absent versus unavailable and bounds metadata reads; no account, signature, SSH compatibility or hardware proof is claimed. Disk identity/persistence, named authenticated XPC and wizard freshness remain separate work. The production runtime is still version-only; #12/#61 and the concrete-probe P1 remain open.

> **Evaluator publication — September 10, 2026, 16:25 UTC:** Published the retained report/evaluator follow-up as [PR #171](https://github.com/PicoMLX/Guesthouse/pull/171) on `mvp/preflight-evaluator`, head `d11120e7d24a8ce685a6f7d82eaf5184dff54935`, stacked on #170: three files/443 additions, with 20 test functions/69 cases. Closed result cases derive their kind/severity and fixed message/recovery; the evaluator reuses the approved memory guard and preserves unknown-state blocking, memory warnings, truthful architecture policies and missing-versus-unavailable app discovery. Immutable reports reject empty, partial or duplicated check sets before allowing progress. Planning storage text is fixed and explicitly not a verified path. Source/diff checks and seven shell-only CI-hook scenarios pass. The original Cloud build 1421 failed in a Swift Testing macro expansion for a key-path allSatisfy predicate. [The diagnosed one-line fix](https://github.com/PicoMLX/Guesthouse/pull/171#issuecomment-5622699623) is pushed as `d11120e7`; the equivalent explicit closure preserves every assertion. Fresh matching Codex review completed at 17:22:56 UTC and the original-message bot thumbs-up at 17:22:59 UTC, with no findings. The exact-head Xcode Cloud Test check completed SUCCESS at 19:05:52 UTC on September 10. Its matching review and original-message thumbs-up are complete with no findings. No local Swift/Xcode build or cache was created. Only the dependency/composition hold remains: #170 must land before #171 settles on main. **Cloud validation has passed for this exact head; dependency settlement is still required.** Under the owner's renewed origin/Cloud request, one existing focused follow-up is published now; the larger unfinished probe stack stays local. Merge #170 first, then retarget/settle #171 on main and verify its own exact-head gates. Never merge the child into its feature-branch base. The owner alone merges. No runtime query or wizard integration is enabled; the concrete-probe P1 and this retained reference remain open.

<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: reusable backend/preflight/workspace/identity contracts (#10, #12, #15, #17, #18). Adapt useful implementation/tests to current Core. A historical Tart ancestor does not make shared functionality obsolete.
>
> September 10 preparation (13:40 UTC): first pure resource slice prepared at `7316bf6773750ca91aa9bfe09bf487716bbcb413` (`mvp/resource-preflight`), three files/180 additions. Reuses planning policy, overflow-safe disk margin and blocking guest-plus-host memory arithmetic; ten test functions/21 cases are authored. No host probe or arbitrary path/detail is carried into this slice. Source checks and seven shell-only hook scenarios pass; **unpublished, uncompiled, resource tests unexecuted and Cloud-unvalidated**. All six retained files and 34 review threads were read, plus #80's unknown-root/proxy-volume/wizard flow. The concrete-probe P1 and full typed report/runtime-query/wizard integration remain open. The saved-volume replacement half of the historical identity finding is not claimed fixed. #12/#48 track next steps; no old review state is changed.
>
> Typed observation follow-up (13:58 UTC): prepared `f20f0a3e785b104b9a7a9dd22f75b63b2917373a` (`mvp/preflight-observations`), three files/195 additions above the guard slice. HostProbeSnapshot, typed disk/storage failures and separate application-presence/version observations replace raw host-detail inputs; eleven test functions/31 cases are authored. Source checks and shell-only hook tests pass, but **no Swift/Xcode compilation, executed observation tests, Cloud validation or publication exists**. Concrete probing, typed report/evaluator, named authenticated XPC and wizard integration remain unfinished. Do not treat the volumeIdentityChanged enum as an implemented volume check.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

</details>

---

## Summary

Implements #12 (`MVP-PLAN.md` §2 first-launch step 1, "Check this Mac"; §4 version/resource policy and per-operation free-space checks). Stacked on #60; base remains `issue-10-fake-backend`.

- `HostProbe` seam, resource policy, pure preflight evaluation, actionable pass/warn/undetermined/fail results, storage summary, and large-operation margin checks.
- Every required check must be present and determined before setup proceeds; missing disk information does not become success.
- Host-sourced result details and architecture/error text are sanitized in their model types.

## Bounded storage-model review correction

`StorageSummary.storageRootPath` now sanitizes construction, assignment (including in-place String edits), and decoding. Its public String API and plain-string JSON shape are preserved. The `PreflightCheck.run` call site delegates sanitation to the model instead of being the only protected path. The path is display text, never authority to access host storage (MVP-PLAN.md §§2–3).

- Deterministic regressions cover synthetic credentials, device codes, control characters, oversized paths, direct assignment, append/replace, decoding, re-encoding, and ordinary-path compatibility.
- The initial regression suite failed 17 assertions against the old model.
- Independent source review completed; its suggested mutation and concrete absence checks were added.
- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: **388 tests in 23 suites passed**.
- No new dependency, warning, secret, or VM/hardware action. No base update or history rewrite.

## Remaining readiness constraints

- [ ] **Runtime ownership remains unresolved**: `SystemHostProbe` is still compiled into Core and performs concrete AppKit/IOKit/sysctl/filesystem queries. It must move to the runtime-owned implementation and be invoked through a named, authenticated XPC preflight query. PR #61 has neither the runtime target nor RuntimeKit yet; no unbuilt-file move or Core→RuntimeKit dependency was introduced as a substitute.
- [ ] **Decomposition remains required**: the cumulative PR exceeded the roughly 500-line guideline before this follow-up. This small correction does not make the whole PR merge-ready.
- [ ] Fresh exact-head CI and automated review must complete.
- [ ] Stacked prerequisite readiness.

The two older memory-overflow and decoded-detail findings were reverified against current code and the passing suite. The concrete-host-probe finding remains open for a coordinated ownership transition across the runtime and wizard layers.

Closes #12

