### PR TITLE
Core: SwiftPM package identity resolution and collision detection

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -48,12 +48,15 @@ public struct PackageIdentity: Hashable, Sendable, CustomStringConvertible {
     /// non-ASCII letters or spaces (`cafékit`, `space kit`), and re-resolving writes the same
     /// file back; refusing those would reject the whole lockfile with advice that cannot
     /// work. Only spellings that could not name a package at all are refused.
+    ///
+    /// A boundary space is part of the identity for the same reason: a checkout named ` Foo `
+    /// is the package `" foo "`, and folding it onto `foo` would merge two distinct pins into
+    /// one identity, report a collision, and block an override no re-resolve could unblock.
     public init?(resolvedIdentity: String) {
-        let text = resolvedIdentity.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !text.contains("/"), text != ".", text != "..",
-              !WorkspaceManifest.containsControlCharacters(text)
+        guard !resolvedIdentity.isEmpty, !resolvedIdentity.contains("/"), resolvedIdentity != ".", resolvedIdentity != "..",
+              !WorkspaceManifest.containsControlCharacters(resolvedIdentity)
         else { return nil }
-        rawValue = text.lowercased()
+        rawValue = resolvedIdentity.lowercased()
     }
 
     public var description: String { rawValue }
@@ -109,10 +112,36 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
             guard let kindRaw = raw["kind"] as? String else { throw .malformed("kind") }
             guard let kind = Pin.Kind(rawValue: kindRaw) else { throw .unknownKind(kindRaw) }
             guard let location = raw["location"] as? String else { throw .malformed("location") }
-            let state = raw["state"] as? [String: Any] ?? [:]
-            pins.append(Pin(identity: identity, kind: kind, location: location, revision: state["revision"] as? String, version: state["version"] as? String, branch: state["branch"] as? String))
+            let state = try decodeState(raw["state"], kind: kind)
+            pins.append(Pin(identity: identity, kind: kind, location: location, revision: state.revision, version: state.version, branch: state.branch))
         }
         return ResolvedPackagesFile(version: version, pins: pins)
+    }
+
+    /// SwiftPM records the commit it checked out for every source-control pin, so a pin whose
+    /// `state` is absent, is not an object, or names no revision is a corrupted lockfile.
+    /// Reading it as a pin with no metadata would let an override be approved against a pin
+    /// that identifies no code, and the failure would surface later, at the build.
+    private static func decodeState(_ raw: Any?, kind: Pin.Kind) throws(ResolvedPackagesError) -> (revision: String?, version: String?, branch: String?) {
+        let isSourceControl = kind == .remoteSourceControl || kind == .localSourceControl
+        guard let raw, !(raw is NSNull) else {
+            if isSourceControl { throw .malformed("state") }
+            return (nil, nil, nil)
+        }
+        guard let fields = raw as? [String: Any] else { throw .malformed("state") }
+        let revision = try string(fields["revision"], field: "state.revision")
+        let version = try string(fields["version"], field: "state.version")
+        let branch = try string(fields["branch"], field: "state.branch")
+        if isSourceControl, revision == nil { throw .malformed("state.revision") }
+        return (revision, version, branch)
+    }
+
+    /// A present-but-unreadable field is refused rather than dropped, so a lockfile that spells
+    /// a version or branch as something other than text is not silently read as having none.
+    private static func string(_ raw: Any?, field: String) throws(ResolvedPackagesError) -> String? {
+        guard let raw, !(raw is NSNull) else { return nil }
+        guard let text = raw as? String else { throw .malformed(field) }
+        return text
     }
 }
 
@@ -147,7 +176,7 @@ public enum ResolvedPackagesError: Error, Hashable, Sendable, LocalizedError {
 /// Decides, for each package repository the user selected, whether it can safely override one
 /// of the app's resolved dependencies (MVP-PLAN.md §6: match identity and canonical origin,
 /// never only the display name; reject ambiguous identities).
-public enum LocalOverrideMatcher {
+public enum LocalOverrideMatcher: Sendable {
     public enum MatchResult: Hashable, Sendable {
         /// The selected repository is exactly this remote-source-control dependency.
         case matched(identity: PackageIdentity, location: String)
@@ -156,6 +185,11 @@ public enum LocalOverrideMatcher {
         case collision(identity: PackageIdentity, locations: [String])
         /// The app does not depend on this package, directly or transitively.
         case notADependency(identity: PackageIdentity)
+        /// The app pins this repository, but under an identity SwiftPM did not derive from the
+        /// pinned location. A dependency mirror does exactly this: SwiftPM writes the mirror's
+        /// identity and maps the location back to the original URL. A local checkout can only
+        /// carry the location's identity, so the override would never take effect.
+        case identityMismatch(identity: PackageIdentity, pinned: PackageIdentity, location: String)
         /// The dependency exists but is not a Git URL dependency (registry or local path).
         case unsupportedKind(identity: PackageIdentity, kind: ResolvedPackagesFile.Pin.Kind)
         /// Same identity, different repository. Overriding would silently substitute code.
@@ -190,7 +224,15 @@ public enum LocalOverrideMatcher {
                 continue
             }
             guard let pins = pinsByIdentity[identity], !pins.isEmpty else {
-                results.append(.notADependency(identity: identity))
+                // A mirrored dependency is pinned at its original location under the mirror's
+                // identity, so the app does depend on the selected repository even though no
+                // pin carries its identity. Reporting that as an absent dependency would send
+                // the user to add a dependency the app already has.
+                if let mirrored = resolved.pins.first(where: { RemoteURL($0.location) == repository.remote }) {
+                    results.append(.identityMismatch(identity: identity, pinned: mirrored.identity, location: mirrored.location))
+                } else {
+                    results.append(.notADependency(identity: identity))
+                }
                 continue
             }
             if pins.count > 1 {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -23,6 +23,14 @@ public struct PackageIdentity: Hashable, Sendable, Codable, CustomStringConverti
         rawValue = remote.name.lowercased()
     }
 
+    /// An identity exactly as `Package.resolved` spells it. SwiftPM has already canonicalized
+    /// it, so no location rules (such as dropping `.git`) are applied again.
+    public init?(resolvedIdentity: String) {
+        let text = resolvedIdentity.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !text.isEmpty, !text.contains("/"), text != ".", text != "..", text.unicodeScalars.allSatisfy({ $0.isASCII && $0.value > 0x20 && $0.value < 0x7F }) else { return nil }
+        rawValue = text.lowercased()
+    }
+
     public var description: String { rawValue }
 }
 
@@ -59,7 +67,7 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
         guard let rawPins = object["pins"] as? [[String: Any]] else { throw .malformed("pins") }
         var pins: [Pin] = []
         for raw in rawPins {
-            guard let identityRaw = raw["identity"] as? String, let identity = PackageIdentity(location: identityRaw) else { throw .malformed("identity") }
+            guard let identityRaw = raw["identity"] as? String, let identity = PackageIdentity(resolvedIdentity: identityRaw) else { throw .malformed("identity") }
             guard let kindRaw = raw["kind"] as? String else { throw .malformed("kind") }
             guard let kind = Pin.Kind(rawValue: kindRaw) else { throw .unknownKind(kindRaw) }
             guard let location = raw["location"] as? String else { throw .malformed("location") }
@@ -70,12 +78,32 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
     }
 }
 
-public enum ResolvedPackagesError: Error, Hashable, Sendable {
+public enum ResolvedPackagesError: Error, Hashable, Sendable, LocalizedError {
     case notJSON
     case missingVersion
     case unsupportedVersion(Int)
     case unknownKind(String)
     case malformed(String)
+
+    public var userMessage: String {
+        switch self {
+        case .notJSON: "The app's Package.resolved is not valid JSON. Resolve packages in Xcode and commit the file, then try again."
+        case .missingVersion: "The app's Package.resolved has no version field. Resolve packages in Xcode and commit the file, then try again."
+        case .unsupportedVersion(let version): "The app's Package.resolved uses format \(version), which this version of Guesthouse does not read. Update Guesthouse, or resolve packages with the Xcode version Guesthouse supports."
+        case .unknownKind(let kind): "The app's Package.resolved pins a dependency of kind \(GuesthouseError.sanitize(kind)), which Guesthouse does not understand. Update Guesthouse."
+        case .malformed(let field): "The app's Package.resolved has an unreadable \(GuesthouseError.sanitize(field)) entry. Resolve packages in Xcode and commit the file, then try again."
+        }
+    }
+
+    /// In preference order. Never empty.
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .unsupportedVersion, .unknownKind: [.reinstallApp, .retry, .cancel]
+        default: [.retry, .cancel]
+        }
+    }
+
+    public var errorDescription: String? { userMessage }
 }
 
 /// Decides, for each package repository the user selected, whether it can safely override one
@@ -94,9 +122,20 @@ public enum LocalOverrideMatcher {
         case unsupportedKind(identity: PackageIdentity, kind: ResolvedPackagesFile.Pin.Kind)
         /// Same identity, different repository. Overriding would silently substitute code.
         case remoteMismatch(identity: PackageIdentity, expected: String, selected: String)
+        /// The checkout directory's basename would give SwiftPM a different local identity,
+        /// so the override would never apply.
+        case checkoutNameMismatch(identity: PackageIdentity, checkout: String)
+        /// The checkout's actual `origin` is not the selected repository.
+        case originMismatch(identity: PackageIdentity, expected: String, observed: String)
     }
 
-    public static func match(selected: [WorkspaceRepository], resolved: ResolvedPackagesFile) -> [MatchResult] {
+    /// - Parameters:
+    ///   - selected: the repositories the workspace names.
+    ///   - resolved: the app's `Package.resolved`.
+    ///   - observedOrigins: the `origin` remote of each existing checkout, keyed by checkout
+    ///     name, as read from the clone by the caller; a checkout whose origin differs from the
+    ///     selected repository is refused rather than trusted.
+    public static func match(selected: [WorkspaceRepository], resolved: ResolvedPackagesFile, observedOrigins: [DirectoryName: RemoteURL] = [:]) -> [MatchResult] {
         let packages = selected.filter { $0.role == .package }
         var results: [MatchResult] = []
         let selectedIdentities = Dictionary(grouping: packages, by: { PackageIdentity(remote: $0.remote) })
@@ -123,6 +162,17 @@ public enum LocalOverrideMatcher {
             }
             guard let pinned = RemoteURL(pin.location), pinned == repository.remote else {
                 results.append(.remoteMismatch(identity: identity, expected: pin.location, selected: repository.remote.canonical))
+                continue
+            }
+            // SwiftPM derives the local package's identity from the directory name, so the
+            // checkout must carry the repository's name (or its derived safe form).
+            let derived = DirectoryName.derived(from: repository.remote.name).identity
+            guard repository.checkoutName.identity == identity.rawValue || repository.checkoutName.identity == derived else {
+                results.append(.checkoutNameMismatch(identity: identity, checkout: repository.checkoutName.rawValue))
+                continue
+            }
+            if let origin = observedOrigins[repository.checkoutName], origin != repository.remote {
+                results.append(.originMismatch(identity: identity, expected: repository.remote.canonical, observed: origin.canonical))
                 continue
             }
             results.append(.matched(identity: identity, location: pin.location))

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -83,7 +83,6 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
             case remoteSourceControl
             case localSourceControl
             case registry
-            case fileSystem
         }
 
         public let identity: PackageIdentity
@@ -113,13 +112,19 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw .notJSON }
         guard let version = object["version"] as? Int else { throw .missingVersion }
         guard version == 2 || version == 3 else { throw .unsupportedVersion(version) }
+        if version == 3 { _ = try string(object["originHash"], field: "originHash") }
         guard let rawPins = object["pins"] as? [[String: Any]] else { throw .malformed("pins") }
         var pins: [Pin] = []
+        var identities: Set<PackageIdentity> = []
         for raw in rawPins {
             guard let identityRaw = raw["identity"] as? String, let identity = PackageIdentity(resolvedIdentity: identityRaw) else { throw .malformed("identity") }
+            guard identities.insert(identity).inserted else { throw .malformed("pins.identity (duplicate)") }
             guard let kindRaw = raw["kind"] as? String else { throw .malformed("kind") }
             guard let kind = Pin.Kind(rawValue: kindRaw) else { throw .unknownKind(kindRaw) }
             guard let location = raw["location"] as? String else { throw .malformed("location") }
+            // SwiftPM's Unix AbsolutePath validation is syntactic: the path must
+            // start with `/`. Do not inspect the host or change the stored spelling.
+            if kind == .localSourceControl, !location.hasPrefix("/") { throw .malformed("location") }
             let state = try decodeState(raw["state"], kind: kind)
             pins.append(Pin(identity: identity, kind: kind, location: location, revision: state.revision, version: state.version, branch: state.branch))
         }
@@ -132,15 +137,7 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
     /// that identifies no code, and the failure would surface later, at the build.
     private static func decodeState(_ raw: Any?, kind: Pin.Kind) throws(ResolvedPackagesError) -> (revision: String?, version: String?, branch: String?) {
         let isSourceControl = kind == .remoteSourceControl || kind == .localSourceControl
-        guard let raw, !(raw is NSNull) else {
-            // A registry pin is pinned by version alone, so SwiftPM refuses one that carries
-            // no state for the same reason it refuses a source-control pin without a commit.
-            // Reading it as a pin with no metadata would approve overrides from a lockfile the
-            // wrapper's own resolution then rejects, where re-resolving is no longer a repair
-            // the user can make.
-            if isSourceControl || kind == .registry { throw .malformed("state") }
-            return (nil, nil, nil)
-        }
+        guard let raw, !(raw is NSNull) else { throw .malformed("state") }
         guard let fields = raw as? [String: Any] else { throw .malformed("state") }
         let revision = try string(fields["revision"], field: "state.revision")
         let version = try string(fields["version"], field: "state.version")
@@ -159,8 +156,9 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
         return (revision, version, branch)
     }
 
-    /// SwiftPM's `Version` grammar: three numeric identifiers, then an optional prerelease and
-    /// optional build metadata, each a dot-separated run of alphanumerics and hyphens.
+    /// SwiftPM's TSCUtility.Version parser accepts leading zeros and empty
+    /// prerelease/build identifiers, but numeric components must fit in Int.
+    /// Keep the canonical lockfile's spelling rather than normalizing it.
     static func isSemanticVersion(_ text: String) -> Bool {
         var numbers = Substring(text)
         // Build metadata is split off first: it may contain hyphens, which would otherwise
@@ -177,15 +175,14 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
         }
         let parts = numbers.split(separator: ".", omittingEmptySubsequences: false)
         return parts.count == 3 && parts.allSatisfy { part in
-            !part.isEmpty && part.allSatisfy { $0.isASCII && $0.isNumber }
+            Int(part) != nil && part.allSatisfy { $0.isASCII && $0.isNumber }
         }
     }
 
     private static func isVersionIdentifiers(_ text: Substring) -> Bool {
         let identifiers = text.split(separator: ".", omittingEmptySubsequences: false)
-        guard !identifiers.isEmpty else { return false }
         return identifiers.allSatisfy { identifier in
-            !identifier.isEmpty && identifier.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+            identifier.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -23,6 +23,15 @@ public struct PackageIdentity: Hashable, Sendable, Codable, CustomStringConverti
         rawValue = remote.name.lowercased()
     }
 
+    /// The identity SwiftPM derives from a local checkout directory: the basename with a
+    /// terminal lowercase `.git` removed, lowercased. This is the rule that decides whether a
+    /// local package can replace a pinned dependency.
+    public init(checkoutName: DirectoryName) {
+        var name = checkoutName.rawValue
+        if name.hasSuffix(".git") { name = String(name.dropLast(4)) }
+        rawValue = name.lowercased()
+    }
+
     /// An identity exactly as `Package.resolved` spells it. SwiftPM has already canonicalized
     /// it, so no location rules (such as dropping `.git`) are applied again.
     public init?(resolvedIdentity: String) {
@@ -127,15 +136,19 @@ public enum LocalOverrideMatcher {
         case checkoutNameMismatch(identity: PackageIdentity, checkout: String)
         /// The checkout's actual `origin` is not the selected repository.
         case originMismatch(identity: PackageIdentity, expected: String, observed: String)
+        /// No `origin` was read for the checkout, so the clone was never inspected. An
+        /// override is never approved on an unread checkout.
+        case originUnknown(identity: PackageIdentity, checkout: String)
     }
 
     /// - Parameters:
     ///   - selected: the repositories the workspace names.
     ///   - resolved: the app's `Package.resolved`.
     ///   - observedOrigins: the `origin` remote of each existing checkout, keyed by checkout
-    ///     name, as read from the clone by the caller; a checkout whose origin differs from the
-    ///     selected repository is refused rather than trusted.
-    public static func match(selected: [WorkspaceRepository], resolved: ResolvedPackagesFile, observedOrigins: [DirectoryName: RemoteURL] = [:]) -> [MatchResult] {
+    ///     name, as read from the clone by the caller. Every selected package needs an entry:
+    ///     an origin that differs is refused, and one that was never read is refused too,
+    ///     since an unread checkout is not evidence of anything.
+    public static func match(selected: [WorkspaceRepository], resolved: ResolvedPackagesFile, observedOrigins: [DirectoryName: RemoteURL]) -> [MatchResult] {
         let packages = selected.filter { $0.role == .package }
         var results: [MatchResult] = []
         let selectedIdentities = Dictionary(grouping: packages, by: { PackageIdentity(remote: $0.remote) })
@@ -165,13 +178,17 @@ public enum LocalOverrideMatcher {
                 continue
             }
             // SwiftPM derives the local package's identity from the directory name, so the
-            // checkout must carry the repository's name (or its derived safe form).
-            let derived = DirectoryName.derived(from: repository.remote.name).identity
-            guard repository.checkoutName.identity == identity.rawValue || repository.checkoutName.identity == derived else {
+            // checkout's own identity must equal the dependency's. A name the workspace had
+            // to derive differently is refused rather than approved under another identity.
+            guard PackageIdentity(checkoutName: repository.checkoutName) == identity else {
                 results.append(.checkoutNameMismatch(identity: identity, checkout: repository.checkoutName.rawValue))
                 continue
             }
-            if let origin = observedOrigins[repository.checkoutName], origin != repository.remote {
+            guard let origin = observedOrigins[repository.checkoutName] else {
+                results.append(.originUnknown(identity: identity, checkout: repository.checkoutName.rawValue))
+                continue
+            }
+            guard origin == repository.remote else {
                 results.append(.originMismatch(identity: identity, expected: repository.remote.canonical, observed: origin.canonical))
                 continue
             }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -8,16 +8,17 @@ public struct PackageIdentity: Hashable, Sendable, CustomStringConvertible {
     public let rawValue: String
 
     public init?(location: String) {
-        var text = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Only line terminators are removed. A checkout directory may begin or end with a
+        // space and SwiftPM keeps it: `/tmp/spmspace/ Foo ` is the package `" foo "`, so
+        // trimming the location would derive an identity no pin carries.
+        var text = location.trimmingCharacters(in: .newlines)
         while text.hasSuffix("/") { text.removeLast() }
-        // An SCP-form remote (`git@host:Name.git`) has no slash at all, so the colon that
-        // separates the host from the path is the only separator there is; splitting on `/`
-        // alone would keep `git@host:` inside the identity.
+        // The path separator is the only separator SwiftPM uses. An SCP-form remote has none,
+        // so `git@host:Name.git` is the package `git@host:name`, not `name`; splitting on the
+        // colon here would name a package that no `Package.resolved` entry carries.
         var name: String
         if let slash = text.lastIndex(of: "/") {
             name = String(text[text.index(after: slash)...])
-        } else if let colon = text.lastIndex(of: ":") {
-            name = String(text[text.index(after: colon)...])
         } else {
             name = text
         }
@@ -101,7 +102,14 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
         self.pins = pins
     }
 
+    /// A lockfile pins one entry of a few hundred bytes per dependency, so this is room for
+    /// thousands of them. The file is committed in a repository the workspace only selected,
+    /// so its size is bounded before `JSONSerialization` materializes the whole document and
+    /// the pin arrays are built from it.
+    public static let maximumEncodedSize = 1024 * 1024
+
     public static func decode(_ data: Data) throws(ResolvedPackagesError) -> ResolvedPackagesFile {
+        guard data.count <= Self.maximumEncodedSize else { throw .tooLarge(bytes: data.count) }
         guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw .notJSON }
         guard let version = object["version"] as? Int else { throw .missingVersion }
         guard version == 2 || version == 3 else { throw .unsupportedVersion(version) }
@@ -125,15 +133,60 @@ public struct ResolvedPackagesFile: Hashable, Sendable {
     private static func decodeState(_ raw: Any?, kind: Pin.Kind) throws(ResolvedPackagesError) -> (revision: String?, version: String?, branch: String?) {
         let isSourceControl = kind == .remoteSourceControl || kind == .localSourceControl
         guard let raw, !(raw is NSNull) else {
-            if isSourceControl { throw .malformed("state") }
+            // A registry pin is pinned by version alone, so SwiftPM refuses one that carries
+            // no state for the same reason it refuses a source-control pin without a commit.
+            // Reading it as a pin with no metadata would approve overrides from a lockfile the
+            // wrapper's own resolution then rejects, where re-resolving is no longer a repair
+            // the user can make.
+            if isSourceControl || kind == .registry { throw .malformed("state") }
             return (nil, nil, nil)
         }
         guard let fields = raw as? [String: Any] else { throw .malformed("state") }
         let revision = try string(fields["revision"], field: "state.revision")
         let version = try string(fields["version"], field: "state.version")
         let branch = try string(fields["branch"], field: "state.branch")
-        if isSourceControl, revision == nil { throw .malformed("state.revision") }
+        // SwiftPM writes the full Git object ID it resolved, so a revision that is not one
+        // names no commit and is as corrupt as an absent one, whether it is blank or a branch
+        // name: an override approved against it would fail at resolution or at the build
+        // instead of here, where the lockfile can still be re-resolved.
+        if isSourceControl, CommitSHA(revision ?? "") == nil { throw .malformed("state.revision") }
+        // SwiftPM parses a pinned version with the semantic-version grammar and refuses the
+        // whole file when it does not parse, so text such as `not-semver` names a lockfile the
+        // wrapper cannot be seeded from. It is caught here, while the repair is still to
+        // resolve packages in Xcode and commit the result.
+        if let version, !isSemanticVersion(version) { throw .malformed("state.version") }
+        if kind == .registry, version == nil { throw .malformed("state.version") }
         return (revision, version, branch)
+    }
+
+    /// SwiftPM's `Version` grammar: three numeric identifiers, then an optional prerelease and
+    /// optional build metadata, each a dot-separated run of alphanumerics and hyphens.
+    static func isSemanticVersion(_ text: String) -> Bool {
+        var numbers = Substring(text)
+        // Build metadata is split off first: it may contain hyphens, which would otherwise
+        // read as the start of a prerelease.
+        if let plus = numbers.firstIndex(of: "+") {
+            let metadata = numbers[numbers.index(after: plus)...]
+            numbers = numbers[..<plus]
+            guard isVersionIdentifiers(metadata) else { return false }
+        }
+        if let hyphen = numbers.firstIndex(of: "-") {
+            let prerelease = numbers[numbers.index(after: hyphen)...]
+            numbers = numbers[..<hyphen]
+            guard isVersionIdentifiers(prerelease) else { return false }
+        }
+        let parts = numbers.split(separator: ".", omittingEmptySubsequences: false)
+        return parts.count == 3 && parts.allSatisfy { part in
+            !part.isEmpty && part.allSatisfy { $0.isASCII && $0.isNumber }
+        }
+    }
+
+    private static func isVersionIdentifiers(_ text: Substring) -> Bool {
+        let identifiers = text.split(separator: ".", omittingEmptySubsequences: false)
+        guard !identifiers.isEmpty else { return false }
+        return identifiers.allSatisfy { identifier in
+            !identifier.isEmpty && identifier.allSatisfy { $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") }
+        }
     }
 
     /// A present-but-unreadable field is refused rather than dropped, so a lockfile that spells
@@ -151,9 +204,12 @@ public enum ResolvedPackagesError: Error, Hashable, Sendable, LocalizedError {
     case unsupportedVersion(Int)
     case unknownKind(String)
     case malformed(String)
+    /// The committed file is larger than any lockfile, so it is refused before it is parsed.
+    case tooLarge(bytes: Int)
 
     public var userMessage: String {
         switch self {
+        case .tooLarge(let bytes): "The app's Package.resolved is \(bytes) bytes, larger than the \(ResolvedPackagesFile.maximumEncodedSize) a lockfile can be, so Guesthouse did not read it. Check that file in the app repository, resolve packages in Xcode, and commit the result, then try again."
         case .notJSON: "The app's Package.resolved is not valid JSON. Resolve packages in Xcode and commit the file, then try again."
         case .missingVersion: "The app's Package.resolved has no version field. Resolve packages in Xcode and commit the file, then try again."
         case .unsupportedVersion(let version): "The app's Package.resolved uses format \(version), which this version of Guesthouse does not read. Update Guesthouse, or resolve packages with the Xcode version Guesthouse supports."
@@ -185,10 +241,11 @@ public enum LocalOverrideMatcher: Sendable {
         case collision(identity: PackageIdentity, locations: [String])
         /// The app does not depend on this package, directly or transitively.
         case notADependency(identity: PackageIdentity)
-        /// The app pins this repository, but under an identity SwiftPM did not derive from the
-        /// pinned location. A dependency mirror does exactly this: SwiftPM writes the mirror's
-        /// identity and maps the location back to the original URL. A local checkout can only
-        /// carry the location's identity, so the override would never take effect.
+        /// The app pins this repository, but under an identity a local checkout cannot carry,
+        /// so the override would never take effect. A dependency mirror does this: SwiftPM
+        /// writes the mirror's identity and maps the location back to the original URL. So
+        /// does a percent-encoded location: GitHub resolves `foo%2Dbar` to the same repository
+        /// as `foo-bar`, while SwiftPM keeps the spelling and pins the identity `foo%2dbar`.
         case identityMismatch(identity: PackageIdentity, pinned: PackageIdentity, location: String)
         /// The dependency exists but is not a Git URL dependency (registry or local path).
         case unsupportedKind(identity: PackageIdentity, kind: ResolvedPackagesFile.Pin.Kind)
@@ -228,8 +285,8 @@ public enum LocalOverrideMatcher: Sendable {
                 // identity, so the app does depend on the selected repository even though no
                 // pin carries its identity. Reporting that as an absent dependency would send
                 // the user to add a dependency the app already has.
-                if let mirrored = resolved.pins.first(where: { RemoteURL($0.location) == repository.remote }) {
-                    results.append(.identityMismatch(identity: identity, pinned: mirrored.identity, location: mirrored.location))
+                if let elsewhere = resolved.pins.first(where: { Self.locates(repository.remote, $0.location) }) {
+                    results.append(.identityMismatch(identity: identity, pinned: elsewhere.identity, location: elsewhere.location))
                 } else {
                     results.append(.notADependency(identity: identity))
                 }
@@ -266,5 +323,17 @@ public enum LocalOverrideMatcher: Sendable {
             results.append(.matched(identity: identity, location: pin.location))
         }
         return results
+    }
+
+    /// Whether a pin's location names this repository, including through percent escapes.
+    ///
+    /// `RemoteURL` refuses an encoded spelling because SwiftPM keeps it when deriving the
+    /// identity, which is exactly why such a pin has to be found here: the repository is a
+    /// dependency, so reporting it as absent would tell the user to add one the app already
+    /// has. The decoded form is only ever used to recognize the pin, never to approve it.
+    private static func locates(_ remote: RemoteURL, _ location: String) -> Bool {
+        if RemoteURL(location) == remote { return true }
+        guard location.contains("%"), let decoded = location.removingPercentEncoding else { return false }
+        return RemoteURL(decoded) == remote
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -4,17 +4,26 @@ import Foundation
 /// the last path component of the location, without a `.git` suffix, lowercased
 /// (`PackageIdentity.swift` in swift-package-manager). It is not the `Package(name:)` in the
 /// manifest, which may differ (MVP-PLAN.md §6).
-public struct PackageIdentity: Hashable, Sendable, Codable, CustomStringConvertible {
+public struct PackageIdentity: Hashable, Sendable, CustomStringConvertible {
     public let rawValue: String
 
     public init?(location: String) {
         var text = location.trimmingCharacters(in: .whitespacesAndNewlines)
         while text.hasSuffix("/") { text.removeLast() }
-        guard let last = text.split(separator: "/").last.map(String.init) ?? text.split(separator: ":").last.map(String.init), !last.isEmpty else {
-            return nil
+        // An SCP-form remote (`git@host:Name.git`) has no slash at all, so the colon that
+        // separates the host from the path is the only separator there is; splitting on `/`
+        // alone would keep `git@host:` inside the identity.
+        var name: String
+        if let slash = text.lastIndex(of: "/") {
+            name = String(text[text.index(after: slash)...])
+        } else if let colon = text.lastIndex(of: ":") {
+            name = String(text[text.index(after: colon)...])
+        } else {
+            name = text
         }
-        var name = last
-        if name.lowercased().hasSuffix(".git") { name = String(name.dropLast(4)) }
+        // SwiftPM strips only a lowercase `.git`, the way `RemoteURL` does, so `Mixed-Repo.GIT`
+        // stays the package `mixed-repo.git` that `Package.resolved` will name.
+        if name.hasSuffix(".git") { name = String(name.dropLast(4)) }
         guard !name.isEmpty, name != ".", name != ".." else { return nil }
         rawValue = name.lowercased()
     }
@@ -34,13 +43,33 @@ public struct PackageIdentity: Hashable, Sendable, Codable, CustomStringConverti
 
     /// An identity exactly as `Package.resolved` spells it. SwiftPM has already canonicalized
     /// it, so no location rules (such as dropping `.git`) are applied again.
+    ///
+    /// SwiftPM derives an identity from a checkout basename, which may legitimately hold
+    /// non-ASCII letters or spaces (`cafékit`, `space kit`), and re-resolving writes the same
+    /// file back; refusing those would reject the whole lockfile with advice that cannot
+    /// work. Only spellings that could not name a package at all are refused.
     public init?(resolvedIdentity: String) {
         let text = resolvedIdentity.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !text.isEmpty, !text.contains("/"), text != ".", text != "..", text.unicodeScalars.allSatisfy({ $0.isASCII && $0.value > 0x20 && $0.value < 0x7F }) else { return nil }
+        guard !text.isEmpty, !text.contains("/"), text != ".", text != "..",
+              !WorkspaceManifest.containsControlCharacters(text)
+        else { return nil }
         rawValue = text.lowercased()
     }
 
     public var description: String { rawValue }
+}
+
+extension PackageIdentity: Codable {
+    /// Decoding is another way into the type, so it applies the same lowercasing and the same
+    /// refusals its initializers do; a hand-edited `SharedUI` or an empty name would otherwise
+    /// hash and compare differently from the identity derived for the same package.
+    public init(from decoder: any Decoder) throws {
+        let raw = try decoder.container(keyedBy: CodingKeys.self).decode(String.self, forKey: .rawValue)
+        guard let identity = PackageIdentity(resolvedIdentity: raw) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "not a package identity: \(raw)"))
+        }
+        self = identity
+    }
 }
 
 /// The parts of `Package.resolved` (versions 2 and 3) that matter for matching local overrides.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/PackageIdentity.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// A SwiftPM package identity, derived the way SwiftPM derives it for a Git URL dependency:
+/// the last path component of the location, without a `.git` suffix, lowercased
+/// (`PackageIdentity.swift` in swift-package-manager). It is not the `Package(name:)` in the
+/// manifest, which may differ (MVP-PLAN.md §6).
+public struct PackageIdentity: Hashable, Sendable, Codable, CustomStringConvertible {
+    public let rawValue: String
+
+    public init?(location: String) {
+        var text = location.trimmingCharacters(in: .whitespacesAndNewlines)
+        while text.hasSuffix("/") { text.removeLast() }
+        guard let last = text.split(separator: "/").last.map(String.init) ?? text.split(separator: ":").last.map(String.init), !last.isEmpty else {
+            return nil
+        }
+        var name = last
+        if name.lowercased().hasSuffix(".git") { name = String(name.dropLast(4)) }
+        guard !name.isEmpty, name != ".", name != ".." else { return nil }
+        rawValue = name.lowercased()
+    }
+
+    public init(remote: RemoteURL) {
+        rawValue = remote.name.lowercased()
+    }
+
+    public var description: String { rawValue }
+}
+
+/// The parts of `Package.resolved` (versions 2 and 3) that matter for matching local overrides.
+public struct ResolvedPackagesFile: Hashable, Sendable {
+    public struct Pin: Hashable, Sendable {
+        public enum Kind: String, Hashable, Sendable {
+            case remoteSourceControl
+            case localSourceControl
+            case registry
+            case fileSystem
+        }
+
+        public let identity: PackageIdentity
+        public let kind: Kind
+        public let location: String
+        public let revision: String?
+        public let version: String?
+        public let branch: String?
+    }
+
+    public let version: Int
+    public let pins: [Pin]
+
+    public init(version: Int, pins: [Pin]) {
+        self.version = version
+        self.pins = pins
+    }
+
+    public static func decode(_ data: Data) throws(ResolvedPackagesError) -> ResolvedPackagesFile {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { throw .notJSON }
+        guard let version = object["version"] as? Int else { throw .missingVersion }
+        guard version == 2 || version == 3 else { throw .unsupportedVersion(version) }
+        guard let rawPins = object["pins"] as? [[String: Any]] else { throw .malformed("pins") }
+        var pins: [Pin] = []
+        for raw in rawPins {
+            guard let identityRaw = raw["identity"] as? String, let identity = PackageIdentity(location: identityRaw) else { throw .malformed("identity") }
+            guard let kindRaw = raw["kind"] as? String else { throw .malformed("kind") }
+            guard let kind = Pin.Kind(rawValue: kindRaw) else { throw .unknownKind(kindRaw) }
+            guard let location = raw["location"] as? String else { throw .malformed("location") }
+            let state = raw["state"] as? [String: Any] ?? [:]
+            pins.append(Pin(identity: identity, kind: kind, location: location, revision: state["revision"] as? String, version: state["version"] as? String, branch: state["branch"] as? String))
+        }
+        return ResolvedPackagesFile(version: version, pins: pins)
+    }
+}
+
+public enum ResolvedPackagesError: Error, Hashable, Sendable {
+    case notJSON
+    case missingVersion
+    case unsupportedVersion(Int)
+    case unknownKind(String)
+    case malformed(String)
+}
+
+/// Decides, for each package repository the user selected, whether it can safely override one
+/// of the app's resolved dependencies (MVP-PLAN.md §6: match identity and canonical origin,
+/// never only the display name; reject ambiguous identities).
+public enum LocalOverrideMatcher {
+    public enum MatchResult: Hashable, Sendable {
+        /// The selected repository is exactly this remote-source-control dependency.
+        case matched(identity: PackageIdentity, location: String)
+        /// The resolved file pins more than one location to this identity, or the selection
+        /// shares an identity with another selected repository. Refuse rather than guess.
+        case collision(identity: PackageIdentity, locations: [String])
+        /// The app does not depend on this package, directly or transitively.
+        case notADependency(identity: PackageIdentity)
+        /// The dependency exists but is not a Git URL dependency (registry or local path).
+        case unsupportedKind(identity: PackageIdentity, kind: ResolvedPackagesFile.Pin.Kind)
+        /// Same identity, different repository. Overriding would silently substitute code.
+        case remoteMismatch(identity: PackageIdentity, expected: String, selected: String)
+    }
+
+    public static func match(selected: [WorkspaceRepository], resolved: ResolvedPackagesFile) -> [MatchResult] {
+        let packages = selected.filter { $0.role == .package }
+        var results: [MatchResult] = []
+        let selectedIdentities = Dictionary(grouping: packages, by: { PackageIdentity(remote: $0.remote) })
+        let pinsByIdentity = Dictionary(grouping: resolved.pins, by: \.identity)
+
+        for repository in packages {
+            let identity = PackageIdentity(remote: repository.remote)
+            if let siblings = selectedIdentities[identity], siblings.count > 1 {
+                results.append(.collision(identity: identity, locations: siblings.map(\.remote.canonical).sorted()))
+                continue
+            }
+            guard let pins = pinsByIdentity[identity], !pins.isEmpty else {
+                results.append(.notADependency(identity: identity))
+                continue
+            }
+            if pins.count > 1 {
+                results.append(.collision(identity: identity, locations: pins.map(\.location).sorted()))
+                continue
+            }
+            let pin = pins[0]
+            guard pin.kind == .remoteSourceControl else {
+                results.append(.unsupportedKind(identity: identity, kind: pin.kind))
+                continue
+            }
+            guard let pinned = RemoteURL(pin.location), pinned == repository.remote else {
+                results.append(.remoteMismatch(identity: identity, expected: pin.location, selected: repository.remote.canonical))
+                continue
+            }
+            results.append(.matched(identity: identity, location: pin.location))
+        }
+        return results
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/RemoteURL.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Workspace/RemoteURL.swift
@@ -60,11 +60,14 @@ public struct RemoteURL: Hashable, Sendable, CustomStringConvertible {
         if isURLForm, path.hasSuffix("/") { path.removeLast() }
         var parts = path.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
         guard parts.count == 2 else { return nil }
-        if parts[1].lowercased().hasSuffix(".git") { parts[1] = String(parts[1].dropLast(4)) }
-        // A repository whose own name ends in `.git` has no round-trippable canonical form:
-        // the canonical URL would lose the suffix on the next parse, silently naming a
-        // different repository. Such a remote is refused rather than normalized.
-        guard !parts[1].lowercased().hasSuffix(".git") else { return nil }
+        // SwiftPM strips only a lowercase `.git` when it derives an identity from a location,
+        // so this parser does the same: `Repo.GIT` keeps its suffix, and its identity stays
+        // `repo.git`, which is what `Package.resolved` will spell.
+        if parts[1].hasSuffix(".git") { parts[1] = String(parts[1].dropLast(4)) }
+        // A repository whose own name then still ends in a lowercase `.git` has no
+        // round-trippable canonical form: the canonical URL would lose the suffix on the next
+        // parse, silently naming a different repository. Such a remote is refused.
+        guard !parts[1].hasSuffix(".git") else { return nil }
         guard Self.isValidOwner(parts[0]), Self.isValidRepositoryName(parts[1]) else { return nil }
         self.host = host
         owner = parts[0]

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Fixtures/swiftpm/Package.resolved.v2.json
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Fixtures/swiftpm/Package.resolved.v2.json
@@ -1,0 +1,22 @@
+{
+  "pins" : [
+    {
+      "identity" : "sharedui",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:PicoMLX/SharedUI.git",
+      "state" : {
+        "revision" : "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "localkit",
+      "kind" : "localSourceControl",
+      "location" : "/Users/dev/LocalKit",
+      "state" : {
+        "revision" : "1111111111111111111111111111111111111111"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Fixtures/swiftpm/Package.resolved.v3.json
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Fixtures/swiftpm/Package.resolved.v3.json
@@ -1,0 +1,41 @@
+{
+  "originHash" : "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+  "pins" : [
+    {
+      "identity" : "sharedui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PicoMLX/SharedUI.git",
+      "state" : {
+        "revision" : "1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "modelkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/PicoMLX/ModelKit",
+      "state" : {
+        "branch" : "main",
+        "revision" : "0b9a8f7e6d5c4b3a2f1e0d9c8b7a6f5e4d3c2b1a"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "abcdefabcdefabcdefabcdefabcdefabcdefabcd",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "registrykit",
+      "kind" : "registry",
+      "location" : "picomlx.registrykit",
+      "state" : {
+        "version" : "2.0.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -30,13 +30,13 @@ import Testing
     @Test func aMixedCaseGitSuffixKeepsSwiftPMsSpelling() {
         // SwiftPM strips only a lowercase `.git`, so `Mixed-Repo.GIT` is the package
         // `mixed-repo.git`, which is what it writes into `Package.resolved`.
-        let remote = try? #require(RemoteURL("https://github.com/Org/Mixed-Repo.GIT"))
-        #expect(remote?.name == "Mixed-Repo.GIT")
-        #expect(PackageIdentity(remote: remote!).rawValue == "mixed-repo.git")
-        #expect(RemoteURL(remote!.canonical) == remote, "the canonical form still parses back to the same repository")
-        let package = WorkspaceRepository(role: .package, remote: remote!, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
-        let file = resolved(identity: "mixed-repo.git", location: remote!.canonical)
-        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote!]) == [.matched(identity: PackageIdentity(remote: remote!), location: remote!.canonical)])
+        let remote = RemoteURL("https://github.com/Org/Mixed-Repo.GIT")!
+        #expect(remote.name == "Mixed-Repo.GIT")
+        #expect(PackageIdentity(remote: remote).rawValue == "mixed-repo.git")
+        #expect(RemoteURL(remote.canonical) == remote, "the canonical form still parses back to the same repository")
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let file = resolved(identity: "mixed-repo.git", location: remote.canonical)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote]) == [.matched(identity: PackageIdentity(remote: remote), location: remote.canonical)])
     }
 
     @Test func anUnreadCheckoutIsNeverApproved() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct PackageIdentityHardeningTests {
+    let sha = CommitSHA("0123456789abcdef0123456789abcdef01234567")!
+
+    func resolved(identity: String, location: String) -> ResolvedPackagesFile {
+        ResolvedPackagesFile(version: 3, pins: [.init(identity: PackageIdentity(resolvedIdentity: identity)!, kind: .remoteSourceControl, location: location, revision: nil, version: "1.0.0", branch: nil)])
+    }
+
+    @Test func resolvedIdentitiesAreKeptVerbatim() throws {
+        let file = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"mixed-repo.git","kind":"remoteSourceControl","location":"https://github.com/Org/Mixed-Repo.GIT","state":{"version":"1.0.0"}}]}"#.utf8))
+        #expect(file.pins.first?.identity.rawValue == "mixed-repo.git")
+        #expect(PackageIdentity(resolvedIdentity: "a/b") == nil)
+        #expect(PackageIdentity(resolvedIdentity: "Ｏrg") == nil)
+    }
+
+    @Test func checkoutNamesAndOriginsMustCarryTheIdentity() {
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let renamed = WorkspaceRepository(role: .package, remote: remote, checkoutName: DirectoryName("UI"), baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let file = resolved(identity: "sharedui", location: "https://github.com/Org/SharedUI.git")
+        #expect(LocalOverrideMatcher.match(selected: [renamed], resolved: file) == [.checkoutNameMismatch(identity: PackageIdentity(remote: remote), checkout: "UI")])
+        let proper = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let elsewhere = RemoteURL("https://github.com/Fork/SharedUI")!
+        #expect(LocalOverrideMatcher.match(selected: [proper], resolved: file, observedOrigins: [proper.checkoutName: elsewhere]) == [.originMismatch(identity: PackageIdentity(remote: remote), expected: remote.canonical, observed: elsewhere.canonical)])
+        #expect(LocalOverrideMatcher.match(selected: [proper], resolved: file, observedOrigins: [proper.checkoutName: remote]) == [.matched(identity: PackageIdentity(remote: remote), location: "https://github.com/Org/SharedUI.git")])
+    }
+
+    @Test func resolvedFileErrorsAreActionable() {
+        for error in [ResolvedPackagesError.notJSON, .missingVersion, .unsupportedVersion(9), .unknownKind("x"), .malformed("pins")] {
+            #expect(!error.userMessage.isEmpty)
+            #expect(!error.recoveryActions.isEmpty)
+            #expect(error.errorDescription == error.userMessage)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -88,10 +88,10 @@ import Testing
         func pin(_ version: String) -> Data {
             Data(#"{"version":3,"pins":[{"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":"\#(version)"}}]}"#.utf8)
         }
-        for bad in ["not-semver", "1.0", "1.0.0.0", "v1.0.0", "1.0.0-", "1.0.0+", "1.0.0-beta..1", "1.0.x"] {
+        for bad in ["not-semver", "1.0", "1.0.0.0", "v1.0.0", "1.0.x"] {
             #expect(throws: ResolvedPackagesError.malformed("state.version")) { try ResolvedPackagesFile.decode(pin(bad)) }
         }
-        for good in ["1.0.0", "0.1.0-beta.1", "1.2.3+build.5", "1.2.3-rc.1+exp.sha.5114f85"] {
+        for good in ["1.0.0", "0.1.0-beta.1", "1.2.3+build.5", "1.2.3-rc.1+exp.sha.5114f85", "1.0.0-", "1.0.0+", "1.0.0-beta..1"] {
             #expect(throws: Never.self) { try ResolvedPackagesFile.decode(pin(good)) }
         }
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -20,11 +20,34 @@ import Testing
         let remote = RemoteURL("https://github.com/Org/SharedUI")!
         let renamed = WorkspaceRepository(role: .package, remote: remote, checkoutName: DirectoryName("UI"), baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
         let file = resolved(identity: "sharedui", location: "https://github.com/Org/SharedUI.git")
-        #expect(LocalOverrideMatcher.match(selected: [renamed], resolved: file) == [.checkoutNameMismatch(identity: PackageIdentity(remote: remote), checkout: "UI")])
+        #expect(LocalOverrideMatcher.match(selected: [renamed], resolved: file, observedOrigins: [renamed.checkoutName: remote]) == [.checkoutNameMismatch(identity: PackageIdentity(remote: remote), checkout: "UI")])
         let proper = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
         let elsewhere = RemoteURL("https://github.com/Fork/SharedUI")!
         #expect(LocalOverrideMatcher.match(selected: [proper], resolved: file, observedOrigins: [proper.checkoutName: elsewhere]) == [.originMismatch(identity: PackageIdentity(remote: remote), expected: remote.canonical, observed: elsewhere.canonical)])
         #expect(LocalOverrideMatcher.match(selected: [proper], resolved: file, observedOrigins: [proper.checkoutName: remote]) == [.matched(identity: PackageIdentity(remote: remote), location: "https://github.com/Org/SharedUI.git")])
+    }
+
+    @Test func anUnreadCheckoutIsNeverApproved() {
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let file = resolved(identity: "sharedui", location: "https://github.com/Org/SharedUI.git")
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [:]) == [.originUnknown(identity: PackageIdentity(remote: remote), checkout: package.checkoutName.rawValue)])
+    }
+
+    @Test func aCheckoutIdentityIsDerivedTheWaySwiftPMDerivesIt() {
+        // SwiftPM strips a terminal `.git` from the directory name, so `repos/foo.git` is the
+        // package `foo` and cannot replace a dependency whose identity is `foo.git`.
+        #expect(PackageIdentity(checkoutName: DirectoryName("foo.git")!).rawValue == "foo")
+        #expect(PackageIdentity(checkoutName: DirectoryName("SharedUI")!).rawValue == "sharedui")
+        // A repository whose own name ends in `.git` has no round-trippable canonical form
+        // and is refused before it can reach a checkout at all.
+        #expect(RemoteURL("https://github.com/Org/foo.git.git") == nil)
+        // A checkout named for another package is refused whatever its spelling.
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let file = resolved(identity: "sharedui", location: "https://github.com/Org/SharedUI.git")
+        let package = WorkspaceRepository(role: .package, remote: remote, checkoutName: DirectoryName("ModelKit.git"), baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let results = LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote])
+        #expect(results == [.checkoutNameMismatch(identity: PackageIdentity(remote: remote), checkout: "ModelKit.git")])
     }
 
     @Test func resolvedFileErrorsAreActionable() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -27,6 +27,18 @@ import Testing
         #expect(LocalOverrideMatcher.match(selected: [proper], resolved: file, observedOrigins: [proper.checkoutName: remote]) == [.matched(identity: PackageIdentity(remote: remote), location: "https://github.com/Org/SharedUI.git")])
     }
 
+    @Test func aMixedCaseGitSuffixKeepsSwiftPMsSpelling() {
+        // SwiftPM strips only a lowercase `.git`, so `Mixed-Repo.GIT` is the package
+        // `mixed-repo.git`, which is what it writes into `Package.resolved`.
+        let remote = try? #require(RemoteURL("https://github.com/Org/Mixed-Repo.GIT"))
+        #expect(remote?.name == "Mixed-Repo.GIT")
+        #expect(PackageIdentity(remote: remote!).rawValue == "mixed-repo.git")
+        #expect(RemoteURL(remote!.canonical) == remote, "the canonical form still parses back to the same repository")
+        let package = WorkspaceRepository(role: .package, remote: remote!, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        let file = resolved(identity: "mixed-repo.git", location: remote!.canonical)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote!]) == [.matched(identity: PackageIdentity(remote: remote!), location: remote!.canonical)])
+    }
+
     @Test func anUnreadCheckoutIsNeverApproved() {
         let remote = RemoteURL("https://github.com/Org/SharedUI")!
         let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -6,14 +6,74 @@ import Testing
     let sha = CommitSHA("0123456789abcdef0123456789abcdef01234567")!
 
     func resolved(identity: String, location: String) -> ResolvedPackagesFile {
-        ResolvedPackagesFile(version: 3, pins: [.init(identity: PackageIdentity(resolvedIdentity: identity)!, kind: .remoteSourceControl, location: location, revision: nil, version: "1.0.0", branch: nil)])
+        ResolvedPackagesFile(version: 3, pins: [.init(identity: PackageIdentity(resolvedIdentity: identity)!, kind: .remoteSourceControl, location: location, revision: sha.rawValue, version: "1.0.0", branch: nil)])
     }
 
     @Test func resolvedIdentitiesAreKeptVerbatim() throws {
-        let file = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"mixed-repo.git","kind":"remoteSourceControl","location":"https://github.com/Org/Mixed-Repo.GIT","state":{"version":"1.0.0"}}]}"#.utf8))
+        let file = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"mixed-repo.git","kind":"remoteSourceControl","location":"https://github.com/Org/Mixed-Repo.GIT","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":"1.0.0"}}]}"#.utf8))
         #expect(file.pins.first?.identity.rawValue == "mixed-repo.git")
         #expect(PackageIdentity(resolvedIdentity: "a/b") == nil)
         #expect(PackageIdentity(resolvedIdentity: "\u{202E}kit") == nil, "an override could make the name read as another package")
+    }
+
+    @Test func aBoundarySpaceBelongsToTheIdentityThatCarriesIt() throws {
+        // SwiftPM takes a local dependency's identity from its checkout basename, so a
+        // directory named ` SharedUI ` is the package `" sharedui "`. Folding it onto
+        // `sharedui` would merge it with the app's real remote dependency and report a
+        // collision that no re-resolve could clear, because the file is what SwiftPM writes.
+        let json = #"""
+        {"version":3,"pins":[
+          {"identity":" sharedui ","kind":"localSourceControl","location":"/Users/dev/ SharedUI ","state":{"revision":"1111111111111111111111111111111111111111"}},
+          {"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":"1.0.0"}}
+        ]}
+        """#
+        let file = try ResolvedPackagesFile.decode(Data(json.utf8))
+        #expect(file.pins.map(\.identity.rawValue) == [" sharedui ", "sharedui"])
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote])
+            == [.matched(identity: PackageIdentity(remote: remote), location: "https://github.com/Org/SharedUI.git")],
+            "a neighbouring checkout whose name has boundary spaces is another package, not a collision")
+    }
+
+    @Test func aMirroredDependencyIsNotReportedAsAbsent() {
+        // A dependency mirror makes SwiftPM record the mirror's identity while mapping the
+        // location back to the original URL, so the app depends on the selected repository
+        // under a name no checkout directory can carry (MVP-PLAN.md §6).
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let file = resolved(identity: "company-cache", location: "https://github.com/Org/SharedUI.git")
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote])
+            == [.identityMismatch(identity: PackageIdentity(remote: remote), pinned: PackageIdentity(resolvedIdentity: "company-cache")!, location: "https://github.com/Org/SharedUI.git")])
+        // A repository the lockfile names nowhere is still reported as no dependency at all.
+        let absent = WorkspaceRepository(role: .package, remote: RemoteURL("https://github.com/Org/Unrelated")!, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        #expect(LocalOverrideMatcher.match(selected: [absent], resolved: file, observedOrigins: [:])
+            == [.notADependency(identity: PackageIdentity(location: "unrelated")!)])
+    }
+
+    @Test func aSourceControlPinWithoutARevisionIsRefused() throws {
+        func pin(_ state: String) -> Data {
+            Data(#"{"version":3,"pins":[{"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git"\#(state)}]}"#.utf8)
+        }
+        // A pin that names no commit pins nothing: seeding the generated workspace from it
+        // would resolve the dependency again instead of building the code the app ships.
+        #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin("")) }
+        #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin(#","state":"1.0.0""#)) }
+        #expect(throws: ResolvedPackagesError.malformed("state.revision")) { try ResolvedPackagesFile.decode(pin(#","state":{"version":"1.0.0"}"#)) }
+        #expect(throws: ResolvedPackagesError.malformed("state.version")) {
+            try ResolvedPackagesFile.decode(pin(#","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":1}"#))
+        }
+        // A registry pin carries a version and no commit, and still decodes.
+        let registry = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"registrykit","kind":"registry","location":"org.registrykit","state":{"version":"2.0.0"}}]}"#.utf8))
+        #expect(registry.pins.first?.version == "2.0.0")
+    }
+
+    @Test func thePublicMatchingTypesAreSendable() {
+        func requiringSendable<T: Sendable>(_ type: T.Type) {}
+        requiringSendable(LocalOverrideMatcher.self)
+        requiringSendable(LocalOverrideMatcher.MatchResult.self)
+        requiringSendable(ResolvedPackagesFile.self)
+        requiringSendable(PackageIdentity.self)
     }
 
     @Test func anIdentityFromALocationMatchesTheOneDerivedFromItsRemote() {
@@ -46,7 +106,7 @@ import Testing
         {"version":3,"pins":[
           {"identity":"cafékit","kind":"localSourceControl","location":"/Users/dev/Café Kit","state":{"revision":"0123456789abcdef0123456789abcdef01234567"}},
           {"identity":"space kit","kind":"localSourceControl","location":"/Users/dev/Space Kit","state":{"revision":"0123456789abcdef0123456789abcdef01234567"}},
-          {"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"version":"1.0.0"}}
+          {"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":"1.0.0"}}
         ]}
         """#
         let file = try ResolvedPackagesFile.decode(Data(json.utf8))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -60,12 +60,75 @@ import Testing
         #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin("")) }
         #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin(#","state":"1.0.0""#)) }
         #expect(throws: ResolvedPackagesError.malformed("state.revision")) { try ResolvedPackagesFile.decode(pin(#","state":{"version":"1.0.0"}"#)) }
+        // A revision that is present but blank identifies no commit either.
+        #expect(throws: ResolvedPackagesError.malformed("state.revision")) { try ResolvedPackagesFile.decode(pin(#","state":{"revision":"","version":"1.0.0"}"#)) }
+        #expect(throws: ResolvedPackagesError.malformed("state.revision")) { try ResolvedPackagesFile.decode(pin(#","state":{"revision":"  ","version":"1.0.0"}"#)) }
         #expect(throws: ResolvedPackagesError.malformed("state.version")) {
             try ResolvedPackagesFile.decode(pin(#","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":1}"#))
         }
         // A registry pin carries a version and no commit, and still decodes.
         let registry = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"registrykit","kind":"registry","location":"org.registrykit","state":{"version":"2.0.0"}}]}"#.utf8))
         #expect(registry.pins.first?.version == "2.0.0")
+    }
+
+    /// GitHub resolves `foo%2Dbar` to the same repository as `foo-bar`, but SwiftPM keeps the
+    /// spelling and pins the identity `foo%2dbar`, which no checkout directory can carry.
+    @Test func anEncodedPinLocationIsAnIdentityMismatchNotAnAbsentDependency() {
+        let remote = RemoteURL("https://github.com/Org/foo-bar")!
+        let file = resolved(identity: "foo%2dbar", location: "https://github.com/Org/foo%2Dbar.git")
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote])
+            == [.identityMismatch(identity: PackageIdentity(remote: remote), pinned: PackageIdentity(resolvedIdentity: "foo%2dbar")!, location: "https://github.com/Org/foo%2Dbar.git")],
+            "the app depends on this repository, so it is never reported as one to add")
+    }
+
+    /// SwiftPM parses a pinned version with the semantic-version grammar and refuses the whole
+    /// lockfile when it does not parse, so a wrapper seeded from it would fail at resolution.
+    @Test func aPinnedVersionMustBeOneSwiftPMCanParse() throws {
+        func pin(_ version: String) -> Data {
+            Data(#"{"version":3,"pins":[{"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"revision":"0123456789abcdef0123456789abcdef01234567","version":"\#(version)"}}]}"#.utf8)
+        }
+        for bad in ["not-semver", "1.0", "1.0.0.0", "v1.0.0", "1.0.0-", "1.0.0+", "1.0.0-beta..1", "1.0.x"] {
+            #expect(throws: ResolvedPackagesError.malformed("state.version")) { try ResolvedPackagesFile.decode(pin(bad)) }
+        }
+        for good in ["1.0.0", "0.1.0-beta.1", "1.2.3+build.5", "1.2.3-rc.1+exp.sha.5114f85"] {
+            #expect(throws: Never.self) { try ResolvedPackagesFile.decode(pin(good)) }
+        }
+    }
+
+    /// A registry pin is pinned by version alone, so SwiftPM refuses one that carries none.
+    @Test func aRegistryPinWithoutAVersionIsRefused() {
+        func pin(_ state: String) -> Data {
+            Data(#"{"version":3,"pins":[{"identity":"registrykit","kind":"registry","location":"org.registrykit"\#(state)}]}"#.utf8)
+        }
+        #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin("")) }
+        #expect(throws: ResolvedPackagesError.malformed("state")) { try ResolvedPackagesFile.decode(pin(#","state":null"#)) }
+        #expect(throws: ResolvedPackagesError.malformed("state.version")) { try ResolvedPackagesFile.decode(pin(#","state":{}"#)) }
+        #expect(throws: ResolvedPackagesError.malformed("state.version")) { try ResolvedPackagesFile.decode(pin(#","state":{"branch":"main"}"#)) }
+        #expect(throws: Never.self) { try ResolvedPackagesFile.decode(pin(#","state":{"version":"2.0.0"}"#)) }
+    }
+
+    /// A source-control pin's revision is the commit SwiftPM checked out, so text that is not
+    /// a Git object ID pins nothing, however plausible it reads.
+    @Test func aRevisionThatIsNotACommitIDIsRefused() throws {
+        func pin(_ revision: String) -> Data {
+            Data(#"{"version":3,"pins":[{"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"revision":"\#(revision)","version":"1.0.0"}}]}"#.utf8)
+        }
+        for bad in ["not-a-commit", "main", "0123456789abcdef", String(repeating: "0", count: 40), "0123456789abcdef0123456789abcdef0123456z"] {
+            #expect(throws: ResolvedPackagesError.malformed("state.revision"), Comment(rawValue: bad)) { try ResolvedPackagesFile.decode(pin(bad)) }
+        }
+        let good = try ResolvedPackagesFile.decode(pin("0123456789ABCDEF0123456789abcdef01234567"))
+        #expect(good.pins.first?.revision == "0123456789ABCDEF0123456789abcdef01234567", "the lockfile's own spelling is kept")
+    }
+
+    /// The lockfile is committed in a repository the user merely selected, so its size is
+    /// bounded before the parser materializes it.
+    @Test func anOversizedLockfileIsRefusedBeforeItIsParsed() {
+        let padding = String(repeating: "p", count: ResolvedPackagesFile.maximumEncodedSize)
+        let data = Data(#"{"version":3,"pins":[],"padding":"\#(padding)"}"#.utf8)
+        #expect(throws: ResolvedPackagesError.tooLarge(bytes: data.count)) { try ResolvedPackagesFile.decode(data) }
+        #expect(!ResolvedPackagesError.tooLarge(bytes: data.count).recoveryActions.isEmpty)
+        #expect(throws: Never.self) { try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[]}"#.utf8)) }
     }
 
     @Test func thePublicMatchingTypesAreSendable() {
@@ -77,15 +140,25 @@ import Testing
     }
 
     @Test func anIdentityFromALocationMatchesTheOneDerivedFromItsRemote() {
-        // The SCP form without a path has only the colon between the host and the repository,
-        // so splitting on `/` alone would keep `git@example.com:` inside the identity.
-        #expect(PackageIdentity(location: "git@example.com:SharedUI.git")?.rawValue == "sharedui")
+        // SwiftPM splits a location on the path separator alone, so the SCP form without a
+        // path keeps its host prefix: `swift package resolve` on `git@github.com:Foo.git`
+        // reports the identity `git@github.com:foo`.
+        #expect(PackageIdentity(location: "git@example.com:SharedUI.git")?.rawValue == "git@example.com:sharedui")
         #expect(PackageIdentity(location: "git@github.com:PicoMLX/SharedUI.git")?.rawValue == "sharedui")
         // SwiftPM strips only a lowercase `.git`, so both routes to an identity keep `.GIT`
         // and a caller cannot derive two spellings for one dependency.
         let remote = RemoteURL("https://github.com/Org/Mixed-Repo.GIT")!
         #expect(PackageIdentity(location: "https://github.com/Org/Mixed-Repo.GIT") == PackageIdentity(remote: remote))
         #expect(PackageIdentity(location: "git@github.com:Org/Mixed-Repo.GIT")?.rawValue == "mixed-repo.git")
+    }
+
+    @Test func aLocationKeepsTheBoundarySpacesOfItsBasename() {
+        // SwiftPM 6.3 writes `" foo "` for a local dependency at `/tmp/spmspace/ Foo `, so an
+        // identity derived here without those spaces would never associate with that pin.
+        #expect(PackageIdentity(location: "/tmp/spmspace/ Foo ")?.rawValue == " foo ")
+        #expect(PackageIdentity(location: "/tmp/spmspace/ Foo ") == PackageIdentity(resolvedIdentity: " foo "))
+        // A line terminator is framing from whatever read the location, never part of a name.
+        #expect(PackageIdentity(location: "https://github.com/Org/SharedUI.git\n")?.rawValue == "sharedui")
     }
 
     @Test func aDecodedIdentityCarriesTheInvariantsADerivedOneHas() throws {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityHardeningTests.swift
@@ -13,7 +13,49 @@ import Testing
         let file = try ResolvedPackagesFile.decode(Data(#"{"version":3,"pins":[{"identity":"mixed-repo.git","kind":"remoteSourceControl","location":"https://github.com/Org/Mixed-Repo.GIT","state":{"version":"1.0.0"}}]}"#.utf8))
         #expect(file.pins.first?.identity.rawValue == "mixed-repo.git")
         #expect(PackageIdentity(resolvedIdentity: "a/b") == nil)
-        #expect(PackageIdentity(resolvedIdentity: "Ｏrg") == nil)
+        #expect(PackageIdentity(resolvedIdentity: "\u{202E}kit") == nil, "an override could make the name read as another package")
+    }
+
+    @Test func anIdentityFromALocationMatchesTheOneDerivedFromItsRemote() {
+        // The SCP form without a path has only the colon between the host and the repository,
+        // so splitting on `/` alone would keep `git@example.com:` inside the identity.
+        #expect(PackageIdentity(location: "git@example.com:SharedUI.git")?.rawValue == "sharedui")
+        #expect(PackageIdentity(location: "git@github.com:PicoMLX/SharedUI.git")?.rawValue == "sharedui")
+        // SwiftPM strips only a lowercase `.git`, so both routes to an identity keep `.GIT`
+        // and a caller cannot derive two spellings for one dependency.
+        let remote = RemoteURL("https://github.com/Org/Mixed-Repo.GIT")!
+        #expect(PackageIdentity(location: "https://github.com/Org/Mixed-Repo.GIT") == PackageIdentity(remote: remote))
+        #expect(PackageIdentity(location: "git@github.com:Org/Mixed-Repo.GIT")?.rawValue == "mixed-repo.git")
+    }
+
+    @Test func aDecodedIdentityCarriesTheInvariantsADerivedOneHas() throws {
+        let derived = PackageIdentity(remote: RemoteURL("https://github.com/Org/SharedUI")!)
+        #expect(try JSONDecoder().decode(PackageIdentity.self, from: JSONEncoder().encode(derived)) == derived)
+        // A hand-written spelling would otherwise hash and compare differently from the
+        // identity derived for the same package, so a pin lookup would miss the dependency.
+        #expect(try JSONDecoder().decode(PackageIdentity.self, from: Data(#"{"rawValue":"SharedUI"}"#.utf8)) == derived)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(PackageIdentity.self, from: Data(#"{"rawValue":""}"#.utf8)) }
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(PackageIdentity.self, from: Data(#"{"rawValue":"a/b"}"#.utf8)) }
+    }
+
+    @Test func anUnusualLocalIdentityDoesNotRejectTheWholeResolvedFile() throws {
+        // SwiftPM derives a local dependency's identity from its checkout basename, so a
+        // lockfile can carry `cafékit` or `space kit`; re-resolving writes the same file back,
+        // so refusing it would leave the user the one advice that cannot work.
+        let json = #"""
+        {"version":3,"pins":[
+          {"identity":"cafékit","kind":"localSourceControl","location":"/Users/dev/Café Kit","state":{"revision":"0123456789abcdef0123456789abcdef01234567"}},
+          {"identity":"space kit","kind":"localSourceControl","location":"/Users/dev/Space Kit","state":{"revision":"0123456789abcdef0123456789abcdef01234567"}},
+          {"identity":"sharedui","kind":"remoteSourceControl","location":"https://github.com/Org/SharedUI.git","state":{"version":"1.0.0"}}
+        ]}
+        """#
+        let file = try ResolvedPackagesFile.decode(Data(json.utf8))
+        #expect(file.pins.map(\.identity.rawValue) == ["cafékit", "space kit", "sharedui"])
+        let remote = RemoteURL("https://github.com/Org/SharedUI")!
+        let package = WorkspaceRepository(role: .package, remote: remote, baseBranch: BranchName("main")!, baseSHA: sha, taskBranch: BranchName("t")!)
+        #expect(LocalOverrideMatcher.match(selected: [package], resolved: file, observedOrigins: [package.checkoutName: remote])
+            == [.matched(identity: PackageIdentity(remote: remote), location: "https://github.com/Org/SharedUI.git")],
+            "an unrelated local dependency no longer hides the selected package")
     }
 
     @Test func checkoutNamesAndOriginsMustCarryTheIdentity() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct PackageIdentityTests {
+    func fixture(_ name: String) throws -> Data {
+        let url = try #require(Bundle.module.url(forResource: name, withExtension: "json", subdirectory: "Fixtures/swiftpm"))
+        return try Data(contentsOf: url)
+    }
+
+    func package(_ remote: String) -> WorkspaceRepository {
+        WorkspaceRepository(role: .package, remote: RemoteURL(remote)!, baseBranch: BranchName("main")!, taskBranch: BranchName("feature/1")!)
+    }
+
+    @Test func identityFollowsSwiftPMRules() {
+        #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI.git")?.rawValue == "sharedui")
+        #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI")?.rawValue == "sharedui")
+        #expect(PackageIdentity(location: "git@github.com:PicoMLX/Shared-UI.GIT")?.rawValue == "shared-ui")
+        #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI/")?.rawValue == "sharedui")
+        #expect(PackageIdentity(location: "sharedui")?.rawValue == "sharedui")
+        #expect(PackageIdentity(location: "") == nil)
+        #expect(PackageIdentity(location: ".git") == nil)
+        #expect(PackageIdentity(remote: RemoteURL("https://github.com/PicoMLX/ModelKit")!).rawValue == "modelkit")
+    }
+
+    @Test func decodesVersion3AndVersion2() throws {
+        let v3 = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        #expect(v3.version == 3)
+        #expect(v3.pins.map(\.identity.rawValue) == ["sharedui", "modelkit", "swift-collections", "registrykit"])
+        #expect(v3.pins[0].version == "1.4.0")
+        #expect(v3.pins[1].branch == "main")
+        #expect(v3.pins[3].kind == .registry)
+
+        let v2 = try ResolvedPackagesFile.decode(fixture("Package.resolved.v2"))
+        #expect(v2.version == 2)
+        #expect(v2.pins[1].kind == .localSourceControl)
+    }
+
+    @Test func rejectsUnsupportedOrMalformedFiles() {
+        #expect(throws: ResolvedPackagesError.notJSON) { try ResolvedPackagesFile.decode(Data("nope".utf8)) }
+        #expect(throws: ResolvedPackagesError.missingVersion) { try ResolvedPackagesFile.decode(Data("{\"pins\":[]}".utf8)) }
+        #expect(throws: ResolvedPackagesError.unsupportedVersion(1)) { try ResolvedPackagesFile.decode(Data("{\"version\":1,\"object\":{}}".utf8)) }
+        #expect(throws: ResolvedPackagesError.unknownKind("mystery")) { try ResolvedPackagesFile.decode(Data("{\"version\":3,\"pins\":[{\"identity\":\"x\",\"kind\":\"mystery\",\"location\":\"y\"}]}".utf8)) }
+        #expect(throws: ResolvedPackagesError.malformed("location")) { try ResolvedPackagesFile.decode(Data("{\"version\":3,\"pins\":[{\"identity\":\"x\",\"kind\":\"registry\"}]}".utf8)) }
+    }
+
+    @Test func matchesDirectAndTransitiveDependenciesByIdentityAndRemote() throws {
+        let resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        let results = LocalOverrideMatcher.match(selected: [
+            package("git@github.com:PicoMLX/SharedUI.git"),
+            package("https://github.com/picomlx/modelkit"),
+            package("https://github.com/apple/swift-collections"),
+        ], resolved: resolved)
+        #expect(results == [
+            .matched(identity: PackageIdentity(location: "sharedui")!, location: "https://github.com/PicoMLX/SharedUI.git"),
+            .matched(identity: PackageIdentity(location: "modelkit")!, location: "https://github.com/PicoMLX/ModelKit"),
+            .matched(identity: PackageIdentity(location: "swift-collections")!, location: "https://github.com/apple/swift-collections.git"),
+        ])
+    }
+
+    @Test func detectsWrongRemoteNotADependencyAndUnsupportedKinds() throws {
+        let resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        let results = LocalOverrideMatcher.match(selected: [
+            package("https://github.com/Fork/SharedUI"),
+            package("https://github.com/PicoMLX/Unrelated"),
+            package("https://github.com/PicoMLX/RegistryKit"),
+        ], resolved: resolved)
+        #expect(results == [
+            .remoteMismatch(identity: PackageIdentity(location: "sharedui")!, expected: "https://github.com/PicoMLX/SharedUI.git", selected: "https://github.com/Fork/SharedUI"),
+            .notADependency(identity: PackageIdentity(location: "unrelated")!),
+            .unsupportedKind(identity: PackageIdentity(location: "registrykit")!, kind: .registry),
+        ])
+        let local = try ResolvedPackagesFile.decode(fixture("Package.resolved.v2"))
+        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/LocalKit")], resolved: local)
+            == [.unsupportedKind(identity: PackageIdentity(location: "localkit")!, kind: .localSourceControl)])
+    }
+
+    @Test func identityCollisionsAreRefused() throws {
+        var resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        resolved = ResolvedPackagesFile(version: 3, pins: resolved.pins + [
+            .init(identity: PackageIdentity(location: "sharedui")!, kind: .remoteSourceControl, location: "https://github.com/Other/SharedUI.git", revision: nil, version: "0.1.0", branch: nil),
+        ])
+        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI")], resolved: resolved)
+            == [.collision(identity: PackageIdentity(location: "sharedui")!, locations: ["https://github.com/Other/SharedUI.git", "https://github.com/PicoMLX/SharedUI.git"])])
+
+        let clean = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        let twoSelected = LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI"), package("https://github.com/Fork/SharedUI")], resolved: clean)
+        #expect(twoSelected.allSatisfy { if case .collision = $0 { true } else { false } })
+    }
+
+    @Test func appRepositoryIsIgnoredByTheMatcher() throws {
+        let resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
+        let app = WorkspaceRepository(role: .app, remote: RemoteURL("https://github.com/PicoMLX/MyApp")!, baseBranch: BranchName("main")!, taskBranch: BranchName("feature/1")!)
+        #expect(LocalOverrideMatcher.match(selected: [app], resolved: resolved).isEmpty)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
@@ -46,11 +46,13 @@ import Testing
 
     @Test func matchesDirectAndTransitiveDependenciesByIdentityAndRemote() throws {
         let resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
-        let results = LocalOverrideMatcher.match(selected: [
+        let selected = [
             package("git@github.com:PicoMLX/SharedUI.git"),
             package("https://github.com/picomlx/modelkit"),
             package("https://github.com/apple/swift-collections"),
-        ], resolved: resolved)
+        ]
+        let origins = Dictionary(uniqueKeysWithValues: selected.map { ($0.checkoutName, $0.remote) })
+        let results = LocalOverrideMatcher.match(selected: selected, resolved: resolved, observedOrigins: origins)
         #expect(results == [
             .matched(identity: PackageIdentity(location: "sharedui")!, location: "https://github.com/PicoMLX/SharedUI.git"),
             .matched(identity: PackageIdentity(location: "modelkit")!, location: "https://github.com/PicoMLX/ModelKit"),
@@ -64,14 +66,14 @@ import Testing
             package("https://github.com/Fork/SharedUI"),
             package("https://github.com/PicoMLX/Unrelated"),
             package("https://github.com/PicoMLX/RegistryKit"),
-        ], resolved: resolved)
+        ], resolved: resolved, observedOrigins: [:])
         #expect(results == [
             .remoteMismatch(identity: PackageIdentity(location: "sharedui")!, expected: "https://github.com/PicoMLX/SharedUI.git", selected: "https://github.com/Fork/SharedUI"),
             .notADependency(identity: PackageIdentity(location: "unrelated")!),
             .unsupportedKind(identity: PackageIdentity(location: "registrykit")!, kind: .registry),
         ])
         let local = try ResolvedPackagesFile.decode(fixture("Package.resolved.v2"))
-        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/LocalKit")], resolved: local)
+        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/LocalKit")], resolved: local, observedOrigins: [:])
             == [.unsupportedKind(identity: PackageIdentity(location: "localkit")!, kind: .localSourceControl)])
     }
 
@@ -80,17 +82,17 @@ import Testing
         resolved = ResolvedPackagesFile(version: 3, pins: resolved.pins + [
             .init(identity: PackageIdentity(location: "sharedui")!, kind: .remoteSourceControl, location: "https://github.com/Other/SharedUI.git", revision: nil, version: "0.1.0", branch: nil),
         ])
-        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI")], resolved: resolved)
+        #expect(LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI")], resolved: resolved, observedOrigins: [:])
             == [.collision(identity: PackageIdentity(location: "sharedui")!, locations: ["https://github.com/Other/SharedUI.git", "https://github.com/PicoMLX/SharedUI.git"])])
 
         let clean = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
-        let twoSelected = LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI"), package("https://github.com/Fork/SharedUI")], resolved: clean)
+        let twoSelected = LocalOverrideMatcher.match(selected: [package("https://github.com/PicoMLX/SharedUI"), package("https://github.com/Fork/SharedUI")], resolved: clean, observedOrigins: [:])
         #expect(twoSelected.allSatisfy { if case .collision = $0 { true } else { false } })
     }
 
     @Test func appRepositoryIsIgnoredByTheMatcher() throws {
         let resolved = try ResolvedPackagesFile.decode(fixture("Package.resolved.v3"))
         let app = WorkspaceRepository(role: .app, remote: RemoteURL("https://github.com/PicoMLX/MyApp")!, baseBranch: BranchName("main")!, taskBranch: BranchName("feature/1")!)
-        #expect(LocalOverrideMatcher.match(selected: [app], resolved: resolved).isEmpty)
+        #expect(LocalOverrideMatcher.match(selected: [app], resolved: resolved, observedOrigins: [:]).isEmpty)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/PackageIdentityTests.swift
@@ -15,7 +15,8 @@ import Testing
     @Test func identityFollowsSwiftPMRules() {
         #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI.git")?.rawValue == "sharedui")
         #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI")?.rawValue == "sharedui")
-        #expect(PackageIdentity(location: "git@github.com:PicoMLX/Shared-UI.GIT")?.rawValue == "shared-ui")
+        // `.GIT` is not the lowercase suffix SwiftPM strips, so it stays part of the identity.
+        #expect(PackageIdentity(location: "git@github.com:PicoMLX/Shared-UI.GIT")?.rawValue == "shared-ui.git")
         #expect(PackageIdentity(location: "https://github.com/PicoMLX/SharedUI/")?.rawValue == "sharedui")
         #expect(PackageIdentity(location: "sharedui")?.rawValue == "sharedui")
         #expect(PackageIdentity(location: "") == nil)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/ResolvedPackagesGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Workspace/ResolvedPackagesGrammarTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+/// MVP-PLAN.md §6 seeds the wrapper from the whole canonical lockfile, so an
+/// invalid unselected pin must block decoding just as an invalid selected pin does.
+@Suite struct ResolvedPackagesGrammarTests {
+    private func pin(
+        identity: String = "unselected",
+        kind: String = "remoteSourceControl",
+        location: String = "https://github.com/Org/Unselected.git",
+        version: String = "1.2.3"
+    ) -> [String: Any] {
+        ["identity": identity, "kind": kind, "location": location,
+         "state": ["revision": "0123456789abcdef0123456789abcdef01234567", "version": version]]
+    }
+
+    private func lockfile(
+        format: Int,
+        pins: [[String: Any]],
+        originHashJSON: String? = nil
+    ) throws -> Data {
+        var root: [String: Any] = ["version": format, "pins": pins]
+        if let originHashJSON {
+            root["originHash"] = try JSONSerialization.jsonObject(
+                with: Data(originHashJSON.utf8), options: .fragmentsAllowed
+            )
+        }
+        return try JSONSerialization.data(withJSONObject: root, options: .sortedKeys)
+    }
+
+    @Test(arguments: [2, 3], [
+        "1.2.3-", "1.2.3+", "1.2.3-+", "1.2.3-alpha..beta", "1.2.3+build..meta",
+        "1.2.3-..", "1.2.3+..", "1.2.3--", "01.002.0003", "\(Int.max).0.0",
+    ])
+    func acceptsSwiftPMVersionSpellingsWithoutChangingThem(_ format: Int, version: String) throws {
+        let data = try lockfile(format: format, pins: [pin(version: version)])
+        #expect(try ResolvedPackagesFile.decode(data).pins.first?.version == version)
+    }
+
+    @Test(arguments: [2, 3], [
+        "1.2", "1.2.3.4", "1..3", "1.2.3-rc_1", "1.2.3+meta+more", "1.2.3-β",
+        "1.2.3+méta", "1.2.3 ", "-1.2.3", "\(Int.max)0.0.0", "0.\(Int.max)0.0",
+    ])
+    func rejectsVersionsSwiftPMCannotParse(_ format: Int, version: String) throws {
+        let data = try lockfile(format: format, pins: [pin(version: version)])
+        #expect(throws: ResolvedPackagesError.malformed("state.version")) {
+            try ResolvedPackagesFile.decode(data)
+        }
+    }
+
+    @Test(arguments: ["123", "true", "[]", "{}"])
+    func version3RejectsNonStringOriginHashes(_ originHashJSON: String) throws {
+        let data = try lockfile(format: 3, pins: [pin()], originHashJSON: originHashJSON)
+        #expect(throws: ResolvedPackagesError.malformed("originHash")) {
+            try ResolvedPackagesFile.decode(data)
+        }
+    }
+
+    @Test(arguments: [nil, "null", #""""#, #""a-swiftpm-origin-hash""#] as [String?])
+    func version3AcceptsAbsentNullAndStringOriginHashes(_ originHashJSON: String?) throws {
+        let data = try lockfile(format: 3, pins: [pin()], originHashJSON: originHashJSON)
+        #expect(try ResolvedPackagesFile.decode(data).pins.count == 1)
+    }
+
+    @Test func version2DoesNotInterpretTheVersion3OriginHashField() throws {
+        let data = try lockfile(format: 2, pins: [pin()], originHashJSON: "123")
+        #expect(try ResolvedPackagesFile.decode(data).pins.count == 1)
+    }
+
+    @Test(arguments: [2, 3], ["fileSystem", "futureKind"])
+    func rejectsKindsThatAreNotRecordedAsResolvedPins(_ format: Int, kind: String) throws {
+        let data = try lockfile(format: format, pins: [pin(kind: kind)])
+        #expect(throws: ResolvedPackagesError.unknownKind(kind)) {
+            try ResolvedPackagesFile.decode(data)
+        }
+    }
+
+    @Test(arguments: [2, 3], ["", ".", "../LocalKit", "LocalKit", "~/LocalKit", "file:///LocalKit"])
+    func localSourceControlRequiresAnAbsolutePath(_ format: Int, location: String) throws {
+        let data = try lockfile(format: format, pins: [pin(kind: "localSourceControl", location: location)])
+        #expect(throws: ResolvedPackagesError.malformed("location")) {
+            try ResolvedPackagesFile.decode(data)
+        }
+    }
+
+    @Test(arguments: [2, 3], ["/", "/Users/dev/ Local Kit ", "/Users/dev/CaféKit", "/Users/dev/../LocalKit"])
+    func localSourceControlKeepsAcceptedAbsolutePathSpellings(_ format: Int, location: String) throws {
+        let data = try lockfile(format: format, pins: [pin(kind: "localSourceControl", location: location)])
+        let decoded = try ResolvedPackagesFile.decode(data)
+        #expect(decoded.pins.first?.location == location)
+        #expect(decoded.pins.first?.kind == .localSourceControl)
+    }
+
+    @Test(arguments: [2, 3], ["unselected", "Unselected"])
+    func duplicateUnselectedIdentitiesRejectTheWholeLockfile(_ format: Int, duplicateIdentity: String) throws {
+        let data = try lockfile(format: format, pins: [
+            pin(identity: "selected", location: "https://github.com/Org/Selected.git"),
+            pin(),
+            pin(identity: duplicateIdentity, kind: "localSourceControl", location: "/Users/dev/Unselected"),
+        ])
+        #expect(throws: ResolvedPackagesError.malformed("pins.identity (duplicate)")) {
+            try ResolvedPackagesFile.decode(data)
+        }
+    }
+
+    @Test(arguments: [2, 3])
+    func validUnselectedPinsDoNotHideAnUnknownSelectedOrigin(_ format: Int) throws {
+        let remote = try #require(RemoteURL("https://github.com/Org/Selected"))
+        let selected = WorkspaceRepository(
+            role: .package, remote: remote,
+            baseBranch: try #require(BranchName("main")), taskBranch: try #require(BranchName("task"))
+        )
+        let data = try lockfile(format: format, pins: [
+            pin(identity: "selected", location: "https://github.com/Org/Selected.git"),
+            pin(kind: "localSourceControl", location: "/Users/dev/Unselected"),
+            pin(identity: "registrykit", kind: "registry", location: ""),
+        ])
+        let decoded = try ResolvedPackagesFile.decode(data)
+        #expect(LocalOverrideMatcher.match(selected: [selected], resolved: decoded, observedOrigins: [:]) == [
+            .originUnknown(identity: PackageIdentity(remote: remote), checkout: selected.checkoutName.rawValue),
+        ])
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: reusable backend/preflight/workspace/identity contracts (#10, #12, #15, #17, #18). Adapt useful implementation/tests to current Core. A historical Tart ancestor does not make shared functionality obsolete.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #17 (`MVP-PLAN.md` §6: resolve each selected package's identity and remote association, preserve the checkout basename, validate observed origin, reject ambiguous identities, and seed the wrapper from the canonical lockfile). Stacked on #64; base remains `issue-16-integration-workspace`.

- `PackageIdentity` derives SwiftPM-style location identities while preserving the canonical resolved identity's meaningful spelling.
- `ResolvedPackagesFile` reads the supported `Package.resolved` versions 2 and 3. Version 1 and future formats remain explicitly unsupported; unknown kinds return an actionable error.
- `LocalOverrideMatcher` distinguishes valid overrides from collisions, identity/remote/checkout mismatches, unsupported kinds, absent dependencies, and unknown observed origins. An unread origin never approves an override.
- No SwiftPM library dependency or Package.swift parsing.

## Bounded lockfile review follow-up

The five latest findings were verified against official Swift 6.3.1 sources and addressed with deterministic in-memory JSON regressions:

- Accept version spellings SwiftPM parses, including empty prerelease/build components, while rejecting numeric overflow and preserving the stored spelling. [Official parser](https://github.com/swiftlang/swift-tools-support-core/blob/swift-6.3.1-RELEASE/Sources/TSCUtility/Version.swift#L105-L157)
- Validate v3's optional `originHash` as a string when present and non-null. V2 continues ignoring this unknown field. [V3 schema](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.1-RELEASE/Sources/PackageGraph/ResolvedPackagesStore.swift#L499-L518)
- Reject `fileSystem`, which is not a resolved-pin kind. [Kind schema](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.1-RELEASE/Sources/PackageGraph/ResolvedPackagesStore.swift#L469-L473)
- Reject relative/empty local-source-control paths using SwiftPM's Unix syntactic rule; no host filesystem inspection or path rewriting. [Path conversion](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.1-RELEASE/Sources/PackageGraph/ResolvedPackagesStore.swift#L555-L568), [Unix validation](https://github.com/swiftlang/swift-tools-support-core/blob/swift-6.3.1-RELEASE/Sources/TSCBasic/Path.swift#L794-L803)
- Reject duplicate identities across the whole lockfile, including unselected dependencies. [Store loading](https://github.com/swiftlang/swift-package-manager/blob/swift-6.3.1-RELEASE/Sources/PackageGraph/ResolvedPackagesStore.swift#L205-L243)

These are bounded compatibility fixes, not a claim that Guesthouse implements every SwiftPM loading behavior. Existing commit-SHA restrictions and supported-layout boundaries remain unchanged.

## Validation

- New regression suite reproduced 40 failures before the decoder fix.
- `swift test --package-path Packages/GuesthouseCore`: **520 tests in 32 suites passed** (Swift 6.3.3).
- No compiler warnings; `git diff --check` clean.
- No new dependencies, network fixture resolution, secrets, host mutations, or VM/hardware runs.
- Fresh CI and automated review must pass on the new head before readiness is claimed.

## Remaining readiness constraints

- [x] Local package tests cover the new logic and pass.
- [x] No new warnings or dependencies.
- [ ] Fresh exact-head CI and automated review complete.
- [ ] PR decomposition / roughly 500-line size guideline: the existing cumulative PR already exceeded the guideline before this bounded follow-up. It is not globally merge-ready solely because these five findings are fixed.
- [ ] Stacked prerequisite readiness; no base update or PR merge performed.

Closes #17
