### PR TITLE
Core: process identity evidence and safe reconciliation after a crash

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// Everything recorded about a process the runtime launched, so that after a crash the same
+/// process can be recognized again, and a reused PID cannot be mistaken for it
+/// (MVP-PLAN.md §4, "Console and process ownership"; §10, Phase 1).
+public struct ProcessIdentity: Codable, Hashable, Sendable {
+    public var pid: Int32
+    /// Kernel start time of the process. Two processes with the same PID never share it.
+    public var startTime: Date
+    public var executablePath: String
+    /// A digest of the argument vector, so a different invocation of the same executable is
+    /// not mistaken for ours. Never the arguments themselves; they can name paths.
+    public var argumentsDigest: String
+    public var vmName: String
+    public var environmentID: EnvironmentID
+    public var recordedAt: Date
+
+    public init(pid: Int32, startTime: Date, executablePath: String, argumentsDigest: String, vmName: String, environmentID: EnvironmentID, recordedAt: Date) {
+        self.pid = pid
+        self.startTime = startTime
+        self.executablePath = executablePath
+        self.argumentsDigest = argumentsDigest
+        self.vmName = vmName
+        self.environmentID = environmentID
+        self.recordedAt = recordedAt
+    }
+}
+
+/// The same observable facts about a process that is running right now. The runtime's
+/// enumerator (issue #24) produces these; nothing here reads the process table.
+public struct LiveProcess: Codable, Hashable, Sendable {
+    public var pid: Int32
+    public var startTime: Date
+    public var executablePath: String
+    public var argumentsDigest: String
+
+    public init(pid: Int32, startTime: Date, executablePath: String, argumentsDigest: String) {
+        self.pid = pid
+        self.startTime = startTime
+        self.executablePath = executablePath
+        self.argumentsDigest = argumentsDigest
+    }
+}
+
+/// The only three answers reconciliation can give. `uncertain` never means "safe to start".
+public enum OwnershipVerdict: Hashable, Sendable {
+    /// The recorded process is alive and is provably ours.
+    case ownedRunning(LiveProcess)
+    /// The recorded process is gone and nothing else claims the VM.
+    case exited
+    /// Something does not add up. Preserve the disk and ask for recovery; never launch a
+    /// second instance and never kill a process that might belong to someone else.
+    case uncertain(UncertaintyReason)
+
+    public enum UncertaintyReason: Hashable, Sendable {
+        /// A process with the recorded PID exists but its start time differs.
+        case pidReusedByAnotherProcess
+        /// Same PID and start time, but a different executable.
+        case executableMismatch
+        /// Same PID, start time, and executable, but different arguments.
+        case argumentsMismatch
+        /// No process matched, yet the VM's lock is still held.
+        case lockHeldWithoutProcess
+        /// More than one live process claims to match the record.
+        case multipleCandidates
+    }
+}
+
+/// Pure decision logic for "is the VM I recorded still mine?".
+public enum ProcessReconciler {
+    /// Start-time comparisons tolerate this much clock noise between the kernel's value at
+    /// record time and at observation time.
+    public static let startTimeTolerance: TimeInterval = 1.0
+
+    /// - Parameters:
+    ///   - recorded: what was journaled when the process was launched.
+    ///   - observed: every live process that could plausibly be ours (usually all processes
+    ///     whose executable is the Tart binary, plus whatever has the recorded PID).
+    ///   - vmLockPresent: whether the VM directory's lock is currently held.
+    public static func reconcile(
+        recorded: ProcessIdentity,
+        observed: [LiveProcess],
+        vmLockPresent: Bool
+    ) -> OwnershipVerdict {
+        let samePID = observed.filter { $0.pid == recorded.pid }
+        if samePID.count > 1 {
+            return .uncertain(.multipleCandidates)
+        }
+        guard let candidate = samePID.first else {
+            return vmLockPresent ? .uncertain(.lockHeldWithoutProcess) : .exited
+        }
+        guard abs(candidate.startTime.timeIntervalSince(recorded.startTime)) <= startTimeTolerance else {
+            return .uncertain(.pidReusedByAnotherProcess)
+        }
+        guard candidate.executablePath == recorded.executablePath else {
+            return .uncertain(.executableMismatch)
+        }
+        guard candidate.argumentsDigest == recorded.argumentsDigest else {
+            return .uncertain(.argumentsMismatch)
+        }
+        return .ownedRunning(candidate)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -15,6 +15,10 @@ public struct ProcessIdentity: Codable, Hashable, Sendable {
     public var environmentID: EnvironmentID
     public var recordedAt: Date
 
+    /// A record whose VM name is not the environment's own name describes some other VM;
+    /// ownership is never granted on it.
+    public var isConsistent: Bool { vmName == environmentID.tartVMName }
+
     public init(pid: Int32, startTime: Date, executablePath: String, argumentsDigest: String, vmName: String, environmentID: EnvironmentID, recordedAt: Date) {
         self.pid = pid
         self.startTime = startTime
@@ -33,12 +37,16 @@ public struct LiveProcess: Codable, Hashable, Sendable {
     public var startTime: Date
     public var executablePath: String
     public var argumentsDigest: String
+    /// The VM the process claims to run (`tart run <name> …`), parsed and validated by the
+    /// enumerator; `nil` when the arguments name no VM.
+    public var claimedVMName: String?
 
-    public init(pid: Int32, startTime: Date, executablePath: String, argumentsDigest: String) {
+    public init(pid: Int32, startTime: Date, executablePath: String, argumentsDigest: String, claimedVMName: String? = nil) {
         self.pid = pid
         self.startTime = startTime
         self.executablePath = executablePath
         self.argumentsDigest = argumentsDigest
+        self.claimedVMName = claimedVMName
     }
 }
 
@@ -63,14 +71,18 @@ public enum OwnershipVerdict: Hashable, Sendable {
         case lockHeldWithoutProcess
         /// More than one live process claims to match the record.
         case multipleCandidates
+        /// The recorded process is gone, but another process claims the same VM (the same
+        /// invocation, or `tart run` naming the VM); it may be acquiring the lock right now.
+        case anotherProcessClaimsVM
+        /// The record names a VM that is not the environment's own.
+        case recordInconsistent
     }
 }
 
 /// Pure decision logic for "is the VM I recorded still mine?".
 public enum ProcessReconciler {
-    /// Start-time comparisons tolerate this much clock noise between the kernel's value at
-    /// record time and at observation time.
-    public static let startTimeTolerance: TimeInterval = 1.0
+    /// The kernel's start time is an identity, stored losslessly and compared exactly; a
+    /// process with the same PID and a different start time is another process.
 
     /// - Parameters:
     ///   - recorded: what was journaled when the process was launched.
@@ -82,14 +94,19 @@ public enum ProcessReconciler {
         observed: [LiveProcess],
         vmLockPresent: Bool
     ) -> OwnershipVerdict {
+        guard recorded.isConsistent else { return .uncertain(.recordInconsistent) }
         let samePID = observed.filter { $0.pid == recorded.pid }
         if samePID.count > 1 {
             return .uncertain(.multipleCandidates)
         }
         guard let candidate = samePID.first else {
-            return vmLockPresent ? .uncertain(.lockHeldWithoutProcess) : .exited
+            if vmLockPresent { return .uncertain(.lockHeldWithoutProcess) }
+            // Another process with the same invocation, or one whose arguments name this VM,
+            // may be about to take the lock; nothing is safe to start under it.
+            let claimants = observed.filter { $0.argumentsDigest == recorded.argumentsDigest || $0.claimedVMName == recorded.vmName }
+            return claimants.isEmpty ? .exited : .uncertain(.anotherProcessClaimsVM)
         }
-        guard abs(candidate.startTime.timeIntervalSince(recorded.startTime)) <= startTimeTolerance else {
+        guard candidate.startTime == recorded.startTime else {
             return .uncertain(.pidReusedByAnotherProcess)
         }
         guard candidate.executablePath == recorded.executablePath else {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -76,6 +76,9 @@ public enum OwnershipVerdict: Hashable, Sendable {
         case anotherProcessClaimsVM
         /// The record names a VM that is not the environment's own.
         case recordInconsistent
+        /// The live process does not name the recorded virtual machine, so it cannot be
+        /// proven to be this environment's VM.
+        case vmNameUnconfirmed
     }
 }
 
@@ -99,11 +102,12 @@ public enum ProcessReconciler {
         if samePID.count > 1 {
             return .uncertain(.multipleCandidates)
         }
+        // Any other live process that claims this VM, by the same invocation or by naming it,
+        // leaves ownership unproven: the lock evidence does not say which process holds it.
+        let claimants = observed.filter { $0.pid != recorded.pid && ($0.argumentsDigest == recorded.argumentsDigest || $0.claimedVMName == recorded.vmName) }
         guard let candidate = samePID.first else {
             if vmLockPresent { return .uncertain(.lockHeldWithoutProcess) }
-            // Another process with the same invocation, or one whose arguments name this VM,
-            // may be about to take the lock; nothing is safe to start under it.
-            let claimants = observed.filter { $0.argumentsDigest == recorded.argumentsDigest || $0.claimedVMName == recorded.vmName }
+            // A competing process may be about to take the lock; nothing is safe to start.
             return claimants.isEmpty ? .exited : .uncertain(.anotherProcessClaimsVM)
         }
         guard candidate.startTime == recorded.startTime else {
@@ -114,6 +118,15 @@ public enum ProcessReconciler {
         }
         guard candidate.argumentsDigest == recorded.argumentsDigest else {
             return .uncertain(.argumentsMismatch)
+        }
+        // The process must name the recorded VM itself. A record that paired this environment
+        // with another VM's invocation, or a process whose arguments cannot be read as a VM
+        // launch, never grants ownership.
+        guard candidate.claimedVMName == recorded.vmName else {
+            return .uncertain(.vmNameUnconfirmed)
+        }
+        guard claimants.isEmpty else {
+            return .uncertain(.anotherProcessClaimsVM)
         }
         return .ownedRunning(candidate)
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -83,7 +83,7 @@ public enum OwnershipVerdict: Hashable, Sendable {
 }
 
 /// Pure decision logic for "is the VM I recorded still mine?".
-public enum ProcessReconciler {
+public enum ProcessReconciler: Sendable {
     /// The kernel's start time is an identity, stored losslessly and compared exactly; a
     /// process with the same PID and a different start time is another process.
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
@@ -10,13 +10,13 @@ import Testing
         ProcessIdentity(pid: 4242, startTime: started, executablePath: "/Library/Application Support/Guesthouse/runtime/2.36.0/Tart.app/Contents/MacOS/tart", argumentsDigest: "sha256:abc", vmName: environment.tartVMName, environmentID: environment, recordedAt: started.addingTimeInterval(1))
     }
 
-    func live(pid: Int32 = 4242, start: Date? = nil, path: String? = nil, digest: String = "sha256:abc") -> LiveProcess {
-        LiveProcess(pid: pid, startTime: start ?? started, executablePath: path ?? recorded.executablePath, argumentsDigest: digest)
+    func live(pid: Int32 = 4242, start: Date? = nil, path: String? = nil, digest: String = "sha256:abc", vm: String? = nil) -> LiveProcess {
+        LiveProcess(pid: pid, startTime: start ?? started, executablePath: path ?? recorded.executablePath, argumentsDigest: digest, claimedVMName: vm ?? environment.tartVMName)
     }
 
     @Test func exactMatchIsOwned() {
         let process = live()
-        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 1, digest: "sha256:other"), process], vmLockPresent: true) == .ownedRunning(process))
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 1, digest: "sha256:other", vm: "guesthouse-other"), process], vmLockPresent: true) == .ownedRunning(process))
         // The start time is an identity: a fraction of a second off is another process.
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(start: started.addingTimeInterval(0.4))], vmLockPresent: true) == .uncertain(.pidReusedByAnotherProcess))
     }
@@ -24,10 +24,28 @@ import Testing
     @Test func anotherProcessClaimingTheVMPreventsASafeStart() {
         let sameInvocation = live(pid: 9, start: started.addingTimeInterval(5))
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [sameInvocation], vmLockPresent: false) == .uncertain(.anotherProcessClaimsVM))
-        let namesTheVM = LiveProcess(pid: 10, startTime: started, executablePath: recorded.executablePath, argumentsDigest: "sha256:flags", claimedVMName: environment.tartVMName)
+        let namesTheVM = live(pid: 10, digest: "sha256:flags")
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [namesTheVM], vmLockPresent: false) == .uncertain(.anotherProcessClaimsVM))
-        let unrelated = LiveProcess(pid: 11, startTime: started, executablePath: recorded.executablePath, argumentsDigest: "sha256:flags", claimedVMName: "guesthouse-other")
+        let unrelated = live(pid: 11, digest: "sha256:flags", vm: "guesthouse-other")
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [unrelated], vmLockPresent: false) == .exited)
+    }
+
+    @Test func aProcessThatDoesNotNameTheRecordedVMIsUncertain() {
+        // The record pairs this environment with another VM's invocation: the live process
+        // says which VM it runs, and it is not this one.
+        let other = EnvironmentID().tartVMName
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(vm: other)], vmLockPresent: true) == .uncertain(.vmNameUnconfirmed))
+        // Arguments that cannot be read as a VM launch prove nothing either.
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(vm: "")], vmLockPresent: true) == .uncertain(.vmNameUnconfirmed))
+    }
+
+    @Test func aCompetingClaimantIsUncertainEvenWhileTheRecordedProcessLives() {
+        let competitor = live(pid: 77, digest: "sha256:flags")
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(), competitor], vmLockPresent: true) == .uncertain(.anotherProcessClaimsVM))
+        let sameInvocation = live(pid: 78)
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(), sameInvocation], vmLockPresent: true) == .uncertain(.anotherProcessClaimsVM))
+        let unrelated = live(pid: 79, digest: "sha256:other", vm: "guesthouse-other")
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(), unrelated], vmLockPresent: true) == .ownedRunning(live()))
     }
 
     @Test func anInconsistentRecordNeverGrantsOwnership() {
@@ -48,7 +66,7 @@ import Testing
     }
 
     @Test func goneWithoutLockIsExitedButGoneWithLockIsUncertain() {
-        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 7, digest: "sha256:other")], vmLockPresent: false) == .exited)
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 7, digest: "sha256:other", vm: "guesthouse-other")], vmLockPresent: false) == .exited)
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [], vmLockPresent: true) == .uncertain(.lockHeldWithoutProcess))
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct ProcessReconcilerTests {
+    let started = Date(timeIntervalSince1970: 1_800_000_000)
+    let environment = EnvironmentID()
+
+    var recorded: ProcessIdentity {
+        ProcessIdentity(pid: 4242, startTime: started, executablePath: "/Library/Application Support/Guesthouse/runtime/2.36.0/Tart.app/Contents/MacOS/tart", argumentsDigest: "sha256:abc", vmName: environment.tartVMName, environmentID: environment, recordedAt: started.addingTimeInterval(1))
+    }
+
+    func live(pid: Int32 = 4242, start: Date? = nil, path: String? = nil, digest: String = "sha256:abc") -> LiveProcess {
+        LiveProcess(pid: pid, startTime: start ?? started, executablePath: path ?? recorded.executablePath, argumentsDigest: digest)
+    }
+
+    @Test func exactMatchIsOwned() {
+        let process = live(start: started.addingTimeInterval(0.4))
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 1), process], vmLockPresent: true) == .ownedRunning(process))
+    }
+
+    @Test func pidReuseIsUncertain() {
+        let reused = live(start: started.addingTimeInterval(3600))
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [reused], vmLockPresent: false) == .uncertain(.pidReusedByAnotherProcess))
+    }
+
+    @Test func executableOrArgumentMismatchIsUncertain() {
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(path: "/usr/bin/yes")], vmLockPresent: false) == .uncertain(.executableMismatch))
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(digest: "sha256:other")], vmLockPresent: false) == .uncertain(.argumentsMismatch))
+    }
+
+    @Test func goneWithoutLockIsExitedButGoneWithLockIsUncertain() {
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 7)], vmLockPresent: false) == .exited)
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [], vmLockPresent: true) == .uncertain(.lockHeldWithoutProcess))
+    }
+
+    @Test func multipleCandidatesAreUncertain() {
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(), live()], vmLockPresent: true) == .uncertain(.multipleCandidates))
+    }
+
+    @Test func uncertainNeverLooksLikeSafeToStart() {
+        let verdicts: [OwnershipVerdict] = [
+            ProcessReconciler.reconcile(recorded: recorded, observed: [live(start: started.addingTimeInterval(10))], vmLockPresent: false),
+            ProcessReconciler.reconcile(recorded: recorded, observed: [], vmLockPresent: true),
+        ]
+        for verdict in verdicts {
+            #expect(verdict != .exited)
+            if case .ownedRunning = verdict { Issue.record("uncertain verdict reported as owned") }
+        }
+    }
+
+    @Test func identitiesRoundTripThroughJSON() throws {
+        let data = try JSONEncoder().encode(recorded)
+        #expect(try JSONDecoder().decode(ProcessIdentity.self, from: data) == recorded)
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(!json.contains("--vnc"), "arguments are stored as a digest, never verbatim")
+        let liveData = try JSONEncoder().encode(live())
+        #expect(try JSONDecoder().decode(LiveProcess.self, from: liveData) == live())
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
@@ -3,6 +3,12 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct ProcessReconcilerTests {
+    @Test func reconcilerConformsToSendable() {
+        // Require the enum itself to conform, not just its always-sendable metatype value.
+        func requiringSendable<T: Sendable>(_ type: T.Type) {}
+        requiringSendable(ProcessReconciler.self)
+    }
+
     let started = Date(timeIntervalSince1970: 1_800_000_000)
     let environment = EnvironmentID()
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Processes/ProcessReconcilerTests.swift
@@ -15,8 +15,26 @@ import Testing
     }
 
     @Test func exactMatchIsOwned() {
-        let process = live(start: started.addingTimeInterval(0.4))
-        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 1), process], vmLockPresent: true) == .ownedRunning(process))
+        let process = live()
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 1, digest: "sha256:other"), process], vmLockPresent: true) == .ownedRunning(process))
+        // The start time is an identity: a fraction of a second off is another process.
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(start: started.addingTimeInterval(0.4))], vmLockPresent: true) == .uncertain(.pidReusedByAnotherProcess))
+    }
+
+    @Test func anotherProcessClaimingTheVMPreventsASafeStart() {
+        let sameInvocation = live(pid: 9, start: started.addingTimeInterval(5))
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [sameInvocation], vmLockPresent: false) == .uncertain(.anotherProcessClaimsVM))
+        let namesTheVM = LiveProcess(pid: 10, startTime: started, executablePath: recorded.executablePath, argumentsDigest: "sha256:flags", claimedVMName: environment.tartVMName)
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [namesTheVM], vmLockPresent: false) == .uncertain(.anotherProcessClaimsVM))
+        let unrelated = LiveProcess(pid: 11, startTime: started, executablePath: recorded.executablePath, argumentsDigest: "sha256:flags", claimedVMName: "guesthouse-other")
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [unrelated], vmLockPresent: false) == .exited)
+    }
+
+    @Test func anInconsistentRecordNeverGrantsOwnership() {
+        var wrong = recorded
+        wrong.vmName = EnvironmentID().tartVMName
+        #expect(!wrong.isConsistent)
+        #expect(ProcessReconciler.reconcile(recorded: wrong, observed: [live()], vmLockPresent: true) == .uncertain(.recordInconsistent))
     }
 
     @Test func pidReuseIsUncertain() {
@@ -30,7 +48,7 @@ import Testing
     }
 
     @Test func goneWithoutLockIsExitedButGoneWithLockIsUncertain() {
-        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 7)], vmLockPresent: false) == .exited)
+        #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [live(pid: 7, digest: "sha256:other")], vmLockPresent: false) == .exited)
         #expect(ProcessReconciler.reconcile(recorded: recorded, observed: [], vmLockPresent: true) == .uncertain(.lockHeldWithoutProcess))
     }
 


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: reusable backend/preflight/workspace/identity contracts (#10, #12, #15, #17, #18). Adapt useful implementation/tests to current Core. A historical Tart ancestor does not make shared functionality obsolete.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #18 (`MVP-PLAN.md` §4 "Console and process ownership": persist process identity evidence and environment ownership, not only PIDs; after a crash identify any surviving Tart process and its exact VM before recovering control; if ownership is uncertain, preserve the disk and request recovery; never launch a duplicate instance or kill an unrelated reused PID). Stacked on #65.

- `ProcessIdentity`: pid, kernel start time, executable path, a digest of the arguments (never the arguments themselves), VM name, environment, recorded-at. `LiveProcess`: the same observable fields for a running process; the enumerator that produces them is issue #24.
- `ProcessReconciler.reconcile(recorded:observed:vmLockPresent:)` → `ownedRunning`, `exited`, or `uncertain(reason)`. Reasons: PID reused (start time differs beyond a one-second tolerance), executable mismatch, argument mismatch, lock held without a process, multiple candidates. Any disagreement is uncertain; uncertain never maps to "safe to start".

Tests (7): exact match, PID reuse, executable and argument mismatch, gone with and without lock, multiple candidates, uncertain never equals exited or owned, and Codable round trips that confirm arguments are stored only as a digest.

Closes #18

## Checklist

- [x] Tests cover the new logic; `swift test --package-path Packages/GuesthouseCore` passes (155 tests)
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] No process launched anywhere in this change
- [x] Diff under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)