### PR TITLE
Runtime: add the GuesthouseRuntime XPC service target with a runtimeVersion operation

### DIFF
--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		F8ACD8A830493E2C00550943 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = F8ACD8A730493E2C00550943 /* GuesthouseCore */; };
+		4DF3B7691BA84C0992A05F43 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9668531454184F48A8F15863 /* GuesthouseCore */; };
+		24C65336F28345A5ACC4C24E /* GuesthouseRuntime.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,7 +27,28 @@
 			remoteGlobalIDString = F8976E89304933D10071C234;
 			remoteInfo = Guesthouse;
 		};
+		B736EBAA2A7A4CC5975E5B05 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8976E82304933D10071C234 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 16255D1DB7F34BFAB6C65BC8;
+			remoteInfo = GuesthouseRuntime;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7B059FE13FBE429E9CE0FDD6 /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				24C65336F28345A5ACC4C24E /* GuesthouseRuntime.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Guesthouse Codex VM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -33,6 +56,7 @@
 		F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuesthouseUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8ACD8A93049406300550943 /* MVP-PLAN.md */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVP-PLAN.md"; sourceTree = "<group>"; };
 		921BF84465C14B2296CA65E2 /* GuesthouseCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseCore; path = Packages/GuesthouseCore; sourceTree = "<group>"; };
+		A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = GuesthouseRuntime.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -49,6 +73,12 @@
 		F8976EA4304933D30071C234 /* GuesthouseUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = GuesthouseUITests;
+			sourceTree = "<group>";
+		};
+		3EAD2573296645A68021C352 /* GuesthouseRuntime */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			name = GuesthouseRuntime;
+			path = GuesthouseRuntime/Sources;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -76,6 +106,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		739B23D1D5D0418FA13E75FD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF3B7691BA84C0992A05F43 /* GuesthouseCore in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -87,6 +125,7 @@
 				F8976E8C304933D10071C234 /* Guesthouse */,
 				F8976E9A304933D30071C234 /* GuesthouseTests */,
 				F8976EA4304933D30071C234 /* GuesthouseUITests */,
+				3EAD2573296645A68021C352 /* GuesthouseRuntime */,
 				F8976E8B304933D10071C234 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -97,6 +136,7 @@
 				F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */,
 				F8976E97304933D30071C234 /* GuesthouseTests.xctest */,
 				F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */,
+				A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -111,10 +151,12 @@
 				F8976E86304933D10071C234 /* Sources */,
 				F8976E87304933D10071C234 /* Frameworks */,
 				F8976E88304933D10071C234 /* Resources */,
+				7B059FE13FBE429E9CE0FDD6 /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4A465B87B26A476B8A414EE2 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F8976E8C304933D10071C234 /* Guesthouse */,
@@ -173,6 +215,29 @@
 			productReference = F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0F136BAB2D67436C81229C09 /* Build configuration list for PBXNativeTarget "GuesthouseRuntime" */;
+			buildPhases = (
+				3F90A9E53755462D9CEF9426 /* Sources */,
+				739B23D1D5D0418FA13E75FD /* Frameworks */,
+				A599CC66E8FD406CA0FDA6CA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3EAD2573296645A68021C352 /* GuesthouseRuntime */,
+			);
+			name = GuesthouseRuntime;
+			packageProductDependencies = (
+				9668531454184F48A8F15863 /* GuesthouseCore */,
+			);
+			productName = GuesthouseRuntime;
+			productReference = A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */;
+			productType = "com.apple.product-type.xpc-service";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -193,6 +258,9 @@
 					F8976EA0304933D30071C234 = {
 						CreatedOnToolsVersion = 26.6;
 						TestTargetID = F8976E89304933D10071C234;
+					};
+					16255D1DB7F34BFAB6C65BC8 = {
+						CreatedOnToolsVersion = 26.6;
 					};
 				};
 			};
@@ -216,6 +284,7 @@
 				F8976E89304933D10071C234 /* Guesthouse */,
 				F8976E96304933D30071C234 /* GuesthouseTests */,
 				F8976EA0304933D30071C234 /* GuesthouseUITests */,
+				16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */,
 			);
 		};
 /* End PBXProject section */
@@ -236,6 +305,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F8976E9F304933D30071C234 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A599CC66E8FD406CA0FDA6CA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -266,6 +342,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3F90A9E53755462D9CEF9426 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -278,6 +361,11 @@
 			isa = PBXTargetDependency;
 			target = F8976E89304933D10071C234 /* Guesthouse */;
 			targetProxy = F8976EA2304933D30071C234 /* PBXContainerItemProxy */;
+		};
+		4A465B87B26A476B8A414EE2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */;
+			targetProxy = B736EBAA2A7A4CC5975E5B05 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -427,6 +515,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse;
+				PRODUCT_MODULE_NAME = Guesthouse;
 				PRODUCT_NAME = "Guesthouse Codex VM";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -471,6 +560,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse;
+				PRODUCT_MODULE_NAME = Guesthouse;
 				PRODUCT_NAME = "Guesthouse Codex VM";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -588,6 +678,64 @@
 			};
 			name = Release;
 		};
+		B25ED7FAA0094EE18B8FCB75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TPKP4XK352;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = GuesthouseRuntime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse.Runtime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		B8F0C7A4BF3B43648D2AE322 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TPKP4XK352;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = GuesthouseRuntime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse.Runtime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -627,6 +775,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		0F136BAB2D67436C81229C09 /* Build configuration list for PBXNativeTarget "GuesthouseRuntime" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B25ED7FAA0094EE18B8FCB75 /* Debug */,
+				B8F0C7A4BF3B43648D2AE322 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -638,6 +795,10 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		F8ACD8A730493E2C00550943 /* GuesthouseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GuesthouseCore;
+		};
+		9668531454184F48A8F15863 /* GuesthouseCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GuesthouseCore;
 		};

--- a/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
+++ b/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:Packages/GuesthouseCore">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "16255D1DB7F34BFAB6C65BC8"
+               BuildableName = "GuesthouseRuntime.xpc"
+               BlueprintName = "GuesthouseRuntime"
+               ReferencedContainer = "container:Guesthouse.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -8,12 +8,21 @@
 import SwiftUI
 
 struct ContentView: View {
+    @Environment(DebugRuntimeProbe.self) private var debugProbe
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
+        VStack(spacing: 12) {
+            Image(systemName: "desktopcomputer")
                 .imageScale(.large)
                 .foregroundStyle(.tint)
-            Text("Hello, world!")
+            Text("Guesthouse")
+            #if DEBUG
+            Text(debugProbe.result)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .textSelection(.enabled)
+                .accessibilityLabel("Runtime version result")
+            #endif
         }
         .padding()
     }
@@ -21,4 +30,5 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        .environment(DebugRuntimeProbe())
 }

--- a/Guesthouse/GuesthouseApp.swift
+++ b/Guesthouse/GuesthouseApp.swift
@@ -9,9 +9,22 @@ import SwiftUI
 
 @main
 struct GuesthouseApp: App {
+    @State private var debugProbe = DebugRuntimeProbe()
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+                .environment(debugProbe)
         }
+        #if DEBUG
+        .commands {
+            CommandMenu("Debug") {
+                Button("Runtime Version") {
+                    debugProbe.requestRuntimeVersion()
+                }
+                .keyboardShortcut("r", modifiers: [.command, .option])
+            }
+        }
+        #endif
     }
 }

--- a/Guesthouse/Runtime/DebugRuntimeProbe.swift
+++ b/Guesthouse/Runtime/DebugRuntimeProbe.swift
@@ -1,0 +1,34 @@
+import Foundation
+import GuesthouseCore
+import Observation
+
+/// Debug-only: exercises the `runtimeVersion` operation against the real service so the
+/// XPC arrangement can be checked outside tests (issue #19). Not part of the product UI.
+@Observable
+final class DebugRuntimeProbe {
+    var result: String = "Not requested"
+    private let backend: any RuntimeBackend
+
+    init(backend: any RuntimeBackend = RuntimeClient()) {
+        self.backend = backend
+    }
+
+    func requestRuntimeVersion() {
+        result = "Requesting…"
+        Task {
+            do {
+                var text = "No reply"
+                for try await event in backend.send(.runtimeVersion) {
+                    if case .runtimeVersion(let info) = event {
+                        text = "Service \(info.serviceVersion) (\(info.serviceBuild)), \(info.protocolVersion), Tart: \(info.tart.map { "\($0.version)\($0.verified ? " verified" : " unverified")" } ?? "not located")"
+                    } else {
+                        text = "Unexpected reply: \(event.caseName)"
+                    }
+                }
+                result = text
+            } catch {
+                result = "Connection interrupted: \(error)"
+            }
+        }
+    }
+}

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -26,6 +26,7 @@ actor RuntimeClient: RuntimeBackend {
         case incoming(RuntimeEvent)
         case interrupted
         case consumerGone(ContinuationKey)
+        case streamFinished(ContinuationKey)
     }
 
     private let transport: any RuntimeTransport
@@ -43,7 +44,8 @@ actor RuntimeClient: RuntimeBackend {
     /// guest output accumulate again.
     private var retired: Set<OperationID> = []
     /// Keys whose request finished without acceptance (a query reply or a failure), so a
-    /// late `consumerGone` for them is ignored.
+    /// late `consumerGone` for them is ignored. A key is held only until its stream
+    /// terminates, which is the last moment a cancellation can still race the reply.
     private var settled: Set<ContinuationKey> = []
     /// Buffered events per operation that has not been accepted yet, bounded so a runtime
     /// that streams before its reply cannot grow this without limit.
@@ -52,11 +54,19 @@ actor RuntimeClient: RuntimeBackend {
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
 
-    /// Progress and log events held for one consumer that is not reading. The client drops
-    /// its own excess rather than letting the stream evict, so control events (`accepted` and
-    /// the terminal event) are never lost and never reordered behind droppable traffic.
+    /// How many events one consumer's stream buffers. The client drops its own excess before
+    /// the stream is full, so control events (`accepted` and the terminal event) are never
+    /// lost and never reordered behind droppable traffic a consumer is not reading.
     static let consumerBufferLimit = 1_024
-    private var bufferedTraffic: [OperationID: Int] = [:]
+    /// Slots of that buffer kept free for control events: droppable traffic stops here.
+    static let consumerControlReserve = 64
+    /// While traffic is being dropped, one event in this many is delivered anyway. A yield is
+    /// the only report of how much room a consumer has left, so without this probe a consumer
+    /// that fell behind once would never receive traffic again for the rest of the operation.
+    static let trafficProbeInterval = 64
+    /// Room left in each consumer's stream, as of its last yield.
+    private var consumerRoom: [OperationID: Int] = [:]
+    private var droppedSinceProbe: [OperationID: Int] = [:]
 
     init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
         self.transport = transport
@@ -73,15 +83,21 @@ actor RuntimeClient: RuntimeBackend {
     /// consumer stops reading an accepted operation, the client unregisters it and asks the
     /// runtime to cancel it, so a host mutation never keeps running unobserved.
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
-        AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
+        // The buffer is bounded and never evicts what it already holds: the client stops
+        // delivering droppable traffic while the room left is down to the reserve, so a
+        // control event always finds a slot even when a consumer stops reading entirely.
+        AsyncThrowingStream(bufferingPolicy: .bufferingOldest(Self.consumerBufferLimit)) { continuation in
             let key = ContinuationKey()
             // The termination closure holds the client, so a caller that keeps only the
             // stream still has a producer: the client is released when the stream ends.
             let owner = self
             continuation.onTermination = { [inboxContinuation] termination in
                 withExtendedLifetime(owner) {
-                    if case .cancelled = termination {
-                        inboxContinuation.yield(.consumerGone(key))
+                    switch termination {
+                    case .cancelled: inboxContinuation.yield(.consumerGone(key))
+                    // The stream ended normally, so no cancellation can still race the reply
+                    // and the key is no longer needed for anything.
+                    default: inboxContinuation.yield(.streamFinished(key))
                     }
                 }
             }
@@ -131,7 +147,8 @@ actor RuntimeClient: RuntimeBackend {
         case .reply(let result, let continuation, let key): handleReply(result, for: continuation, key: key)
         case .incoming(let event): route(event)
         case .interrupted: connectionDropped()
-        case .consumerGone(let continuation): consumerGone(continuation)
+        case .consumerGone(let key): consumerGone(key)
+        case .streamFinished(let key): streamFinished(key)
         }
     }
 
@@ -171,24 +188,59 @@ actor RuntimeClient: RuntimeBackend {
     /// How many events are held for an operation that has not been accepted. Test seam.
     func pendingEventCount(for id: OperationID) -> Int { pendingEvents[id]?.count ?? 0 }
 
+    /// How many finished requests are still held against a cancellation race. Test seam.
+    func settledKeyCount() -> Int { settled.count }
+
+    /// Whether an operation has ended, so nothing more will be delivered for it. Test seam.
+    func isRetired(_ id: OperationID) -> Bool { retired.contains(id) }
+
     private func settle(_ key: ContinuationKey) {
         settled.insert(key)
+    }
+
+    /// A stream that ended on its own can no longer produce a `consumerGone`, so everything
+    /// remembered about it is released; otherwise one key per query would be held for the
+    /// life of the client.
+    private func streamFinished(_ key: ContinuationKey) {
+        settled.remove(key)
+        abandonedBeforeAccept.remove(key)
+        consumers.removeValue(forKey: key)
     }
 
     private func retire(_ id: OperationID) {
         retired.insert(id)
         pendingEvents.removeValue(forKey: id)
-        bufferedTraffic.removeValue(forKey: id)
+        consumerRoom.removeValue(forKey: id)
+        droppedSinceProbe.removeValue(forKey: id)
     }
 
-    /// Droppable traffic. The stream itself buffers without limit, so the control events
-    /// (`accepted` and the terminal event) can never be evicted or reordered; the excess that
-    /// a consumer is not reading is dropped here instead, and counted.
+    /// Droppable traffic: progress and log lines. It is delivered while the consumer's stream
+    /// has room beyond the reserve, so the control events (`accepted` and the terminal event)
+    /// can never be crowded out or reordered behind traffic nobody is reading. The room is
+    /// what the stream reports, not a count of everything ever sent, so a consumer keeping up
+    /// in real time is never cut off.
     private func deliver(_ event: RuntimeEvent, to continuation: Continuation, id: OperationID) {
-        let buffered = bufferedTraffic[id, default: 0]
-        guard buffered < Self.consumerBufferLimit else { return }
-        bufferedTraffic[id] = buffered + 1
-        continuation.yield(event)
+        if consumerRoom[id, default: Self.consumerBufferLimit] <= Self.consumerControlReserve {
+            let dropped = droppedSinceProbe[id, default: 0] + 1
+            guard dropped >= Self.trafficProbeInterval else {
+                droppedSinceProbe[id] = dropped
+                return
+            }
+            // Probe: the stream refuses a yield it has no room for, so this measures the room
+            // again without displacing anything already queued.
+            droppedSinceProbe[id] = 0
+        }
+        yieldTracking(event, to: continuation, id: id)
+    }
+
+    /// Yields and records the room the stream reports it has left, which is how a consumer
+    /// that has caught up is noticed.
+    private func yieldTracking(_ event: RuntimeEvent, to continuation: Continuation, id: OperationID) {
+        if case .enqueued(let remaining) = continuation.yield(event) {
+            consumerRoom[id] = remaining
+        } else {
+            consumerRoom[id] = 0
+        }
     }
 
     private func route(_ event: RuntimeEvent) {
@@ -210,15 +262,26 @@ actor RuntimeClient: RuntimeBackend {
             } else if !retired.contains(id) {
                 append(event, for: id)
             }
-        case .status, .runtimeVersion, .accepted, .log(nil, _):
-            for continuation in operations.values { continuation.yield(event) }
+        case .status, .runtimeVersion, .accepted:
+            for (id, continuation) in operations { yieldTracking(event, to: continuation, id: id) }
+        case .log(nil, _):
+            // Unscoped guest output is droppable traffic for every operation, not a control
+            // event: it takes the bounded path too, so high-volume output cannot accumulate
+            // in the stream of a consumer that is not reading.
+            for (id, continuation) in operations { deliver(event, to: continuation, id: id) }
         }
     }
 
     /// Buffers an event for an operation that has not been accepted yet, bounded.
     private func append(_ event: RuntimeEvent, for id: OperationID) {
         var events = pendingEvents[id] ?? []
-        guard events.count < Self.pendingEventLimit else { return }
+        if events.count >= Self.pendingEventLimit {
+            // The terminal event is what ends the consumer's stream: dropping it would leave
+            // the caller waiting forever once the operation is finally accepted. Room is made
+            // for it by dropping the oldest droppable event instead.
+            guard event.endsOperation, let droppable = events.firstIndex(where: { !$0.endsOperation }) else { return }
+            events.remove(at: droppable)
+        }
         events.append(event)
         pendingEvents[id] = events
     }
@@ -240,9 +303,22 @@ actor RuntimeClient: RuntimeBackend {
         let pending = operations
         operations.removeAll()
         pendingEvents.removeAll()
+        consumerRoom.removeAll()
+        droppedSinceProbe.removeAll()
         for (id, continuation) in pending {
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }
         consumers.removeAll()
+    }
+}
+
+nonisolated extension RuntimeEvent {
+    /// Ends an operation. A consumer that never receives one waits forever, so these events
+    /// are never dropped to make room for traffic.
+    fileprivate var endsOperation: Bool {
+        switch self {
+        case .completed, .failed: true
+        case .runtimeVersion, .accepted, .progress, .log, .status: false
+        }
     }
 }

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -1,0 +1,96 @@
+import Foundation
+import GuesthouseCore
+
+/// The GUI's `RuntimeBackend` over XPC.
+///
+/// Connects lazily, maps a dropped connection to `RuntimeConnectionInterrupted` so callers
+/// treat in-flight work as unknown outcome (MVP-PLAN.md §3), and reconnects on the next
+/// request. Long-running operations stream their events through the transport's incoming
+/// handler and are demultiplexed by `OperationID`.
+actor RuntimeClient: RuntimeBackend {
+    typealias Continuation = AsyncThrowingStream<RuntimeEvent, any Error>.Continuation
+
+    private let transport: any RuntimeTransport
+    private var operations: [OperationID: Continuation] = [:]
+    /// Events that arrived for an operation before its `accepted` reply registered a consumer.
+    /// The reply and the pushed events travel on different paths, so either can come first.
+    private var pendingEvents: [OperationID: [RuntimeEvent]] = [:]
+    private var handlersInstalled = false
+
+    init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
+        self.transport = transport
+    }
+
+    nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
+        AsyncThrowingStream { continuation in
+            Task { await self.start(request, continuation) }
+        }
+    }
+
+    private func start(_ request: RuntimeRequest, _ continuation: Continuation) {
+        installHandlersIfNeeded()
+        do {
+            try transport.send(RuntimeRequestEnvelope(request: request)) { result in
+                Task { await self.handleReply(result, for: continuation) }
+            }
+        } catch {
+            continuation.finish(throwing: RuntimeConnectionInterrupted())
+        }
+    }
+
+    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation) {
+        switch result {
+        case .success(let event):
+            continuation.yield(event)
+            switch event {
+            case .accepted(let id):
+                // More events follow through the incoming handler until completed or failed.
+                operations[id] = continuation
+                for buffered in pendingEvents.removeValue(forKey: id) ?? [] {
+                    route(buffered)
+                }
+            case .runtimeVersion, .status, .completed, .failed, .progress, .log:
+                continuation.finish()
+            }
+        case .failure:
+            continuation.finish(throwing: RuntimeConnectionInterrupted())
+        }
+    }
+
+    private func installHandlersIfNeeded() {
+        guard !handlersInstalled else { return }
+        handlersInstalled = true
+        transport.setHandlers(
+            incoming: { event in Task { await self.route(event) } },
+            interrupted: { Task { await self.connectionDropped() } }
+        )
+    }
+
+    private func route(_ event: RuntimeEvent) {
+        switch event {
+        case .progress(let id, _), .log(let id?, _):
+            if let continuation = operations[id] {
+                continuation.yield(event)
+            } else {
+                pendingEvents[id, default: []].append(event)
+            }
+        case .completed(let id), .failed(let id, _):
+            if let continuation = operations.removeValue(forKey: id) {
+                continuation.yield(event)
+                continuation.finish()
+            } else {
+                pendingEvents[id, default: []].append(event)
+            }
+        case .status, .runtimeVersion, .accepted, .log(nil, _):
+            for continuation in operations.values { continuation.yield(event) }
+        }
+    }
+
+    private func connectionDropped() {
+        let pending = operations
+        operations.removeAll()
+        for (id, continuation) in pending {
+            continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
+        }
+    }
+}

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -35,6 +35,12 @@ actor RuntimeClient: RuntimeBackend {
     /// Consumers that went away before their `accepted` reply arrived; the operation is
     /// canceled the moment it is accepted.
     private var abandonedBeforeAccept: Set<ObjectIdentifier> = []
+    /// Operations whose consumer left; their late events are dropped, not kept. Bounded.
+    private var retired: [OperationID] = []
+    /// Keys whose request finished without acceptance (a query reply or a failure), so a
+    /// late `consumerGone` for them is ignored. Bounded like `retired`.
+    private var settled: Set<ObjectIdentifier> = []
+    static let retiredLimit = 256
     private let inbox: AsyncStream<Inbound>
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
@@ -76,7 +82,9 @@ actor RuntimeClient: RuntimeBackend {
                 inboxContinuation.yield(.reply(result, continuation, key))
             }
         } catch {
-            continuation.finish(throwing: RuntimeConnectionInterrupted())
+            // The failure takes the ordered path a reply would, so a `consumerGone` queued
+            // behind this send finds its key settled instead of marking it abandoned forever.
+            inboxContinuation.yield(.reply(.failure(error), continuation, key))
         }
     }
 
@@ -120,6 +128,7 @@ actor RuntimeClient: RuntimeBackend {
                     // it is canceled right away instead of running unobserved.
                     continuation.finish()
                     pendingEvents.removeValue(forKey: id)
+                    retire(id)
                     try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
                     return
                 }
@@ -131,11 +140,32 @@ actor RuntimeClient: RuntimeBackend {
                 }
             case .runtimeVersion, .status, .completed, .failed, .progress, .log:
                 abandonedBeforeAccept.remove(key)
+                settle(key)
                 continuation.finish()
             }
         case .failure:
             abandonedBeforeAccept.remove(key)
+            settle(key)
             continuation.finish(throwing: RuntimeConnectionInterrupted())
+        }
+    }
+
+    private func settle(_ key: ObjectIdentifier) {
+        settled.insert(key)
+        if settled.count > Self.retiredLimit { settled.removeAll() }
+    }
+
+    private func retire(_ id: OperationID) {
+        retired.append(id)
+        if retired.count > Self.retiredLimit { retired.removeFirst(retired.count - Self.retiredLimit) }
+    }
+
+    /// Progress and log traffic may be evicted from a full consumer buffer; the operation's
+    /// `accepted` event never is. If the buffer drops it, it is yielded again at once, so a
+    /// consumer always learns the operation id even behind a flood.
+    private func deliver(_ event: RuntimeEvent, to continuation: Continuation, id: OperationID) {
+        if case .dropped(.accepted) = continuation.yield(event) {
+            continuation.yield(.accepted(id))
         }
     }
 
@@ -143,8 +173,8 @@ actor RuntimeClient: RuntimeBackend {
         switch event {
         case .progress(let id, _), .log(let id?, _):
             if let continuation = operations[id] {
-                continuation.yield(event)
-            } else {
+                deliver(event, to: continuation, id: id)
+            } else if !retired.contains(id) {
                 pendingEvents[id, default: []].append(event)
             }
         case .completed(let id), .failed(let id, _):
@@ -152,7 +182,7 @@ actor RuntimeClient: RuntimeBackend {
                 consumers = consumers.filter { $0.value != id }
                 continuation.yield(event)
                 continuation.finish()
-            } else {
+            } else if !retired.contains(id) {
                 pendingEvents[id, default: []].append(event)
             }
         case .status, .runtimeVersion, .accepted, .log(nil, _):
@@ -162,12 +192,14 @@ actor RuntimeClient: RuntimeBackend {
 
     private func consumerGone(_ key: ObjectIdentifier) {
         guard let id = consumers.removeValue(forKey: key) else {
-            // Not accepted yet (or a query): remembered until the reply says which it was.
-            abandonedBeforeAccept.insert(key)
+            // Already answered (a query or a failed send): nothing to cancel. Otherwise not
+            // accepted yet: remembered until the reply says which it was.
+            if settled.remove(key) == nil { abandonedBeforeAccept.insert(key) }
             return
         }
         guard operations.removeValue(forKey: id) != nil else { return }
         pendingEvents.removeValue(forKey: id)
+        retire(id)
         try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
     }
 

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -1,6 +1,10 @@
 import Foundation
 import GuesthouseCore
 
+/// Identity for one consumer stream, so its termination can be matched to the operation.
+nonisolated final class ContinuationKey: Sendable {
+}
+
 /// The GUI's `RuntimeBackend` over XPC.
 ///
 /// Connects lazily, maps a dropped connection to `RuntimeConnectionInterrupted` so callers
@@ -15,15 +19,19 @@ actor RuntimeClient: RuntimeBackend {
     typealias Continuation = AsyncThrowingStream<RuntimeEvent, any Error>.Continuation
 
     private enum Inbound: Sendable {
-        case reply(Result<RuntimeEvent, any Error>, Continuation)
+        case send(RuntimeRequest, Continuation, ObjectIdentifier)
+        case reply(Result<RuntimeEvent, any Error>, Continuation, ObjectIdentifier)
         case incoming(RuntimeEvent)
         case interrupted
+        case consumerGone(ObjectIdentifier)
     }
 
     private let transport: any RuntimeTransport
     private var operations: [OperationID: Continuation] = [:]
     /// Events that arrived for an operation before its `accepted` reply registered a consumer.
     private var pendingEvents: [OperationID: [RuntimeEvent]] = [:]
+    /// Which accepted operation each consumer stream owns, keyed by the stream's identity.
+    private var consumers: [ObjectIdentifier: OperationID] = [:]
     private let inbox: AsyncStream<Inbound>
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
@@ -33,17 +41,27 @@ actor RuntimeClient: RuntimeBackend {
         (inbox, inboxContinuation) = AsyncStream.makeStream(of: Inbound.self, bufferingPolicy: .unbounded)
     }
 
+    /// Requests are enqueued on the same ordered inbox as every callback, synchronously, so
+    /// two back-to-back sends reach the transport in the order they were made. When the
+    /// consumer stops reading an accepted operation, the client unregisters it and asks the
+    /// runtime to cancel it, so a host mutation never keeps running unobserved.
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
         AsyncThrowingStream { continuation in
-            Task { await self.start(request, continuation) }
+            let key = ContinuationKey()
+            continuation.onTermination = { [inboxContinuation] termination in
+                if case .cancelled = termination {
+                    inboxContinuation.yield(.consumerGone(ObjectIdentifier(key)))
+                }
+            }
+            inboxContinuation.yield(.send(request, continuation, ObjectIdentifier(key)))
+            Task { await self.startIfNeeded() }
         }
     }
 
-    private func start(_ request: RuntimeRequest, _ continuation: Continuation) {
-        startIfNeeded()
+    private func start(_ request: RuntimeRequest, _ continuation: Continuation, key: ObjectIdentifier) {
         do {
             try transport.send(RuntimeRequestEnvelope(request: request)) { [inboxContinuation] result in
-                inboxContinuation.yield(.reply(result, continuation))
+                inboxContinuation.yield(.reply(result, continuation, key))
             }
         } catch {
             continuation.finish(throwing: RuntimeConnectionInterrupted())
@@ -64,14 +82,16 @@ actor RuntimeClient: RuntimeBackend {
     private func drain() async {
         for await item in inbox {
             switch item {
-            case .reply(let result, let continuation): handleReply(result, for: continuation)
+            case .send(let request, let continuation, let key): start(request, continuation, key: key)
+            case .reply(let result, let continuation, let key): handleReply(result, for: continuation, key: key)
             case .incoming(let event): route(event)
             case .interrupted: connectionDropped()
+            case .consumerGone(let continuation): consumerGone(continuation)
             }
         }
     }
 
-    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation) {
+    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation, key: ObjectIdentifier) {
         switch result {
         case .success(let event):
             continuation.yield(event)
@@ -79,6 +99,7 @@ actor RuntimeClient: RuntimeBackend {
             case .accepted(let id):
                 // More events follow through the incoming handler until completed or failed.
                 operations[id] = continuation
+                consumers[key] = id
                 for buffered in pendingEvents.removeValue(forKey: id) ?? [] {
                     route(buffered)
                 }
@@ -100,6 +121,7 @@ actor RuntimeClient: RuntimeBackend {
             }
         case .completed(let id), .failed(let id, _):
             if let continuation = operations.removeValue(forKey: id) {
+                consumers = consumers.filter { $0.value != id }
                 continuation.yield(event)
                 continuation.finish()
             } else {
@@ -110,6 +132,12 @@ actor RuntimeClient: RuntimeBackend {
         }
     }
 
+    private func consumerGone(_ key: ObjectIdentifier) {
+        guard let id = consumers.removeValue(forKey: key), operations.removeValue(forKey: id) != nil else { return }
+        pendingEvents.removeValue(forKey: id)
+        try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
+    }
+
     private func connectionDropped() {
         let pending = operations
         operations.removeAll()
@@ -117,5 +145,6 @@ actor RuntimeClient: RuntimeBackend {
         for (id, continuation) in pending {
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }
+        consumers.removeAll()
     }
 }

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -7,18 +7,30 @@ import GuesthouseCore
 /// treat in-flight work as unknown outcome (MVP-PLAN.md §3), and reconnects on the next
 /// request. Long-running operations stream their events through the transport's incoming
 /// handler and are demultiplexed by `OperationID`.
+///
+/// Every transport callback (reply, pushed event, interruption) is enqueued synchronously on
+/// one ordered inbox and applied by a single task, so callback order is preserved: an
+/// interruption that follows an `accepted` reply always finds the operation registered.
 actor RuntimeClient: RuntimeBackend {
     typealias Continuation = AsyncThrowingStream<RuntimeEvent, any Error>.Continuation
+
+    private enum Inbound: Sendable {
+        case reply(Result<RuntimeEvent, any Error>, Continuation)
+        case incoming(RuntimeEvent)
+        case interrupted
+    }
 
     private let transport: any RuntimeTransport
     private var operations: [OperationID: Continuation] = [:]
     /// Events that arrived for an operation before its `accepted` reply registered a consumer.
-    /// The reply and the pushed events travel on different paths, so either can come first.
     private var pendingEvents: [OperationID: [RuntimeEvent]] = [:]
-    private var handlersInstalled = false
+    private let inbox: AsyncStream<Inbound>
+    private let inboxContinuation: AsyncStream<Inbound>.Continuation
+    private var started = false
 
     init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
         self.transport = transport
+        (inbox, inboxContinuation) = AsyncStream.makeStream(of: Inbound.self, bufferingPolicy: .unbounded)
     }
 
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
@@ -28,13 +40,34 @@ actor RuntimeClient: RuntimeBackend {
     }
 
     private func start(_ request: RuntimeRequest, _ continuation: Continuation) {
-        installHandlersIfNeeded()
+        startIfNeeded()
         do {
-            try transport.send(RuntimeRequestEnvelope(request: request)) { result in
-                Task { await self.handleReply(result, for: continuation) }
+            try transport.send(RuntimeRequestEnvelope(request: request)) { [inboxContinuation] result in
+                inboxContinuation.yield(.reply(result, continuation))
             }
         } catch {
             continuation.finish(throwing: RuntimeConnectionInterrupted())
+        }
+    }
+
+    private func startIfNeeded() {
+        guard !started else { return }
+        started = true
+        let inboxContinuation = inboxContinuation
+        transport.setHandlers(
+            incoming: { event in inboxContinuation.yield(.incoming(event)) },
+            interrupted: { inboxContinuation.yield(.interrupted) }
+        )
+        Task { await self.drain() }
+    }
+
+    private func drain() async {
+        for await item in inbox {
+            switch item {
+            case .reply(let result, let continuation): handleReply(result, for: continuation)
+            case .incoming(let event): route(event)
+            case .interrupted: connectionDropped()
+            }
         }
     }
 
@@ -55,15 +88,6 @@ actor RuntimeClient: RuntimeBackend {
         case .failure:
             continuation.finish(throwing: RuntimeConnectionInterrupted())
         }
-    }
-
-    private func installHandlersIfNeeded() {
-        guard !handlersInstalled else { return }
-        handlersInstalled = true
-        transport.setHandlers(
-            incoming: { event in Task { await self.route(event) } },
-            interrupted: { Task { await self.connectionDropped() } }
-        )
     }
 
     private func route(_ event: RuntimeEvent) {
@@ -89,6 +113,7 @@ actor RuntimeClient: RuntimeBackend {
     private func connectionDropped() {
         let pending = operations
         operations.removeAll()
+        pendingEvents.removeAll()
         for (id, continuation) in pending {
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -32,13 +32,25 @@ actor RuntimeClient: RuntimeBackend {
     private var pendingEvents: [OperationID: [RuntimeEvent]] = [:]
     /// Which accepted operation each consumer stream owns, keyed by the stream's identity.
     private var consumers: [ObjectIdentifier: OperationID] = [:]
+    /// Consumers that went away before their `accepted` reply arrived; the operation is
+    /// canceled the moment it is accepted.
+    private var abandonedBeforeAccept: Set<ObjectIdentifier> = []
     private let inbox: AsyncStream<Inbound>
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
 
+    /// Events buffered for one consumer before it reads them. Progress and log traffic beyond
+    /// this drops the oldest entries; the terminal event is always the newest, so it survives.
+    static let consumerBufferLimit = 1_024
+
     init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
         self.transport = transport
         (inbox, inboxContinuation) = AsyncStream.makeStream(of: Inbound.self, bufferingPolicy: .unbounded)
+    }
+
+    deinit {
+        // Ends the drain loop of a discarded client; it holds no strong reference to self.
+        inboxContinuation.finish()
     }
 
     /// Requests are enqueued on the same ordered inbox as every callback, synchronously, so
@@ -46,7 +58,7 @@ actor RuntimeClient: RuntimeBackend {
     /// consumer stops reading an accepted operation, the client unregisters it and asks the
     /// runtime to cancel it, so a host mutation never keeps running unobserved.
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
-        AsyncThrowingStream { continuation in
+        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(Self.consumerBufferLimit)) { continuation in
             let key = ContinuationKey()
             continuation.onTermination = { [inboxContinuation] termination in
                 if case .cancelled = termination {
@@ -76,18 +88,24 @@ actor RuntimeClient: RuntimeBackend {
             incoming: { event in inboxContinuation.yield(.incoming(event)) },
             interrupted: { inboxContinuation.yield(.interrupted) }
         )
-        Task { await self.drain() }
+        // The loop borrows `self` per item only, so a client nobody holds is released while
+        // the loop waits, and `deinit` then ends the inbox.
+        let inbox = inbox
+        Task { [weak self] in
+            for await item in inbox {
+                guard let self else { return }
+                await self.handle(item)
+            }
+        }
     }
 
-    private func drain() async {
-        for await item in inbox {
-            switch item {
-            case .send(let request, let continuation, let key): start(request, continuation, key: key)
-            case .reply(let result, let continuation, let key): handleReply(result, for: continuation, key: key)
-            case .incoming(let event): route(event)
-            case .interrupted: connectionDropped()
-            case .consumerGone(let continuation): consumerGone(continuation)
-            }
+    private func handle(_ item: Inbound) {
+        switch item {
+        case .send(let request, let continuation, let key): start(request, continuation, key: key)
+        case .reply(let result, let continuation, let key): handleReply(result, for: continuation, key: key)
+        case .incoming(let event): route(event)
+        case .interrupted: connectionDropped()
+        case .consumerGone(let continuation): consumerGone(continuation)
         }
     }
 
@@ -97,6 +115,14 @@ actor RuntimeClient: RuntimeBackend {
             continuation.yield(event)
             switch event {
             case .accepted(let id):
+                if abandonedBeforeAccept.remove(key) != nil {
+                    // The consumer left before acceptance: nobody observes this mutation, so
+                    // it is canceled right away instead of running unobserved.
+                    continuation.finish()
+                    pendingEvents.removeValue(forKey: id)
+                    try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
+                    return
+                }
                 // More events follow through the incoming handler until completed or failed.
                 operations[id] = continuation
                 consumers[key] = id
@@ -104,9 +130,11 @@ actor RuntimeClient: RuntimeBackend {
                     route(buffered)
                 }
             case .runtimeVersion, .status, .completed, .failed, .progress, .log:
+                abandonedBeforeAccept.remove(key)
                 continuation.finish()
             }
         case .failure:
+            abandonedBeforeAccept.remove(key)
             continuation.finish(throwing: RuntimeConnectionInterrupted())
         }
     }
@@ -133,7 +161,12 @@ actor RuntimeClient: RuntimeBackend {
     }
 
     private func consumerGone(_ key: ObjectIdentifier) {
-        guard let id = consumers.removeValue(forKey: key), operations.removeValue(forKey: id) != nil else { return }
+        guard let id = consumers.removeValue(forKey: key) else {
+            // Not accepted yet (or a query): remembered until the reply says which it was.
+            abandonedBeforeAccept.insert(key)
+            return
+        }
+        guard operations.removeValue(forKey: id) != nil else { return }
         pendingEvents.removeValue(forKey: id)
         try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
     }

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -7,6 +7,35 @@ nonisolated final class ContinuationKey: Hashable, Sendable {
     func hash(into hasher: inout Hasher) { hasher.combine(ObjectIdentifier(self)) }
 }
 
+/// How much droppable traffic the client's inbox is holding.
+///
+/// The limits that protect a consumer's stream apply only once an event has been dequeued, so
+/// without a bound here output the service produces faster than the actor drains it would grow
+/// the app's memory without limit and delay replies, cancellation and interruption behind it.
+/// Control events are never counted and never refused: they have to stay ordered.
+nonisolated final class TrafficMeter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var queued = 0
+    private let limit: Int
+
+    init(limit: Int) { self.limit = limit }
+
+    /// Takes a slot for one droppable event, or refuses it when the inbox already holds the
+    /// limit. The event is dropped at ingress rather than after it has cost memory.
+    func admit() -> Bool {
+        lock.withLock {
+            guard queued < limit else { return false }
+            queued += 1
+            return true
+        }
+    }
+
+    /// Returns the slot of an event the client has finished routing.
+    func release() { lock.withLock { queued -= 1 } }
+
+    var queuedCount: Int { lock.withLock { queued } }
+}
+
 /// The GUI's `RuntimeBackend` over XPC.
 ///
 /// Connects lazily, maps a dropped connection to `RuntimeConnectionInterrupted` so callers
@@ -22,7 +51,9 @@ actor RuntimeClient: RuntimeBackend {
 
     private enum Inbound: Sendable {
         case send(RuntimeRequest, Continuation, ContinuationKey)
-        case reply(Result<RuntimeEvent, any Error>, Continuation, ContinuationKey)
+        /// `mutating` records whether the request changes host state, which decides what an
+        /// interruption before acceptance may offer the user.
+        case reply(Result<RuntimeEvent, any Error>, Continuation, ContinuationKey, mutating: Bool)
         case incoming(RuntimeEvent)
         case interrupted
         case consumerGone(ContinuationKey)
@@ -50,6 +81,18 @@ actor RuntimeClient: RuntimeBackend {
     /// Buffered events per operation that has not been accepted yet, bounded so a runtime
     /// that streams before its reply cannot grow this without limit.
     static let pendingEventLimit = 256
+    /// How many operations may hold such a buffer at once.
+    ///
+    /// Each bucket is only ever justified by a request that has not been answered yet, since
+    /// that is the only thing an acceptance can follow; the per-id cap above says nothing
+    /// about how many ids there are, and terminal events are never refused at ingress. Without
+    /// this a service streaming events for ids nothing asked for would grow the dictionary
+    /// itself. It is far above the operations one app runs at a time (MVP-PLAN.md §6,
+    /// "Concurrency"), so an honest runtime never reaches it.
+    static let pendingOperationLimit = 64
+    /// Requests sent and not yet answered. An `accepted` can only ever come from one of these,
+    /// so while there are none, an event naming an unknown operation belongs to nothing.
+    private var awaitingReply = 0
     private let inbox: AsyncStream<Inbound>
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
@@ -64,9 +107,24 @@ actor RuntimeClient: RuntimeBackend {
     /// the only report of how much room a consumer has left, so without this probe a consumer
     /// that fell behind once would never receive traffic again for the rest of the operation.
     static let trafficProbeInterval = 64
+    /// Slots of the buffer only an event that ends the stream may occupy. Every other yield
+    /// stops here — traffic, the probes that measure the room left, and status snapshots
+    /// alike — so the terminal event a consumer waits for always finds a slot, however far
+    /// behind that consumer is. It is a few slots rather than one because the `accepted`
+    /// event is yielded before the stream is tracked, so the recorded room can briefly
+    /// overstate the real room by that much.
+    static let terminalReserve = 4
+    /// How much droppable traffic the inbox holds before further traffic is refused at
+    /// ingress. Large enough that a consumer reading in real time never notices it.
+    static let inboxTrafficLimit = 4_096
     /// Room left in each consumer's stream, as of its last yield.
     private var consumerRoom: [OperationID: Int] = [:]
     private var droppedSinceProbe: [OperationID: Int] = [:]
+    private let traffic = TrafficMeter(limit: RuntimeClient.inboxTrafficLimit)
+
+    /// How much droppable traffic is waiting in the inbox. Test seam; readable without the
+    /// actor, so it can be sampled while the actor is busy routing.
+    nonisolated var inboxTrafficCount: Int { traffic.queuedCount }
 
     init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
         self.transport = transport
@@ -107,14 +165,19 @@ actor RuntimeClient: RuntimeBackend {
     }
 
     private func start(_ request: RuntimeRequest, _ continuation: Continuation, key: ContinuationKey) {
+        // Whether the request changes the host travels with its reply: once the reply fails
+        // there is no operation id to say so, and a mutating request that may already have
+        // reached the service must never be offered a blind retry.
+        let mutating = request.mutatesHost
+        awaitingReply += 1
         do {
             try transport.send(RuntimeRequestEnvelope(request: request)) { [inboxContinuation] result in
-                inboxContinuation.yield(.reply(result, continuation, key))
+                inboxContinuation.yield(.reply(result, continuation, key, mutating: mutating))
             }
         } catch {
             // The failure takes the ordered path a reply would, so a `consumerGone` queued
             // behind this send finds its key settled instead of marking it abandoned forever.
-            inboxContinuation.yield(.reply(.failure(error), continuation, key))
+            inboxContinuation.yield(.reply(.failure(error), continuation, key, mutating: mutating))
         }
     }
 
@@ -122,8 +185,16 @@ actor RuntimeClient: RuntimeBackend {
         guard !started else { return }
         started = true
         let inboxContinuation = inboxContinuation
+        let traffic = traffic
         transport.setHandlers(
-            incoming: { event in inboxContinuation.yield(.incoming(event)) },
+            // Traffic is bounded where it is enqueued, not only where it is delivered: a
+            // service producing output faster than the actor drains it loses the excess here
+            // instead of growing the inbox. Control events are always admitted, so acceptance,
+            // the terminal event and an interruption keep their order.
+            incoming: { event in
+                guard !event.isDroppableTraffic || traffic.admit() else { return }
+                inboxContinuation.yield(.incoming(event))
+            },
             interrupted: { inboxContinuation.yield(.interrupted) }
         )
         // The loop borrows `self` per item only, so a client nobody holds is released while
@@ -144,15 +215,24 @@ actor RuntimeClient: RuntimeBackend {
     private func handle(_ item: Inbound) {
         switch item {
         case .send(let request, let continuation, let key): start(request, continuation, key: key)
-        case .reply(let result, let continuation, let key): handleReply(result, for: continuation, key: key)
-        case .incoming(let event): route(event)
+        case .reply(let result, let continuation, let key, let mutating):
+            handleReply(result, for: continuation, key: key, mutating: mutating)
+        case .incoming(let event):
+            route(event)
+            // The slot this event took at ingress is returned once it has been routed, so the
+            // bound tracks what the client is actually holding.
+            if event.isDroppableTraffic { traffic.release() }
         case .interrupted: connectionDropped()
         case .consumerGone(let key): consumerGone(key)
         case .streamFinished(let key): streamFinished(key)
         }
     }
 
-    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation, key: ContinuationKey) {
+    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation, key: ContinuationKey, mutating: Bool) {
+        // Exactly one reply arrives per request, whether the transport answered it or refused
+        // the send outright. `max` keeps the count meaningful if a session is ever lost
+        // without delivering one: the bound may loosen, never invert.
+        awaitingReply = max(0, awaitingReply - 1)
         switch result {
         case .success(let event):
             continuation.yield(event)
@@ -174,27 +254,44 @@ actor RuntimeClient: RuntimeBackend {
                     route(buffered)
                 }
             case .runtimeVersion, .status, .completed, .failed, .progress, .log:
-                abandonedBeforeAccept.remove(key)
                 settle(key)
                 continuation.finish()
             }
         case .failure:
-            abandonedBeforeAccept.remove(key)
             settle(key)
-            continuation.finish(throwing: RuntimeConnectionInterrupted())
+            // No operation id: the request was never accepted. A read-only query changed
+            // nothing and may simply be asked again, but a mutating request may already have
+            // reached the service and been journaled or started, so its outcome is unknown
+            // and the user is sent to inspect state rather than offered a retry.
+            continuation.finish(throwing: RuntimeConnectionInterrupted(mayHaveMutated: mutating))
         }
     }
 
     /// How many events are held for an operation that has not been accepted. Test seam.
     func pendingEventCount(for id: OperationID) -> Int { pendingEvents[id]?.count ?? 0 }
 
+    /// How many operations hold such a buffer. Test seam.
+    func pendingOperationCount() -> Int { pendingEvents.count }
+
     /// How many finished requests are still held against a cancellation race. Test seam.
     func settledKeyCount() -> Int { settled.count }
+
+    /// How many consumers left before their request was accepted. Test seam.
+    func abandonedKeyCount() -> Int { abandonedBeforeAccept.count }
 
     /// Whether an operation has ended, so nothing more will be delivered for it. Test seam.
     func isRetired(_ id: OperationID) -> Bool { retired.contains(id) }
 
+    /// Remembers a key whose request was answered without acceptance, so a cancellation still
+    /// racing that reply is recognised instead of being mistaken for an operation that was
+    /// never accepted.
+    ///
+    /// A key whose stream has already terminated is not remembered: its `consumerGone` has
+    /// been handled, nothing further will arrive for it, and `finish` on an ended continuation
+    /// produces no second termination to release it. Remembering it would hold one key per
+    /// canceled request for the life of the client.
     private func settle(_ key: ContinuationKey) {
+        guard abandonedBeforeAccept.remove(key) == nil else { return }
         settled.insert(key)
     }
 
@@ -214,6 +311,17 @@ actor RuntimeClient: RuntimeBackend {
         droppedSinceProbe.removeValue(forKey: id)
     }
 
+    /// Releases the consumer keys of an operation that has ended. They become settled rather
+    /// than forgotten, so a cancellation that was already racing the operation's last event is
+    /// recognised as arriving after the fact; a forgotten key would instead be remembered as
+    /// an acceptance that never came, and nothing would ever release it.
+    private func retireConsumers(of id: OperationID) {
+        for key in consumers.filter({ $0.value == id }).keys {
+            consumers.removeValue(forKey: key)
+            settled.insert(key)
+        }
+    }
+
     /// Droppable traffic: progress and log lines. It is delivered while the consumer's stream
     /// has room beyond the reserve, so the control events (`accepted` and the terminal event)
     /// can never be crowded out or reordered behind traffic nobody is reading. The room is
@@ -230,6 +338,20 @@ actor RuntimeClient: RuntimeBackend {
             // again without displacing anything already queued.
             droppedSinceProbe[id] = 0
         }
+        yieldNonTerminal(event, to: continuation, id: id)
+    }
+
+    /// Yields an event that does not end the stream, and only while the room left is beyond
+    /// the slots kept for one that does.
+    ///
+    /// A probe occupies a slot of the buffer like any other yield, so without this floor a
+    /// consumer that stops reading has its whole control reserve consumed by probes and status
+    /// snapshots; the terminal event is then refused by the full buffer and its stream ends
+    /// with no result at all. The recorded room can only be stale in the safe direction — a
+    /// consumer that reads leaves more room, never less — so room above the floor means the
+    /// terminal yield is certain to find a slot.
+    private func yieldNonTerminal(_ event: RuntimeEvent, to continuation: Continuation, id: OperationID) {
+        guard consumerRoom[id, default: Self.consumerBufferLimit] > Self.terminalReserve else { return }
         yieldTracking(event, to: continuation, id: id)
     }
 
@@ -253,7 +375,7 @@ actor RuntimeClient: RuntimeBackend {
             }
         case .completed(let id), .failed(let id, _):
             if let continuation = operations.removeValue(forKey: id) {
-                consumers = consumers.filter { $0.value != id }
+                retireConsumers(of: id)
                 continuation.yield(event)
                 continuation.finish()
                 // The operation is over: anything that arrives for it afterwards is dropped
@@ -262,8 +384,28 @@ actor RuntimeClient: RuntimeBackend {
             } else if !retired.contains(id) {
                 append(event, for: id)
             }
-        case .status, .runtimeVersion, .accepted:
-            for (id, continuation) in operations { yieldTracking(event, to: continuation, id: id) }
+        case .status(let status):
+            // A snapshot that names the operation it belongs to is that operation's event:
+            // each stream carries the events of its own request (`RuntimeBackend.send`), and
+            // one that arrives before the `accepted` reply waits in the same bounded buffer
+            // the operation's progress does instead of being lost. A snapshot that names no
+            // operation describes the environment rather than any one request, so it still
+            // reaches every stream.
+            //
+            // Either way a snapshot is superseded by the next one, so it takes the bounded
+            // delivery path: a consumer that is not reading loses snapshots rather than the
+            // room its terminal event needs.
+            if let owner = status.inFlightOperation {
+                if let continuation = operations[owner] {
+                    deliver(event, to: continuation, id: owner)
+                } else if !retired.contains(owner) {
+                    append(event, for: owner)
+                }
+            } else {
+                for (id, continuation) in operations { deliver(event, to: continuation, id: id) }
+            }
+        case .runtimeVersion, .accepted:
+            for (id, continuation) in operations { yieldNonTerminal(event, to: continuation, id: id) }
         case .log(nil, _):
             // Unscoped guest output is droppable traffic for every operation, not a control
             // event: it takes the bounded path too, so high-volume output cannot accumulate
@@ -272,8 +414,15 @@ actor RuntimeClient: RuntimeBackend {
         }
     }
 
-    /// Buffers an event for an operation that has not been accepted yet, bounded.
+    /// Buffers an event for an operation that has not been accepted yet, bounded per operation
+    /// and in the number of operations.
     private func append(_ event: RuntimeEvent, for id: OperationID) {
+        if pendingEvents[id] == nil {
+            // Nothing can ever accept this id unless a request is still unanswered, and only
+            // so many buffers are worth holding even then, so a stream of ids the app never
+            // asked for is dropped here instead of taking a buffer of its own.
+            guard awaitingReply > 0, pendingEvents.count < Self.pendingOperationLimit else { return }
+        }
         var events = pendingEvents[id] ?? []
         if events.count >= Self.pendingEventLimit {
             // The terminal event is what ends the consumer's stream: dropping it would leave
@@ -305,10 +454,14 @@ actor RuntimeClient: RuntimeBackend {
         pendingEvents.removeAll()
         consumerRoom.removeAll()
         droppedSinceProbe.removeAll()
+        // Every id these hold belonged to the session that just ended, and the registry
+        // already refuses that session's callbacks, so nothing can still arrive for them.
+        // Keeping them would hold one id per operation for the rest of the app's life.
+        retired.removeAll()
         for (id, continuation) in pending {
+            retireConsumers(of: id)
             continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
         }
-        consumers.removeAll()
     }
 }
 
@@ -319,6 +472,16 @@ nonisolated extension RuntimeEvent {
         switch self {
         case .completed, .failed: true
         case .runtimeVersion, .accepted, .progress, .log, .status: false
+        }
+    }
+
+    /// Detail the client may drop. Only `accepted` and the terminal events say what happened
+    /// to an operation; progress, log lines and status snapshots are what a consumer that has
+    /// fallen behind loses first, so they are also what the inbox refuses when it is full.
+    fileprivate var isDroppableTraffic: Bool {
+        switch self {
+        case .progress, .log, .status: true
+        case .runtimeVersion, .accepted, .completed, .failed: false
         }
     }
 }

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -2,7 +2,9 @@ import Foundation
 import GuesthouseCore
 
 /// Identity for one consumer stream, so its termination can be matched to the operation.
-nonisolated final class ContinuationKey: Sendable {
+nonisolated final class ContinuationKey: Hashable, Sendable {
+    static func == (lhs: ContinuationKey, rhs: ContinuationKey) -> Bool { lhs === rhs }
+    func hash(into hasher: inout Hasher) { hasher.combine(ObjectIdentifier(self)) }
 }
 
 /// The GUI's `RuntimeBackend` over XPC.
@@ -19,35 +21,42 @@ actor RuntimeClient: RuntimeBackend {
     typealias Continuation = AsyncThrowingStream<RuntimeEvent, any Error>.Continuation
 
     private enum Inbound: Sendable {
-        case send(RuntimeRequest, Continuation, ObjectIdentifier)
-        case reply(Result<RuntimeEvent, any Error>, Continuation, ObjectIdentifier)
+        case send(RuntimeRequest, Continuation, ContinuationKey)
+        case reply(Result<RuntimeEvent, any Error>, Continuation, ContinuationKey)
         case incoming(RuntimeEvent)
         case interrupted
-        case consumerGone(ObjectIdentifier)
+        case consumerGone(ContinuationKey)
     }
 
     private let transport: any RuntimeTransport
     private var operations: [OperationID: Continuation] = [:]
     /// Events that arrived for an operation before its `accepted` reply registered a consumer.
     private var pendingEvents: [OperationID: [RuntimeEvent]] = [:]
-    /// Which accepted operation each consumer stream owns, keyed by the stream's identity.
-    private var consumers: [ObjectIdentifier: OperationID] = [:]
+    /// Which accepted operation each consumer stream owns. The key object itself is held, so
+    /// an address freed and reused by a later stream can never be mistaken for this one.
+    private var consumers: [ContinuationKey: OperationID] = [:]
     /// Consumers that went away before their `accepted` reply arrived; the operation is
     /// canceled the moment it is accepted.
-    private var abandonedBeforeAccept: Set<ObjectIdentifier> = []
-    /// Operations whose consumer left; their late events are dropped, not kept. Bounded.
-    private var retired: [OperationID] = []
+    private var abandonedBeforeAccept: Set<ContinuationKey> = []
+    /// Operations that have ended or whose consumer left: their late events are dropped, not
+    /// kept. Held for the session, since an id is small and a forgotten one would let late
+    /// guest output accumulate again.
+    private var retired: Set<OperationID> = []
     /// Keys whose request finished without acceptance (a query reply or a failure), so a
-    /// late `consumerGone` for them is ignored. Bounded like `retired`.
-    private var settled: Set<ObjectIdentifier> = []
-    static let retiredLimit = 256
+    /// late `consumerGone` for them is ignored.
+    private var settled: Set<ContinuationKey> = []
+    /// Buffered events per operation that has not been accepted yet, bounded so a runtime
+    /// that streams before its reply cannot grow this without limit.
+    static let pendingEventLimit = 256
     private let inbox: AsyncStream<Inbound>
     private let inboxContinuation: AsyncStream<Inbound>.Continuation
     private var started = false
 
-    /// Events buffered for one consumer before it reads them. Progress and log traffic beyond
-    /// this drops the oldest entries; the terminal event is always the newest, so it survives.
+    /// Progress and log events held for one consumer that is not reading. The client drops
+    /// its own excess rather than letting the stream evict, so control events (`accepted` and
+    /// the terminal event) are never lost and never reordered behind droppable traffic.
     static let consumerBufferLimit = 1_024
+    private var bufferedTraffic: [OperationID: Int] = [:]
 
     init(transport: any RuntimeTransport = XPCRuntimeTransport()) {
         self.transport = transport
@@ -64,19 +73,24 @@ actor RuntimeClient: RuntimeBackend {
     /// consumer stops reading an accepted operation, the client unregisters it and asks the
     /// runtime to cancel it, so a host mutation never keeps running unobserved.
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
-        AsyncThrowingStream(bufferingPolicy: .bufferingNewest(Self.consumerBufferLimit)) { continuation in
+        AsyncThrowingStream(bufferingPolicy: .unbounded) { continuation in
             let key = ContinuationKey()
+            // The termination closure holds the client, so a caller that keeps only the
+            // stream still has a producer: the client is released when the stream ends.
+            let owner = self
             continuation.onTermination = { [inboxContinuation] termination in
-                if case .cancelled = termination {
-                    inboxContinuation.yield(.consumerGone(ObjectIdentifier(key)))
+                withExtendedLifetime(owner) {
+                    if case .cancelled = termination {
+                        inboxContinuation.yield(.consumerGone(key))
+                    }
                 }
             }
-            inboxContinuation.yield(.send(request, continuation, ObjectIdentifier(key)))
+            inboxContinuation.yield(.send(request, continuation, key))
             Task { await self.startIfNeeded() }
         }
     }
 
-    private func start(_ request: RuntimeRequest, _ continuation: Continuation, key: ObjectIdentifier) {
+    private func start(_ request: RuntimeRequest, _ continuation: Continuation, key: ContinuationKey) {
         do {
             try transport.send(RuntimeRequestEnvelope(request: request)) { [inboxContinuation] result in
                 inboxContinuation.yield(.reply(result, continuation, key))
@@ -98,6 +112,10 @@ actor RuntimeClient: RuntimeBackend {
         )
         // The loop borrows `self` per item only, so a client nobody holds is released while
         // the loop waits, and `deinit` then ends the inbox.
+        // The loop borrows the client per item only, so a client with no live streams is
+        // released while the loop waits and `deinit` then ends the inbox. A live stream keeps
+        // the client alive on its own (see `send`), so an accepted operation always has a
+        // producer to finish it.
         let inbox = inbox
         Task { [weak self] in
             for await item in inbox {
@@ -117,7 +135,7 @@ actor RuntimeClient: RuntimeBackend {
         }
     }
 
-    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation, key: ObjectIdentifier) {
+    private func handleReply(_ result: Result<RuntimeEvent, any Error>, for continuation: Continuation, key: ContinuationKey) {
         switch result {
         case .success(let event):
             continuation.yield(event)
@@ -150,23 +168,27 @@ actor RuntimeClient: RuntimeBackend {
         }
     }
 
-    private func settle(_ key: ObjectIdentifier) {
+    /// How many events are held for an operation that has not been accepted. Test seam.
+    func pendingEventCount(for id: OperationID) -> Int { pendingEvents[id]?.count ?? 0 }
+
+    private func settle(_ key: ContinuationKey) {
         settled.insert(key)
-        if settled.count > Self.retiredLimit { settled.removeAll() }
     }
 
     private func retire(_ id: OperationID) {
-        retired.append(id)
-        if retired.count > Self.retiredLimit { retired.removeFirst(retired.count - Self.retiredLimit) }
+        retired.insert(id)
+        pendingEvents.removeValue(forKey: id)
+        bufferedTraffic.removeValue(forKey: id)
     }
 
-    /// Progress and log traffic may be evicted from a full consumer buffer; the operation's
-    /// `accepted` event never is. If the buffer drops it, it is yielded again at once, so a
-    /// consumer always learns the operation id even behind a flood.
+    /// Droppable traffic. The stream itself buffers without limit, so the control events
+    /// (`accepted` and the terminal event) can never be evicted or reordered; the excess that
+    /// a consumer is not reading is dropped here instead, and counted.
     private func deliver(_ event: RuntimeEvent, to continuation: Continuation, id: OperationID) {
-        if case .dropped(.accepted) = continuation.yield(event) {
-            continuation.yield(.accepted(id))
-        }
+        let buffered = bufferedTraffic[id, default: 0]
+        guard buffered < Self.consumerBufferLimit else { return }
+        bufferedTraffic[id] = buffered + 1
+        continuation.yield(event)
     }
 
     private func route(_ event: RuntimeEvent) {
@@ -175,22 +197,33 @@ actor RuntimeClient: RuntimeBackend {
             if let continuation = operations[id] {
                 deliver(event, to: continuation, id: id)
             } else if !retired.contains(id) {
-                pendingEvents[id, default: []].append(event)
+                append(event, for: id)
             }
         case .completed(let id), .failed(let id, _):
             if let continuation = operations.removeValue(forKey: id) {
                 consumers = consumers.filter { $0.value != id }
                 continuation.yield(event)
                 continuation.finish()
+                // The operation is over: anything that arrives for it afterwards is dropped
+                // rather than buffered for an acceptance that will never come again.
+                retire(id)
             } else if !retired.contains(id) {
-                pendingEvents[id, default: []].append(event)
+                append(event, for: id)
             }
         case .status, .runtimeVersion, .accepted, .log(nil, _):
             for continuation in operations.values { continuation.yield(event) }
         }
     }
 
-    private func consumerGone(_ key: ObjectIdentifier) {
+    /// Buffers an event for an operation that has not been accepted yet, bounded.
+    private func append(_ event: RuntimeEvent, for id: OperationID) {
+        var events = pendingEvents[id] ?? []
+        guard events.count < Self.pendingEventLimit else { return }
+        events.append(event)
+        pendingEvents[id] = events
+    }
+
+    private func consumerGone(_ key: ContinuationKey) {
         guard let id = consumers.removeValue(forKey: key) else {
             // Already answered (a query or a failed send): nothing to cancel. Otherwise not
             // accepted yet: remembered until the reply says which it was.

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -39,8 +39,11 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     private func activeSession() throws -> XPCSession {
         try lock.withLock {
             if let session { return session }
+            // Created inactive: the session is activated once below. Creating it active and
+            // activating again is an XPC API misuse that traps on first use.
             let created = try XPCSession(
                 xpcService: Self.serviceName,
+                options: .inactive,
                 incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
                     guard let self else { return nil }
                     if let event = try? message.decode(as: RuntimeEvent.self) {

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -13,10 +13,24 @@ nonisolated protocol RuntimeTransport: Sendable {
     func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void)
 }
 
+/// What the transport needs of one connection to the service, so the rules around it — lazy
+/// reconnect, gated replies, retiring a session that refuses work — can be exercised without a
+/// live XPC connection.
+nonisolated protocol RuntimeSessionHandle: AnyObject, Sendable {
+    func sendEnvelope(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws
+    func cancel(reason: String)
+}
+
+nonisolated extension XPCSession: RuntimeSessionHandle {
+    func sendEnvelope(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        try send(envelope, replyHandler: reply)
+    }
+}
+
 /// Which session the transport is talking to and what its callbacks may reach. Sessions are
 /// numbered, so a callback of a session that has been retired never touches its replacement.
 /// Generic over the session type, so those rules can be tested without a live XPC connection.
-nonisolated final class SessionRegistry<Session: AnyObject>: @unchecked Sendable {
+nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     private let lock = NSLock()
     private var session: Session?
     private var generation = 0
@@ -43,14 +57,23 @@ nonisolated final class SessionRegistry<Session: AnyObject>: @unchecked Sendable
         }
     }
 
-    /// Whether `generation` is still the session the client is talking to.
-    func isLive(_ generation: Int) -> Bool { lock.withLock { self.generation == generation } }
-
-    /// The result of a send, or an interruption when the session that carried it has been
-    /// retired. A late `accepted` from a dead session would otherwise register an operation
-    /// nothing can ever end, so the outcome is reported as unknown instead.
-    func gate(_ result: Result<RuntimeEvent, any Error>, from generation: Int) -> Result<RuntimeEvent, any Error> {
-        isLive(generation) ? result : .failure(RuntimeConnectionInterrupted())
+    /// Delivers the result of a send, or an interruption when the session that carried it has
+    /// been retired. A late `accepted` from a dead session would otherwise register an
+    /// operation nothing can ever end, so the outcome is reported as unknown instead.
+    ///
+    /// The check and the delivery are one step under the lock, exactly as a pushed event is.
+    /// A retirement racing this call therefore happens either entirely before it, and the
+    /// reply is reported as an interruption, or entirely after it, so the interruption can
+    /// never be queued ahead of a reply that was gated as live. `reply` only enqueues on the
+    /// client's unbounded inbox, so nothing waits while the lock is held.
+    func deliverReply(
+        _ result: Result<RuntimeEvent, any Error>,
+        from generation: Int,
+        to reply: @Sendable (Result<RuntimeEvent, any Error>) -> Void
+    ) {
+        lock.withLock {
+            reply(self.generation == generation ? result : .failure(RuntimeConnectionInterrupted()))
+        }
     }
 
     /// Delivers a pushed event, but only while its session is live. The handler runs under the
@@ -65,16 +88,22 @@ nonisolated final class SessionRegistry<Session: AnyObject>: @unchecked Sendable
         }
     }
 
-    /// Retires `generation`, handing back the session to cancel and the handler that reports
-    /// the interruption. Both are `nil` when that generation was already retired, so a failure
-    /// and the cancellation that follows it are reported once.
-    func retire(_ generation: Int) -> (session: Session?, interrupted: (@Sendable () -> Void)?) {
+    /// Retires `generation` and reports the interruption before the lock is released, handing
+    /// back the session to cancel.
+    ///
+    /// The report happens under the lock because a replacement session can only be made by
+    /// taking that same lock: the interruption is therefore always enqueued ahead of anything
+    /// the replacement carries, and can never fail an operation that belongs to it. Nothing
+    /// is reported and no session is returned when that generation was already retired, so a
+    /// failure and the cancellation that follows it are reported once.
+    func retire(_ generation: Int) -> Session? {
         lock.withLock {
-            guard self.generation == generation else { return (nil, nil) }
+            guard self.generation == generation else { return nil }
             self.generation += 1
             let doomed = session
             session = nil
-            return (doomed, interrupted)
+            interrupted?()
+            return doomed
         }
     }
 }
@@ -83,7 +112,20 @@ nonisolated final class SessionRegistry<Session: AnyObject>: @unchecked Sendable
 nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendable {
     static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
 
-    private let registry = SessionRegistry<XPCSession>()
+    /// Opens one connection to the service. `incoming` takes a pushed event; `dropped` reports
+    /// that this connection is gone, carrying the reason to cancel it for, or `nil` when it has
+    /// already been cancelled. Injected so the transport's rules can be tested without XPC.
+    typealias Connect = @Sendable (
+        _ incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+        _ dropped: @escaping @Sendable (String?) -> Void
+    ) throws -> any RuntimeSessionHandle
+
+    private let registry = SessionRegistry<any RuntimeSessionHandle>()
+    private let connect: Connect
+
+    init(connect: @escaping Connect = XPCRuntimeTransport.connectToService) {
+        self.connect = connect
+    }
 
     func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
         registry.setHandlers(incoming: incoming, interrupted: interrupted)
@@ -91,51 +133,76 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
 
     func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
         let (session, generation) = try activeSession()
-        try session.send(envelope) { [weak self] (result: Result<RuntimeEvent, any Error>) in
-            // A completed send races its own session's cancellation, so the reply is gated on
-            // the generation it was sent from, exactly as a pushed event is.
-            guard let self else {
-                reply(.failure(RuntimeConnectionInterrupted()))
-                return
+        do {
+            try session.sendEnvelope(envelope) { [weak self] (result: Result<RuntimeEvent, any Error>) in
+                // A completed send races its own session's cancellation, so the reply is gated
+                // on the generation it was sent from, exactly as a pushed event is.
+                guard let self else {
+                    reply(.failure(RuntimeConnectionInterrupted()))
+                    return
+                }
+                // A failed reply is the session saying it produced no answer: the connection
+                // was interrupted, or the peer sent something this contract cannot decode. The
+                // session is retired here rather than left to a cancellation handler, which a
+                // decoding failure never triggers, so the next request reconnects instead of
+                // being handed the same dead session. Retiring first also orders the
+                // interruption ahead of this reply, so the operations that shared the session
+                // are told their outcome is unknown before it is delivered.
+                if case .failure = result { self.dropSession(generation: generation, reason: "reply failed") }
+                self.registry.deliverReply(result, from: generation, to: reply)
             }
-            reply(self.registry.gate(result, from: generation))
+        } catch {
+            // The session refused the send, so it is unusable: it is retired here instead of
+            // waiting for its cancellation handler, so the next request performs the
+            // documented lazy reconnect rather than being handed the same dead session.
+            // Retirement reports the interruption once, so a handler that follows adds nothing.
+            dropSession(generation: generation, reason: "send failed")
+            throw error
         }
     }
 
-    private func activeSession() throws -> (session: XPCSession, generation: Int) {
+    private func activeSession() throws -> (session: any RuntimeSessionHandle, generation: Int) {
         try registry.session { generation in
-            // Created inactive: the session is activated once below. Creating it active and
-            // activating again is an XPC API misuse that traps on first use.
-            let created = try XPCSession(
-                xpcService: Self.serviceName,
-                options: .inactive,
-                incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
-                    guard let self else { return nil }
-                    if let event = try? message.decode(as: RuntimeEvent.self) {
-                        self.registry.deliverIncoming(event, from: generation)
-                    } else {
-                        // An undecodable push means a contract mismatch: treat it as a lost
-                        // connection so waiting operations report an unknown outcome.
-                        self.dropSession(generation: generation, reason: "undecodable event")
-                    }
-                    return nil
-                },
-                cancellationHandler: { [weak self] _ in
-                    self?.dropSession(generation: generation, reason: nil)
-                }
+            try connect(
+                { [weak self] event in self?.registry.deliverIncoming(event, from: generation) },
+                { [weak self] reason in self?.dropSession(generation: generation, reason: reason) }
             )
-            try created.activate()
-            return created
         }
+    }
+
+    /// The real connection to the embedded service.
+    static func connectToService(
+        incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+        dropped: @escaping @Sendable (String?) -> Void
+    ) throws -> any RuntimeSessionHandle {
+        // Created inactive: the session is activated once below. Creating it active and
+        // activating again is an XPC API misuse that traps on first use.
+        let created = try XPCSession(
+            xpcService: serviceName,
+            options: .inactive,
+            incomingMessageHandler: { (message: XPCReceivedMessage) -> (any Encodable)? in
+                if let event = try? message.decode(as: RuntimeEvent.self) {
+                    incoming(event)
+                } else {
+                    // An undecodable push means a contract mismatch: treat it as a lost
+                    // connection so waiting operations report an unknown outcome.
+                    dropped("undecodable event")
+                }
+                return nil
+            },
+            cancellationHandler: { _ in dropped(nil) }
+        )
+        try created.activate()
+        return created
     }
 
     /// Clears the session and reports an interruption only if the session that failed is
     /// still the current one.
     private func dropSession(generation: Int, reason: String?) {
-        // The generation is retired before the session is canceled, so the cancellation
-        // handler that follows reports nothing a second time.
-        let (doomed, handler) = registry.retire(generation)
+        // The generation is retired and the interruption reported while the registry is
+        // locked, so no replacement session can carry a request past that report. The
+        // cancellation runs afterwards, outside the lock, because it calls this method back.
+        let doomed = registry.retire(generation)
         if let doomed, let reason { doomed.cancel(reason: reason) }
-        handler?()
     }
 }

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -7,8 +7,9 @@ import XPC
 nonisolated protocol RuntimeTransport: Sendable {
     /// Sends one envelope and delivers exactly one reply or an error.
     func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws
-    /// Called when the connection drops. Pushed events (progress, log, status) also arrive here
-    /// once the service streams them (#25).
+    /// Pushed events (progress, log, status) arrive through `incoming`; `interrupted` is called
+    /// when the connection drops or when a pushed message cannot be decoded, which means the
+    /// peer speaks a different contract and every in-flight outcome is unknown.
     func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void)
 }
 
@@ -41,8 +42,19 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
             let created = try XPCSession(
                 xpcService: Self.serviceName,
                 incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
-                    guard let self, let event = try? message.decode(as: RuntimeEvent.self) else { return nil }
-                    self.lock.withLock { self.incoming }?(event)
+                    guard let self else { return nil }
+                    if let event = try? message.decode(as: RuntimeEvent.self) {
+                        self.lock.withLock { self.incoming }?(event)
+                    } else {
+                        // An undecodable push means a contract mismatch: treat it as a lost
+                        // connection so waiting operations report an unknown outcome.
+                        let handler = self.lock.withLock { () -> (@Sendable () -> Void)? in
+                            self.session?.cancel(reason: "undecodable event")
+                            self.session = nil
+                            return self.interrupted
+                        }
+                        handler?()
+                    }
                     return nil
                 },
                 cancellationHandler: { [weak self] _ in

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -52,7 +52,11 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
                 incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
                     guard let self else { return nil }
                     if let event = try? message.decode(as: RuntimeEvent.self) {
-                        self.lock.withLock { self.incoming }?(event)
+                        // The generation is re-checked under the lock: an event decoded by a
+                        // session that has since been replaced is dropped, never delivered
+                        // into the operations of its replacement.
+                        let handler = self.lock.withLock { self.generation == mine ? self.incoming : nil }
+                        handler?(event)
                     } else {
                         // An undecodable push means a contract mismatch: treat it as a lost
                         // connection so waiting operations report an unknown outcome.

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -73,12 +73,16 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     /// Clears the session and reports an interruption only if the session that failed is
     /// still the current one.
     private func dropSession(generation: Int, reason: String?) {
-        let handler = lock.withLock { () -> (@Sendable () -> Void)? in
-            guard self.generation == generation else { return nil }
-            if let reason { session?.cancel(reason: reason) }
+        // The generation is retired before the session is canceled, so the cancellation
+        // handler that follows reports nothing a second time.
+        let (doomed, handler) = lock.withLock { () -> (XPCSession?, (@Sendable () -> Void)?) in
+            guard self.generation == generation else { return (nil, nil) }
+            self.generation += 1
+            let doomed = session
             session = nil
-            return interrupted
+            return (reason == nil ? nil : doomed, interrupted)
         }
+        if let doomed, let reason { doomed.cancel(reason: reason) }
         handler?()
     }
 }

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -13,14 +13,12 @@ nonisolated protocol RuntimeTransport: Sendable {
     func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void)
 }
 
-/// The real transport over the embedded service.
-nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendable {
-    static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
-
+/// Which session the transport is talking to and what its callbacks may reach. Sessions are
+/// numbered, so a callback of a session that has been retired never touches its replacement.
+/// Generic over the session type, so those rules can be tested without a live XPC connection.
+nonisolated final class SessionRegistry<Session: AnyObject>: @unchecked Sendable {
     private let lock = NSLock()
-    private var session: XPCSession?
-    /// Incremented per session, so a callback from a canceled session never clears its
-    /// replacement or reports a second interruption for it.
+    private var session: Session?
     private var generation = 0
     private var incoming: (@Sendable (RuntimeEvent) -> Void)?
     private var interrupted: (@Sendable () -> Void)?
@@ -32,18 +30,80 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
         }
     }
 
-    func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
-        let session = try activeSession()
-        try session.send(envelope) { (result: Result<RuntimeEvent, any Error>) in
-            reply(result)
+    /// The live session and its generation, creating one with `make` when there is none.
+    /// `make` is given the generation, because a session's callbacks are written before the
+    /// session exists and each one has to name the session it belongs to.
+    func session(_ make: (Int) throws -> Session) rethrows -> (session: Session, generation: Int) {
+        try lock.withLock {
+            if let session { return (session, generation) }
+            generation += 1
+            let created = try make(generation)
+            session = created
+            return (created, generation)
         }
     }
 
-    private func activeSession() throws -> XPCSession {
-        try lock.withLock {
-            if let session { return session }
-            generation += 1
-            let mine = generation
+    /// Whether `generation` is still the session the client is talking to.
+    func isLive(_ generation: Int) -> Bool { lock.withLock { self.generation == generation } }
+
+    /// The result of a send, or an interruption when the session that carried it has been
+    /// retired. A late `accepted` from a dead session would otherwise register an operation
+    /// nothing can ever end, so the outcome is reported as unknown instead.
+    func gate(_ result: Result<RuntimeEvent, any Error>, from generation: Int) -> Result<RuntimeEvent, any Error> {
+        isLive(generation) ? result : .failure(RuntimeConnectionInterrupted())
+    }
+
+    /// Delivers a pushed event, but only while its session is live. The handler runs under the
+    /// lock, so the check and the delivery are one step: a retirement racing this call either
+    /// happens entirely before it, and the event is dropped, or entirely after the event is
+    /// queued behind the operations it belongs to. The handler only enqueues on the client's
+    /// unbounded inbox, so nothing waits while the lock is held.
+    func deliverIncoming(_ event: RuntimeEvent, from generation: Int) {
+        lock.withLock {
+            guard self.generation == generation else { return }
+            incoming?(event)
+        }
+    }
+
+    /// Retires `generation`, handing back the session to cancel and the handler that reports
+    /// the interruption. Both are `nil` when that generation was already retired, so a failure
+    /// and the cancellation that follows it are reported once.
+    func retire(_ generation: Int) -> (session: Session?, interrupted: (@Sendable () -> Void)?) {
+        lock.withLock {
+            guard self.generation == generation else { return (nil, nil) }
+            self.generation += 1
+            let doomed = session
+            session = nil
+            return (doomed, interrupted)
+        }
+    }
+}
+
+/// The real transport over the embedded service.
+nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendable {
+    static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
+
+    private let registry = SessionRegistry<XPCSession>()
+
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+        registry.setHandlers(incoming: incoming, interrupted: interrupted)
+    }
+
+    func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        let (session, generation) = try activeSession()
+        try session.send(envelope) { [weak self] (result: Result<RuntimeEvent, any Error>) in
+            // A completed send races its own session's cancellation, so the reply is gated on
+            // the generation it was sent from, exactly as a pushed event is.
+            guard let self else {
+                reply(.failure(RuntimeConnectionInterrupted()))
+                return
+            }
+            reply(self.registry.gate(result, from: generation))
+        }
+    }
+
+    private func activeSession() throws -> (session: XPCSession, generation: Int) {
+        try registry.session { generation in
             // Created inactive: the session is activated once below. Creating it active and
             // activating again is an XPC API misuse that traps on first use.
             let created = try XPCSession(
@@ -52,24 +112,19 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
                 incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
                     guard let self else { return nil }
                     if let event = try? message.decode(as: RuntimeEvent.self) {
-                        // The generation is re-checked under the lock: an event decoded by a
-                        // session that has since been replaced is dropped, never delivered
-                        // into the operations of its replacement.
-                        let handler = self.lock.withLock { self.generation == mine ? self.incoming : nil }
-                        handler?(event)
+                        self.registry.deliverIncoming(event, from: generation)
                     } else {
                         // An undecodable push means a contract mismatch: treat it as a lost
                         // connection so waiting operations report an unknown outcome.
-                        self.dropSession(generation: mine, reason: "undecodable event")
+                        self.dropSession(generation: generation, reason: "undecodable event")
                     }
                     return nil
                 },
                 cancellationHandler: { [weak self] _ in
-                    self?.dropSession(generation: mine, reason: nil)
+                    self?.dropSession(generation: generation, reason: nil)
                 }
             )
             try created.activate()
-            session = created
             return created
         }
     }
@@ -79,13 +134,7 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     private func dropSession(generation: Int, reason: String?) {
         // The generation is retired before the session is canceled, so the cancellation
         // handler that follows reports nothing a second time.
-        let (doomed, handler) = lock.withLock { () -> (XPCSession?, (@Sendable () -> Void)?) in
-            guard self.generation == generation else { return (nil, nil) }
-            self.generation += 1
-            let doomed = session
-            session = nil
-            return (reason == nil ? nil : doomed, interrupted)
-        }
+        let (doomed, handler) = registry.retire(generation)
         if let doomed, let reason { doomed.cancel(reason: reason) }
         handler?()
     }

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -1,0 +1,62 @@
+import Foundation
+import GuesthouseCore
+import XPC
+
+/// The thin seam between `RuntimeClient` and XPC, so the client's decoding and interruption
+/// handling can be tested without a live service.
+nonisolated protocol RuntimeTransport: Sendable {
+    /// Sends one envelope and delivers exactly one reply or an error.
+    func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws
+    /// Called when the connection drops. Pushed events (progress, log, status) also arrive here
+    /// once the service streams them (#25).
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void)
+}
+
+/// The real transport over the embedded service.
+nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendable {
+    static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
+
+    private let lock = NSLock()
+    private var session: XPCSession?
+    private var incoming: (@Sendable (RuntimeEvent) -> Void)?
+    private var interrupted: (@Sendable () -> Void)?
+
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+        lock.withLock {
+            self.incoming = incoming
+            self.interrupted = interrupted
+        }
+    }
+
+    func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        let session = try activeSession()
+        try session.send(envelope) { (result: Result<RuntimeEvent, any Error>) in
+            reply(result)
+        }
+    }
+
+    private func activeSession() throws -> XPCSession {
+        try lock.withLock {
+            if let session { return session }
+            let created = try XPCSession(
+                xpcService: Self.serviceName,
+                incomingMessageHandler: { [weak self] (message: XPCReceivedMessage) -> (any Encodable)? in
+                    guard let self, let event = try? message.decode(as: RuntimeEvent.self) else { return nil }
+                    self.lock.withLock { self.incoming }?(event)
+                    return nil
+                },
+                cancellationHandler: { [weak self] _ in
+                    guard let self else { return }
+                    let handler = self.lock.withLock { () -> (@Sendable () -> Void)? in
+                        self.session = nil
+                        return self.interrupted
+                    }
+                    handler?()
+                }
+            )
+            try created.activate()
+            session = created
+            return created
+        }
+    }
+}

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -19,6 +19,9 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
 
     private let lock = NSLock()
     private var session: XPCSession?
+    /// Incremented per session, so a callback from a canceled session never clears its
+    /// replacement or reports a second interruption for it.
+    private var generation = 0
     private var incoming: (@Sendable (RuntimeEvent) -> Void)?
     private var interrupted: (@Sendable () -> Void)?
 
@@ -39,6 +42,8 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     private func activeSession() throws -> XPCSession {
         try lock.withLock {
             if let session { return session }
+            generation += 1
+            let mine = generation
             // Created inactive: the session is activated once below. Creating it active and
             // activating again is an XPC API misuse that traps on first use.
             let created = try XPCSession(
@@ -51,27 +56,29 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
                     } else {
                         // An undecodable push means a contract mismatch: treat it as a lost
                         // connection so waiting operations report an unknown outcome.
-                        let handler = self.lock.withLock { () -> (@Sendable () -> Void)? in
-                            self.session?.cancel(reason: "undecodable event")
-                            self.session = nil
-                            return self.interrupted
-                        }
-                        handler?()
+                        self.dropSession(generation: mine, reason: "undecodable event")
                     }
                     return nil
                 },
                 cancellationHandler: { [weak self] _ in
-                    guard let self else { return }
-                    let handler = self.lock.withLock { () -> (@Sendable () -> Void)? in
-                        self.session = nil
-                        return self.interrupted
-                    }
-                    handler?()
+                    self?.dropSession(generation: mine, reason: nil)
                 }
             )
             try created.activate()
             session = created
             return created
         }
+    }
+
+    /// Clears the session and reports an interruption only if the session that failed is
+    /// still the current one.
+    private func dropSession(generation: Int, reason: String?) {
+        let handler = lock.withLock { () -> (@Sendable () -> Void)? in
+            guard self.generation == generation else { return nil }
+            if let reason { session?.cancel(reason: reason) }
+            session = nil
+            return interrupted
+        }
+        handler?()
     }
 }

--- a/GuesthouseRuntime/Info.plist
+++ b/GuesthouseRuntime/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>XPCService</key>
+	<dict>
+		<key>ServiceType</key>
+		<string>Application</string>
+		<!-- Run in the logged-in user's session so Keychain access and Tart's first-boot window
+		     behave as they would for the app itself. Gate #34 verifies the actual behavior. -->
+		<key>JoinExistingSession</key>
+		<true/>
+	</dict>
+</dict>
+</plist>

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -3,11 +3,38 @@ import GuesthouseCore
 import OSLog
 import XPC
 
+/// The service's only log sink.
+///
+/// It accepts `RedactedLine` and nothing else, so a diagnostic built from guest, CLI, or
+/// request text cannot reach the system log unredacted (MVP-PLAN.md §3, "Local storage"). The
+/// text is written as public on purpose: it has already passed the redaction layer, and hiding
+/// it would only make a line that is safe to read unreadable in a diagnostics report.
+struct ServiceLog: Sendable {
+    private let log: Logger
+
+    init(category: String) {
+        log = Logger(subsystem: RuntimeService.serviceName, category: category)
+    }
+
+    func error(_ line: RedactedLine) { log.error("\(line.text, privacy: .public)") }
+    func notice(_ line: RedactedLine) { log.notice("\(line.text, privacy: .public)") }
+}
+
 /// Decodes envelopes, dispatches named operations, and replies with `RuntimeEvent`s.
 final class RuntimeService: Sendable {
     static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
 
-    private let log = Logger(subsystem: serviceName, category: "service")
+    private let log = ServiceLog(category: "service")
+
+    /// A diagnostic that carries a value, as a line the sink accepts.
+    ///
+    /// The values interpolated today are the service's own case names and protocol numbers,
+    /// but they go through `Redactor` like any other text, so a line built later from guest,
+    /// CLI, or request data cannot reach the log unredacted.
+    private static func line(_ message: StaticString, _ value: String) -> RedactedLine {
+        var state = Redactor.StreamState()
+        return Redactor().redact(line: "\(message) \(value)", state: &state)
+    }
 
     /// One reply per request. Streaming events for long operations arrive with #25.
     func handle(_ message: XPCReceivedMessage) -> (any Encodable)? {
@@ -17,31 +44,31 @@ final class RuntimeService: Sendable {
         } catch let mismatch as RuntimeRequestEnvelope.ProtocolMismatch {
             // A version-skewed installation is not corrupt input: the client gets the
             // protocol-mismatch error and its reinstall recovery.
-            log.error("protocol mismatch: client \(mismatch.client.rawValue, privacy: .public)")
+            log.error(Self.line("protocol mismatch: client", "\(mismatch.client.rawValue)"))
             return RuntimeEvent.failed(OperationID(), mismatch.error)
         } catch {
             // Never log the decoding error text: it can quote the raw offending value.
-            log.error("undecodable request rejected")
+            log.error(RedactedLine(literal: "undecodable request rejected"))
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
         }
         do {
             try RequestValidator.validate(envelope)
         } catch {
-            log.error("rejected request: \(error.guesthouseError.caseName, privacy: .public)")
+            log.error(Self.line("rejected request:", error.guesthouseError.caseName))
             return RuntimeEvent.failed(OperationID(), error.guesthouseError)
         }
         switch envelope.request {
         case .runtimeVersion:
             return RuntimeEvent.runtimeVersion(Self.versionInfo)
         case .environmentStatus, .startEnvironment, .stopEnvironment, .importXcode, .cancelOperation:
-            log.notice("operation not implemented yet: \(envelope.request.caseName, privacy: .public)")
+            log.notice(Self.line("operation not implemented yet:", envelope.request.caseName))
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation))
         }
     }
 
     func sessionEnded(_ error: XPCRichError) {
         // The rich error's description is opaque and may quote context; log a fixed message.
-        log.notice("session ended")
+        log.notice(RedactedLine(literal: "session ended"))
     }
 
     static var versionInfo: RuntimeVersionInfo {

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -35,7 +35,8 @@ final class RuntimeService: Sendable {
     }
 
     func sessionEnded(_ error: XPCRichError) {
-        log.notice("session ended: \(String(describing: error), privacy: .public)")
+        // The rich error's description is opaque and may quote context; log a fixed message.
+        log.notice("session ended")
     }
 
     static var versionInfo: RuntimeVersionInfo {

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -1,0 +1,49 @@
+import Foundation
+import GuesthouseCore
+import OSLog
+import XPC
+
+/// Decodes envelopes, dispatches named operations, and replies with `RuntimeEvent`s.
+final class RuntimeService: Sendable {
+    static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
+
+    private let log = Logger(subsystem: serviceName, category: "service")
+
+    /// One reply per request. Streaming events for long operations arrive with #25.
+    func handle(_ message: XPCReceivedMessage) -> (any Encodable)? {
+        let envelope: RuntimeRequestEnvelope
+        do {
+            envelope = try message.decode(as: RuntimeRequestEnvelope.self)
+        } catch {
+            log.error("undecodable request: \(String(describing: error), privacy: .public)")
+            return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
+        }
+        do {
+            try RequestValidator.validate(envelope)
+        } catch {
+            log.error("rejected request: \(String(describing: error), privacy: .public)")
+            return RuntimeEvent.failed(OperationID(), error.guesthouseError)
+        }
+        switch envelope.request {
+        case .runtimeVersion:
+            return RuntimeEvent.runtimeVersion(Self.versionInfo)
+        case .environmentStatus, .startEnvironment, .stopEnvironment, .importXcode, .cancelOperation:
+            log.notice("operation not implemented yet: \(envelope.request.caseName, privacy: .public)")
+            return RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation))
+        }
+    }
+
+    func sessionEnded(_ error: XPCRichError) {
+        log.notice("session ended: \(String(describing: error), privacy: .public)")
+    }
+
+    static var versionInfo: RuntimeVersionInfo {
+        let info = Bundle.main.infoDictionary ?? [:]
+        return RuntimeVersionInfo(
+            serviceVersion: info["CFBundleShortVersionString"] as? String ?? "0",
+            serviceBuild: info["CFBundleVersion"] as? String ?? "0",
+            protocolVersion: .current,
+            tart: nil
+        )
+    }
+}

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -14,6 +14,11 @@ final class RuntimeService: Sendable {
         let envelope: RuntimeRequestEnvelope
         do {
             envelope = try message.decode(as: RuntimeRequestEnvelope.self)
+        } catch let mismatch as RuntimeRequestEnvelope.ProtocolMismatch {
+            // A version-skewed installation is not corrupt input: the client gets the
+            // protocol-mismatch error and its reinstall recovery.
+            log.error("protocol mismatch: client \(mismatch.client.rawValue, privacy: .public)")
+            return RuntimeEvent.failed(OperationID(), mismatch.error)
         } catch {
             // Never log the decoding error text: it can quote the raw offending value.
             log.error("undecodable request rejected")

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -15,13 +15,14 @@ final class RuntimeService: Sendable {
         do {
             envelope = try message.decode(as: RuntimeRequestEnvelope.self)
         } catch {
-            log.error("undecodable request: \(String(describing: error), privacy: .public)")
+            // Never log the decoding error text: it can quote the raw offending value.
+            log.error("undecodable request rejected")
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
         }
         do {
             try RequestValidator.validate(envelope)
         } catch {
-            log.error("rejected request: \(String(describing: error), privacy: .public)")
+            log.error("rejected request: \(error.guesthouseError.caseName, privacy: .public)")
             return RuntimeEvent.failed(OperationID(), error.guesthouseError)
         }
         switch envelope.request {

--- a/GuesthouseRuntime/Sources/main.swift
+++ b/GuesthouseRuntime/Sources/main.swift
@@ -1,4 +1,5 @@
 import Foundation
+import GuesthouseCore
 import XPC
 
 // The embedded, non-sandboxed runtime service. It answers named operations from the
@@ -9,6 +10,7 @@ import XPC
 // onward. Every other operation is refused with `unsupportedOperation`.
 
 let service = RuntimeService()
+let startupLog = ServiceLog(category: "startup")
 let listener: XPCListener
 do {
     listener = try XPCListener(service: RuntimeService.serviceName) { request in
@@ -20,13 +22,13 @@ do {
     }
 } catch {
     // A fixed message: the system error's text is opaque and could quote context.
-    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot create the XPC listener\n".utf8))
+    startupLog.error(RedactedLine(literal: "GuesthouseRuntime: cannot create the XPC listener"))
     exit(EXIT_FAILURE)
 }
 do {
     try listener.activate()
 } catch {
-    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot activate the XPC listener\n".utf8))
+    startupLog.error(RedactedLine(literal: "GuesthouseRuntime: cannot activate the XPC listener"))
     exit(EXIT_FAILURE)
 }
 dispatchMain()

--- a/GuesthouseRuntime/Sources/main.swift
+++ b/GuesthouseRuntime/Sources/main.swift
@@ -19,13 +19,14 @@ do {
         }
     }
 } catch {
-    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot create listener: \(error)\n".utf8))
+    // A fixed message: the system error's text is opaque and could quote context.
+    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot create the XPC listener\n".utf8))
     exit(EXIT_FAILURE)
 }
 do {
     try listener.activate()
 } catch {
-    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot activate listener: \(error)\n".utf8))
+    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot activate the XPC listener\n".utf8))
     exit(EXIT_FAILURE)
 }
 dispatchMain()

--- a/GuesthouseRuntime/Sources/main.swift
+++ b/GuesthouseRuntime/Sources/main.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XPC
+
+// The embedded, non-sandboxed runtime service. It answers named operations from the
+// sandboxed GUI and nothing else (MVP-PLAN.md §3, "Sandbox and XPC boundary").
+//
+// Only the `runtimeVersion` operation is implemented here (issue #19). Caller
+// authentication and request validation follow in #20; process execution and Tart in #21
+// onward. Every other operation is refused with `unsupportedOperation`.
+
+let service = RuntimeService()
+let listener: XPCListener
+do {
+    listener = try XPCListener(service: RuntimeService.serviceName) { request in
+        request.accept { (message: XPCReceivedMessage) -> (any Encodable)? in
+            service.handle(message)
+        } cancellationHandler: { error in
+            service.sessionEnded(error)
+        }
+    }
+} catch {
+    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot create listener: \(error)\n".utf8))
+    exit(EXIT_FAILURE)
+}
+do {
+    try listener.activate()
+} catch {
+    FileHandle.standardError.write(Data("GuesthouseRuntime: cannot activate listener: \(error)\n".utf8))
+    exit(EXIT_FAILURE)
+}
+dispatchMain()

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -82,6 +82,27 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         #expect(events.map(\.caseName) == ["accepted", "progress", "completed"])
     }
 
+    @Test func requestsReachTheTransportInSendOrder() async throws {
+        let transport = FakeTransport(.reply(.completed(OperationID())))
+        let client = RuntimeClient(transport: transport)
+        let requests: [RuntimeRequest] = (0..<25).map { $0.isMultiple(of: 2) ? .startEnvironment(EnvironmentID(), StartOptions()) : .stopEnvironment(EnvironmentID(), .force) }
+        var streams: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        for request in requests { streams.append(client.send(request)) }
+        for stream in streams { _ = try await collect(stream) }
+        #expect(transport.sent.map(\.request) == requests)
+    }
+
+    @Test func abandonedConsumerCancelsTheOperation() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        for _ in 0..<200 where transport.sent.isEmpty { try await Task.sleep(for: .milliseconds(5)) }
+        consumer.cancel()
+        for _ in 0..<200 where transport.sent.count < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        guard transport.sent.count == 2, case .cancelOperation = transport.sent[1].request else { Issue.record("no cancelOperation sent: \(transport.sent.map(\.request))"); return }
+    }
+
     @Test func droppedConnectionFailsInFlightOperationsWithTheirID() async {
         let client = RuntimeClient(transport: FakeTransport(.acceptThenDrop))
         var seen: [String] = []

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import Guesthouse
+
+/// A transport that answers from a script and can simulate a dropped connection.
+final class FakeTransport: RuntimeTransport, @unchecked Sendable {
+    enum Behavior { case reply(RuntimeEvent), fail, throwOnSend, acceptThenStream([RuntimeEvent]), acceptThenDrop }
+    let lock = NSLock()
+    var behavior: Behavior
+    var incoming: (@Sendable (RuntimeEvent) -> Void)?
+    var interrupted: (@Sendable () -> Void)?
+    var sent: [RuntimeRequestEnvelope] = []
+
+    init(_ behavior: Behavior) { self.behavior = behavior }
+
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+        lock.withLock { self.incoming = incoming; self.interrupted = interrupted }
+    }
+
+    func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        lock.withLock { sent.append(envelope) }
+        switch behavior {
+        case .reply(let event): reply(.success(event))
+        case .fail: reply(.failure(CocoaError(.xpcConnectionInterrupted)))
+        case .throwOnSend: throw CocoaError(.xpcConnectionInvalid)
+        case .acceptThenStream(let events):
+            let id = OperationID()
+            reply(.success(.accepted(id)))
+            let incoming = lock.withLock { self.incoming }
+            for event in events {
+                switch event {
+                case .progress(_, let phase): incoming?(.progress(id, phase))
+                case .completed: incoming?(.completed(id))
+                case .failed(_, let error): incoming?(.failed(id, error))
+                default: incoming?(event)
+                }
+            }
+        case .acceptThenDrop:
+            reply(.success(.accepted(OperationID())))
+            lock.withLock { self.interrupted }?()
+        }
+    }
+}
+
+@Suite struct RuntimeClientTests {
+    func collect(_ stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> [RuntimeEvent] {
+        var events: [RuntimeEvent] = []
+        for try await event in stream { events.append(event) }
+        return events
+    }
+
+    @Test func runtimeVersionReplyBecomesOneEventAndFinishes() async throws {
+        let info = RuntimeVersionInfo(serviceVersion: "1.0", serviceBuild: "7")
+        let transport = FakeTransport(.reply(.runtimeVersion(info)))
+        let client = RuntimeClient(transport: transport)
+        let events = try await collect(client.send(.runtimeVersion))
+        #expect(events == [.runtimeVersion(info)])
+        #expect(transport.sent.map(\.request) == [.runtimeVersion])
+        #expect(transport.sent.first?.protocolVersion == .current)
+    }
+
+    @Test func replyFailureIsAnInterruption() async {
+        let client = RuntimeClient(transport: FakeTransport(.fail))
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await _ in client.send(.runtimeVersion) {}
+        }
+    }
+
+    @Test func sendFailureIsAnInterruption() async {
+        let client = RuntimeClient(transport: FakeTransport(.throwOnSend))
+        await #expect(throws: RuntimeConnectionInterrupted.self) {
+            for try await _ in client.send(.runtimeVersion) {}
+        }
+    }
+
+    @Test func acceptedOperationsStreamUntilCompleted() async throws {
+        let phase = ProgressPhase(kind: .startingVM)
+        let transport = FakeTransport(.acceptThenStream([.progress(OperationID(), phase), .completed(OperationID())]))
+        let client = RuntimeClient(transport: transport)
+        let events = try await collect(client.send(.startEnvironment(EnvironmentID(), StartOptions())))
+        #expect(events.map(\.caseName) == ["accepted", "progress", "completed"])
+    }
+
+    @Test func droppedConnectionFailsInFlightOperationsWithTheirID() async {
+        let client = RuntimeClient(transport: FakeTransport(.acceptThenDrop))
+        var seen: [String] = []
+        var interruption: RuntimeConnectionInterrupted?
+        do {
+            for try await event in client.send(.startEnvironment(EnvironmentID(), StartOptions())) { seen.append(event.caseName) }
+        } catch let error as RuntimeConnectionInterrupted {
+            interruption = error
+        } catch {}
+        #expect(seen == ["accepted"])
+        #expect(interruption?.operationID != nil)
+    }
+}

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -26,6 +26,10 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
     var behavior: Behavior
     var incoming: (@Sendable (RuntimeEvent) -> Void)?
     var interrupted: (@Sendable () -> Void)?
+    /// Run at the start of the next send, while the client is inside the transport and so
+    /// cannot drain its inbox. Lets a test enqueue callbacks in a known order, and observe
+    /// what an undrained inbox holds. Consumed by the send that runs it.
+    var beforeSend: (@Sendable () -> Void)?
     private var sentEnvelopes: [RuntimeRequestEnvelope] = []
     /// Snapshots taken under the lock, so a test polling while the client drains sees
     /// consistent state.
@@ -38,7 +42,21 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         lock.withLock { self.incoming = incoming; self.interrupted = interrupted }
     }
 
+    /// For `.acceptLater`: fails the reply held back by the last send.
+    func failPendingReply() {
+        let reply = lock.withLock { () -> (@Sendable (Result<RuntimeEvent, any Error>) -> Void)? in
+            defer { pendingReply = nil }
+            return pendingReply
+        }
+        reply?(.failure(CocoaError(.xpcConnectionInterrupted)))
+    }
+
     func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        let hook = lock.withLock { () -> (@Sendable () -> Void)? in
+            defer { beforeSend = nil }
+            return beforeSend
+        }
+        hook?()
         lock.withLock { sentEnvelopes.append(envelope) }
         switch behavior {
         case .reply(let event): reply(.success(event))
@@ -70,6 +88,32 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
 }
 
 private struct MissedDeadline: Error {}
+
+/// A value handed to a callback, readable from the thread that waits for it.
+final class Box<Value: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var stored: Value?
+    var value: Value? {
+        get { lock.withLock { stored } }
+        set { lock.withLock { stored = newValue } }
+    }
+}
+
+/// How many times a callback ran.
+final class Counter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+    func increment() { lock.withLock { count += 1 } }
+    var value: Int { lock.withLock { count } }
+}
+
+/// The order in which things happened across threads.
+final class Order: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recorded: [String] = []
+    func append(_ entry: String) { lock.withLock { recorded.append(entry) } }
+    var entries: [String] { lock.withLock { recorded } }
+}
 
 /// Runs `work` with a deadline, so a client that stops delivering fails the test instead of
 /// hanging the run.
@@ -314,19 +358,308 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
         #expect(seen == ["accepted"])
         #expect(interruption?.operationID != nil)
     }
+
+    @Test func aTerminalEventSurvivesAConsumerThatNeverReads() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id)? = try await iterator.next() else {
+            Issue.record("no accepted event")
+            return
+        }
+        let incoming = transport.lock.withLock { transport.incoming }
+        // Far more traffic than the control reserve can absorb. The probe that measures how
+        // much room a consumer has left occupies a slot itself, so without a floor these
+        // probes fill the buffer to the brim and the terminal event is refused. Nothing is
+        // read in between, so this is a consumer that has stopped entirely.
+        for _ in 0..<12 {
+            for _ in 0..<1_000 { incoming?(.progress(id, ProgressPhase(kind: .copying))) }
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        incoming?(.completed(id))
+        for _ in 0..<400 where await client.isRetired(id) == false { try await Task.sleep(for: .milliseconds(5)) }
+        var delivered: [RuntimeEvent] = []
+        while let event = try await iterator.next() { delivered.append(event) }
+        #expect(delivered.last?.caseName == "completed", "the terminal event outlives a consumer that stopped reading")
+    }
+
+    @Test func statusSnapshotsNeverCrowdOutTheTerminalEvent() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id)? = try await iterator.next() else {
+            Issue.record("no accepted event")
+            return
+        }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .ready)
+        for _ in 0..<(RuntimeClient.consumerBufferLimit * 4) { incoming?(.status(status)) }
+        incoming?(.completed(id))
+        for _ in 0..<400 where await client.isRetired(id) == false { try await Task.sleep(for: .milliseconds(5)) }
+        var delivered: [RuntimeEvent] = []
+        while let event = try await iterator.next() { delivered.append(event) }
+        #expect(delivered.count <= RuntimeClient.consumerBufferLimit, "repeated snapshots cannot accumulate without limit")
+        #expect(delivered.last?.caseName == "completed", "a snapshot never takes the slot the terminal event needs")
+    }
+
+    /// A snapshot that names the operation it belongs to is that operation's event; the
+    /// stream of another request must not be told about it.
+    @Test func aStatusReachesOnlyTheOperationItNames() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let first = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        var firstEvents = first.makeAsyncIterator()
+        guard case .accepted(let firstID)? = try await firstEvents.next() else {
+            Issue.record("no accepted event for the first operation")
+            return
+        }
+        let second = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        var secondEvents = second.makeAsyncIterator()
+        guard case .accepted(let secondID)? = try await secondEvents.next() else {
+            Issue.record("no accepted event for the second operation")
+            return
+        }
+        let incoming = transport.lock.withLock { transport.incoming }
+        incoming?(.status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .running, readiness: .ready, inFlightOperation: secondID)))
+        // A snapshot that names no operation describes the environment, so it still reaches
+        // every stream.
+        incoming?(.status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .ready)))
+        incoming?(.completed(firstID))
+        incoming?(.completed(secondID))
+        var delivered: [String] = []
+        while let event = try await firstEvents.next() { delivered.append(event.caseName) }
+        #expect(delivered == ["status", "completed"], "only the unscoped snapshot reached the other operation")
+        var owned: [String] = []
+        while let event = try await secondEvents.next() { owned.append(event.caseName) }
+        #expect(owned == ["status", "status", "completed"])
+    }
+
+    /// A snapshot naming an operation whose `accepted` reply has not arrived yet waits in the
+    /// same bounded buffer its progress does, instead of being dropped.
+    @Test func aStatusThatArrivesBeforeAcceptanceIsNotLost() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<200 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let id = transport.preparedID
+        incoming?(.status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .running, readiness: .ready, inFlightOperation: id)))
+        incoming?(.completed(id))
+        transport.deliverPendingAccept()
+        let events = try await withDeadline { try await collected(from: stream) }
+        #expect(events.map(\.caseName) == ["accepted", "status", "completed"])
+    }
+
+    /// The per-operation cap says nothing about how many operations there are, and a terminal
+    /// event is never refused at ingress, so a service streaming ids nothing asked for would
+    /// otherwise grow the buffer dictionary itself.
+    @Test func preAcceptanceBuffersAreBoundedAcrossOperations() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<200 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let id = transport.preparedID
+        incoming?(.progress(id, ProgressPhase(kind: .copying)))
+        for _ in 0..<(RuntimeClient.pendingOperationLimit * 4) { incoming?(.completed(OperationID())) }
+        incoming?(.completed(id))
+        transport.deliverPendingAccept()
+        let events = try await withDeadline { try await collected(from: stream) }
+        #expect(events.last?.caseName == "completed", "the operation the app asked for kept its buffer")
+        let held = await client.pendingOperationCount()
+        #expect(held <= RuntimeClient.pendingOperationLimit, "ids nothing asked for cannot grow the buffer without limit")
+    }
+
+    @Test func trafficIsBoundedBeforeItReachesTheInbox() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let measured = Box<Int>()
+        transport.beforeSend = { [weak client] in
+            guard let client else { return }
+            let incoming = transport.lock.withLock { transport.incoming }
+            let id = OperationID()
+            // The client is inside this send, so none of this can have been drained yet: what
+            // the inbox holds afterwards is what it was willing to accept.
+            for _ in 0..<(RuntimeClient.inboxTrafficLimit + 500) { incoming?(.progress(id, ProgressPhase(kind: .copying))) }
+            measured.value = client.inboxTrafficCount
+        }
+        let held = client.send(.runtimeVersion)
+        for _ in 0..<400 where measured.value == nil { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(measured.value == RuntimeClient.inboxTrafficLimit, "traffic the client has not reached yet is bounded at ingress")
+        _ = held
+    }
+
+    @Test func aReplyThatArrivesAfterCancellationReleasesItsKey() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.runtimeVersion)
+        let consumer = Task { for try await _ in stream {} }
+        for _ in 0..<400 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        consumer.cancel()
+        _ = try? await consumer.value
+        try await Task.sleep(for: .milliseconds(50))
+        transport.failPendingReply()
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await client.settledKeyCount() == 0, "a request answered after its stream ended is not remembered for the life of the client")
+    }
+
+    @Test func aCancellationRacingTheTerminalEventLeavesNothingBehind() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let received = Box<String>()
+        let consumer = Task { for try await event in stream { received.value = event.caseName } }
+        for _ in 0..<400 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        transport.deliverPendingAccept()
+        // The consumer has its acceptance and is waiting on the stream, so cancelling it below
+        // reports a cancellation rather than a stream that simply ended.
+        for _ in 0..<400 where received.value == nil { try await Task.sleep(for: .milliseconds(5)) }
+        let id = try #require(transport.lastAcceptedID)
+        transport.beforeSend = {
+            let incoming = transport.lock.withLock { transport.incoming }
+            // Both are enqueued while the client is inside this send, so the operation's last
+            // event is handled first and the cancellation arrives behind it.
+            incoming?(.completed(id))
+            consumer.cancel()
+        }
+        let held = client.send(.runtimeVersion)
+        for _ in 0..<400 where await client.isRetired(id) == false { try await Task.sleep(for: .milliseconds(5)) }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await client.abandonedKeyCount() == 0, "a cancellation that lost the race to the terminal event is not held forever")
+        _ = held
+    }
+
+    @Test func retiredOperationIDsAreClearedWhenTheSessionEnds() async throws {
+        let transport = FakeTransport(.acceptThenStream([.completed(OperationID())]))
+        let client = RuntimeClient(transport: transport)
+        let events = try await collect(client.send(.startEnvironment(EnvironmentID(), StartOptions())))
+        guard case .accepted(let id)? = events.first else {
+            Issue.record("no accepted event")
+            return
+        }
+        #expect(await client.isRetired(id))
+        transport.lock.withLock { transport.interrupted }?()
+        for _ in 0..<400 where await client.isRetired(id) { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(await client.isRetired(id) == false, "a new session does not carry the previous session's ids")
+    }
+
+    @Test func anInterruptedMutationIsNeverOfferedABlindRetry() async throws {
+        let mutating = RuntimeClient(transport: FakeTransport(.fail))
+        var caught: RuntimeConnectionInterrupted?
+        do {
+            for try await _ in mutating.send(.startEnvironment(EnvironmentID(), StartOptions())) {}
+        } catch let error as RuntimeConnectionInterrupted {
+            caught = error
+        }
+        #expect(caught?.recoveryActions == [.inspectState, .cancel], "a mutation that may have reached the service is inspected, not repeated")
+        #expect(caught?.userMessage.contains("may or may not") == true)
+
+        let query = RuntimeClient(transport: FakeTransport(.fail))
+        var queryError: RuntimeConnectionInterrupted?
+        do {
+            for try await _ in query.send(.runtimeVersion) {}
+        } catch let error as RuntimeConnectionInterrupted {
+            queryError = error
+        }
+        #expect(queryError?.recoveryActions == [.retry], "a read-only query changed nothing and may be asked again")
+    }
+}
+
+/// A session that answers no send, either by throwing or by failing the reply, so the
+/// transport's reconnect rules can be exercised without a live XPC connection.
+final class RefusingSession: RuntimeSessionHandle, @unchecked Sendable {
+    /// How the send is refused: synchronously, or through the reply an interrupted connection
+    /// or an undecodable answer would deliver.
+    enum Refusal { case throwOnSend, failTheReply }
+    struct Refused: Error {}
+    private let lock = NSLock()
+    private var reasons: [String] = []
+    let refusal: Refusal
+    var cancelReasons: [String] { lock.withLock { reasons } }
+
+    init(_ refusal: Refusal = .throwOnSend) { self.refusal = refusal }
+
+    func sendEnvelope(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
+        switch refusal {
+        case .throwOnSend: throw Refused()
+        case .failTheReply: reply(.failure(CocoaError(.xpcConnectionInterrupted)))
+        }
+    }
+
+    func cancel(reason: String) { lock.withLock { reasons.append(reason) } }
+}
+
+/// Every session the transport opened.
+final class OpenedSessions: @unchecked Sendable {
+    private let lock = NSLock()
+    private var opened: [RefusingSession] = []
+    var all: [RefusingSession] { lock.withLock { opened } }
+
+    func open(_ refusal: RefusingSession.Refusal = .throwOnSend) -> RefusingSession {
+        let session = RefusingSession(refusal)
+        lock.withLock { opened.append(session) }
+        return session
+    }
+}
+
+@Suite struct XPCRuntimeTransportTests {
+    @Test func aSessionThatRefusedASendIsNotHandedToTheNextRequest() {
+        let sessions = OpenedSessions()
+        let transport = XPCRuntimeTransport(connect: { _, _ in sessions.open() })
+        let interruptions = Counter()
+        transport.setHandlers(incoming: { _ in }, interrupted: { interruptions.increment() })
+        for _ in 0..<2 {
+            #expect(throws: RefusingSession.Refused.self) {
+                try transport.send(RuntimeRequestEnvelope(request: .runtimeVersion)) { _ in }
+            }
+        }
+        #expect(sessions.all.count == 2, "the refused session was retired rather than reused")
+        #expect(sessions.all.first?.cancelReasons == ["send failed"])
+        #expect(interruptions.value == 2, "each lost session reported its interruption once")
+    }
+
+    /// A reply that fails is the other way a session says it produced no answer, and an
+    /// undecodable reply never triggers the cancellation handler that would retire it.
+    @Test func aSessionWhoseReplyFailedIsNotHandedToTheNextRequest() {
+        let sessions = OpenedSessions()
+        let transport = XPCRuntimeTransport(connect: { _, _ in sessions.open(.failTheReply) })
+        let interruptions = Counter()
+        let failures = Counter()
+        transport.setHandlers(incoming: { _ in }, interrupted: { interruptions.increment() })
+        for _ in 0..<2 {
+            #expect(throws: Never.self) {
+                try transport.send(RuntimeRequestEnvelope(request: .runtimeVersion)) { result in
+                    if case .failure = result { failures.increment() }
+                }
+            }
+        }
+        #expect(sessions.all.count == 2, "the session that failed a reply was retired rather than reused")
+        #expect(sessions.all.first?.cancelReasons == ["reply failed"])
+        #expect(interruptions.value == 2, "every operation on the lost session was told once")
+        #expect(failures.value == 2, "the caller still receives its failure")
+    }
 }
 
 /// The transport's session rules, exercised without a live XPC connection.
 @Suite struct SessionRegistryTests {
+    /// Collects a `Result` handed to a reply callback.
+    private func delivered(_ registry: SessionRegistry<NSObject>, _ result: Result<RuntimeEvent, any Error>, from generation: Int) -> Result<RuntimeEvent, any Error>? {
+        let box = Box<Result<RuntimeEvent, any Error>>()
+        registry.deliverReply(result, from: generation) { box.value = $0 }
+        return box.value
+    }
+
     @Test func aReplyFromARetiredSessionBecomesAnInterruption() {
         let registry = SessionRegistry<NSObject>()
         let (_, generation) = registry.session { _ in NSObject() }
-        guard case .success = registry.gate(.success(.accepted(OperationID())), from: generation) else {
+        guard case .success? = delivered(registry, .success(.accepted(OperationID())), from: generation) else {
             Issue.record("the live session's reply was not forwarded")
             return
         }
         _ = registry.retire(generation)
-        guard case .failure(let error) = registry.gate(.success(.accepted(OperationID())), from: generation) else {
+        guard case .failure(let error)? = delivered(registry, .success(.accepted(OperationID())), from: generation) else {
             Issue.record("an accepted reply from a retired session was forwarded")
             return
         }
@@ -336,9 +669,53 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
     @Test func aSessionIsRetiredOnce() {
         let registry = SessionRegistry<NSObject>()
         let (_, generation) = registry.session { _ in NSObject() }
+        let reports = Counter()
+        registry.setHandlers(incoming: { _ in }, interrupted: { reports.increment() })
+        _ = registry.retire(generation)
+        #expect(reports.value == 1)
+        _ = registry.retire(generation)
+        #expect(reports.value == 1, "a second failure of the same session reports nothing")
+    }
+
+    @Test func aRetirementIsReportedBeforeAReplacementSessionExists() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        let order = Order()
+        registry.setHandlers(
+            incoming: { _ in },
+            interrupted: {
+                // A replacement is only made by taking the registry's lock, so a request
+                // racing this report has to wait for it. Without that ordering the
+                // replacement's operations are failed by an interruption that predates them.
+                DispatchQueue.global().async {
+                    _ = registry.session { _ in NSObject() }
+                    order.append("replacement")
+                }
+                Thread.sleep(forTimeInterval: 0.05)
+                order.append("interrupted")
+            }
+        )
+        _ = registry.retire(generation)
+        for _ in 0..<200 where order.entries.count < 2 { Thread.sleep(forTimeInterval: 0.005) }
+        #expect(order.entries == ["interrupted", "replacement"])
+    }
+
+    @Test func aRetirementCannotOvertakeAReplyBeingDelivered() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        let retired = DispatchSemaphore(value: 0)
         registry.setHandlers(incoming: { _ in }, interrupted: {})
-        #expect(registry.retire(generation).interrupted != nil)
-        #expect(registry.retire(generation).interrupted == nil, "a second failure of the same session reports nothing")
+        registry.deliverReply(.success(.accepted(OperationID())), from: generation) { _ in
+            DispatchQueue.global().async {
+                _ = registry.retire(generation)
+                retired.signal()
+            }
+            // The gate check and the handoff to the client are one step: an interruption can
+            // never be enqueued in front of a reply that was already gated as live, which
+            // would leave the accepted operation registered on a dead session forever.
+            #expect(retired.wait(timeout: .now() + .milliseconds(300)) == .timedOut)
+        }
+        #expect(retired.wait(timeout: .now() + .seconds(5)) == .success)
     }
 
     @Test func aRetirementCannotOvertakeAnEventBeingDelivered() {

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -5,12 +5,29 @@ import Testing
 
 /// A transport that answers from a script and can simulate a dropped connection.
 final class FakeTransport: RuntimeTransport, @unchecked Sendable {
-    enum Behavior { case reply(RuntimeEvent), fail, throwOnSend, acceptThenStream([RuntimeEvent]), acceptThenDrop }
+    enum Behavior { case reply(RuntimeEvent), fail, throwOnSend, acceptThenStream([RuntimeEvent]), acceptThenDrop, acceptLater }
+    private var pendingReply: (@Sendable (Result<RuntimeEvent, any Error>) -> Void)?
+    private(set) var lastAcceptedID: OperationID?
+
+    /// For `.acceptLater`: delivers the `accepted` reply held back by the last send.
+    func deliverPendingAccept() {
+        let (reply, id) = lock.withLock { () -> ((@Sendable (Result<RuntimeEvent, any Error>) -> Void)?, OperationID) in
+            let id = OperationID()
+            lastAcceptedID = id
+            defer { pendingReply = nil }
+            return (pendingReply, id)
+        }
+        reply?(.success(.accepted(id)))
+    }
     let lock = NSLock()
     var behavior: Behavior
     var incoming: (@Sendable (RuntimeEvent) -> Void)?
     var interrupted: (@Sendable () -> Void)?
-    var sent: [RuntimeRequestEnvelope] = []
+    private var sentEnvelopes: [RuntimeRequestEnvelope] = []
+    /// Snapshots taken under the lock, so a test polling while the client drains sees
+    /// consistent state.
+    var sent: [RuntimeRequestEnvelope] { lock.withLock { sentEnvelopes } }
+    var sentCount: Int { lock.withLock { sentEnvelopes.count } }
 
     init(_ behavior: Behavior) { self.behavior = behavior }
 
@@ -19,7 +36,7 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
     }
 
     func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
-        lock.withLock { sent.append(envelope) }
+        lock.withLock { sentEnvelopes.append(envelope) }
         switch behavior {
         case .reply(let event): reply(.success(event))
         case .fail: reply(.failure(CocoaError(.xpcConnectionInterrupted)))
@@ -39,6 +56,12 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         case .acceptThenDrop:
             reply(.success(.accepted(OperationID())))
             lock.withLock { self.interrupted }?()
+        case .acceptLater:
+            if case .cancelOperation = envelope.request {
+                reply(.success(.completed(OperationID())))
+            } else {
+                lock.withLock { pendingReply = reply }
+            }
         }
     }
 }
@@ -97,10 +120,37 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         let client = RuntimeClient(transport: transport)
         let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
         let consumer = Task { for try await _ in stream {} }
-        for _ in 0..<200 where transport.sent.isEmpty { try await Task.sleep(for: .milliseconds(5)) }
+        for _ in 0..<200 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
         consumer.cancel()
-        for _ in 0..<200 where transport.sent.count < 2 { try await Task.sleep(for: .milliseconds(5)) }
-        guard transport.sent.count == 2, case .cancelOperation = transport.sent[1].request else { Issue.record("no cancelOperation sent: \(transport.sent.map(\.request))"); return }
+        for _ in 0..<200 where transport.sentCount < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        let sent = transport.sent
+        guard sent.count == 2, case .cancelOperation = sent[1].request else { Issue.record("no cancelOperation sent: \(sent.map(\.request))"); return }
+    }
+
+    @Test func aConsumerGoneBeforeAcceptanceStillCancelsTheOperation() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        for _ in 0..<200 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        consumer.cancel()
+        try await Task.sleep(for: .milliseconds(30))
+        transport.deliverPendingAccept()
+        for _ in 0..<200 where transport.sentCount < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        let sent = transport.sent
+        guard sent.count == 2, case .cancelOperation(let id) = sent[1].request else { Issue.record("no cancelOperation sent: \(sent.map(\.request))"); return }
+        #expect(id == transport.lastAcceptedID)
+    }
+
+    @Test func aDiscardedClientIsReleased() async throws {
+        weak var weakClient: RuntimeClient?
+        do {
+            let client = RuntimeClient(transport: FakeTransport(.reply(.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")))))
+            _ = try await collect(client.send(.runtimeVersion))
+            weakClient = client
+        }
+        for _ in 0..<100 where weakClient != nil { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(weakClient == nil)
     }
 
     @Test func droppedConnectionFailsInFlightOperationsWithTheirID() async {

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -142,6 +142,33 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         #expect(id == transport.lastAcceptedID)
     }
 
+    @Test func aFloodNeverEvictsTheAcceptedEvent() async throws {
+        let flood = (0..<3_000).map { _ in RuntimeEvent.progress(OperationID(), ProgressPhase(kind: .copying)) } + [.completed(OperationID())]
+        let transport = FakeTransport(.acceptThenStream(flood))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        try await Task.sleep(for: .milliseconds(200))
+        let events = try await collect(stream)
+        #expect(events.contains { if case .accepted = $0 { true } else { false } })
+        #expect(events.last?.caseName == "completed")
+        #expect(events.count <= RuntimeClient.consumerBufferLimit + 2)
+    }
+
+    @Test func aFailedSendDoesNotLeaveAnAbandonedMarker() async throws {
+        let transport = FakeTransport(.throwOnSend)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let consumer = Task { for try await _ in stream {} }
+        consumer.cancel()
+        _ = try? await consumer.value
+        try await Task.sleep(for: .milliseconds(50))
+        let later = FakeTransport(.acceptThenStream([.completed(OperationID())]))
+        let client2 = RuntimeClient(transport: later)
+        let events = try await collect(client2.send(.startEnvironment(EnvironmentID(), StartOptions())))
+        #expect(events.map(\.caseName) == ["accepted", "completed"])
+        #expect(later.sent.count == 1, "no cancel was sent for a fresh operation")
+    }
+
     @Test func aDiscardedClientIsReleased() async throws {
         weak var weakClient: RuntimeClient?
         do {

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -73,6 +73,29 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         return events
     }
 
+    @Test func theAcceptedEventArrivesBeforeAnyTraffic() async throws {
+        let flood = (0..<(RuntimeClient.consumerBufferLimit * 2)).map { index in RuntimeEvent.log(OperationID(), Redactor().redact(lines: ["line \(index)"])[0]) } + [.completed(OperationID())]
+        let transport = FakeTransport(.acceptThenStream(flood))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        try await Task.sleep(for: .milliseconds(200))
+        let events = try await collect(stream)
+        #expect(events.first?.caseName == "accepted", "the operation id is learned before any traffic")
+        #expect(events.last?.caseName == "completed")
+        #expect(events.count <= RuntimeClient.consumerBufferLimit + 2, "the excess was dropped, not buffered")
+    }
+
+    @Test func lateEventsForAFinishedOperationAreDropped() async throws {
+        let transport = FakeTransport(.acceptThenStream([.completed(OperationID())]))
+        let client = RuntimeClient(transport: transport)
+        let events = try await collect(client.send(.startEnvironment(EnvironmentID(), StartOptions())))
+        guard case .accepted(let id)? = events.first else { Issue.record("no accepted event"); return }
+        let incoming = transport.lock.withLock { transport.incoming }
+        for index in 0..<10 { incoming?(.log(id, Redactor().redact(lines: ["late \(index)"])[0])) }
+        try await Task.sleep(for: .milliseconds(50))
+        #expect(await client.pendingEventCount(for: id) == 0, "a finished operation buffers nothing")
+    }
+
     @Test func runtimeVersionReplyBecomesOneEventAndFinishes() async throws {
         let info = RuntimeVersionInfo(serviceVersion: "1.0", serviceBuild: "7")
         let transport = FakeTransport(.reply(.runtimeVersion(info)))

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -9,15 +9,18 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
     private var pendingReply: (@Sendable (Result<RuntimeEvent, any Error>) -> Void)?
     private(set) var lastAcceptedID: OperationID?
 
+    /// The id the held-back `accepted` reply will carry, known before acceptance so a test can
+    /// push events that arrive before it.
+    let preparedID = OperationID()
+
     /// For `.acceptLater`: delivers the `accepted` reply held back by the last send.
     func deliverPendingAccept() {
-        let (reply, id) = lock.withLock { () -> ((@Sendable (Result<RuntimeEvent, any Error>) -> Void)?, OperationID) in
-            let id = OperationID()
-            lastAcceptedID = id
+        let reply = lock.withLock { () -> (@Sendable (Result<RuntimeEvent, any Error>) -> Void)? in
+            lastAcceptedID = preparedID
             defer { pendingReply = nil }
-            return (pendingReply, id)
+            return pendingReply
         }
-        reply?(.success(.accepted(id)))
+        reply?(.success(.accepted(preparedID)))
     }
     let lock = NSLock()
     var behavior: Behavior
@@ -64,6 +67,30 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
             }
         }
     }
+}
+
+private struct MissedDeadline: Error {}
+
+/// Runs `work` with a deadline, so a client that stops delivering fails the test instead of
+/// hanging the run.
+private func withDeadline<T: Sendable>(_ duration: Duration = .seconds(10), _ work: @escaping @Sendable () async throws -> T) async throws -> T {
+    try await withThrowingTaskGroup(of: T?.self) { group in
+        group.addTask { try await work() }
+        group.addTask {
+            try? await Task.sleep(for: duration)
+            return nil
+        }
+        let finished = try await group.next()
+        group.cancelAll()
+        guard let value = finished ?? nil else { throw MissedDeadline() }
+        return value
+    }
+}
+
+private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> [RuntimeEvent] {
+    var events: [RuntimeEvent] = []
+    for try await event in stream { events.append(event) }
+    return events
 }
 
 @Suite struct RuntimeClientTests {
@@ -203,6 +230,78 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         #expect(weakClient == nil)
     }
 
+    @Test func aTerminalEventSurvivesAFloodThatArrivesBeforeAcceptance() async throws {
+        let transport = FakeTransport(.acceptLater)
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<200 where transport.sentCount == 0 { try await Task.sleep(for: .milliseconds(5)) }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let id = transport.preparedID
+        // Every push is enqueued on the client's ordered inbox before the acceptance below,
+        // so all of this traffic is handled while the operation is still unaccepted.
+        for _ in 0..<(RuntimeClient.pendingEventLimit * 2) { incoming?(.progress(id, ProgressPhase(kind: .copying))) }
+        incoming?(.completed(id))
+        transport.deliverPendingAccept()
+        let events = try await withDeadline { try await collected(from: stream) }
+        #expect(events.last?.caseName == "completed", "the terminal event outlives the traffic that preceded it")
+        #expect(events.count <= RuntimeClient.pendingEventLimit + 1, "the buffer stayed bounded")
+    }
+
+    @Test func aConsumerThatKeepsUpNeverStopsReceivingTraffic() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let total = RuntimeClient.consumerBufferLimit * 2
+        let received = try await withDeadline { () -> Int in
+            var iterator = stream.makeAsyncIterator()
+            guard case .accepted(let id)? = try await iterator.next() else { return 0 }
+            let incoming = transport.lock.withLock { transport.incoming }
+            var received = 0
+            for _ in 0..<total {
+                incoming?(.progress(id, ProgressPhase(kind: .copying)))
+                if case .progress? = try await iterator.next() { received += 1 }
+            }
+            return received
+        }
+        #expect(received == total, "a consumer reading in real time is never cut off")
+    }
+
+    @Test func unscopedLogsAreBoundedLikeOtherTraffic() async throws {
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        var iterator = stream.makeAsyncIterator()
+        guard case .accepted(let id)? = try await iterator.next() else {
+            Issue.record("no accepted event")
+            return
+        }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let line = Redactor().redact(lines: ["unscoped guest output"])[0]
+        for _ in 0..<(RuntimeClient.consumerBufferLimit * 4) { incoming?(.log(nil, line)) }
+        incoming?(.completed(id))
+        // Nothing is read until the flood has been routed and the stream finished, so this
+        // measures what the client was willing to hold for a consumer that is not keeping up,
+        // and the drain below cannot wait on anything.
+        for _ in 0..<400 where await client.isRetired(id) == false { try await Task.sleep(for: .milliseconds(5)) }
+        guard await client.isRetired(id) else {
+            Issue.record("the flood was never routed")
+            return
+        }
+        var delivered: [RuntimeEvent] = []
+        while let event = try await iterator.next() { delivered.append(event) }
+        #expect(delivered.count <= RuntimeClient.consumerBufferLimit, "unscoped output cannot accumulate without limit")
+        #expect(delivered.last?.caseName == "completed", "unscoped output never crowds out the terminal event")
+    }
+
+    @Test func aQueryThatFinishesNormallyReleasesItsKey() async throws {
+        let info = RuntimeVersionInfo(serviceVersion: "1.0", serviceBuild: "7")
+        let transport = FakeTransport(.reply(.runtimeVersion(info)))
+        let client = RuntimeClient(transport: transport)
+        for _ in 0..<10 { _ = try await collect(client.send(.runtimeVersion)) }
+        for _ in 0..<200 where await client.settledKeyCount() > 0 { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(await client.settledKeyCount() == 0, "finished queries do not accumulate for the life of the client")
+    }
+
     @Test func droppedConnectionFailsInFlightOperationsWithTheirID() async {
         let client = RuntimeClient(transport: FakeTransport(.acceptThenDrop))
         var seen: [String] = []
@@ -214,5 +313,62 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         } catch {}
         #expect(seen == ["accepted"])
         #expect(interruption?.operationID != nil)
+    }
+}
+
+/// The transport's session rules, exercised without a live XPC connection.
+@Suite struct SessionRegistryTests {
+    @Test func aReplyFromARetiredSessionBecomesAnInterruption() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        guard case .success = registry.gate(.success(.accepted(OperationID())), from: generation) else {
+            Issue.record("the live session's reply was not forwarded")
+            return
+        }
+        _ = registry.retire(generation)
+        guard case .failure(let error) = registry.gate(.success(.accepted(OperationID())), from: generation) else {
+            Issue.record("an accepted reply from a retired session was forwarded")
+            return
+        }
+        #expect(error is RuntimeConnectionInterrupted)
+    }
+
+    @Test func aSessionIsRetiredOnce() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        registry.setHandlers(incoming: { _ in }, interrupted: {})
+        #expect(registry.retire(generation).interrupted != nil)
+        #expect(registry.retire(generation).interrupted == nil, "a second failure of the same session reports nothing")
+    }
+
+    @Test func aRetirementCannotOvertakeAnEventBeingDelivered() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        let retired = DispatchSemaphore(value: 0)
+        registry.setHandlers(
+            incoming: { _ in
+                DispatchQueue.global().async {
+                    _ = registry.retire(generation)
+                    retired.signal()
+                }
+                // A retirement racing this delivery must wait for it: the generation check and
+                // the handoff to the client are one step, so a stale event can never be queued
+                // behind the operations of a replacement session.
+                #expect(retired.wait(timeout: .now() + .milliseconds(300)) == .timedOut)
+            },
+            interrupted: {}
+        )
+        registry.deliverIncoming(.progress(OperationID(), ProgressPhase(kind: .copying)), from: generation)
+        #expect(retired.wait(timeout: .now() + .seconds(5)) == .success, "the retirement completed once delivery was done")
+    }
+
+    @Test func aRetiredSessionDeliversNothing() {
+        let registry = SessionRegistry<NSObject>()
+        let (_, generation) = registry.session { _ in NSObject() }
+        let delivered = DispatchSemaphore(value: 0)
+        registry.setHandlers(incoming: { _ in delivered.signal() }, interrupted: {})
+        _ = registry.retire(generation)
+        registry.deliverIncoming(.progress(OperationID(), ProgressPhase(kind: .copying)), from: generation)
+        #expect(delivered.wait(timeout: .now()) == .timedOut)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/RuntimeBackend.swift
@@ -17,31 +17,42 @@ public protocol RuntimeBackend: Sendable {
 
 /// Thrown by a backend when the connection dropped before the request reported a result.
 ///
-/// Carries the same presentation contract as `GuesthouseError`: when an operation was in
-/// flight the user is told the outcome is unknown and offered an inspection, never a blind
-/// retry (MVP-PLAN.md §3). A read-only query names no operation, changed nothing, and is
-/// offered the retry that its own failure calls for.
+/// Carries the same presentation contract as `GuesthouseError`: when host state may have
+/// changed the user is told the outcome is unknown and offered an inspection, never a blind
+/// retry (MVP-PLAN.md §3). That covers an operation that was in flight and a mutating request
+/// that may have reached the service before it was accepted. A read-only query names no
+/// operation, changed nothing, and is offered the retry that its own failure calls for.
 public struct RuntimeConnectionInterrupted: Error, Hashable, Sendable, LocalizedError {
     public let operationID: OperationID?
+    /// Whether a request that changes the host may already have reached the service.
+    ///
+    /// A request interrupted before its `accepted` reply has no operation id, but the service
+    /// may still have received it and started or journaled the mutation. Such a request has an
+    /// unknown outcome just as an accepted one does, so it is never offered a blind retry.
+    public let mayHaveMutated: Bool
 
-    public init(operationID: OperationID? = nil) {
+    public init(operationID: OperationID? = nil, mayHaveMutated: Bool = false) {
         self.operationID = operationID
+        self.mayHaveMutated = mayHaveMutated
     }
 
+    /// Whether host state may have changed, so it has to be inspected before anything else.
+    private var outcomeUnknown: Bool { operationID != nil || mayHaveMutated }
+
     public var userMessage: String {
-        operationID == nil
-            ? "Guesthouse lost contact with its runtime service before it answered."
-            : "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+        outcomeUnknown
+            ? "Guesthouse lost contact with its runtime service. The operation may or may not have completed."
+            : "Guesthouse lost contact with its runtime service before it answered."
     }
 
     public var recoveryMessage: String {
-        operationID == nil
-            ? "Ask again once the service is back."
-            : "Check the environment before doing anything else."
+        outcomeUnknown
+            ? "Check the environment before doing anything else."
+            : "Ask again once the service is back."
     }
 
     public var recoveryActions: [RecoveryAction] {
-        operationID == nil ? [.retry] : [.inspectState, .cancel]
+        outcomeUnknown ? [.inspectState, .cancel] : [.retry]
     }
 
     public var errorDescription: String? { userMessage }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -23,6 +23,20 @@ public enum RuntimeRequest: Codable, Hashable, Sendable {
         case .cancelOperation: "cancelOperation"
         }
     }
+
+    /// Whether the service changes host state for this request.
+    ///
+    /// A request that is interrupted before it is accepted carries no operation id, but it may
+    /// still have reached the service and been journaled or started. A mutating one therefore
+    /// has an unknown outcome and is never offered a blind retry; a read-only query changed
+    /// nothing and may simply be asked again. Cancelling counts as read-only because asking
+    /// twice cannot leave the host anywhere asking once would not.
+    public var mutatesHost: Bool {
+        switch self {
+        case .runtimeVersion, .environmentStatus, .cancelOperation: false
+        case .startEnvironment, .stopEnvironment, .importXcode: true
+        }
+    }
 }
 
 /// Every message from the GUI carries the protocol version it speaks.

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Backend/FakeRuntimeBackendTests.swift
@@ -158,6 +158,24 @@ import Testing
         #expect(RuntimeConnectionInterrupted(operationID: OperationID()).recoveryActions == [.inspectState, .cancel])
     }
 
+    @Test func aMutationInterruptedBeforeAcceptanceIsAnUnknownOutcome() {
+        let mutation = RuntimeConnectionInterrupted(mayHaveMutated: true)
+        #expect(mutation.operationID == nil, "it was never accepted, so it has no id")
+        #expect(mutation.recoveryActions == [.inspectState, .cancel], "the service may already have started it")
+        #expect(mutation.userMessage.contains("may or may not"))
+        #expect(RuntimeConnectionInterrupted().recoveryActions == [.retry])
+    }
+
+    @Test func onlyHostChangingRequestsCountAsMutations() {
+        let environment = EnvironmentID()
+        #expect(RuntimeRequest.startEnvironment(environment, StartOptions()).mutatesHost)
+        #expect(RuntimeRequest.stopEnvironment(environment, .force).mutatesHost)
+        #expect(RuntimeRequest.importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")).mutatesHost)
+        #expect(!RuntimeRequest.runtimeVersion.mutatesHost)
+        #expect(!RuntimeRequest.environmentStatus(environment).mutatesHost)
+        #expect(!RuntimeRequest.cancelOperation(OperationID()).mutatesHost)
+    }
+
     @Test func queriesReplyWithoutOperationIDs() async throws {
         let backend = FakeRuntimeBackend()
         let status = EnvironmentStatus(environmentID: environment, vm: .stopped, readiness: .ready)


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: typed/native XPC service and client (#9, #19, #20, #112). Replacements #144–#161 are now on main, including authenticated query-only service/client integration, explicit reply ownership, correlation and retirement. This replaces the earlier integration-pending banner; it does not prove every original regression, later mutation adapter, signed-peer or hardware acceptance item is complete. Finish the retained-scope audit before closing this reference. The closed #110 remains evidence, not proof that all of #112 is complete.
>
> September 9 closure audit: Service embedding, native transport, GUI query and bounded owner/event handling have landed through #151–#160. Finish the retained fake-backend/test and manual-validation scope audit before closing; unsigned fixtures are not signed-app or hardware proof.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #19 (`MVP-PLAN.md` §3 "Sandbox and XPC boundary": a child of a sandboxed app inherits the sandbox, so host operations live in an embedded XPC service with its own policy; §10 Phase 0: "First prove one named Runtime version request"). Stacked on #66.

- New target `GuesthouseRuntime` (`com.starlingprotocol.Guesthouse.Runtime`), an XPC Service embedded at `Contents/XPCServices/`, App Sandbox off, Hardened Runtime on, Swift 6, linked to `GuesthouseCore`. Its Info.plist sets `XPCService.JoinExistingSession`; gate #34 verifies the UI and Keychain behavior. Added to the shared scheme. Verified in the built product: the service bundle is embedded, unsandboxed, and signed with the runtime flag while the app stays sandboxed.
- Service (`main.swift`, `RuntimeService.swift`): `XPCListener` accepting sessions whose messages decode as `RuntimeRequestEnvelope`, validated with `RequestValidator`; `runtimeVersion` replies with the bundle version, build, and protocol version; every other operation is refused with `invalidRequest(.unsupportedOperation)` until later issues implement it.
- GUI: `RuntimeClient` actor conforming to `RuntimeBackend` over a small `RuntimeTransport` seam. `XPCRuntimeTransport` wraps `XPCSession` (lazy connect, `send` with reply handler, incoming-message handler for pushed events, cancellation handler). The client demultiplexes streamed events by `OperationID`, buffers events that arrive before their `accepted` reply, and maps a dropped connection to `RuntimeConnectionInterrupted` so callers treat in-flight work as unknown outcome; it reconnects on the next request.
- Debug-only `Debug ▸ Runtime Version` menu item (⌥⌘R) drives the real service and shows the reply in the window.
- Sets `PRODUCT_MODULE_NAME = Guesthouse` on the app so tests can `@testable import` it.

Tests (5, in `GuesthouseTests` with a fake transport): version reply becomes one event, reply failure and send failure are interruptions, accepted operations stream until completed (with out-of-order arrival), and a dropped connection fails in-flight operations with their id. Package tests remain at 162.

Closes #19

## Checklist

- [x] Tests cover the new logic; package and app test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] No process launched anywhere in this change
- [x] Diff under 500 lines of logic (the project file adds one target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)