### PR TITLE
Runtime: keep XPC transactions open during supervised operations and persist process identity

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -79,6 +79,12 @@ public enum OwnershipVerdict: Hashable, Sendable {
         /// The live process does not name the recorded virtual machine, so it cannot be
         /// proven to be this environment's VM.
         case vmNameUnconfirmed
+        /// The VM appears to be running but no launch was ever recorded for it: the service
+        /// was interrupted between spawning Tart and persisting the identity, or something
+        /// else started the VM.
+        case unrecordedLaunch
+        /// The VM inventory could not be read, so nothing about the VM's lock is known.
+        case inventoryUnavailable
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -85,6 +85,9 @@ public enum OwnershipVerdict: Hashable, Sendable {
         case unrecordedLaunch
         /// The VM inventory could not be read, so nothing about the VM's lock is known.
         case inventoryUnavailable
+        /// The recorded process exists but could not be read from the process table (for
+        /// example it now belongs to another user), so it cannot be matched or ruled out.
+        case processUnobservable
     }
 }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -26,14 +26,40 @@ public struct LiveProcessEnumerator: Sendable {
         return result
     }
 
-    /// The identity of one running process, or `nil` if it does not exist or cannot be read.
-    public func live(pid: Int32) -> LiveProcess? {
-        guard let first = startTime(pid: pid), let path = executablePath(pid: pid) else { return nil }
-        let digest = Self.digest(of: arguments(pid: pid) ?? [])
+    /// What the process table says about one PID. "Absent" and "unreadable" are different
+    /// answers: a process that exists but cannot be read (another user's, or a transient
+    /// failure) must not be mistaken for one that exited.
+    public enum Observation: Hashable, Sendable {
+        case absent
+        case present(LiveProcess)
+        case unavailable(reason: String)
+    }
+
+    public func observe(pid: Int32) -> Observation {
+        guard pid > 0 else { return .absent }
+        if kill(pid, 0) != 0, errno == ESRCH { return .absent }
+        guard let first = startTime(pid: pid) else { return .unavailable(reason: "start time unreadable") }
+        guard let path = executablePath(pid: pid) else { return .unavailable(reason: "executable path unreadable") }
+        guard let arguments = arguments(pid: pid) else { return .unavailable(reason: "arguments unreadable") }
         // The fields came from separate calls; if the PID was reused in between, the start
         // time has changed and the observation describes two processes, so it is discarded.
-        guard startTime(pid: pid) == first else { return nil }
-        return LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: digest)
+        guard startTime(pid: pid) == first else { return .unavailable(reason: "process replaced during observation") }
+        return .present(LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: Self.digest(of: arguments), claimedVMName: Self.claimedVMName(in: arguments)))
+    }
+
+    /// The identity of one running process, or `nil` if it does not exist or cannot be read.
+    public func live(pid: Int32) -> LiveProcess? {
+        if case .present(let process) = observe(pid: pid) { return process }
+        return nil
+    }
+
+    /// The VM a `tart run <name> …` invocation names, if it is an app-managed VM name; any
+    /// other argument shape yields `nil`. Only the first positional argument after `run`
+    /// counts, so a flag value can never be taken for a name.
+    public static func claimedVMName(in arguments: [String]) -> String? {
+        guard let run = arguments.firstIndex(of: "run") else { return nil }
+        guard let name = arguments[arguments.index(after: run)...].first(where: { !$0.hasPrefix("-") }) else { return nil }
+        return (try? RequestValidator.validateVMName(name)) == nil ? nil : name
     }
 
     /// The digest `ProcessIdentity` records for a launch: SHA-256 over the arguments joined by

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -1,0 +1,98 @@
+import CryptoKit
+import Darwin
+import Foundation
+import GuesthouseCore
+
+/// Reads the process table to produce `LiveProcess` values for reconciliation
+/// (MVP-PLAN.md §4: identify any surviving Tart process and its exact VM before recovering
+/// control). Pure observation; nothing here signals or kills.
+public struct LiveProcessEnumerator: Sendable {
+    public init() {}
+
+    /// Every process the current user can inspect whose executable is `executable`, plus the
+    /// process with `pid` if it exists (whatever it runs), so a reused PID is still observed.
+    public func candidates(executable: URL?, pid: Int32?) -> [LiveProcess] {
+        var seen: Set<Int32> = []
+        var result: [LiveProcess] = []
+        if let pid, let process = live(pid: pid) {
+            seen.insert(pid)
+            result.append(process)
+        }
+        guard let executable else { return result }
+        for candidate in allPIDs() where !seen.contains(candidate) {
+            guard let path = executablePath(pid: candidate), path == executable.path, let process = live(pid: candidate) else { continue }
+            result.append(process)
+        }
+        return result
+    }
+
+    /// The identity of one running process, or `nil` if it does not exist or cannot be read.
+    public func live(pid: Int32) -> LiveProcess? {
+        guard let startTime = startTime(pid: pid), let path = executablePath(pid: pid) else { return nil }
+        return LiveProcess(pid: pid, startTime: startTime, executablePath: path, argumentsDigest: Self.digest(of: arguments(pid: pid) ?? []))
+    }
+
+    /// The digest `ProcessIdentity` records for a launch: SHA-256 over the arguments joined by
+    /// NUL, never the arguments themselves.
+    public static func digest(of arguments: [String]) -> String {
+        let joined = Data(arguments.joined(separator: "\0").utf8)
+        return "sha256:" + SHA256.hash(data: joined).map { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Process table
+
+    func allPIDs() -> [Int32] {
+        let count = proc_listallpids(nil, 0)
+        guard count > 0 else { return [] }
+        var pids = [Int32](repeating: 0, count: Int(count) * 2)
+        let filled = pids.withUnsafeMutableBufferPointer { buffer in
+            proc_listallpids(buffer.baseAddress, Int32(buffer.count) * Int32(MemoryLayout<Int32>.size))
+        }
+        return Array(pids.prefix(Int(max(0, filled)))).filter { $0 > 0 }
+    }
+
+    func executablePath(pid: Int32) -> String? {
+        // PROC_PIDPATHINFO_MAXSIZE is a macro (4 * MAXPATHLEN) that Swift does not import.
+        var buffer = [CChar](repeating: 0, count: 4 * Int(MAXPATHLEN))
+        let length = proc_pidpath(pid, &buffer, UInt32(buffer.count))
+        guard length > 0 else { return nil }
+        return String(decoding: buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }, as: UTF8.self)
+    }
+
+    func startTime(pid: Int32) -> Date? {
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.stride
+        var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        guard sysctl(&name, UInt32(name.count), &info, &size, nil, 0) == 0, size > 0, info.kp_proc.p_pid == pid else { return nil }
+        let start = info.kp_proc.p_starttime
+        return Date(timeIntervalSince1970: TimeInterval(start.tv_sec) + TimeInterval(start.tv_usec) / 1_000_000)
+    }
+
+    /// Arguments as the kernel recorded them at exec, without the executable path.
+    func arguments(pid: Int32) -> [String]? {
+        var name: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size = 0
+        guard sysctl(&name, UInt32(name.count), nil, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else { return nil }
+        var buffer = [UInt8](repeating: 0, count: size)
+        guard sysctl(&name, UInt32(name.count), &buffer, &size, nil, 0) == 0 else { return nil }
+        let argc = Int(buffer.prefix(MemoryLayout<Int32>.size).withUnsafeBytes { $0.load(as: Int32.self) })
+        var cursor = MemoryLayout<Int32>.size
+        // Skip the executable path and its padding NULs.
+        while cursor < size, buffer[cursor] != 0 { cursor += 1 }
+        while cursor < size, buffer[cursor] == 0 { cursor += 1 }
+        var strings: [String] = []
+        var current: [UInt8] = []
+        while cursor < size, strings.count < argc {
+            let byte = buffer[cursor]
+            if byte == 0 {
+                strings.append(String(decoding: current, as: UTF8.self))
+                current.removeAll()
+            } else {
+                current.append(byte)
+            }
+            cursor += 1
+        }
+        // argv[0] is the program name; ProcessIdentity records the arguments after it.
+        return Array(strings.dropFirst())
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -7,7 +7,24 @@ import GuesthouseCore
 /// (MVP-PLAN.md §4: identify any surviving Tart process and its exact VM before recovering
 /// control). Pure observation; nothing here signals or kills.
 public struct LiveProcessEnumerator: Sendable {
-    public init() {}
+    /// The two kernel reads whose refusal changes a verdict: listing the process table, and
+    /// reading one process's argument vector. Nothing else can make the kernel decline on
+    /// demand, and a refusal that reads as "nothing is there" is the difference between an
+    /// environment that is free and one that must not be touched.
+    struct KernelReads: Sendable {
+        var pids: @Sendable () -> [Int32]?
+        var arguments: @Sendable (Int32) -> [String]?
+    }
+
+    let kernel: KernelReads
+
+    public init() {
+        self.init(kernel: KernelReads(pids: { Self.listAllPIDs() }, arguments: { Self.readArguments(pid: $0) }))
+    }
+
+    init(kernel: KernelReads) {
+        self.kernel = kernel
+    }
 
     /// Every process the current user can inspect whose executable is `executable`, plus the
     /// process with `pid` if it exists (whatever it runs), so a reused PID is still observed.
@@ -41,7 +58,10 @@ public struct LiveProcessEnumerator: Sendable {
             }
         }
         guard let executable else { return Candidates(processes: result, unreadable: unreadable) }
-        for candidate in allPIDs() where !seen.contains(candidate) {
+        // A process table the kernel refused to list is not an empty one. Reporting it as a
+        // complete scan with nothing in it would let a caller conclude an environment exited.
+        guard let candidates = kernel.pids() else { return Candidates(processes: result, unreadable: true) }
+        for candidate in candidates where !seen.contains(candidate) {
             guard let path = executablePath(pid: candidate), path == executable.path else { continue }
             switch observe(pid: candidate) {
             case .present(let process): result.append(process)
@@ -68,10 +88,15 @@ public struct LiveProcessEnumerator: Sendable {
         if kill(pid, 0) != 0, errno == ESRCH { return .absent }
         guard let first = startTime(pid: pid) else { return .unavailable(reason: "start time unreadable") }
         guard let path = executablePath(pid: pid) else { return .unavailable(reason: "executable path unreadable") }
-        guard let arguments = arguments(pid: pid) else { return .unavailable(reason: "arguments unreadable") }
+        guard let arguments = kernel.arguments(pid) else { return .unavailable(reason: "arguments unreadable") }
         // The fields came from separate calls; if the PID was reused in between, the start
         // time has changed and the observation describes two processes, so it is discarded.
-        guard startTime(pid: pid) == first else { return .unavailable(reason: "process replaced during observation") }
+        // `exec` keeps both the PID and the start time, so the path is read again as well: it
+        // is the field that tells the same process now running a different program, and without
+        // it this could accept the old executable beside the new image's arguments.
+        guard startTime(pid: pid) == first, executablePath(pid: pid) == path else {
+            return .unavailable(reason: "process replaced during observation")
+        }
         return .present(LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: Self.digest(of: arguments), claimedVMName: Self.claimedVMName(in: arguments)))
     }
 
@@ -80,8 +105,22 @@ public struct LiveProcessEnumerator: Sendable {
     public func claimants(ofVM vmName: String) -> Candidates {
         var found: [LiveProcess] = []
         var unreadable = false
-        for candidate in allPIDs() {
-            guard let arguments = arguments(pid: candidate) else { continue }
+        guard let candidates = kernel.pids() else { return Candidates(processes: found, unreadable: true) }
+        for candidate in candidates {
+            guard let arguments = kernel.arguments(candidate) else {
+                // A running process of this user's whose arguments the kernel declined to
+                // describe could be the launch that has not taken the VM's lock yet. One that
+                // belongs to somebody else, or that has already exited, never could be: the
+                // service launches Tart as this user, and those failures are the ordinary
+                // answer for every other process on the Mac. An ownership lookup the kernel
+                // also refused says nothing either way, and reading that as somebody else's
+                // process would turn an interrupted start into a free environment.
+                switch ownership(of: candidate) {
+                case .own, .unavailable: unreadable = true
+                case .notOurs: break
+                }
+                continue
+            }
             guard Self.claimedVMName(in: arguments) == vmName else { continue }
             switch observe(pid: candidate) {
             case .present(let process): found.append(process)
@@ -116,14 +155,38 @@ public struct LiveProcessEnumerator: Sendable {
 
     // MARK: - Process table
 
-    func allPIDs() -> [Int32] {
+    /// Every PID the kernel reports, or `nil` when it would not list them. A negative answer
+    /// from `proc_listallpids` is a refusal, and a refusal is not an empty process table.
+    static func listAllPIDs() -> [Int32]? {
         let count = proc_listallpids(nil, 0)
-        guard count > 0 else { return [] }
+        guard count > 0 else { return count == 0 ? [] : nil }
         var pids = [Int32](repeating: 0, count: Int(count) * 2)
         let filled = pids.withUnsafeMutableBufferPointer { buffer in
             proc_listallpids(buffer.baseAddress, Int32(buffer.count) * Int32(MemoryLayout<Int32>.size))
         }
-        return Array(pids.prefix(Int(max(0, filled)))).filter { $0 > 0 }
+        guard filled >= 0 else { return nil }
+        return Array(pids.prefix(Int(filled))).filter { $0 > 0 }
+    }
+
+    /// Whose process a PID is, as three answers rather than two. A lookup the kernel refused is
+    /// not the same as another account's process or one that has already exited: collapsing it
+    /// into "not ours" would let an interrupted start of our own read as nothing at all.
+    enum Ownership: Hashable, Sendable {
+        /// A running process this user owns: the only kind the service could have launched.
+        case own
+        /// Another account's process, or one that has exited; a zombie holds no VM either.
+        case notOurs
+        /// The kernel would not say.
+        case unavailable
+    }
+
+    func ownership(of pid: Int32) -> Ownership {
+        guard let info = processInfo(pid: pid) else {
+            // A PID that is simply gone answers `ESRCH`; anything else is a refusal.
+            return kill(pid, 0) != 0 && errno == ESRCH ? .notOurs : .unavailable
+        }
+        let mine = info.kp_eproc.e_ucred.cr_uid == getuid() && info.kp_proc.p_stat != Int8(SZOMB)
+        return mine ? .own : .notOurs
     }
 
     func executablePath(pid: Int32) -> String? {
@@ -134,17 +197,22 @@ public struct LiveProcessEnumerator: Sendable {
         return String(decoding: buffer.prefix(Int(length)).map { UInt8(bitPattern: $0) }, as: UTF8.self)
     }
 
-    func startTime(pid: Int32) -> Date? {
+    func processInfo(pid: Int32) -> kinfo_proc? {
         var info = kinfo_proc()
         var size = MemoryLayout<kinfo_proc>.stride
         var name: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
         guard sysctl(&name, UInt32(name.count), &info, &size, nil, 0) == 0, size > 0, info.kp_proc.p_pid == pid else { return nil }
+        return info
+    }
+
+    func startTime(pid: Int32) -> Date? {
+        guard let info = processInfo(pid: pid) else { return nil }
         let start = info.kp_proc.p_starttime
         return Date(timeIntervalSince1970: TimeInterval(start.tv_sec) + TimeInterval(start.tv_usec) / 1_000_000)
     }
 
     /// Arguments as the kernel recorded them at exec, without the executable path.
-    func arguments(pid: Int32) -> [String]? {
+    static func readArguments(pid: Int32) -> [String]? {
         var name: [Int32] = [CTL_KERN, KERN_PROCARGS2, pid]
         var size = 0
         guard sysctl(&name, UInt32(name.count), nil, &size, nil, 0) == 0, size > MemoryLayout<Int32>.size else { return nil }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -11,19 +11,47 @@ public struct LiveProcessEnumerator: Sendable {
 
     /// Every process the current user can inspect whose executable is `executable`, plus the
     /// process with `pid` if it exists (whatever it runs), so a reused PID is still observed.
-    public func candidates(executable: URL?, pid: Int32?) -> [LiveProcess] {
+    /// What one scan of the process table found: the processes it could read, and whether any
+    /// process that looked like a candidate could not be read. An unreadable candidate is not
+    /// evidence of absence, so callers treat it as uncertainty rather than as "nothing there".
+    public struct Candidates: Sendable {
+        public var processes: [LiveProcess]
+        public var unreadable: Bool
+
+        public init(processes: [LiveProcess], unreadable: Bool) {
+            self.processes = processes
+            self.unreadable = unreadable
+        }
+    }
+
+    public func candidates(executable: URL?, pid: Int32?) -> Candidates {
         var seen: Set<Int32> = []
         var result: [LiveProcess] = []
-        if let pid, let process = live(pid: pid) {
-            seen.insert(pid)
-            result.append(process)
+        var unreadable = false
+        if let pid {
+            switch observe(pid: pid) {
+            case .present(let process):
+                seen.insert(pid)
+                result.append(process)
+            case .unavailable:
+                seen.insert(pid)
+                unreadable = true
+            case .absent:
+                break
+            }
         }
-        guard let executable else { return result }
+        guard let executable else { return Candidates(processes: result, unreadable: unreadable) }
         for candidate in allPIDs() where !seen.contains(candidate) {
-            guard let path = executablePath(pid: candidate), path == executable.path, let process = live(pid: candidate) else { continue }
-            result.append(process)
+            guard let path = executablePath(pid: candidate), path == executable.path else { continue }
+            switch observe(pid: candidate) {
+            case .present(let process): result.append(process)
+            // The process runs the recorded program but could not be read: it may be a
+            // claimant, so its absence from the list must not be read as an exit.
+            case .unavailable: unreadable = true
+            case .absent: break
+            }
         }
-        return result
+        return Candidates(processes: result, unreadable: unreadable)
     }
 
     /// What the process table says about one PID. "Absent" and "unreadable" are different
@@ -45,6 +73,23 @@ public struct LiveProcessEnumerator: Sendable {
         // time has changed and the observation describes two processes, so it is discarded.
         guard startTime(pid: pid) == first else { return .unavailable(reason: "process replaced during observation") }
         return .present(LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: Self.digest(of: arguments), claimedVMName: Self.claimedVMName(in: arguments)))
+    }
+
+    /// Every readable process whose arguments name `vmName`, and whether any process could
+    /// not be read. Used to notice a launch that has not taken the VM's lock yet.
+    public func claimants(ofVM vmName: String) -> Candidates {
+        var found: [LiveProcess] = []
+        var unreadable = false
+        for candidate in allPIDs() {
+            guard let arguments = arguments(pid: candidate) else { continue }
+            guard Self.claimedVMName(in: arguments) == vmName else { continue }
+            switch observe(pid: candidate) {
+            case .present(let process): found.append(process)
+            case .unavailable: unreadable = true
+            case .absent: break
+            }
+        }
+        return Candidates(processes: found, unreadable: unreadable)
     }
 
     /// The identity of one running process, or `nil` if it does not exist or cannot be read.

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -28,8 +28,12 @@ public struct LiveProcessEnumerator: Sendable {
 
     /// The identity of one running process, or `nil` if it does not exist or cannot be read.
     public func live(pid: Int32) -> LiveProcess? {
-        guard let startTime = startTime(pid: pid), let path = executablePath(pid: pid) else { return nil }
-        return LiveProcess(pid: pid, startTime: startTime, executablePath: path, argumentsDigest: Self.digest(of: arguments(pid: pid) ?? []))
+        guard let first = startTime(pid: pid), let path = executablePath(pid: pid) else { return nil }
+        let digest = Self.digest(of: arguments(pid: pid) ?? [])
+        // The fields came from separate calls; if the PID was reused in between, the start
+        // time has changed and the observation describes two processes, so it is discarded.
+        guard startTime(pid: pid) == first else { return nil }
+        return LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: digest)
     }
 
     /// The digest `ProcessIdentity` records for a launch: SHA-256 over the arguments joined by

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -69,6 +69,12 @@ public final class OperationSupervisor: Sendable {
         guard live.executablePath == executable.path, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
             throw SupervisionError.processMismatch(pid: pid)
         }
+        // The process must name the VM the caller says it launched: arguments for one VM
+        // recorded under another environment would make later reconciliation claim the wrong
+        // machine (MVP-PLAN.md §4).
+        guard live.claimedVMName == vmName else {
+            throw SupervisionError.processMismatch(pid: pid)
+        }
         // The start time is stored exactly as observed: the reconciler compares it for
         // equality, and the store persists dates losslessly.
         let identity = ProcessIdentity(
@@ -110,12 +116,14 @@ public final class OperationSupervisor: Sendable {
         for environment in Set(environments).union(recordedIdentities.keys) {
             let lock = vmLock(environment)
             if let recorded = recordedIdentities[environment] {
-                // A process that exists but cannot be read is neither matched nor ruled out.
-                if case .unavailable = enumerator.observe(pid: recorded.pid) {
+                // One scan answers both questions: which processes are there, and whether any
+                // candidate could not be read. An unreadable one is never an exit.
+                let scan = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
+                guard !scan.unreadable else {
                     verdicts[environment] = .uncertain(.processUnobservable)
                     continue
                 }
-                let observed = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
+                let observed = scan.processes
                 switch lock {
                 case .unknown:
                     // Without the inventory, "no process" cannot become "exited".
@@ -128,7 +136,13 @@ public final class OperationSupervisor: Sendable {
                 switch lock {
                 case .present: verdicts[environment] = .uncertain(.unrecordedLaunch)
                 case .unknown: verdicts[environment] = .uncertain(.inventoryUnavailable)
-                case .absent: break
+                case .absent:
+                    // No record and no lock, but a live process may already be claiming this
+                    // VM between its launch and the lock: that is not a free environment.
+                    let claimants = enumerator.claimants(ofVM: environment.tartVMName)
+                    if !claimants.processes.isEmpty {
+                        verdicts[environment] = .uncertain(.anotherProcessClaimsVM)
+                    }
                 }
             }
         }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -125,34 +125,60 @@ public final class OperationSupervisor: Sendable {
                     continue
                 }
                 let observed = scan.processes
+                let verdict: OwnershipVerdict
                 switch lock {
                 case .unknown:
                     // Without the inventory, "no process" cannot become "exited".
-                    let verdict = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: true)
-                    verdicts[environment] = verdict == .uncertain(.lockHeldWithoutProcess) ? .uncertain(.inventoryUnavailable) : verdict
+                    let unlocked = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: true)
+                    verdict = unlocked == .uncertain(.lockHeldWithoutProcess) ? .uncertain(.inventoryUnavailable) : unlocked
                 case .present, .absent:
-                    verdicts[environment] = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: lock == .present)
+                    verdict = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: lock == .present)
+                }
+                // That verdict was decided from processes running the *recorded* binary. A Tart
+                // at another path — what a runtime upgrade leaves behind — can be starting the
+                // same VM right now and appears in no such scan, so the VM's own name is asked
+                // for before an exit or an ownership is declared. This holds whatever the
+                // inventory said: a missing inventory is a reason to check the process table
+                // harder, not to skip it (MVP-PLAN.md §4).
+                if verdict == .exited {
+                    verdicts[environment] = claimVerdict(forVM: recorded.vmName) ?? .exited
+                } else if case .ownedRunning = verdict, otherClaimantExists(ofVM: recorded.vmName, besides: recorded.pid) {
+                    // The same scan matters when the record does match: the lock cannot say
+                    // which of two processes naming this VM controls it, so an exact match on
+                    // its own is not ownership. Only a claimant actually read downgrades this
+                    // verdict; an incomplete scan does not, because the recorded process was
+                    // read and matched, which an empty scan cannot claim.
+                    verdicts[environment] = .uncertain(.anotherProcessClaimsVM)
+                } else {
+                    verdicts[environment] = verdict
                 }
             } else {
                 switch lock {
                 case .present: verdicts[environment] = .uncertain(.unrecordedLaunch)
                 case .unknown: verdicts[environment] = .uncertain(.inventoryUnavailable)
-                case .absent:
-                    // No record and no lock, but a live process may already be claiming this
-                    // VM between its launch and the lock: that is not a free environment.
-                    let claimants = enumerator.claimants(ofVM: environment.tartVMName)
-                    if !claimants.processes.isEmpty {
-                        verdicts[environment] = .uncertain(.anotherProcessClaimsVM)
-                    } else if claimants.unreadable {
-                        // The scan found a matching VM argument but could not finish reading
-                        // the process. An environment whose claimant could not be observed is
-                        // not an environment that is free.
-                        verdicts[environment] = .uncertain(.processUnobservable)
-                    }
+                // No record and no lock, but a live process may already be claiming this VM
+                // between its launch and the lock: that is not a free environment.
+                case .absent: verdicts[environment] = claimVerdict(forVM: environment.tartVMName)
                 }
             }
         }
         return verdicts
+    }
+
+    /// What a scan for processes naming `vmName` says about the VM being free: a claimant that
+    /// was read, a claimant the scan could not finish reading, or `nil` when the scan proved
+    /// neither. `nil` is the only answer that leaves an environment available.
+    private func claimVerdict(forVM vmName: String) -> OwnershipVerdict? {
+        let claimants = enumerator.claimants(ofVM: vmName)
+        if !claimants.processes.isEmpty { return .uncertain(.anotherProcessClaimsVM) }
+        return claimants.unreadable ? .uncertain(.processUnobservable) : nil
+    }
+
+    /// Whether a process other than `pid` names `vmName`. Used where the recorded process is
+    /// alive: a second claimant makes ownership uncertain, but a scan that could not be
+    /// finished does not, because the record itself was read and matched.
+    private func otherClaimantExists(ofVM vmName: String, besides pid: Int32) -> Bool {
+        enumerator.claimants(ofVM: vmName).processes.contains { $0.pid != pid }
     }
 
     /// Pure helper for tests and for callers that already enumerated: the verdict for one

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -59,10 +59,15 @@ public final class OperationSupervisor: Sendable {
         }
     }
 
-    /// Records a launched process durably before the caller reports it as started.
+    /// Records a launched process durably before the caller reports it as started. The
+    /// observed process must be the one described: same executable and arguments, so a PID
+    /// reused by another process between launch and observation is never recorded as ours.
     public func recordLaunch(pid: Int32, executable: URL, arguments: [String], vmName: String, environment: EnvironmentID) async throws -> ProcessIdentity {
         guard let live = enumerator.live(pid: pid) else {
             throw SupervisionError.processNotObservable(pid: pid)
+        }
+        guard live.executablePath == executable.path, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
+            throw SupervisionError.processMismatch(pid: pid)
         }
         // Dates are rounded to milliseconds so the persisted record reads back exactly; the
         // reconciler's one-second start-time tolerance covers the lost microseconds.
@@ -84,15 +89,43 @@ public final class OperationSupervisor: Sendable {
         try await store.remove(environment)
     }
 
-    /// Reconciles every recorded identity against the live process table.
-    /// - Parameter vmLockPresent: whether the VM's lock is held, per environment, as observed
-    ///   by the caller; unknown lock state is treated as present so the verdict errs toward
-    ///   uncertainty.
-    public func reconcile(vmLockPresent: (EnvironmentID) -> Bool?) async -> [EnvironmentID: OwnershipVerdict] {
+    /// What the caller knows about a VM's lock.
+    public enum LockObservation: Sendable {
+        case present
+        case absent
+        /// The inventory could not be read.
+        case unknown
+    }
+
+    /// Reconciles every known environment against the live process table.
+    ///
+    /// Environments with a recorded identity get the reconciler's verdict; an environment
+    /// without one whose VM lock is held is `uncertain(.unrecordedLaunch)` (the service died
+    /// between spawning Tart and persisting the identity, or someone else started the VM);
+    /// an unknown lock state is `uncertain(.inventoryUnavailable)`. An environment with no
+    /// record and no lock has no verdict.
+    public func reconcile(environments: [EnvironmentID], vmLock: (EnvironmentID) -> LockObservation) async -> [EnvironmentID: OwnershipVerdict] {
         var verdicts: [EnvironmentID: OwnershipVerdict] = [:]
-        for (environment, recorded) in await store.all {
-            let observed = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
-            verdicts[environment] = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: vmLockPresent(environment) ?? true)
+        let recordedIdentities = await store.all
+        for environment in Set(environments).union(recordedIdentities.keys) {
+            let lock = vmLock(environment)
+            if let recorded = recordedIdentities[environment] {
+                let observed = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
+                switch lock {
+                case .unknown:
+                    // Without the inventory, "no process" cannot become "exited".
+                    let verdict = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: true)
+                    verdicts[environment] = verdict == .uncertain(.lockHeldWithoutProcess) ? .uncertain(.inventoryUnavailable) : verdict
+                case .present, .absent:
+                    verdicts[environment] = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: lock == .present)
+                }
+            } else {
+                switch lock {
+                case .present: verdicts[environment] = .uncertain(.unrecordedLaunch)
+                case .unknown: verdicts[environment] = .uncertain(.inventoryUnavailable)
+                case .absent: break
+                }
+            }
         }
         return verdicts
     }
@@ -110,6 +143,23 @@ extension OperationSupervisor {
     }
 }
 
-public enum SupervisionError: Error, Hashable, Sendable {
+/// Failures while recording a launch. Each leaves the outcome unknown until the caller
+/// inspects the actual state, and says so.
+public enum SupervisionError: Error, Hashable, Sendable, LocalizedError {
+    /// The launched process could not be read from the process table.
     case processNotObservable(pid: Int32)
+    /// The process with that PID is not the one that was launched.
+    case processMismatch(pid: Int32)
+
+    public var userMessage: String {
+        switch self {
+        case .processNotObservable:
+            "Guesthouse started the development Mac's virtual machine but could not observe the process afterwards. Guesthouse will inspect the actual state before offering anything else."
+        case .processMismatch:
+            "The process Guesthouse started for the development Mac was replaced by another process before it could be recorded. Guesthouse will inspect the actual state before offering anything else."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.inspectState, .cancel] }
+    public var errorDescription: String? { userMessage }
 }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -69,10 +69,11 @@ public final class OperationSupervisor: Sendable {
         guard live.executablePath == executable.path, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
             throw SupervisionError.processMismatch(pid: pid)
         }
-        // The process must name the VM the caller says it launched: arguments for one VM
-        // recorded under another environment would make later reconciliation claim the wrong
-        // machine (MVP-PLAN.md §4).
-        guard live.claimedVMName == vmName else {
+        // The process must name the VM the caller says it launched, and that VM must be the
+        // one this environment owns: all three have to agree, or later reconciliation would
+        // claim the wrong machine, and a record that disagrees with itself would make the
+        // whole identity document unreadable on the next start (MVP-PLAN.md §4).
+        guard live.claimedVMName == vmName, vmName == environment.tartVMName else {
             throw SupervisionError.processMismatch(pid: pid)
         }
         // The start time is stored exactly as observed: the reconciler compares it for
@@ -142,6 +143,11 @@ public final class OperationSupervisor: Sendable {
                     let claimants = enumerator.claimants(ofVM: environment.tartVMName)
                     if !claimants.processes.isEmpty {
                         verdicts[environment] = .uncertain(.anotherProcessClaimsVM)
+                    } else if claimants.unreadable {
+                        // The scan found a matching VM argument but could not finish reading
+                        // the process. An environment whose claimant could not be observed is
+                        // not an environment that is free.
+                        verdicts[environment] = .uncertain(.processUnobservable)
                     }
                 }
             }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -1,0 +1,115 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import XPC
+
+/// Keeps the service alive while it supervises work, and answers "is the VM I recorded still
+/// mine?" after a relaunch (MVP-PLAN.md §3, "Keep documented XPC activity/transactions
+/// outstanding while supervising running VMs or operations"; §4, process ownership).
+///
+/// Finding, documented as the plan asks: the Swift `XPCListener`/`XPCSession` API keeps a
+/// bundled XPC service alive only while a message is being handled or a reply is pending.
+/// Once `runtimeVersion` or `startEnvironment` has replied, launchd may terminate an idle
+/// service and abandon a running VM. Supervision therefore holds an explicit
+/// `xpc_transaction_begin()` per in-flight operation and one for every supervised VM
+/// process, ended only when the operation finishes or the process is confirmed gone. This
+/// does not outlive the client: when the app quits, the service still goes with it (§3).
+public final class OperationSupervisor: Sendable {
+    /// A held transaction. Ending it twice is harmless.
+    public final class Token: Sendable {
+        private let ended = Mutex(false)
+        private let onEnd: @Sendable () -> Void
+
+        init(onEnd: @escaping @Sendable () -> Void) {
+            self.onEnd = onEnd
+        }
+
+        public func end() {
+            let first = ended.withLock { flag -> Bool in
+                if flag { return false }
+                flag = true
+                return true
+            }
+            if first { onEnd() }
+        }
+
+        deinit { end() }
+    }
+
+    private let outstanding = Mutex(0)
+    private let enumerator: LiveProcessEnumerator
+    private let store: ProcessIdentityStore
+
+    public init(store: ProcessIdentityStore, enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) {
+        self.store = store
+        self.enumerator = enumerator
+    }
+
+    /// How many transactions are currently held. Zero means the service may idle-exit.
+    public var outstandingTransactions: Int { outstanding.withLock { $0 } }
+
+    /// Begins a transaction for an operation or a supervised process. Keep the token for as
+    /// long as the work must keep the service alive.
+    public func hold(_ reason: String) -> Token {
+        outstanding.withLock { $0 += 1 }
+        xpc_transaction_begin()
+        return Token { [self] in
+            self.outstanding.withLock { $0 -= 1 }
+            xpc_transaction_end()
+        }
+    }
+
+    /// Records a launched process durably before the caller reports it as started.
+    public func recordLaunch(pid: Int32, executable: URL, arguments: [String], vmName: String, environment: EnvironmentID) async throws -> ProcessIdentity {
+        guard let live = enumerator.live(pid: pid) else {
+            throw SupervisionError.processNotObservable(pid: pid)
+        }
+        // Dates are rounded to milliseconds so the persisted record reads back exactly; the
+        // reconciler's one-second start-time tolerance covers the lost microseconds.
+        let identity = ProcessIdentity(
+            pid: pid,
+            startTime: Self.millisecondPrecision(live.startTime),
+            executablePath: executable.path,
+            argumentsDigest: LiveProcessEnumerator.digest(of: arguments),
+            vmName: vmName,
+            environmentID: environment,
+            recordedAt: Self.millisecondPrecision(Date())
+        )
+        try await store.record(identity)
+        return identity
+    }
+
+    /// Forgets a process that is confirmed gone.
+    public func forget(_ environment: EnvironmentID) async throws {
+        try await store.remove(environment)
+    }
+
+    /// Reconciles every recorded identity against the live process table.
+    /// - Parameter vmLockPresent: whether the VM's lock is held, per environment, as observed
+    ///   by the caller; unknown lock state is treated as present so the verdict errs toward
+    ///   uncertainty.
+    public func reconcile(vmLockPresent: (EnvironmentID) -> Bool?) async -> [EnvironmentID: OwnershipVerdict] {
+        var verdicts: [EnvironmentID: OwnershipVerdict] = [:]
+        for (environment, recorded) in await store.all {
+            let observed = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
+            verdicts[environment] = ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: vmLockPresent(environment) ?? true)
+        }
+        return verdicts
+    }
+
+    /// Pure helper for tests and for callers that already enumerated: the verdict for one
+    /// recorded identity against a supplied observation.
+    public static func verdict(recorded: ProcessIdentity, observed: [LiveProcess], vmLockPresent: Bool) -> OwnershipVerdict {
+        ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: vmLockPresent)
+    }
+}
+
+extension OperationSupervisor {
+    static func millisecondPrecision(_ date: Date) -> Date {
+        Date(timeIntervalSince1970: (date.timeIntervalSince1970 * 1000).rounded() / 1000)
+    }
+}
+
+public enum SupervisionError: Error, Hashable, Sendable {
+    case processNotObservable(pid: Int32)
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -69,16 +69,16 @@ public final class OperationSupervisor: Sendable {
         guard live.executablePath == executable.path, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
             throw SupervisionError.processMismatch(pid: pid)
         }
-        // Dates are rounded to milliseconds so the persisted record reads back exactly; the
-        // reconciler's one-second start-time tolerance covers the lost microseconds.
+        // The start time is stored exactly as observed: the reconciler compares it for
+        // equality, and the store persists dates losslessly.
         let identity = ProcessIdentity(
             pid: pid,
-            startTime: Self.millisecondPrecision(live.startTime),
+            startTime: live.startTime,
             executablePath: executable.path,
             argumentsDigest: LiveProcessEnumerator.digest(of: arguments),
             vmName: vmName,
             environmentID: environment,
-            recordedAt: Self.millisecondPrecision(Date())
+            recordedAt: Date()
         )
         try await store.record(identity)
         return identity
@@ -110,6 +110,11 @@ public final class OperationSupervisor: Sendable {
         for environment in Set(environments).union(recordedIdentities.keys) {
             let lock = vmLock(environment)
             if let recorded = recordedIdentities[environment] {
+                // A process that exists but cannot be read is neither matched nor ruled out.
+                if case .unavailable = enumerator.observe(pid: recorded.pid) {
+                    verdicts[environment] = .uncertain(.processUnobservable)
+                    continue
+                }
                 let observed = enumerator.candidates(executable: URL(fileURLWithPath: recorded.executablePath), pid: recorded.pid)
                 switch lock {
                 case .unknown:
@@ -134,12 +139,6 @@ public final class OperationSupervisor: Sendable {
     /// recorded identity against a supplied observation.
     public static func verdict(recorded: ProcessIdentity, observed: [LiveProcess], vmLockPresent: Bool) -> OwnershipVerdict {
         ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: vmLockPresent)
-    }
-}
-
-extension OperationSupervisor {
-    static func millisecondPrecision(_ date: Date) -> Date {
-        Date(timeIntervalSince1970: (date.timeIntervalSince1970 * 1000).rounded() / 1000)
     }
 }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
@@ -12,23 +12,30 @@ public actor ProcessIdentityStore {
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
 
+    /// Dates are stored as `Date`'s own value (seconds since the reference date, full double
+    /// precision), so a start time reads back bit-for-bit: the reconciler compares it for
+    /// equality with the kernel's value. Converting to another epoch would round.
     public init(directory: URL) throws {
         url = directory.appending(path: Self.fileName)
-        let style = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
         encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        encoder.dateEncodingStrategy = .custom { date, encoder in
-            var container = encoder.singleValueContainer()
-            try container.encode(style.format(date))
-        }
+        encoder.dateEncodingStrategy = .deferredToDate
         decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .custom { decoder in
-            try style.parse(try decoder.singleValueContainer().decode(String.self))
-        }
-        if FileManager.default.fileExists(atPath: url.path) {
-            identities = try decoder.decode([EnvironmentID: ProcessIdentity].self, from: try Data(contentsOf: url))
-        } else {
+        decoder.dateDecodingStrategy = .deferredToDate
+        guard FileManager.default.fileExists(atPath: url.path) else {
             identities = [:]
+            return
+        }
+        let data: Data
+        do {
+            data = try Data(contentsOf: url)
+        } catch {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: SanitizedText(error.localizedDescription, limit: 120).value)
+        }
+        do {
+            identities = try decoder.decode([EnvironmentID: ProcessIdentity].self, from: data)
+        } catch {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file is not a valid process record")
         }
     }
 
@@ -83,18 +90,28 @@ public actor ProcessIdentityStore {
     }
 }
 
-/// A process identity could not be persisted. The launched VM may still be running, so the
-/// outcome is unknown until the state is inspected.
+/// A process identity could not be persisted or read back. Either way a launched VM may be
+/// running, so the outcome is unknown until the state is inspected.
 public enum ProcessIdentityStoreError: Error, Hashable, Sendable, LocalizedError {
     case unwritable(path: String, reason: String)
+    /// The record exists but could not be read or decoded; nothing it described can be
+    /// trusted, and the service must not start VMs over ones it may have launched.
+    case unreadable(path: String, reason: String)
 
     public var userMessage: String {
         switch self {
         case .unwritable(let path, let reason):
             "Guesthouse could not record the development Mac's process in \(GuesthouseError.sanitize(path, limit: 200)) (\(GuesthouseError.sanitize(reason))). The virtual machine may still be running; Guesthouse will inspect the actual state. Free disk space or check the storage location in Settings if this persists."
+        case .unreadable(let path, let reason):
+            "Guesthouse could not read its record of launched development Macs at \(GuesthouseError.sanitize(path, limit: 200)) (\(GuesthouseError.sanitize(reason))). A development Mac started earlier may still be running. Guesthouse will inspect the actual state before starting anything; if the file is damaged, move it aside and check again."
         }
     }
 
-    public var recoveryActions: [RecoveryAction] { [.inspectState, .freeDiskSpace, .openSettings, .cancel] }
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .unwritable: [.inspectState, .freeDiskSpace, .openSettings, .cancel]
+        case .unreadable: [.inspectState, .openSettings, .cancel]
+        }
+    }
     public var errorDescription: String? { userMessage }
 }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
@@ -8,7 +8,19 @@ import GuesthouseCore
 public actor ProcessIdentityStore {
     public static let fileName = "processes.json"
 
+    /// The document holds one small record per managed environment. A file far larger than
+    /// that was planted or restored, not written here, and reading it before saying so would
+    /// mean allocating whatever it contains inside the service.
+    static let maximumFileSize: off_t = 1 << 20
+
     public nonisolated let url: URL
+    /// An open descriptor for the state directory this store was given. Every read, write,
+    /// rename, removal and synchronization goes through it, so a directory renamed or replaced
+    /// with a link after the store opened cannot redirect ownership evidence out of the
+    /// runtime's own tree (MVP-PLAN.md §3, "Local storage").
+    private nonisolated let directory: Int32
+    /// The folder the store was given, so a write can confirm the descriptor still names it.
+    private nonisolated let folder: URL
     private var identities: [EnvironmentID: ProcessIdentity]
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -16,46 +28,36 @@ public actor ProcessIdentityStore {
     /// Dates are stored as `Date`'s own value (seconds since the reference date, full double
     /// precision), so a start time reads back bit-for-bit: the reconciler compares it for
     /// equality with the kernel's value. Converting to another epoch would round.
-    public init(directory: URL) throws {
-        url = directory.appending(path: Self.fileName)
-        encoder = JSONEncoder()
-        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
-        encoder.dateEncodingStrategy = .deferredToDate
-        decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .deferredToDate
-        // Leftovers from a write that was interrupted before its rename are removed first, so
-        // repeated interruptions cannot fill the state volume with orphaned snapshots.
-        Self.removeStaleTemporaries(in: directory)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            identities = [:]
-            return
+    public init(directory folder: URL) throws {
+        let file = folder.appending(path: Self.fileName)
+        url = file
+        self.folder = folder
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        jsonEncoder.dateEncodingStrategy = .deferredToDate
+        encoder = jsonEncoder
+        let jsonDecoder = JSONDecoder()
+        jsonDecoder.dateDecodingStrategy = .deferredToDate
+        decoder = jsonDecoder
+        let descriptor = open(folder.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        // Thrown before `identities` is assigned, so the actor is never fully initialized and
+        // no deinitializer runs for a descriptor that was never taken.
+        guard descriptor >= 0 else {
+            throw ProcessIdentityStoreError.unreadable(path: folder.path, reason: errno == ELOOP ? "the state folder is a symbolic link" : String(cString: strerror(errno)))
         }
-        // Opened without following links and verified as a regular file: a link planted here
-        // must not turn some other document into ownership evidence.
-        let data: Data
+        directory = descriptor
         do {
-            data = try Self.readRegularFile(at: url)
-        } catch let error as ProcessIdentityStoreError {
+            // Leftovers from a write that was interrupted before its rename are removed first,
+            // so repeated interruptions cannot fill the state volume with orphaned snapshots.
+            Self.removeStaleTemporaries(in: descriptor)
+            identities = try Self.load(from: descriptor, path: file.path, decoder: jsonDecoder)
+        } catch {
+            close(descriptor)
             throw error
-        } catch {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: SanitizedText(error.localizedDescription, limit: 120).value)
         }
-        let document: Document
-        do {
-            document = try decoder.decode(Document.self, from: data)
-        } catch {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file is not a valid process record")
-        }
-        guard document.schemaVersion <= SchemaVersion.current else {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file was written by a newer Guesthouse")
-        }
-        // A record filed under one environment that describes another is not evidence of
-        // anything: the whole document is refused rather than half-trusted.
-        guard document.identities.allSatisfy({ $0.key == $0.value.environmentID && $0.value.isConsistent }) else {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "a record does not match the environment it is filed under")
-        }
-        identities = document.identities
     }
+
+    deinit { close(directory) }
 
     /// The persisted shape: the records plus the format they are written in, so a later
     /// change can migrate rather than guess.
@@ -64,27 +66,116 @@ public actor ProcessIdentityStore {
         var identities: [EnvironmentID: ProcessIdentity]
     }
 
-    /// Reads a regular file without following a link at the final component.
-    static func readRegularFile(at url: URL) throws -> Data {
-        let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
-        guard descriptor >= 0 else {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: errno == ELOOP ? "the file is a symbolic link" : String(cString: strerror(errno)))
+    private static func load(from directory: Int32, path: String, decoder: JSONDecoder) throws -> [EnvironmentID: ProcessIdentity] {
+        guard let data = try readIdentityFile(from: directory, path: path) else { return [:] }
+        let document: Document
+        do {
+            document = try decoder.decode(Document.self, from: data)
+        } catch {
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file is not a valid process record")
         }
-        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
-        defer { try? handle.close() }
+        guard document.schemaVersion <= SchemaVersion.current else {
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file was written by a newer Guesthouse")
+        }
+        // A record filed under one environment that describes another is not evidence of
+        // anything: the whole document is refused rather than half-trusted.
+        guard document.identities.allSatisfy({ $0.key == $0.value.environmentID && $0.value.isConsistent }) else {
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "a record does not match the environment it is filed under")
+        }
+        return document.identities
+    }
+
+    /// The identity file's bytes, or `nil` when the directory holds no such entry.
+    ///
+    /// `O_NOFOLLOW` refuses a link planted in its place, including one whose target is missing:
+    /// a path-existence check reports that as no file at all and would make damaged evidence
+    /// look like a clean first run. `O_NONBLOCK` refuses a named pipe left here instead of
+    /// waiting for a writer that never comes, which would hang the service.
+    private static func readIdentityFile(from directory: Int32, path: String) throws -> Data? {
+        let descriptor = openat(directory, fileName, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            switch errno {
+            case ENOENT: return nil
+            case ELOOP: throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file is a symbolic link")
+            default: throw ProcessIdentityStoreError.unreadable(path: path, reason: String(cString: strerror(errno)))
+            }
+        }
+        defer { close(descriptor) }
         var info = stat()
         guard fstat(descriptor, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else {
-            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file is not a regular file")
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file is not a regular file")
         }
-        return try handle.readToEnd() ?? Data()
+        // A second link means these bytes also answer to a name outside the state directory,
+        // and whoever holds that name can rewrite the ownership evidence.
+        guard info.st_nlink == 1 else {
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file has more than one name")
+        }
+        guard info.st_size <= maximumFileSize else {
+            throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file is too large to be a process record")
+        }
+        return try readAll(descriptor, path: path)
+    }
+
+    private static func readAll(_ descriptor: Int32, path: String) throws -> Data {
+        var data = Data()
+        var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+        while true {
+            let count = buffer.withUnsafeMutableBytes { read(descriptor, $0.baseAddress, $0.count) }
+            if count > 0 {
+                data.append(contentsOf: buffer.prefix(count))
+                guard data.count <= Int(maximumFileSize) else {
+                    throw ProcessIdentityStoreError.unreadable(path: path, reason: "the file is too large to be a process record")
+                }
+            } else if count == 0 {
+                return data
+            } else if errno != EINTR {
+                throw ProcessIdentityStoreError.unreadable(path: path, reason: String(cString: strerror(errno)))
+            }
+        }
     }
 
     /// Removes leftovers from writes that were interrupted before their rename.
-    static func removeStaleTemporaries(in directory: URL) {
-        let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
-        for name in names where name.hasPrefix(".\(fileName).tmp-") {
-            try? FileManager.default.removeItem(at: directory.appending(path: name))
+    static func removeStaleTemporaries(in directory: Int32) {
+        // Cleanup takes the same exclusive folder lock `update` holds while it writes. The
+        // per-temporary lock below is taken only after `openat` has already published the
+        // name, so a store opening this folder in that window would find an unlocked file that
+        // a writer is about to rename: unlinking it makes that rename fail after the VM it
+        // records may already be running. Sharing the folder lock removes the window rather
+        // than narrowing it (MVP-PLAN.md §4).
+        guard lock(directory, LOCK_EX) else { return }
+        defer { _ = lock(directory, LOCK_UN) }
+        // `fdopendir` takes ownership of the descriptor it is handed, so it gets a duplicate:
+        // the store keeps its own for every later operation.
+        let duplicate = dup(directory)
+        guard duplicate >= 0 else { return }
+        guard let listing = fdopendir(duplicate) else {
+            close(duplicate)
+            return
         }
+        defer { closedir(listing) }
+        while let entry = readdir(listing) {
+            let name = withUnsafeBytes(of: entry.pointee.d_name) { raw in
+                String(cString: raw.baseAddress!.assumingMemoryBound(to: CChar.self))
+            }
+            guard name.hasPrefix(".\(fileName).tmp-") else { continue }
+            let candidate = openat(directory, name, O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC)
+            guard candidate >= 0 else { continue }
+            // A temporary another store still holds is that store's live write, not a leftover.
+            // Unlinking it would make its rename fail on a healthy directory and leave a VM it
+            // may already have launched with no ownership evidence at all. `StateStore` skips
+            // locked temporaries the same way.
+            if lock(candidate, LOCK_EX | LOCK_NB) { unlinkat(directory, name, 0) }
+            close(candidate)
+        }
+    }
+
+    /// `flock`, retrying the interruption a signal can cause. `false` means the lock is held
+    /// by somebody else, or could not be taken at all.
+    static func lock(_ descriptor: Int32, _ operation: Int32) -> Bool {
+        while flock(descriptor, operation) != 0 {
+            guard errno == EINTR else { return false }
+        }
+        return true
     }
 
     public var all: [EnvironmentID: ProcessIdentity] { identities }
@@ -94,16 +185,56 @@ public actor ProcessIdentityStore {
     /// Records the identity durably. Returns only after the file is on disk; memory changes
     /// only then, so a failed write never leaves the actor describing state the disk lacks.
     public func record(_ identity: ProcessIdentity) throws {
-        var staged = identities
-        staged[identity.environmentID] = identity
-        try persist(staged)
-        identities = staged
+        // A record naming a VM the environment does not own would be persisted happily and
+        // then make the whole document unreadable on the next start, stranding every surviving
+        // VM. The write path enforces the same ownership invariant the load path does.
+        guard identity.isConsistent else {
+            throw ProcessIdentityStoreError.inconsistentIdentity(vmName: identity.vmName)
+        }
+        try update { staged in
+            staged[identity.environmentID] = identity
+            return true
+        }
     }
 
     public func remove(_ environment: EnvironmentID) throws {
-        guard identities[environment] != nil else { return }
-        var staged = identities
-        staged.removeValue(forKey: environment)
+        try update { $0.removeValue(forKey: environment) != nil }
+    }
+
+    /// Applies one change to the document that is on disk, not to the snapshot this store read
+    /// when it opened.
+    ///
+    /// Two stores can be open on one state folder — a reload while the first is still live, and
+    /// the tests keep both — and each would otherwise stage its change onto its own
+    /// initialization-time copy: the second write would replace the first store's record with a
+    /// document that never contained it, and a VM that store launched would be left with no
+    /// ownership evidence at all. So the read, the change and the write are held under one
+    /// exclusive lock and the document is re-read inside it (MVP-PLAN.md §4).
+    ///
+    /// - Parameter change: mutates the refreshed document and answers whether it changed
+    ///   anything; nothing is written when it did not.
+    private func update(_ change: (inout [EnvironmentID: ProcessIdentity]) -> Bool) throws {
+        // The folder's own descriptor is what is locked. A lock on the document would be a lock
+        // on the inode `persist` is about to replace by rename, which excludes nobody; the
+        // folder is the one object every writer here shares and never replaces.
+        guard Self.lock(directory, LOCK_EX) else {
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder could not be locked")
+        }
+        defer { _ = Self.lock(directory, LOCK_UN) }
+        // The refreshed document is only evidence about what the next launch will read if the
+        // descriptor still names the configured folder. Adopting one read from a folder that
+        // has been moved or removed would leave the store describing a document nothing will
+        // open — including reporting a removal as done because that document was already gone.
+        guard isStillTheConfiguredFolder() else {
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder is no longer at this path")
+        }
+        // A document that cannot be read now is refused rather than overwritten: whatever it
+        // holds may be another store's evidence for a VM that is running.
+        var staged = try Self.load(from: directory, path: url.path, decoder: decoder)
+        guard change(&staged) else {
+            identities = staged
+            return
+        }
         try persist(staged)
         identities = staged
     }
@@ -115,32 +246,101 @@ public actor ProcessIdentityStore {
         } catch {
             throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "could not be encoded")
         }
-        let temp = url.deletingLastPathComponent().appending(path: ".\(Self.fileName).tmp-\(UUID().uuidString)")
-        guard FileManager.default.createFile(atPath: temp.path, contents: nil, attributes: [.posixPermissions: 0o600]),
-              let handle = try? FileHandle(forWritingTo: temp)
-        else {
+        // The descriptor keeps naming the directory it opened even after that directory is
+        // renamed, which is what stops a link planted at the path from redirecting a write. It
+        // also means the write can land somewhere the next launch will not look: the service
+        // opens the configured path, finds no record, and a VM this process launched loses its
+        // ownership evidence. Reporting success for that would be claiming a durability the
+        // record does not have, so it is refused instead (MVP-PLAN.md §3).
+        guard isStillTheConfiguredFolder() else {
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder is no longer at this path")
+        }
+        let temporary = ".\(Self.fileName).tmp-\(UUID().uuidString)"
+        let descriptor = openat(directory, temporary, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0o600)
+        guard descriptor >= 0 else {
             throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder is not writable")
         }
-        do {
-            try handle.write(contentsOf: data)
-            try handle.synchronize()
-            try handle.close()
-        } catch {
-            try? handle.close()
-            try? FileManager.default.removeItem(at: temp)
-            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: SanitizedText(error.localizedDescription, limit: 120).value)
+        // `openat` masks the mode it is given with the process umask, and the rename below
+        // publishes this temporary as `processes.json` itself: a umask that clears the owner's
+        // read bit leaves a record no later update and no next launch can reopen, while
+        // `record` still returned successfully and a VM was launched on the strength of it.
+        // `StateStore` normalizes every state file the same way (MVP-PLAN.md §3).
+        var created = stat()
+        guard fstat(descriptor, &created) == 0 else {
+            close(descriptor)
+            unlinkat(directory, temporary, 0)
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: String(cString: strerror(errno)))
         }
-        guard rename(temp.path, url.path) == 0 else {
+        if created.st_mode & 0o777 != 0o600, fchmod(descriptor, 0o600) != 0 {
+            close(descriptor)
+            unlinkat(directory, temporary, 0)
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the file could not be made private")
+        }
+        // Held until the rename has happened, so a store opening this directory meanwhile can
+        // tell this live write from a temporary an interrupted one left behind.
+        guard Self.lock(descriptor, LOCK_EX) else {
+            close(descriptor)
+            unlinkat(directory, temporary, 0)
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder is not writable")
+        }
+        defer { close(descriptor) }
+        do {
+            try Self.writeAll(descriptor, data, path: url.path)
+            try Self.fullySynchronize(descriptor, path: url.path)
+        } catch {
+            unlinkat(directory, temporary, 0)
+            throw error
+        }
+        guard renameat(directory, temporary, directory, Self.fileName) == 0 else {
             let reason = String(cString: strerror(errno))
-            try? FileManager.default.removeItem(at: temp)
+            unlinkat(directory, temporary, 0)
             throw ProcessIdentityStoreError.unwritable(path: url.path, reason: reason)
         }
         // The rename itself must be durable: synchronizing only the file leaves the directory
-        // entry in the cache, so a power loss could lose the record that was just reported.
-        let directory = open(url.deletingLastPathComponent().path, O_RDONLY | O_CLOEXEC)
-        if directory >= 0 {
-            _ = fsync(directory)
-            close(directory)
+        // entry in the cache, so a power loss could lose the record that was just reported. A
+        // synchronization that failed proves nothing about the disk, so it is never ignored.
+        try Self.fullySynchronize(directory, path: url.path)
+    }
+
+    /// Whether the descriptor this store holds is still the folder it was given, compared by
+    /// volume and inode so a folder renamed back and forth is judged by what it is.
+    private nonisolated func isStillTheConfiguredFolder() -> Bool {
+        var opened = stat()
+        var configured = stat()
+        guard fstat(directory, &opened) == 0, lstat(folder.path, &configured) == 0 else { return false }
+        return opened.st_dev == configured.st_dev && opened.st_ino == configured.st_ino
+    }
+
+    private static func writeAll(_ descriptor: Int32, _ data: Data, path: String) throws {
+        var written = 0
+        while written < data.count {
+            let count = data.withUnsafeBytes { raw in
+                write(descriptor, raw.baseAddress! + written, data.count - written)
+            }
+            if count > 0 {
+                written += count
+            } else if count < 0, errno == EINTR {
+                continue
+            } else {
+                throw ProcessIdentityStoreError.unwritable(path: path, reason: String(cString: strerror(errno)))
+            }
+        }
+    }
+
+    /// Forces bytes and directory entries onto permanent media. On macOS `fsync` can leave
+    /// them in the drive's volatile cache, so an identity `recordLaunch` already reported as
+    /// persisted could still vanish in a power loss; `F_FULLFSYNC` is the barrier that does
+    /// not. A volume that does not implement it gets `fsync`, its strongest offer. `StateStore`
+    /// does the same in the other package, which cannot be imported here.
+    static func fullySynchronize(_ descriptor: Int32, path: String) throws {
+        if fcntl(descriptor, F_FULLFSYNC) == 0 { return }
+        switch errno {
+        case ENOTSUP, ENOTTY, EINVAL, EPERM, ENODEV:
+            guard fsync(descriptor) == 0 else {
+                throw ProcessIdentityStoreError.unwritable(path: path, reason: String(cString: strerror(errno)))
+            }
+        default:
+            throw ProcessIdentityStoreError.unwritable(path: path, reason: String(cString: strerror(errno)))
         }
     }
 }
@@ -152,6 +352,9 @@ public enum ProcessIdentityStoreError: Error, Hashable, Sendable, LocalizedError
     /// The record exists but could not be read or decoded; nothing it described can be
     /// trusted, and the service must not start VMs over ones it may have launched.
     case unreadable(path: String, reason: String)
+    /// The identity offered for a write names a VM the environment does not own. Nothing was
+    /// written, so the document on disk is still the one the next start can read.
+    case inconsistentIdentity(vmName: String)
 
     public var userMessage: String {
         switch self {
@@ -159,6 +362,8 @@ public enum ProcessIdentityStoreError: Error, Hashable, Sendable, LocalizedError
             "Guesthouse could not record the development Mac's process in \(GuesthouseError.sanitize(path, limit: 200)) (\(GuesthouseError.sanitize(reason))). The virtual machine may still be running; Guesthouse will inspect the actual state. Free disk space or check the storage location in Settings if this persists."
         case .unreadable(let path, let reason):
             "Guesthouse could not read its record of launched development Macs at \(GuesthouseError.sanitize(path, limit: 200)) (\(GuesthouseError.sanitize(reason))). A development Mac started earlier may still be running. Guesthouse will inspect the actual state before starting anything; if the file is damaged, move it aside and check again."
+        case .inconsistentIdentity(let vmName):
+            "Guesthouse was asked to record the virtual machine \(GuesthouseError.sanitize(vmName, limit: 100)) for a development Mac that does not own it, so nothing was recorded. A virtual machine started for this development Mac may still be running; Guesthouse will inspect the actual state before starting anything else."
         }
     }
 
@@ -166,6 +371,7 @@ public enum ProcessIdentityStoreError: Error, Hashable, Sendable, LocalizedError
         switch self {
         case .unwritable: [.inspectState, .freeDiskSpace, .openSettings, .cancel]
         case .unreadable: [.inspectState, .openSettings, .cancel]
+        case .inconsistentIdentity: [.inspectState, .cancel]
         }
     }
     public var errorDescription: String? { userMessage }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
@@ -1,0 +1,69 @@
+import Foundation
+import GuesthouseCore
+
+/// Persists the identities of processes the service launched, so a relaunched service can
+/// recognize a survivor or refuse to guess (MVP-PLAN.md §4). Written atomically before the
+/// process is reported as started; one file under the runtime's `state/` directory.
+public actor ProcessIdentityStore {
+    public static let fileName = "processes.json"
+
+    public nonisolated let url: URL
+    private var identities: [EnvironmentID: ProcessIdentity]
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init(directory: URL) throws {
+        url = directory.appending(path: Self.fileName)
+        let style = Date.ISO8601FormatStyle(includingFractionalSeconds: true)
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        encoder.dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(style.format(date))
+        }
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            try style.parse(try decoder.singleValueContainer().decode(String.self))
+        }
+        if FileManager.default.fileExists(atPath: url.path) {
+            identities = try decoder.decode([EnvironmentID: ProcessIdentity].self, from: try Data(contentsOf: url))
+        } else {
+            identities = [:]
+        }
+    }
+
+    public var all: [EnvironmentID: ProcessIdentity] { identities }
+
+    public func identity(for environment: EnvironmentID) -> ProcessIdentity? { identities[environment] }
+
+    /// Records the identity durably. Returns only after the file is on disk.
+    public func record(_ identity: ProcessIdentity) throws {
+        identities[identity.environmentID] = identity
+        try persist()
+    }
+
+    public func remove(_ environment: EnvironmentID) throws {
+        guard identities.removeValue(forKey: environment) != nil else { return }
+        try persist()
+    }
+
+    private func persist() throws {
+        let data = try encoder.encode(identities)
+        let temp = url.deletingLastPathComponent().appending(path: ".\(Self.fileName).tmp-\(UUID().uuidString)")
+        FileManager.default.createFile(atPath: temp.path, contents: nil, attributes: [.posixPermissions: 0o600])
+        let handle = try FileHandle(forWritingTo: temp)
+        do {
+            try handle.write(contentsOf: data)
+            try handle.synchronize()
+            try handle.close()
+        } catch {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: temp)
+            throw error
+        }
+        guard rename(temp.path, url.path) == 0 else {
+            try? FileManager.default.removeItem(at: temp)
+            throw CocoaError(.fileWriteUnknown)
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
@@ -36,22 +36,36 @@ public actor ProcessIdentityStore {
 
     public func identity(for environment: EnvironmentID) -> ProcessIdentity? { identities[environment] }
 
-    /// Records the identity durably. Returns only after the file is on disk.
+    /// Records the identity durably. Returns only after the file is on disk; memory changes
+    /// only then, so a failed write never leaves the actor describing state the disk lacks.
     public func record(_ identity: ProcessIdentity) throws {
-        identities[identity.environmentID] = identity
-        try persist()
+        var staged = identities
+        staged[identity.environmentID] = identity
+        try persist(staged)
+        identities = staged
     }
 
     public func remove(_ environment: EnvironmentID) throws {
-        guard identities.removeValue(forKey: environment) != nil else { return }
-        try persist()
+        guard identities[environment] != nil else { return }
+        var staged = identities
+        staged.removeValue(forKey: environment)
+        try persist(staged)
+        identities = staged
     }
 
-    private func persist() throws {
-        let data = try encoder.encode(identities)
+    private func persist(_ staged: [EnvironmentID: ProcessIdentity]) throws {
+        let data: Data
+        do {
+            data = try encoder.encode(staged)
+        } catch {
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "could not be encoded")
+        }
         let temp = url.deletingLastPathComponent().appending(path: ".\(Self.fileName).tmp-\(UUID().uuidString)")
-        FileManager.default.createFile(atPath: temp.path, contents: nil, attributes: [.posixPermissions: 0o600])
-        let handle = try FileHandle(forWritingTo: temp)
+        guard FileManager.default.createFile(atPath: temp.path, contents: nil, attributes: [.posixPermissions: 0o600]),
+              let handle = try? FileHandle(forWritingTo: temp)
+        else {
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "the state folder is not writable")
+        }
         do {
             try handle.write(contentsOf: data)
             try handle.synchronize()
@@ -59,11 +73,28 @@ public actor ProcessIdentityStore {
         } catch {
             try? handle.close()
             try? FileManager.default.removeItem(at: temp)
-            throw error
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: SanitizedText(error.localizedDescription, limit: 120).value)
         }
         guard rename(temp.path, url.path) == 0 else {
+            let reason = String(cString: strerror(errno))
             try? FileManager.default.removeItem(at: temp)
-            throw CocoaError(.fileWriteUnknown)
+            throw ProcessIdentityStoreError.unwritable(path: url.path, reason: reason)
         }
     }
+}
+
+/// A process identity could not be persisted. The launched VM may still be running, so the
+/// outcome is unknown until the state is inspected.
+public enum ProcessIdentityStoreError: Error, Hashable, Sendable, LocalizedError {
+    case unwritable(path: String, reason: String)
+
+    public var userMessage: String {
+        switch self {
+        case .unwritable(let path, let reason):
+            "Guesthouse could not record the development Mac's process in \(GuesthouseError.sanitize(path, limit: 200)) (\(GuesthouseError.sanitize(reason))). The virtual machine may still be running; Guesthouse will inspect the actual state. Free disk space or check the storage location in Settings if this persists."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.inspectState, .freeDiskSpace, .openSettings, .cancel] }
+    public var errorDescription: String? { userMessage }
 }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/ProcessIdentityStore.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GuesthouseCore
 
@@ -22,20 +23,67 @@ public actor ProcessIdentityStore {
         encoder.dateEncodingStrategy = .deferredToDate
         decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .deferredToDate
+        // Leftovers from a write that was interrupted before its rename are removed first, so
+        // repeated interruptions cannot fill the state volume with orphaned snapshots.
+        Self.removeStaleTemporaries(in: directory)
         guard FileManager.default.fileExists(atPath: url.path) else {
             identities = [:]
             return
         }
+        // Opened without following links and verified as a regular file: a link planted here
+        // must not turn some other document into ownership evidence.
         let data: Data
         do {
-            data = try Data(contentsOf: url)
+            data = try Self.readRegularFile(at: url)
+        } catch let error as ProcessIdentityStoreError {
+            throw error
         } catch {
             throw ProcessIdentityStoreError.unreadable(path: url.path, reason: SanitizedText(error.localizedDescription, limit: 120).value)
         }
+        let document: Document
         do {
-            identities = try decoder.decode([EnvironmentID: ProcessIdentity].self, from: data)
+            document = try decoder.decode(Document.self, from: data)
         } catch {
             throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file is not a valid process record")
+        }
+        guard document.schemaVersion <= SchemaVersion.current else {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file was written by a newer Guesthouse")
+        }
+        // A record filed under one environment that describes another is not evidence of
+        // anything: the whole document is refused rather than half-trusted.
+        guard document.identities.allSatisfy({ $0.key == $0.value.environmentID && $0.value.isConsistent }) else {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "a record does not match the environment it is filed under")
+        }
+        identities = document.identities
+    }
+
+    /// The persisted shape: the records plus the format they are written in, so a later
+    /// change can migrate rather than guess.
+    struct Document: Codable {
+        var schemaVersion: SchemaVersion = .current
+        var identities: [EnvironmentID: ProcessIdentity]
+    }
+
+    /// Reads a regular file without following a link at the final component.
+    static func readRegularFile(at url: URL) throws -> Data {
+        let descriptor = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: errno == ELOOP ? "the file is a symbolic link" : String(cString: strerror(errno)))
+        }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        defer { try? handle.close() }
+        var info = stat()
+        guard fstat(descriptor, &info) == 0, (info.st_mode & S_IFMT) == S_IFREG else {
+            throw ProcessIdentityStoreError.unreadable(path: url.path, reason: "the file is not a regular file")
+        }
+        return try handle.readToEnd() ?? Data()
+    }
+
+    /// Removes leftovers from writes that were interrupted before their rename.
+    static func removeStaleTemporaries(in directory: URL) {
+        let names = (try? FileManager.default.contentsOfDirectory(atPath: directory.path)) ?? []
+        for name in names where name.hasPrefix(".\(fileName).tmp-") {
+            try? FileManager.default.removeItem(at: directory.appending(path: name))
         }
     }
 
@@ -63,7 +111,7 @@ public actor ProcessIdentityStore {
     private func persist(_ staged: [EnvironmentID: ProcessIdentity]) throws {
         let data: Data
         do {
-            data = try encoder.encode(staged)
+            data = try encoder.encode(Document(identities: staged))
         } catch {
             throw ProcessIdentityStoreError.unwritable(path: url.path, reason: "could not be encoded")
         }
@@ -86,6 +134,13 @@ public actor ProcessIdentityStore {
             let reason = String(cString: strerror(errno))
             try? FileManager.default.removeItem(at: temp)
             throw ProcessIdentityStoreError.unwritable(path: url.path, reason: reason)
+        }
+        // The rename itself must be durable: synchronizing only the file leaves the directory
+        // entry in the cache, so a power loss could lose the record that was just reported.
+        let directory = open(url.deletingLastPathComponent().path, O_RDONLY | O_CLOEXEC)
+        if directory >= 0 {
+            _ = fsync(directory)
+            close(directory)
         }
     }
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -20,9 +20,9 @@ import Testing
         #expect(live.argumentsDigest == LiveProcessEnumerator.digest(of: ["37"]))
         #expect(live.argumentsDigest != LiveProcessEnumerator.digest(of: ["38"]))
         let bySleepPath = enumerator.candidates(executable: URL(fileURLWithPath: "/bin/sleep"), pid: nil)
-        #expect(bySleepPath.contains(live))
+        #expect(bySleepPath.processes.contains(live))
         let byPID = enumerator.candidates(executable: nil, pid: pid)
-        #expect(byPID == [live])
+        #expect(byPID.processes == [live])
         #expect(enumerator.live(pid: 2_000_000_000) == nil)
     }
 
@@ -161,6 +161,54 @@ import Testing
         #expect(path.hasSuffix(ProcessIdentityStore.fileName))
         #expect(error?.recoveryActions.first == .inspectState)
         #expect(error?.userMessage.contains("inspect") == true)
+    }
+
+    @Test func aRecordFiledUnderTheWrongEnvironmentIsRefused() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Identity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let a = EnvironmentID(), b = EnvironmentID()
+        let identity = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "sha256:0", vmName: b.tartVMName, environmentID: b, recordedAt: Date())
+        let document = ProcessIdentityStore.Document(identities: [a: identity])
+        let encoder = JSONEncoder(); encoder.dateEncodingStrategy = .deferredToDate
+        try encoder.encode(document).write(to: directory.appending(path: ProcessIdentityStore.fileName))
+        let error = #expect(throws: ProcessIdentityStoreError.self) { try ProcessIdentityStore(directory: directory) }
+        guard case .unreadable? = error else { Issue.record("expected unreadable, got \(String(describing: error))"); return }
+    }
+
+    @Test func aLinkedIdentityFileIsRefusedAndStaleTemporariesAreRemoved() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Identity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let elsewhere = directory.appending(path: "elsewhere.json")
+        try Data("{}".utf8).write(to: elsewhere)
+        try FileManager.default.createSymbolicLink(at: directory.appending(path: ProcessIdentityStore.fileName), withDestinationURL: elsewhere)
+        #expect(throws: ProcessIdentityStoreError.self) { try ProcessIdentityStore(directory: directory) }
+        try FileManager.default.removeItem(at: directory.appending(path: ProcessIdentityStore.fileName))
+        let stale = directory.appending(path: ".\(ProcessIdentityStore.fileName).tmp-old")
+        try Data("leftover".utf8).write(to: stale)
+        _ = try ProcessIdentityStore(directory: directory)
+        #expect(!FileManager.default.fileExists(atPath: stale.path), "an interrupted write leaves nothing behind")
+    }
+
+    @Test func aLaunchMustNameTheVMItIsRecordedFor() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let supervisor = OperationSupervisor(store: store)
+        let environment = EnvironmentID(), other = EnvironmentID()
+        let arguments = ["-e", "sleep 41", "run", other.tartVMName]
+        let fixture = URL(fileURLWithPath: "/usr/bin/perl")
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: fixture, arguments: arguments, timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        await #expect(throws: SupervisionError.processMismatch(pid: run.processIdentifier)) {
+            _ = try await supervisor.recordLaunch(pid: run.processIdentifier, executable: fixture, arguments: arguments, vmName: environment.tartVMName, environment: environment)
+        }
+    }
+
+    @Test func aClaimantWithoutARecordOrLockIsUncertain() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let environment = EnvironmentID()
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/perl"), arguments: ["-e", "sleep 41", "run", environment.tartVMName], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        let verdicts = await OperationSupervisor(store: store).reconcile(environments: [environment]) { _ in .absent }
+        #expect(verdicts[environment] == .uncertain(.anotherProcessClaimsVM), "a launch that has not taken the lock yet is not a free environment")
     }
 
     @Test func transactionsAreCountedAndEndedOnce() {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -29,9 +29,15 @@ import Testing
     @Test func recordedLaunchIsDurableAndReconcilesAsOwnedThenExited() async throws {
         let store = try ProcessIdentityStore(directory: root)
         let supervisor = OperationSupervisor(store: store)
-        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["41"], timeout: .seconds(20)))
         let environment = EnvironmentID()
-        let identity = try await supervisor.recordLaunch(pid: run.processIdentifier, executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["41"], vmName: environment.tartVMName, environment: environment)
+        // A stand-in for `tart run <vm>`: the trailing arguments are ignored by the program
+        // but land in its argv, so the process names the VM the way a real launch does.
+        // (A shell is unusable here: `/bin/sh` is reported as `/bin/bash` moments after it
+        // starts, so its executable path is not stable.)
+        let arguments = ["-e", "sleep 41", "run", environment.tartVMName]
+        let fixture = URL(fileURLWithPath: "/usr/bin/perl")
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: fixture, arguments: arguments, timeout: .seconds(20)))
+        let identity = try await supervisor.recordLaunch(pid: run.processIdentifier, executable: fixture, arguments: arguments, vmName: environment.tartVMName, environment: environment)
         let reloaded = try ProcessIdentityStore(directory: root)
         let persisted = try #require(await reloaded.identity(for: environment), "the file is on disk before recordLaunch returns")
         #expect(persisted.pid == identity.pid)

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.serialized) struct SupervisionTests {
+    let root = FileManager.default.temporaryDirectory.appending(path: "SupervisionTests-\(UUID().uuidString)")
+
+    init() { try? FileManager.default.createDirectory(at: root, withIntermediateDirectories: true) }
+
+    @Test func enumeratorObservesASpawnedProcessExactly() async throws {
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["37"], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        let pid = run.processIdentifier
+        let enumerator = LiveProcessEnumerator()
+        let live = try #require(enumerator.live(pid: pid))
+        #expect(live.pid == pid)
+        #expect(live.executablePath == "/bin/sleep")
+        #expect(abs(live.startTime.timeIntervalSinceNow) < 30)
+        #expect(live.argumentsDigest == LiveProcessEnumerator.digest(of: ["37"]))
+        #expect(live.argumentsDigest != LiveProcessEnumerator.digest(of: ["38"]))
+        let bySleepPath = enumerator.candidates(executable: URL(fileURLWithPath: "/bin/sleep"), pid: nil)
+        #expect(bySleepPath.contains(live))
+        let byPID = enumerator.candidates(executable: nil, pid: pid)
+        #expect(byPID == [live])
+        #expect(enumerator.live(pid: 2_000_000_000) == nil)
+    }
+
+    @Test func recordedLaunchIsDurableAndReconcilesAsOwnedThenExited() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let supervisor = OperationSupervisor(store: store)
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["41"], timeout: .seconds(20)))
+        let environment = EnvironmentID()
+        let identity = try await supervisor.recordLaunch(pid: run.processIdentifier, executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["41"], vmName: environment.tartVMName, environment: environment)
+        let reloaded = try ProcessIdentityStore(directory: root)
+        let persisted = try #require(await reloaded.identity(for: environment), "the file is on disk before recordLaunch returns")
+        #expect(persisted.pid == identity.pid)
+        #expect(persisted.executablePath == identity.executablePath)
+        #expect(persisted.argumentsDigest == identity.argumentsDigest)
+        #expect(persisted.vmName == identity.vmName)
+        #expect(persisted.environmentID == identity.environmentID)
+        #expect(abs(persisted.startTime.timeIntervalSince(identity.startTime)) < 0.001, "millisecond precision survives the file")
+        // Recorded dates are rounded to milliseconds when persisted; the difference is at most one.
+        #expect(abs(persisted.recordedAt.timeIntervalSince(identity.recordedAt)) <= 0.0015)
+        let owned = await supervisor.reconcile { _ in true }
+        guard case .ownedRunning(let live)? = owned[environment] else { Issue.record("expected owned, got \(String(describing: owned[environment]))"); return }
+        #expect(live.pid == run.processIdentifier)
+
+        run.terminate(gracePeriod: .milliseconds(100))
+        _ = await run.exit()
+        let gone = await supervisor.reconcile { _ in false }
+        #expect(gone[environment] == .exited)
+        let locked = await supervisor.reconcile { _ in nil }
+        #expect(locked[environment] == .uncertain(.lockHeldWithoutProcess), "unknown lock state errs toward uncertainty")
+        try await supervisor.forget(environment)
+        #expect(await store.all.isEmpty)
+    }
+
+    @Test func aReusedPIDIsNeverMistakenForTheRecordedProcess() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let supervisor = OperationSupervisor(store: store)
+        let first = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["43"], timeout: .seconds(20)))
+        defer { first.terminate(gracePeriod: .milliseconds(100)) }
+        let live = try #require(LiveProcessEnumerator().live(pid: first.processIdentifier))
+        let environment = EnvironmentID()
+        let stale = ProcessIdentity(pid: live.pid, startTime: live.startTime.addingTimeInterval(-3600), executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        try await store.record(stale)
+        let verdicts = await supervisor.reconcile { _ in false }
+        #expect(verdicts[environment] == .uncertain(.pidReusedByAnotherProcess))
+    }
+
+    @Test func transactionsAreCountedAndEndedOnce() {
+        let supervisor = OperationSupervisor(store: try! ProcessIdentityStore(directory: root))
+        #expect(supervisor.outstandingTransactions == 0)
+        let a = supervisor.hold("operation")
+        let b = supervisor.hold("vm")
+        #expect(supervisor.outstandingTransactions == 2)
+        a.end(); a.end()
+        #expect(supervisor.outstandingTransactions == 1)
+        b.end()
+        #expect(supervisor.outstandingTransactions == 0)
+    }
+
+    @Test func identityStoreWritesRestrictedFilesAtomically() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let environment = EnvironmentID()
+        try await store.record(ProcessIdentity(pid: 1, startTime: Date(timeIntervalSince1970: 1_800_000_000.25), executablePath: "/x", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date(timeIntervalSince1970: 1_800_000_001)))
+        let attributes = try FileManager.default.attributesOfItem(atPath: store.url.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o600)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).filter { $0.hasPrefix(".processes.json.tmp-") }.isEmpty)
+        let reloaded = try ProcessIdentityStore(directory: root)
+        #expect(await reloaded.identity(for: environment)?.startTime == Date(timeIntervalSince1970: 1_800_000_000.25))
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -110,10 +110,11 @@ import Testing
         let directory = FileManager.default.temporaryDirectory.appending(path: "Supervision-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let store = try ProcessIdentityStore(directory: directory)
-        let identity = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "d", vmName: "vm", environmentID: EnvironmentID(), recordedAt: Date())
+        let first = EnvironmentID(), second = EnvironmentID()
+        let identity = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "d", vmName: first.tartVMName, environmentID: first, recordedAt: Date())
         try await store.record(identity)
         try FileManager.default.removeItem(at: directory)
-        let other = ProcessIdentity(pid: 2, startTime: Date(), executablePath: "/y", argumentsDigest: "e", vmName: "vm2", environmentID: EnvironmentID(), recordedAt: Date())
+        let other = ProcessIdentity(pid: 2, startTime: Date(), executablePath: "/y", argumentsDigest: "e", vmName: second.tartVMName, environmentID: second, recordedAt: Date())
         await #expect(throws: ProcessIdentityStoreError.self) { try await store.record(other) }
         #expect(await store.all.count == 1)
         await #expect(throws: ProcessIdentityStoreError.self) { try await store.remove(identity.environmentID) }
@@ -249,5 +250,258 @@ import Testing
         #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).filter { $0.hasPrefix(".processes.json.tmp-") }.isEmpty)
         let reloaded = try ProcessIdentityStore(directory: root)
         #expect(await reloaded.identity(for: environment)?.startTime == Date(timeIntervalSince1970: 1_800_000_000.25))
+    }
+
+    /// A fixture folder is created `0700` explicitly: continuous integration runs with a
+    /// permissive umask, and the storage code refuses a folder other users can change.
+    private func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Identity-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        return directory
+    }
+
+    private func writeDocument(_ identities: [EnvironmentID: ProcessIdentity], to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .deferredToDate
+        try encoder.encode(ProcessIdentityStore.Document(identities: identities)).write(to: url)
+    }
+
+    @Test func aTartAtAnotherPathClaimingTheVMIsNotAnExit() async throws {
+        let store = try ProcessIdentityStore(directory: try makeDirectory())
+        let supervisor = OperationSupervisor(store: store)
+        let environment = EnvironmentID()
+        // A claimant started from a Tart at a path the record does not name, which is what a
+        // runtime upgrade leaves behind.
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/perl"), arguments: ["-e", "sleep 43", "run", environment.tartVMName], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        let recorded = ProcessIdentity(pid: 2_000_000_000, startTime: Date(), executablePath: "/opt/guesthouse/older/tart", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        try await store.record(recorded)
+        let verdicts = await supervisor.reconcile(environments: []) { _ in .absent }
+        #expect(verdicts[environment] == .uncertain(.anotherProcessClaimsVM), "a claimant at another executable path still holds the VM")
+    }
+
+    /// A VM lock says the VM is held, never by whom. While a second process names the same VM,
+    /// an exact match on the record is not enough to call the environment ours.
+    @Test func aCrossPathClaimantMakesAMatchingRecordUncertain() async throws {
+        let environment = EnvironmentID()
+        let owner = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/perl"), arguments: ["-e", "sleep 44"], timeout: .seconds(20)))
+        defer { owner.terminate(gracePeriod: .milliseconds(100)) }
+        let rival = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["44"], timeout: .seconds(20)))
+        defer { rival.terminate(gracePeriod: .milliseconds(100)) }
+        // Both name the VM; only their executables differ, which is what a runtime upgrade
+        // leaves behind. Only the recorded one is found by the scan for the recorded binary.
+        let arguments = ["run", environment.tartVMName]
+        let enumerator = LiveProcessEnumerator(kernel: .init(
+            pids: { [owner.processIdentifier, rival.processIdentifier] },
+            arguments: { _ in arguments }
+        ))
+        let live = try #require(enumerator.live(pid: owner.processIdentifier))
+        let store = try ProcessIdentityStore(directory: try makeDirectory())
+        try await store.record(ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: LiveProcessEnumerator.digest(of: arguments), vmName: environment.tartVMName, environmentID: environment, recordedAt: Date()))
+        let supervisor = OperationSupervisor(store: store, enumerator: enumerator)
+        let verdicts = await supervisor.reconcile(environments: []) { _ in .present }
+        #expect(verdicts[environment] == .uncertain(.anotherProcessClaimsVM), "the record matched, but so does somebody else's claim on the VM")
+        // An inventory that could not be read is a reason to ask the process table harder, not
+        // to hand the environment to the recorded process unchecked.
+        let withoutInventory = await supervisor.reconcile(environments: []) { _ in .unknown }
+        #expect(withoutInventory[environment] == .uncertain(.anotherProcessClaimsVM), "a rival claimant counts whether or not the inventory answered")
+    }
+
+    @Test func aProcessTableTheKernelWillNotListIsNotAnEmptyOne() async throws {
+        let refusing = LiveProcessEnumerator(kernel: .init(pids: { nil }, arguments: { _ in nil }))
+        #expect(refusing.candidates(executable: URL(fileURLWithPath: "/bin/sleep"), pid: nil).unreadable)
+        #expect(refusing.claimants(ofVM: EnvironmentID().tartVMName).unreadable)
+        let environment = EnvironmentID()
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: try makeDirectory()), enumerator: refusing)
+        let verdicts = await supervisor.reconcile(environments: [environment]) { _ in .absent }
+        #expect(verdicts[environment] == .uncertain(.processUnobservable), "a scan that never happened never frees an environment")
+    }
+
+    @Test func onlyThisUsersRunningProcessesMakeAnUnreadableScanUncertain() async throws {
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["45"], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        let vmName = EnvironmentID().tartVMName
+        let mine = LiveProcessEnumerator(kernel: .init(pids: { [run.processIdentifier] }, arguments: { _ in nil }))
+        #expect(mine.claimants(ofVM: vmName).unreadable, "a running process of ours whose arguments cannot be read may be the claimant")
+        // PID 1 is launchd: another user's process, whose arguments no ordinary user can read.
+        // Treating that everyday refusal as uncertainty would make every environment unusable.
+        let launchd = LiveProcessEnumerator(kernel: .init(pids: { [1] }, arguments: { _ in nil }))
+        #expect(!launchd.claimants(ofVM: vmName).unreadable)
+        #expect(LiveProcessEnumerator().ownership(of: 1) == .notOurs)
+        #expect(LiveProcessEnumerator().ownership(of: run.processIdentifier) == .own)
+        // A child that exited but has not been reaped is still listed and its arguments are
+        // gone; it holds nothing, so it must not make a scan uncertain either.
+        var zombie: pid_t = 0
+        var argv: [UnsafeMutablePointer<CChar>?] = [strdup("/usr/bin/true"), nil]
+        defer { for argument in argv { free(argument) } }
+        // An explicitly empty environment, never `environ`: nothing this process was launched
+        // with — a developer's shell or a continuous-integration runner's credentials — belongs
+        // in a child, in a fixture no less than in the product.
+        var environment: [UnsafeMutablePointer<CChar>?] = [nil]
+        #expect(posix_spawn(&zombie, "/usr/bin/true", nil, nil, &argv, &environment) == 0)
+        for _ in 0..<100 where LiveProcessEnumerator().ownership(of: zombie) == .own {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        let reaped = zombie
+        #expect(LiveProcessEnumerator().ownership(of: reaped) == .notOurs)
+        #expect(!LiveProcessEnumerator(kernel: .init(pids: { [reaped] }, arguments: { _ in nil })).claimants(ofVM: vmName).unreadable)
+        // A PID that is simply gone is an answer, not a refusal: absence has to stay absence,
+        // or every scan would end uncertain.
+        #expect(LiveProcessEnumerator().ownership(of: 0x7FFF_FFFE) == .notOurs)
+    }
+
+    @Test func anIdentityNamingAnotherVMIsNeverWritten() async throws {
+        let directory = try makeDirectory()
+        let store = try ProcessIdentityStore(directory: directory)
+        let environment = EnvironmentID(), other = EnvironmentID()
+        let inconsistent = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "sha256:0", vmName: other.tartVMName, environmentID: environment, recordedAt: Date())
+        let error = await #expect(throws: ProcessIdentityStoreError.self) { try await store.record(inconsistent) }
+        guard case .inconsistentIdentity? = error else { Issue.record("expected inconsistentIdentity, got \(String(describing: error))"); return }
+        #expect(error?.recoveryActions.first == .inspectState && error?.userMessage.isEmpty == false)
+        #expect(await store.all.isEmpty)
+        // The document a later start reads is still the one this store wrote, not a record
+        // that would make every surviving VM unrecoverable.
+        _ = try ProcessIdentityStore(directory: directory)
+    }
+
+    @Test func aPlantedIdentityFileIsRefusedInsteadOfTrustedOrWaitedOn() async throws {
+        let dangling = try makeDirectory()
+        try FileManager.default.createSymbolicLink(atPath: dangling.appending(path: ProcessIdentityStore.fileName).path, withDestinationPath: dangling.appending(path: "gone.json").path)
+        #expect(throws: ProcessIdentityStoreError.self, "a link with no target is damaged evidence, not a first run") {
+            try ProcessIdentityStore(directory: dangling)
+        }
+
+        let pipe = try makeDirectory()
+        #expect(mkfifo(pipe.appending(path: ProcessIdentityStore.fileName).path, 0o600) == 0)
+        let opened = #expect(throws: ProcessIdentityStoreError.self, "a named pipe is refused rather than waited on") {
+            try ProcessIdentityStore(directory: pipe)
+        }
+        guard case .unreadable(_, let reason)? = opened else { Issue.record("expected unreadable, got \(String(describing: opened))"); return }
+        #expect(reason.contains("not a regular file"))
+
+        let linked = try makeDirectory()
+        try writeDocument([:], to: linked.appending(path: ProcessIdentityStore.fileName))
+        #expect(link(linked.appending(path: ProcessIdentityStore.fileName).path, linked.appending(path: "second-name.json").path) == 0)
+        let multiplyLinked = #expect(throws: ProcessIdentityStoreError.self) { try ProcessIdentityStore(directory: linked) }
+        guard case .unreadable(_, let linkReason)? = multiplyLinked else { Issue.record("expected unreadable, got \(String(describing: multiplyLinked))"); return }
+        #expect(linkReason.contains("more than one name"))
+
+        let oversized = try makeDirectory()
+        let file = oversized.appending(path: ProcessIdentityStore.fileName)
+        #expect(FileManager.default.createFile(atPath: file.path, contents: nil, attributes: [.posixPermissions: 0o600]))
+        let handle = try FileHandle(forWritingTo: file)
+        try handle.truncate(atOffset: UInt64(ProcessIdentityStore.maximumFileSize) + 1)
+        try handle.close()
+        let tooLarge = #expect(throws: ProcessIdentityStoreError.self) { try ProcessIdentityStore(directory: oversized) }
+        guard case .unreadable(_, let sizeReason)? = tooLarge else { Issue.record("expected unreadable, got \(String(describing: tooLarge))"); return }
+        #expect(sizeReason.contains("too large"), "the size is refused before the bytes are read")
+    }
+
+    /// The descriptor keeps naming the folder that was opened, so nothing is ever written
+    /// through whatever takes its name. A write into a folder the next launch will not open is
+    /// not durable either, and reporting it as recorded would strand a VM that is running.
+    @Test func aRecordIsRefusedWhenTheStateFolderIsNoLongerAtItsPath() async throws {
+        let original = try makeDirectory()
+        let store = try ProcessIdentityStore(directory: original)
+        let moved = original.deletingLastPathComponent().appending(path: "Moved-\(UUID().uuidString)")
+        try FileManager.default.moveItem(at: original, to: moved)
+        // Something else now answers to the name the store was given.
+        try FileManager.default.createDirectory(at: original, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+        let environment = EnvironmentID()
+        let identity = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        await #expect(throws: ProcessIdentityStoreError.self) { try await store.record(identity) }
+        #expect(!FileManager.default.fileExists(atPath: moved.appending(path: ProcessIdentityStore.fileName).path), "nothing was written where the next launch will not look")
+        #expect(!FileManager.default.fileExists(atPath: original.appending(path: ProcessIdentityStore.fileName).path), "nothing was written through whatever took the folder's name")
+        #expect(await store.identity(for: environment) == nil, "a refused write leaves the store describing the disk")
+    }
+
+    /// Two stores can be open on one directory — a reload while the first is still live — and
+    /// the second's cleanup must not unlink the write the first is about to rename into place.
+    @Test func staleTemporaryCleanupSkipsAnotherStoresLiveWrite() async throws {
+        let directory = try makeDirectory()
+        let store = try ProcessIdentityStore(directory: directory)
+        let live = directory.appending(path: ".\(ProcessIdentityStore.fileName).tmp-\(UUID().uuidString)")
+        let leftover = directory.appending(path: ".\(ProcessIdentityStore.fileName).tmp-\(UUID().uuidString)")
+        try Data("live".utf8).write(to: live)
+        try Data("leftover".utf8).write(to: leftover)
+        let held = open(live.path, O_RDONLY)
+        try #require(held >= 0)
+        defer { close(held) }
+        try #require(flock(held, LOCK_EX | LOCK_NB) == 0)
+
+        _ = try ProcessIdentityStore(directory: directory)
+        #expect(FileManager.default.fileExists(atPath: live.path), "a temporary another store still holds is its live write")
+        #expect(!FileManager.default.fileExists(atPath: leftover.path), "an unheld temporary is a leftover and goes")
+        _ = store
+    }
+
+    /// A temporary is visible under its name from the moment `openat` creates it, which is
+    /// before its writer can `flock` it. A store opening the folder in that window would find
+    /// an unlocked file and unlink a live write, so cleanup waits for the same folder lock
+    /// every update is made under.
+    @Test func staleTemporaryCleanupWaitsForTheFolderLock() throws {
+        let directory = try makeDirectory()
+        let temporary = directory.appending(path: ".\(ProcessIdentityStore.fileName).tmp-\(UUID().uuidString)")
+        try Data("a write that has not been locked yet".utf8).write(to: temporary)
+        // The lock a writing store holds across its whole read-modify-write.
+        let folder = open(directory.path, O_RDONLY | O_DIRECTORY | O_CLOEXEC)
+        try #require(folder >= 0)
+        defer { close(folder) }
+        try #require(flock(folder, LOCK_EX | LOCK_NB) == 0)
+
+        // Opened on a thread of its own: the store blocks on the folder lock, and a blocked
+        // cooperative thread would be one the rest of the suite cannot use.
+        let opened = DispatchSemaphore(value: 0)
+        let thread = Thread {
+            _ = try? ProcessIdentityStore(directory: directory)
+            opened.signal()
+        }
+        thread.start()
+        #expect(opened.wait(timeout: .now() + .milliseconds(250)) == .timedOut, "the store finished its cleanup while another writer held the folder")
+        #expect(FileManager.default.fileExists(atPath: temporary.path), "a live write survives a store opening beside it")
+        #expect(flock(folder, LOCK_UN) == 0)
+        #expect(opened.wait(timeout: .now() + .seconds(10)) == .success)
+        #expect(!FileManager.default.fileExists(atPath: temporary.path), "once no writer holds the folder the leftover goes")
+    }
+
+    /// Each store stages its change onto the document on disk, not onto the copy it read when
+    /// it opened, so the second write cannot drop the first store's record and strand the VM
+    /// that record is the ownership evidence for.
+    @Test func aWriteThroughOneStoreKeepsWhatAnotherAlreadyRecorded() async throws {
+        let directory = try makeDirectory()
+        let first = try ProcessIdentityStore(directory: directory)
+        // Opened while the first is still live and while the document is still empty: this is
+        // the snapshot that would overwrite the other store's record.
+        let second = try ProcessIdentityStore(directory: directory)
+        let one = EnvironmentID(), two = EnvironmentID()
+        try await first.record(identity(for: one, pid: 11))
+        // The record is published by renaming a temporary `openat` created, and `openat` masks
+        // its mode with the umask: a document the next launch cannot reopen is ownership
+        // evidence lost.
+        var published = stat()
+        #expect(stat(directory.appending(path: ProcessIdentityStore.fileName).path, &published) == 0)
+        #expect(published.st_mode & 0o777 == 0o600, "the published record is private and still readable by its owner")
+        try await second.record(identity(for: two, pid: 22))
+        let reloaded = try ProcessIdentityStore(directory: directory)
+        #expect(await reloaded.identity(for: one)?.pid == 11, "the record the first store wrote survived the second store's write")
+        #expect(await reloaded.identity(for: two)?.pid == 22)
+        #expect(await second.identity(for: one)?.pid == 11, "the writing store describes the whole document, not only its own change")
+        // A removal through one store is equally visible to the other's next write.
+        try await first.remove(one)
+        try await second.record(identity(for: two, pid: 23))
+        #expect(await (try ProcessIdentityStore(directory: directory)).all.count == 1)
+        #expect(await second.identity(for: one) == nil)
+    }
+
+    private func identity(for environment: EnvironmentID, pid: pid_t) -> ProcessIdentity {
+        ProcessIdentity(
+            pid: pid,
+            startTime: Date(timeIntervalSince1970: 1_800_000_000),
+            executablePath: "/x",
+            argumentsDigest: "sha256:0",
+            vmName: environment.tartVMName,
+            environmentID: environment,
+            recordedAt: Date(timeIntervalSince1970: 1_800_000_001)
+        )
     }
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -202,6 +202,23 @@ import Testing
         }
     }
 
+    @Test func aVMNameThatIsNotTheEnvironmentsIsRefused() async throws {
+        // Arguments and vmName agree on VM B while the environment is A: recording that would
+        // file a self-contradicting identity, which makes the whole document unreadable on
+        // the next start.
+        let store = try ProcessIdentityStore(directory: root)
+        let supervisor = OperationSupervisor(store: store)
+        let environment = EnvironmentID(), other = EnvironmentID()
+        let arguments = ["-e", "sleep 41", "run", other.tartVMName]
+        let fixture = URL(fileURLWithPath: "/usr/bin/perl")
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: fixture, arguments: arguments, timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        await #expect(throws: SupervisionError.processMismatch(pid: run.processIdentifier)) {
+            _ = try await supervisor.recordLaunch(pid: run.processIdentifier, executable: fixture, arguments: arguments, vmName: other.tartVMName, environment: environment)
+        }
+        #expect(await store.identity(for: environment) == nil, "nothing was recorded")
+    }
+
     @Test func aClaimantWithoutARecordOrLockIsUncertain() async throws {
         let store = try ProcessIdentityStore(directory: root)
         let environment = EnvironmentID()

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -39,9 +39,8 @@ import Testing
         #expect(persisted.argumentsDigest == identity.argumentsDigest)
         #expect(persisted.vmName == identity.vmName)
         #expect(persisted.environmentID == identity.environmentID)
-        #expect(abs(persisted.startTime.timeIntervalSince(identity.startTime)) < 0.001, "millisecond precision survives the file")
-        // Recorded dates are rounded to milliseconds when persisted; the difference is at most one.
-        #expect(abs(persisted.recordedAt.timeIntervalSince(identity.recordedAt)) <= 0.0015)
+        #expect(persisted.startTime == identity.startTime, "the start time is an identity and survives the file exactly")
+        #expect(persisted.recordedAt == identity.recordedAt)
         let owned = await supervisor.reconcile(environments: []) { _ in .present }
         guard case .ownedRunning(let live)? = owned[environment] else { Issue.record("expected owned, got \(String(describing: owned[environment]))"); return }
         #expect(live.pid == run.processIdentifier)
@@ -115,6 +114,47 @@ import Testing
         #expect(await store.all.count == 1)
         let error = ProcessIdentityStoreError.unwritable(path: "/x", reason: "ENOSPC")
         #expect(error.recoveryActions.first == .inspectState && !error.userMessage.isEmpty)
+    }
+
+    @Test func absentAndUnobservableProcessesAreDifferentAnswers() async throws {
+        let enumerator = LiveProcessEnumerator()
+        #expect(enumerator.observe(pid: 2_000_000_000) == .absent)
+        #expect(enumerator.observe(pid: 0) == .absent)
+        // launchd exists but its arguments are not readable by an ordinary user.
+        guard case .unavailable = enumerator.observe(pid: 1) else { Issue.record("expected launchd to be unobservable"); return }
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["39"], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        guard case .present(let live) = enumerator.observe(pid: run.processIdentifier) else { Issue.record("expected the spawned process"); return }
+        #expect(live.claimedVMName == nil)
+    }
+
+    @Test func anUnobservableRecordedProcessIsUncertainNotExited() async throws {
+        let store = try ProcessIdentityStore(directory: root)
+        let environment = EnvironmentID()
+        try await store.record(ProcessIdentity(pid: 1, startTime: Date(timeIntervalSince1970: 0), executablePath: "/sbin/launchd", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date()))
+        let verdicts = await OperationSupervisor(store: store).reconcile(environments: []) { _ in .absent }
+        #expect(verdicts[environment] == .uncertain(.processUnobservable))
+    }
+
+    @Test func theClaimedVMNameIsTheFirstPositionalAfterRunAndMustBeAppManaged() {
+        let name = EnvironmentID().tartVMName
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["run", name, "--no-graphics"]) == name)
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["run", "--no-graphics", name]) == name)
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["--vnc", name]) == nil)
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["run", "ubuntu"]) == nil)
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["run"]) == nil)
+        #expect(LiveProcessEnumerator.claimedVMName(in: ["stop", name]) == nil)
+    }
+
+    @Test func anUnreadableRecordIsActionable() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Supervision-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("not json".utf8).write(to: directory.appending(path: ProcessIdentityStore.fileName))
+        let error = #expect(throws: ProcessIdentityStoreError.self) { try ProcessIdentityStore(directory: directory) }
+        guard case .unreadable(let path, _)? = error else { Issue.record("expected unreadable, got \(String(describing: error))"); return }
+        #expect(path.hasSuffix(ProcessIdentityStore.fileName))
+        #expect(error?.recoveryActions.first == .inspectState)
+        #expect(error?.userMessage.contains("inspect") == true)
     }
 
     @Test func transactionsAreCountedAndEndedOnce() {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -42,16 +42,16 @@ import Testing
         #expect(abs(persisted.startTime.timeIntervalSince(identity.startTime)) < 0.001, "millisecond precision survives the file")
         // Recorded dates are rounded to milliseconds when persisted; the difference is at most one.
         #expect(abs(persisted.recordedAt.timeIntervalSince(identity.recordedAt)) <= 0.0015)
-        let owned = await supervisor.reconcile { _ in true }
+        let owned = await supervisor.reconcile(environments: []) { _ in .present }
         guard case .ownedRunning(let live)? = owned[environment] else { Issue.record("expected owned, got \(String(describing: owned[environment]))"); return }
         #expect(live.pid == run.processIdentifier)
 
         run.terminate(gracePeriod: .milliseconds(100))
         _ = await run.exit()
-        let gone = await supervisor.reconcile { _ in false }
+        let gone = await supervisor.reconcile(environments: []) { _ in .absent }
         #expect(gone[environment] == .exited)
-        let locked = await supervisor.reconcile { _ in nil }
-        #expect(locked[environment] == .uncertain(.lockHeldWithoutProcess), "unknown lock state errs toward uncertainty")
+        let locked = await supervisor.reconcile(environments: []) { _ in .unknown }
+        #expect(locked[environment] == .uncertain(.inventoryUnavailable), "unknown lock state errs toward uncertainty")
         try await supervisor.forget(environment)
         #expect(await store.all.isEmpty)
     }
@@ -65,8 +65,56 @@ import Testing
         let environment = EnvironmentID()
         let stale = ProcessIdentity(pid: live.pid, startTime: live.startTime.addingTimeInterval(-3600), executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
         try await store.record(stale)
-        let verdicts = await supervisor.reconcile { _ in false }
+        let verdicts = await supervisor.reconcile(environments: []) { _ in .absent }
         #expect(verdicts[environment] == .uncertain(.pidReusedByAnotherProcess))
+    }
+
+    @Test func aMismatchedObservationIsNeverRecorded() async throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Supervision-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = try ProcessIdentityStore(directory: directory)
+        let supervisor = OperationSupervisor(store: store)
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["5"], timeout: .seconds(10)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        await #expect(throws: SupervisionError.processMismatch(pid: run.processIdentifier)) {
+            try await supervisor.recordLaunch(pid: run.processIdentifier, executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["6"], vmName: "vm", environment: EnvironmentID())
+        }
+        await #expect(throws: SupervisionError.processMismatch(pid: run.processIdentifier)) {
+            try await supervisor.recordLaunch(pid: run.processIdentifier, executable: URL(fileURLWithPath: "/usr/bin/true"), arguments: ["5"], vmName: "vm", environment: EnvironmentID())
+        }
+        #expect(await store.all.isEmpty)
+        for error in [SupervisionError.processNotObservable(pid: 1), .processMismatch(pid: 1)] {
+            #expect(!error.userMessage.isEmpty && error.recoveryActions.first == .inspectState)
+        }
+    }
+
+    @Test func unrecordedAndUnknownInventoriesAreUncertain() async throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Supervision-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: directory))
+        let locked = EnvironmentID(), free = EnvironmentID(), unknown = EnvironmentID()
+        let verdicts = await supervisor.reconcile(environments: [locked, free, unknown]) { id in
+            id == locked ? .present : id == free ? .absent : .unknown
+        }
+        #expect(verdicts[locked] == .uncertain(.unrecordedLaunch))
+        #expect(verdicts[free] == nil)
+        #expect(verdicts[unknown] == .uncertain(.inventoryUnavailable))
+    }
+
+    @Test func aFailedPersistLeavesMemoryUnchanged() async throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Supervision-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = try ProcessIdentityStore(directory: directory)
+        let identity = ProcessIdentity(pid: 1, startTime: Date(), executablePath: "/x", argumentsDigest: "d", vmName: "vm", environmentID: EnvironmentID(), recordedAt: Date())
+        try await store.record(identity)
+        try FileManager.default.removeItem(at: directory)
+        let other = ProcessIdentity(pid: 2, startTime: Date(), executablePath: "/y", argumentsDigest: "e", vmName: "vm2", environmentID: EnvironmentID(), recordedAt: Date())
+        await #expect(throws: ProcessIdentityStoreError.self) { try await store.record(other) }
+        #expect(await store.all.count == 1)
+        await #expect(throws: ProcessIdentityStoreError.self) { try await store.remove(identity.environmentID) }
+        #expect(await store.all.count == 1)
+        let error = ProcessIdentityStoreError.unwritable(path: "/x", reason: "ENOSPC")
+        #expect(error.recoveryActions.first == .inspectState && !error.userMessage.isEmpty)
     }
 
     @Test func transactionsAreCountedAndEndedOnce() {


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: process execution, private storage, supervision and file handoff (#21, #22, #24, #26). Reuse the implementation and regressions with bounded temporary parser input, structured diagnostics and preserved process/ownership safeguards. These features have not been declared complete.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #24 (`MVP-PLAN.md` §3 "Keep documented XPC activity/transactions outstanding while supervising running VMs or operations"; §4 "Persist process identity evidence and environment ownership, not only PIDs… identify any surviving Tart process and its exact VM before recovering control"). Stacked on #71.

- `OperationSupervisor`: `hold(_:)` begins an explicit `xpc_transaction` and returns a token that ends it exactly once; the service is expected to hold one per in-flight operation and one per supervised VM process. The finding the plan asked for is documented in the type: the Swift `XPCListener`/`XPCSession` API keeps a bundled service alive only while a message is being handled or a reply is pending, so without these transactions launchd could idle-exit the service and abandon a running VM. `recordLaunch` reads the live process and writes a `ProcessIdentity` durably before returning, so nothing is ever reported as started before the journal knows it. `reconcile` evaluates every recorded identity against the live process table with `ProcessReconciler`; an unknown VM-lock state is treated as present so the verdict errs toward uncertainty.
- `LiveProcessEnumerator`: pid, kernel start time (`sysctl KERN_PROC_PID`), executable path (`proc_pidpath`), and an argument digest (`KERN_PROCARGS2`, SHA-256 over the arguments, never the arguments themselves). `candidates(executable:pid:)` returns every process running the executable plus whatever holds the recorded pid, so a reused pid is observed and rejected.
- `ProcessIdentityStore`: `state/processes.json`, written atomically (temp file, fsync, rename) with mode 0600; dates persisted at millisecond precision.
- Wiring the verdicts into `environmentStatus` and refusing starts on `uncertain` is #25, which builds on this.

Tests (5): the enumerator observes a spawned `sleep` exactly (pid, path, start time, argument digest, lookup by path and by pid); a recorded launch is durable and reconciles as owned, then exited after termination, then uncertain when the lock state is unknown; a stale identity with the same pid but an older start time is uncertain; transactions are counted and end once; the store's file mode and atomic write.

Closes #24

## Checklist

- [x] Tests cover the new logic; kit, core, and app test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] Processes are launched only through `ProcessRunning` (tests use it to spawn `sleep`)
- [x] Diff under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)