### PR TITLE
Runtime: startEnvironment, stopEnvironment, and environmentStatus for one VM slot

### DIFF
--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -253,7 +253,7 @@ actor RuntimeClient: RuntimeBackend {
                 for buffered in pendingEvents.removeValue(forKey: id) ?? [] {
                     route(buffered)
                 }
-            case .runtimeVersion, .status, .completed, .failed, .progress, .log:
+            case .runtimeVersion, .environments, .status, .completed, .failed, .progress, .log:
                 settle(key)
                 continuation.finish()
             }
@@ -404,7 +404,7 @@ actor RuntimeClient: RuntimeBackend {
             } else {
                 for (id, continuation) in operations { deliver(event, to: continuation, id: id) }
             }
-        case .runtimeVersion, .accepted:
+        case .runtimeVersion, .environments, .accepted:
             for (id, continuation) in operations { yieldNonTerminal(event, to: continuation, id: id) }
         case .log(nil, _):
             // Unscoped guest output is droppable traffic for every operation, not a control

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -471,7 +471,7 @@ nonisolated extension RuntimeEvent {
     fileprivate var endsOperation: Bool {
         switch self {
         case .completed, .failed: true
-        case .runtimeVersion, .accepted, .progress, .log, .status: false
+        case .runtimeVersion, .environments, .accepted, .progress, .log, .status: false
         }
     }
 

--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -475,13 +475,16 @@ nonisolated extension RuntimeEvent {
         }
     }
 
-    /// Detail the client may drop. Only `accepted` and the terminal events say what happened
-    /// to an operation; progress, log lines and status snapshots are what a consumer that has
-    /// fallen behind loses first, so they are also what the inbox refuses when it is full.
+    /// Detail the client may drop. Only the replies to a query, `accepted` and the terminal
+    /// events say what happened to a request; progress, log lines and status snapshots are what
+    /// a consumer that has fallen behind loses first, so they are also what the inbox refuses
+    /// when it is full. `environments` answers `listEnvironments` exactly as `runtimeVersion`
+    /// answers its own request: dropping it would leave the caller waiting for a reply that
+    /// has already been thrown away.
     fileprivate var isDroppableTraffic: Bool {
         switch self {
         case .progress, .log, .status: true
-        case .runtimeVersion, .accepted, .completed, .failed: false
+        case .runtimeVersion, .environments, .accepted, .completed, .failed: false
         }
     }
 }

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -27,9 +27,6 @@ struct ServiceLog: Sendable {
 /// Callers are authenticated twice: the listener only accepts sessions whose peer is signed by
 /// this app's team with this app's signing identifier, and every message is checked again
 /// against the same requirement before it is decoded (MVP-PLAN.md §3, "Authenticate callers").
-///
-/// Queries reply synchronously. Lifecycle operations reply `accepted` once the journal has
-/// the operation, then stream progress, status, and the result to the session.
 final class RuntimeService: Sendable {
     static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
     /// The only process allowed to talk to this service.
@@ -70,6 +67,14 @@ final class RuntimeService: Sendable {
     }
     /// Lifecycle operations, available once a verified runtime bundle exists.
     private let lifecycleState = Mutex<LifecycleState>(.initializing)
+    /// What lifecycle initialization needs, kept from discovery so a failure the user repairs
+    /// can be retried while the service runs.
+    private let lifecycleInputs = Mutex<LifecycleInputs?>(nil)
+
+    struct LifecycleInputs: Sendable {
+        let backend: TartBackend
+        let storage: RuntimeStorage
+    }
 
     /// Accepts a session and returns a per-session handler that tracks in-flight requests.
     func acceptSession(_ session: XPCSession) -> SessionHandler {
@@ -80,9 +85,9 @@ final class RuntimeService: Sendable {
     /// Returns a synchronous reply, or `nil` when the reply is sent later through `message.reply`.
     ///
     /// `refusal` is read rather than passed in, because another request on the same session can
-    /// refuse it while this one is still being decoded. `finished` is called when a reply the
-    /// service sends later, from an operation, has been handed to the transport: a synchronous
-    /// answer is finished by the caller instead.
+    /// refuse it while this one is still being decoded. `finished` is called exactly once, by
+    /// whoever hands the reply to the transport: the caller for a synchronous answer, the
+    /// operation's own reply box for one that is sent later.
     func handle(_ message: XPCReceivedMessage, session: XPCSession, inFlight: Int, refusal: () -> RuntimeEvent?, finished: @escaping @Sendable () -> Void = {}, refuse: @escaping @Sendable (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
         // A message that asks for no reply is never decoded or dispatched. An operation whose
         // ID, acceptance, and terminal event have nowhere to go is a host mutation the client
@@ -104,7 +109,7 @@ final class RuntimeService: Sendable {
         // request pipelined behind the refusal still gets an actionable answer. The session is
         // closed by its lifetime once every reply it owes has been handed over.
         if let refused = refusal() {
-            return reply(RuntimeDispatcher.refused(refused), session: session, message: message, reason: "session refused")
+            return reply(RuntimeDispatcher.refused(refused), session: session, message: message, finished: finished, reason: "session refused")
         }
         guard message.senderSatisfies(Self.peerRequirement) else {
             log.error(RedactedLine(literal: "message from a peer that does not satisfy the requirement; closing session"))
@@ -128,7 +133,6 @@ final class RuntimeService: Sendable {
         } catch {
             // Never log the decoding error text: it can quote the raw offending value.
             log.error(RedactedLine(literal: "undecodable request rejected"))
-            finished()
             if case .reply(let event) = RuntimeDispatcher.undecodable() { return event }
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
         }
@@ -144,7 +148,6 @@ final class RuntimeService: Sendable {
         switch decision {
         case .reply(let event):
             log.error(Self.line("rejected request:", event.caseName))
-            finished()
             return event
         case .replyAndClose(let event):
             log.error(Self.line("refusing session:", reason))
@@ -152,7 +155,6 @@ final class RuntimeService: Sendable {
             // rejection has been handed to the transport would discard the very answer the
             // client needs. `SessionHandler` closes it once the session owes nothing more.
             refuse(event)
-            finished()
             return event
         case .dispatch(let request):
             return perform(request, message: message, session: session, finished: finished)
@@ -175,13 +177,17 @@ final class RuntimeService: Sendable {
             case .ready(let ready):
                 lifecycle = ready
             case .failed(let error):
-                finished()
-                return RuntimeEvent.failed(OperationID(), error)
+                // The saved state that failed can be repaired while the service runs, and
+                // `runtimeStateUnavailable` sends the user to Inspect State to do exactly
+                // that. Inspection is routed through here too, so a cached failure would
+                // outlive the repair until the service process happened to be replaced: the
+                // request is answered with the error it has and initialization is tried again.
+                retryLifecycleInitialization()
+                    return RuntimeEvent.failed(OperationID(), error)
             case .initializing:
                 // A verified runtime still bringing up its state is not incompatible with itself.
                 let info = tartInfo.withLock { $0 }
-                finished()
-                return RuntimeEvent.failed(OperationID(), info?.problem ?? .runtimeStarting)
+                    return RuntimeEvent.failed(OperationID(), info?.problem ?? .runtimeStarting)
             }
             let reply = ReplyBox(message, onReply: finished)
             let sink = SessionSink(session: session, log: log)
@@ -189,7 +195,6 @@ final class RuntimeService: Sendable {
             return nil
         case .importXcode:
             log.notice(Self.line("operation not implemented yet:", request.caseName))
-            finished()
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation))
         }
     }
@@ -198,7 +203,7 @@ final class RuntimeService: Sendable {
         do {
             switch request {
             case .listEnvironments:
-                reply.send(RuntimeEvent.environments(await lifecycle.environments()))
+                reply.send(RuntimeEvent.environments(try await lifecycle.environments()))
             case .environmentStatus(let id):
                 reply.send(RuntimeEvent.status(try await lifecycle.status(of: id)))
             case .startEnvironment(let id, let options):
@@ -218,7 +223,7 @@ final class RuntimeService: Sendable {
         } catch {
             // A dependency failure (Tart, the state store, supervision) is reported as the
             // runtime problem it is, with its recovery actions; never as a malformed request.
-            log.error("operation failed: \(request.caseName, privacy: .public) \(Self.describe(error), privacy: .public)")
+            log.error(Self.line("operation failed:", "\(request.caseName) \(Self.describe(error))"))
             reply.send(RuntimeEvent.failed(OperationID(), Self.mapDependencyFailure(error, request: request)))
         }
     }
@@ -245,7 +250,7 @@ final class RuntimeService: Sendable {
 
     func sessionEnded(_ error: XPCRichError) {
         // The rich error's description is opaque and may quote context; log a fixed message.
-        log.notice("session ended")
+        log.notice(RedactedLine(literal: "session ended"))
     }
 
     var versionInfo: RuntimeVersionInfo {
@@ -365,18 +370,49 @@ final class RuntimeService: Sendable {
         }
         tartInfo.withLock { $0 = .init(version: version.description, verified: true) }
         log.notice(Self.line("Tart located and verified:", version.description))
+        let inputs = LifecycleInputs(backend: backend, storage: storage)
+        lifecycleInputs.withLock { $0 = inputs }
+        await startLifecycle(inputs)
+    }
+
+    /// Loads state and brings the lifecycle up, or records why it could not.
+    private func startLifecycle(_ inputs: LifecycleInputs) async {
         do {
-            let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
-            let store = try StateStore(rootURL: storage.url(for: .state))
-            let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: backend, supervisor: supervisor, store: store))
+            let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: inputs.storage.url(for: .state)))
+            let store = try StateStore(rootURL: inputs.storage.url(for: .state))
+            let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: inputs.backend, supervisor: supervisor, store: store))
             try await lifecycle.prepare()
             lifecycleState.withLock { $0 = .ready(lifecycle) }
-            let count = await lifecycle.environments().count
-            log.notice(Self.line("lifecycle ready; environments:", "\(count)"))
+            // The count is only for the log. A listing that cannot be completed is a real
+            // failure for a client that asked for one, but it must not undo a lifecycle that
+            // is otherwise ready.
+            if let count = try? await lifecycle.environments().count {
+                log.notice(Self.line("lifecycle ready; environments:", "\(count)"))
+            } else {
+                log.notice(RedactedLine(literal: "lifecycle ready; the list of virtual machines could not be read"))
+            }
         } catch {
             // The runtime itself is fine; its state is not. The two are reported apart.
             log.error(Self.line("lifecycle could not start:", Self.describe(error)))
             lifecycleState.withLock { $0 = .failed(Self.mapDependencyFailure(error, request: .listEnvironments)) }
+        }
+    }
+
+    /// Tries lifecycle initialization once more after a failure. Moving out of `failed` is what
+    /// claims the attempt, so overlapping requests start one retry between them; while it runs,
+    /// requests are answered as the initialization it is.
+    private func retryLifecycleInitialization() {
+        guard let inputs = lifecycleInputs.withLock({ $0 }) else { return }
+        let claimed = lifecycleState.withLock { state -> Bool in
+            guard case .failed = state else { return false }
+            state = .initializing
+            return true
+        }
+        guard claimed else { return }
+        Task {
+            xpc_transaction_begin()
+            defer { xpc_transaction_end() }
+            await self.startLifecycle(inputs)
         }
     }
 
@@ -458,9 +494,6 @@ final class RuntimeService: Sendable {
     }
 }
 
-    func sessionEnded(_ error: XPCRichError) {
-        // The rich error's description is opaque and may quote context; log a fixed message.
-        log.notice(RedactedLine(literal: "session ended"))
 /// Lets a message be answered after an asynchronous operation. `XPCReceivedMessage` is only
 /// ever touched from the task that replies.
 final class ReplyBox: @unchecked Sendable {
@@ -499,9 +532,9 @@ final class ReplyBox: @unchecked Sendable {
 /// client treats a dropped session as an unknown outcome and re-queries status.
 final class SessionSink: @unchecked Sendable {
     private let session: XPCSession
-    private let log: Logger
+    private let log: ServiceLog
 
-    init(session: XPCSession, log: Logger) {
+    init(session: XPCSession, log: ServiceLog) {
         self.session = session
         self.log = log
     }
@@ -510,7 +543,8 @@ final class SessionSink: @unchecked Sendable {
         do {
             try session.send(event)
         } catch {
-            log.error("could not push \(event.caseName, privacy: .public) to the client")
+            var state = Redactor.StreamState()
+            log.error(Redactor().redact(line: "could not push to the client: \(event.caseName)", state: &state))
         }
     }
 }

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -59,8 +59,17 @@ final class RuntimeService: Sendable {
     /// attempt keeps running; this only stops a wedged host from holding the session's message
     /// queue. `version()` carries its own 15-second timeout, so this is the backstop.
     static let rediscoveryWait: DispatchTimeInterval = .seconds(25)
+
+
+    /// Where the lifecycle is: initializing, ready, or failed for a reason of its own that is
+    /// never confused with the runtime's compatibility.
+    enum LifecycleState: Sendable {
+        case initializing
+        case ready(EnvironmentLifecycle)
+        case failed(GuesthouseError)
+    }
     /// Lifecycle operations, available once a verified runtime bundle exists.
-    private let lifecycle = Mutex<EnvironmentLifecycle?>(nil)
+    private let lifecycleState = Mutex<LifecycleState>(.initializing)
 
     /// Accepts a session and returns a per-session handler that tracks in-flight requests.
     func acceptSession(_ session: XPCSession) -> SessionHandler {
@@ -71,8 +80,10 @@ final class RuntimeService: Sendable {
     /// Returns a synchronous reply, or `nil` when the reply is sent later through `message.reply`.
     ///
     /// `refusal` is read rather than passed in, because another request on the same session can
-    /// refuse it while this one is still being decoded.
-    func handle(_ message: XPCReceivedMessage, session: XPCSession, inFlight: Int, refusal: () -> RuntimeEvent?, refuse: @escaping (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
+    /// refuse it while this one is still being decoded. `finished` is called when a reply the
+    /// service sends later, from an operation, has been handed to the transport: a synchronous
+    /// answer is finished by the caller instead.
+    func handle(_ message: XPCReceivedMessage, session: XPCSession, inFlight: Int, refusal: () -> RuntimeEvent?, finished: @escaping @Sendable () -> Void = {}, refuse: @escaping @Sendable (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
         // A message that asks for no reply is never decoded or dispatched. An operation whose
         // ID, acceptance, and terminal event have nowhere to go is a host mutation the client
         // could neither follow nor cancel, and the client would have no record that it ran.
@@ -97,14 +108,14 @@ final class RuntimeService: Sendable {
         }
         guard message.senderSatisfies(Self.peerRequirement) else {
             log.error(RedactedLine(literal: "message from a peer that does not satisfy the requirement; closing session"))
-            return reply(.replyAndClose(.failed(OperationID(), .unauthorizedCaller)), session: session, message: message, reason: "unauthorized caller", refuse: refuse)
+            return reply(.replyAndClose(.failed(OperationID(), .unauthorizedCaller)), session: session, message: message, finished: finished, reason: "unauthorized caller", refuse: refuse)
         }
         // The concurrency cap is applied before the request is decoded, so a peer over the cap
         // costs nothing to refuse. Only its version header is read, and only at the cap, so
         // that the refusal is one the peer's own protocol version can decode.
         let clientVersion = { try? message.decode(as: RuntimeRequestEnvelope.Header.self).protocolVersion }
         if let refused = RuntimeDispatcher.admit(inFlight: inFlight, clientVersion: clientVersion) {
-            return reply(refused, session: session, message: message, reason: "protocol mismatch over the request cap", refuse: refuse)
+            return reply(refused, session: session, message: message, finished: finished, reason: "protocol mismatch over the request cap", refuse: refuse)
         }
         let envelope: RuntimeRequestEnvelope
         do {
@@ -113,10 +124,11 @@ final class RuntimeService: Sendable {
             // A version-skewed installation is not corrupt input: the client gets the
             // protocol-mismatch error and its reinstall recovery, and the session closes.
             log.error(Self.line("protocol mismatch: client", "\(mismatch.client.rawValue)"))
-            return reply(RuntimeDispatcher.mismatch(mismatch.error), session: session, message: message, refuse: refuse)
+            return reply(RuntimeDispatcher.mismatch(mismatch.error), session: session, message: message, finished: finished, refuse: refuse)
         } catch {
             // Never log the decoding error text: it can quote the raw offending value.
             log.error(RedactedLine(literal: "undecodable request rejected"))
+            finished()
             if case .reply(let event) = RuntimeDispatcher.undecodable() { return event }
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
         }
@@ -125,13 +137,14 @@ final class RuntimeService: Sendable {
         // evaluate the refusal before it, honoring an answer that is already stale by the time
         // the decision is acted on.
         let decision = RuntimeDispatcher.decide(envelope, inFlight: inFlight)
-        return reply(RuntimeDispatcher.honoring(refusal(), decision), session: session, message: message)
+        return reply(RuntimeDispatcher.honoring(refusal(), decision), session: session, message: message, finished: finished)
     }
 
-    private func reply(_ decision: RuntimeDispatcher.Decision, session: XPCSession, message: XPCReceivedMessage, reason: String = "protocol mismatch", refuse: @escaping (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
+    private func reply(_ decision: RuntimeDispatcher.Decision, session: XPCSession, message: XPCReceivedMessage, finished: @escaping @Sendable () -> Void, reason: String = "protocol mismatch", refuse: @escaping @Sendable (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
         switch decision {
         case .reply(let event):
             log.error(Self.line("rejected request:", event.caseName))
+            finished()
             return event
         case .replyAndClose(let event):
             log.error(Self.line("refusing session:", reason))
@@ -139,13 +152,14 @@ final class RuntimeService: Sendable {
             // rejection has been handed to the transport would discard the very answer the
             // client needs. `SessionHandler` closes it once the session owes nothing more.
             refuse(event)
+            finished()
             return event
         case .dispatch(let request):
-            return perform(request, message: message, session: session)
+            return perform(request, message: message, session: session, finished: finished)
         }
     }
 
-    private func perform(_ request: RuntimeRequest, message: XPCReceivedMessage, session: XPCSession) -> (any Encodable)? {
+    private func perform(_ request: RuntimeRequest, message: XPCReceivedMessage, session: XPCSession, finished: @escaping @Sendable () -> Void) -> (any Encodable)? {
         switch request {
         case .runtimeVersion:
             // Discovery ran once at launch. A problem the user was told they could retry —
@@ -156,16 +170,26 @@ final class RuntimeService: Sendable {
             rediscoverIfRetryable()
             return RuntimeEvent.runtimeVersion(versionInfo)
         case .listEnvironments, .environmentStatus, .startEnvironment, .stopEnvironment, .cancelOperation:
-            guard let lifecycle = lifecycle.withLock({ $0 }) else {
+            let lifecycle: EnvironmentLifecycle
+            switch lifecycleState.withLock({ $0 }) {
+            case .ready(let ready):
+                lifecycle = ready
+            case .failed(let error):
+                finished()
+                return RuntimeEvent.failed(OperationID(), error)
+            case .initializing:
+                // A verified runtime still bringing up its state is not incompatible with itself.
                 let info = tartInfo.withLock { $0 }
-                return RuntimeEvent.failed(OperationID(), info?.problem ?? .runtimeMissing)
+                finished()
+                return RuntimeEvent.failed(OperationID(), info?.problem ?? .runtimeStarting)
             }
-            let reply = ReplyBox(message)
+            let reply = ReplyBox(message, onReply: finished)
             let sink = SessionSink(session: session, log: log)
             Task { await self.performAsync(request, lifecycle: lifecycle, reply: reply, events: sink) }
             return nil
         case .importXcode:
             log.notice(Self.line("operation not implemented yet:", request.caseName))
+            finished()
             return RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation))
         }
     }
@@ -192,9 +216,31 @@ final class RuntimeService: Sendable {
         } catch let error as GuesthouseError {
             reply.send(RuntimeEvent.failed(OperationID(), error))
         } catch {
-            log.error("operation failed: \(request.caseName, privacy: .public)")
-            reply.send(RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed)))
+            // A dependency failure (Tart, the state store, supervision) is reported as the
+            // runtime problem it is, with its recovery actions; never as a malformed request.
+            log.error("operation failed: \(request.caseName, privacy: .public) \(Self.describe(error), privacy: .public)")
+            reply.send(RuntimeEvent.failed(OperationID(), Self.mapDependencyFailure(error, request: request)))
         }
+    }
+
+    static func mapDependencyFailure(_ error: any Error, request: RuntimeRequest) -> GuesthouseError {
+        let environment: EnvironmentID? = switch request {
+        case .environmentStatus(let id), .startEnvironment(let id, _), .stopEnvironment(let id, _), .importXcode(let id, _): id
+        default: nil
+        }
+        if let error = error as? TartInvocationError, let environment {
+            return EnvironmentLifecycle.map(error, environment: environment)
+        }
+        if let error = error as? StateStoreError {
+            return .runtimeStateUnavailable(reason: SanitizedText(error.userMessage, limit: 200))
+        }
+        if let error = error as? SupervisionError {
+            return .runtimeStateUnavailable(reason: SanitizedText(error.userMessage, limit: 200))
+        }
+        if let error = error as? ProcessIdentityStoreError {
+            return .runtimeStateUnavailable(reason: SanitizedText(error.userMessage, limit: 200))
+        }
+        return .runtimeStateUnavailable(reason: SanitizedText("an unexpected \(describe(error)) failure", limit: 200))
     }
 
     func sessionEnded(_ error: XPCRichError) {
@@ -247,6 +293,10 @@ final class RuntimeService: Sendable {
     /// after launch; until it finishes, `runtimeVersion` reports the runtime as not located
     /// and lifecycle requests fail with `runtimeMissing`.
     func discoverTart() async {
+        // Discovery and lifecycle bring-up hold a transaction, so launchd cannot idle the
+        // service out while it verifies the bundle, asks for its version, and loads state.
+        xpc_transaction_begin()
+        defer { xpc_transaction_end() }
         let storage: RuntimeStorage
         do {
             storage = try RuntimeStorage(root: try RuntimeStorage.defaultRoot())
@@ -320,12 +370,13 @@ final class RuntimeService: Sendable {
             let store = try StateStore(rootURL: storage.url(for: .state))
             let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: backend, supervisor: supervisor, store: store))
             try await lifecycle.prepare()
-            self.lifecycle.withLock { $0 = lifecycle }
+            lifecycleState.withLock { $0 = .ready(lifecycle) }
             let count = await lifecycle.environments().count
             log.notice(Self.line("lifecycle ready; environments:", "\(count)"))
         } catch {
+            // The runtime itself is fine; its state is not. The two are reported apart.
             log.error(Self.line("lifecycle could not start:", Self.describe(error)))
-            tartInfo.withLock { $0 = .init(version: version.description, verified: true, problem: .operationOutcomeUnknown(OperationID())) }
+            lifecycleState.withLock { $0 = .failed(Self.mapDependencyFailure(error, request: .listEnvironments)) }
         }
     }
 
@@ -365,13 +416,19 @@ final class RuntimeService: Sendable {
             self.session = session
         }
 
+        /// The count is released when the request is answered, synchronously or later, so
+        /// asynchronous lifecycle requests keep counting against the cap until their reply.
         func handleIncomingRequest(_ message: XPCReceivedMessage) -> (any Encodable)? {
             // The count taken here excludes this message, so it says how much else the
             // session still owes an answer for. A session whose close has already been taken
             // admits nothing: answering here would race that cancel and hand the peer a
             // connection interruption in place of the rejection it is owed.
             guard let others = lock.withLock({ lifetime.began() }) else { return nil }
-            let answer = service.handle(message, inFlight: others, refusal: { self.refusalEvent }) { [weak self] event in
+            let finished: @Sendable () -> Void = { [weak self] in
+                guard let self else { return }
+                if self.lock.withLock({ self.lifetime.finished() }) { self.session.cancel(reason: "session refused") }
+            }
+            let answer = service.handle(message, session: session, inFlight: others, refusal: { self.refusalEvent }, finished: finished) { [weak self] event in
                 self?.markRefused(with: event)
             }
             // The reply is handed to the transport here rather than by returning it: a
@@ -382,10 +439,9 @@ final class RuntimeService: Sendable {
             if let answer { message.reply(answer) }
             // A refused session closes as soon as it owes nothing further. Waiting instead for
             // another message would keep an incompatible connection open for as long as the
-            // app runs, because a client that has been told to stop sends nothing more.
-            if lock.withLock({ lifetime.finished() }) {
-                session.cancel(reason: "session refused")
-            }
+            // app runs, because a client that has been told to stop sends nothing more. A
+            // request whose reply is sent later keeps counting until then, and finishes itself.
+            if answer != nil { finished() }
             return nil
         }
 
@@ -410,8 +466,12 @@ final class RuntimeService: Sendable {
 final class ReplyBox: @unchecked Sendable {
     private let message: XPCReceivedMessage
     private let replied = Mutex(false)
+    private let onReply: @Sendable () -> Void
 
-    init(_ message: XPCReceivedMessage) { self.message = message }
+    init(_ message: XPCReceivedMessage, onReply: @escaping @Sendable () -> Void = {}) {
+        self.message = message
+        self.onReply = onReply
+    }
 
     func send(_ event: RuntimeEvent) {
         let first = replied.withLock { flag -> Bool in
@@ -421,6 +481,17 @@ final class ReplyBox: @unchecked Sendable {
         }
         guard first else { return }
         message.reply(event)
+        onReply()
+    }
+
+    deinit {
+        // A reply that never happened still releases its place in the session's count.
+        let unreplied = replied.withLock { flag -> Bool in
+            if flag { return false }
+            flag = true
+            return true
+        }
+        if unreplied { onReply() }
     }
 }
 

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -27,6 +27,9 @@ struct ServiceLog: Sendable {
 /// Callers are authenticated twice: the listener only accepts sessions whose peer is signed by
 /// this app's team with this app's signing identifier, and every message is checked again
 /// against the same requirement before it is decoded (MVP-PLAN.md §3, "Authenticate callers").
+///
+/// Queries reply synchronously. Lifecycle operations reply `accepted` once the journal has
+/// the operation, then stream progress, status, and the result to the session.
 final class RuntimeService: Sendable {
     static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
     /// The only process allowed to talk to this service.
@@ -56,6 +59,8 @@ final class RuntimeService: Sendable {
     /// attempt keeps running; this only stops a wedged host from holding the session's message
     /// queue. `version()` carries its own 15-second timeout, so this is the backstop.
     static let rediscoveryWait: DispatchTimeInterval = .seconds(25)
+    /// Lifecycle operations, available once a verified runtime bundle exists.
+    private let lifecycle = Mutex<EnvironmentLifecycle?>(nil)
 
     /// Accepts a session and returns a per-session handler that tracks in-flight requests.
     func acceptSession(_ session: XPCSession) -> SessionHandler {
@@ -63,11 +68,11 @@ final class RuntimeService: Sendable {
         return SessionHandler(service: self, session: session)
     }
 
-    /// One reply per request. Streaming events for long operations arrive with #25.
+    /// Returns a synchronous reply, or `nil` when the reply is sent later through `message.reply`.
     ///
     /// `refusal` is read rather than passed in, because another request on the same session can
     /// refuse it while this one is still being decoded.
-    func handle(_ message: XPCReceivedMessage, inFlight: Int, refusal: () -> RuntimeEvent?, refuse: (RuntimeEvent) -> Void = { _ in }) -> RuntimeEvent? {
+    func handle(_ message: XPCReceivedMessage, session: XPCSession, inFlight: Int, refusal: () -> RuntimeEvent?, refuse: @escaping (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
         // A message that asks for no reply is never decoded or dispatched. An operation whose
         // ID, acceptance, and terminal event have nowhere to go is a host mutation the client
         // could neither follow nor cancel, and the client would have no record that it ran.
@@ -88,18 +93,18 @@ final class RuntimeService: Sendable {
         // request pipelined behind the refusal still gets an actionable answer. The session is
         // closed by its lifetime once every reply it owes has been handed over.
         if let refused = refusal() {
-            return reply(RuntimeDispatcher.refused(refused), reason: "session refused")
+            return reply(RuntimeDispatcher.refused(refused), session: session, message: message, reason: "session refused")
         }
         guard message.senderSatisfies(Self.peerRequirement) else {
             log.error(RedactedLine(literal: "message from a peer that does not satisfy the requirement; closing session"))
-            return reply(.replyAndClose(.failed(OperationID(), .unauthorizedCaller)), reason: "unauthorized caller", refuse: refuse)
+            return reply(.replyAndClose(.failed(OperationID(), .unauthorizedCaller)), session: session, message: message, reason: "unauthorized caller", refuse: refuse)
         }
         // The concurrency cap is applied before the request is decoded, so a peer over the cap
         // costs nothing to refuse. Only its version header is read, and only at the cap, so
         // that the refusal is one the peer's own protocol version can decode.
         let clientVersion = { try? message.decode(as: RuntimeRequestEnvelope.Header.self).protocolVersion }
         if let refused = RuntimeDispatcher.admit(inFlight: inFlight, clientVersion: clientVersion) {
-            return reply(refused, reason: "protocol mismatch over the request cap", refuse: refuse)
+            return reply(refused, session: session, message: message, reason: "protocol mismatch over the request cap", refuse: refuse)
         }
         let envelope: RuntimeRequestEnvelope
         do {
@@ -108,21 +113,22 @@ final class RuntimeService: Sendable {
             // A version-skewed installation is not corrupt input: the client gets the
             // protocol-mismatch error and its reinstall recovery, and the session closes.
             log.error(Self.line("protocol mismatch: client", "\(mismatch.client.rawValue)"))
-            return reply(RuntimeDispatcher.mismatch(mismatch.error), refuse: refuse)
+            return reply(RuntimeDispatcher.mismatch(mismatch.error), session: session, message: message, refuse: refuse)
         } catch {
             // Never log the decoding error text: it can quote the raw offending value.
             log.error(RedactedLine(literal: "undecodable request rejected"))
-            return reply(RuntimeDispatcher.undecodable())
+            if case .reply(let event) = RuntimeDispatcher.undecodable() { return event }
+            return RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed))
         }
         // Nothing runs on a refused session. Deciding first and reading the refusal after is
         // deliberate: validating the envelope is the longest step, and one expression would
         // evaluate the refusal before it, honoring an answer that is already stale by the time
         // the decision is acted on.
         let decision = RuntimeDispatcher.decide(envelope, inFlight: inFlight)
-        return reply(RuntimeDispatcher.honoring(refusal(), decision))
+        return reply(RuntimeDispatcher.honoring(refusal(), decision), session: session, message: message)
     }
 
-    private func reply(_ decision: RuntimeDispatcher.Decision, reason: String = "protocol mismatch", refuse: (RuntimeEvent) -> Void = { _ in }) -> RuntimeEvent? {
+    private func reply(_ decision: RuntimeDispatcher.Decision, session: XPCSession, message: XPCReceivedMessage, reason: String = "protocol mismatch", refuse: @escaping (RuntimeEvent) -> Void = { _ in }) -> (any Encodable)? {
         switch decision {
         case .reply(let event):
             log.error(Self.line("rejected request:", event.caseName))
@@ -135,11 +141,11 @@ final class RuntimeService: Sendable {
             refuse(event)
             return event
         case .dispatch(let request):
-            return perform(request)
+            return perform(request, message: message, session: session)
         }
     }
 
-    private func perform(_ request: RuntimeRequest) -> RuntimeEvent {
+    private func perform(_ request: RuntimeRequest, message: XPCReceivedMessage, session: XPCSession) -> (any Encodable)? {
         switch request {
         case .runtimeVersion:
             // Discovery ran once at launch. A problem the user was told they could retry —
@@ -148,11 +154,52 @@ final class RuntimeService: Sendable {
             // ends on this one answer, so a cache only a restart could change would make the
             // Retry the user was offered need a second press.
             rediscoverIfRetryable()
-            return .runtimeVersion(versionInfo)
-        case .environmentStatus, .startEnvironment, .stopEnvironment, .importXcode, .cancelOperation:
+            return RuntimeEvent.runtimeVersion(versionInfo)
+        case .listEnvironments, .environmentStatus, .startEnvironment, .stopEnvironment, .cancelOperation:
+            guard let lifecycle = lifecycle.withLock({ $0 }) else {
+                let info = tartInfo.withLock { $0 }
+                return RuntimeEvent.failed(OperationID(), info?.problem ?? .runtimeMissing)
+            }
+            let reply = ReplyBox(message)
+            let sink = SessionSink(session: session, log: log)
+            Task { await self.performAsync(request, lifecycle: lifecycle, reply: reply, events: sink) }
+            return nil
+        case .importXcode:
             log.notice(Self.line("operation not implemented yet:", request.caseName))
-            return .failed(OperationID(), .invalidRequest(.unsupportedOperation))
+            return RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation))
         }
+    }
+
+    private func performAsync(_ request: RuntimeRequest, lifecycle: EnvironmentLifecycle, reply: ReplyBox, events: SessionSink) async {
+        do {
+            switch request {
+            case .listEnvironments:
+                reply.send(RuntimeEvent.environments(await lifecycle.environments()))
+            case .environmentStatus(let id):
+                reply.send(RuntimeEvent.status(try await lifecycle.status(of: id)))
+            case .startEnvironment(let id, let options):
+                let operation = try await lifecycle.start(id, options: options) { event in events.send(event) }
+                reply.send(RuntimeEvent.accepted(operation))
+            case .stopEnvironment(let id, let mode):
+                let operation = try await lifecycle.stop(id, mode: mode) { event in events.send(event) }
+                reply.send(RuntimeEvent.accepted(operation))
+            case .cancelOperation(let operation):
+                await lifecycle.cancel(operation)
+                reply.send(RuntimeEvent.completed(operation))
+            case .runtimeVersion, .importXcode:
+                reply.send(RuntimeEvent.failed(OperationID(), .invalidRequest(.unsupportedOperation)))
+            }
+        } catch let error as GuesthouseError {
+            reply.send(RuntimeEvent.failed(OperationID(), error))
+        } catch {
+            log.error("operation failed: \(request.caseName, privacy: .public)")
+            reply.send(RuntimeEvent.failed(OperationID(), .invalidRequest(.malformed)))
+        }
+    }
+
+    func sessionEnded(_ error: XPCRichError) {
+        // The rich error's description is opaque and may quote context; log a fixed message.
+        log.notice("session ended")
     }
 
     var versionInfo: RuntimeVersionInfo {
@@ -195,9 +242,10 @@ final class RuntimeService: Sendable {
     }
 
     /// Locates the pinned Tart bundle under runtime storage, verifies its signature and
-    /// entitlements, and asks it for its version. Runs once after launch; until it finishes,
-    /// `runtimeVersion` reports the runtime as not located. A bundle that fails verification
-    /// is reported with `verified: false` and its claimed version, never treated as usable.
+    /// entitlements, asks it for its version, and, when it verified, brings up the lifecycle
+    /// (loading state, adopting hand-created VMs, reconciling recorded processes). Runs once
+    /// after launch; until it finishes, `runtimeVersion` reports the runtime as not located
+    /// and lifecycle requests fail with `runtimeMissing`.
     func discoverTart() async {
         let storage: RuntimeStorage
         do {
@@ -267,6 +315,18 @@ final class RuntimeService: Sendable {
         }
         tartInfo.withLock { $0 = .init(version: version.description, verified: true) }
         log.notice(Self.line("Tart located and verified:", version.description))
+        do {
+            let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
+            let store = try StateStore(rootURL: storage.url(for: .state))
+            let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: backend, supervisor: supervisor, store: store))
+            try await lifecycle.prepare()
+            self.lifecycle.withLock { $0 = lifecycle }
+            let count = await lifecycle.environments().count
+            log.notice(Self.line("lifecycle ready; environments:", "\(count)"))
+        } catch {
+            log.error(Self.line("lifecycle could not start:", Self.describe(error)))
+            tartInfo.withLock { $0 = .init(version: version.description, verified: true, problem: .operationOutcomeUnknown(OperationID())) }
+        }
     }
 
     /// Which bundle check a verification error names, for the user-facing error.
@@ -340,9 +400,46 @@ final class RuntimeService: Sendable {
             service.sessionEnded(error)
         }
     }
+}
 
     func sessionEnded(_ error: XPCRichError) {
         // The rich error's description is opaque and may quote context; log a fixed message.
         log.notice(RedactedLine(literal: "session ended"))
+/// Lets a message be answered after an asynchronous operation. `XPCReceivedMessage` is only
+/// ever touched from the task that replies.
+final class ReplyBox: @unchecked Sendable {
+    private let message: XPCReceivedMessage
+    private let replied = Mutex(false)
+
+    init(_ message: XPCReceivedMessage) { self.message = message }
+
+    func send(_ event: RuntimeEvent) {
+        let first = replied.withLock { flag -> Bool in
+            if flag { return false }
+            flag = true
+            return true
+        }
+        guard first else { return }
+        message.reply(event)
+    }
+}
+
+/// Pushes streamed events to the client session. Send failures are logged (redacted); the
+/// client treats a dropped session as an unknown outcome and re-queries status.
+final class SessionSink: @unchecked Sendable {
+    private let session: XPCSession
+    private let log: Logger
+
+    init(session: XPCSession, log: Logger) {
+        self.session = session
+        self.log = log
+    }
+
+    func send(_ event: RuntimeEvent) {
+        do {
+            try session.send(event)
+        } catch {
+            log.error("could not push \(event.caseName, privacy: .public) to the client")
+        }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Backend/FakeRuntimeBackend.swift
@@ -48,6 +48,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
 
     private nonisolated let configuration = Mutex(Configuration())
     private var statuses: [EnvironmentID: EnvironmentStatus] = [:]
+    private var environments: [DevelopmentEnvironment] = []
     private var versionInfo: RuntimeVersionInfo
     private var canceledOperations: Set<OperationID> = []
     /// Where a recorded request falls in the order the requests were *made*, which is the order
@@ -99,6 +100,11 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         statuses[status.environmentID] = status
     }
 
+    /// The environments returned for `listEnvironments`.
+    public func setEnvironments(_ environments: [DevelopmentEnvironment]) {
+        self.environments = environments
+    }
+
     public func setVersionInfo(_ info: RuntimeVersionInfo) {
         versionInfo = info
     }
@@ -138,7 +144,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         let scenario = binding.scenario
 
         switch request {
-        case .runtimeVersion, .environmentStatus:
+        case .runtimeVersion, .environmentStatus, .listEnvironments:
             advanceTurn()
             await pause()
             switch scenario {
@@ -151,9 +157,12 @@ public actor FakeRuntimeBackend: RuntimeBackend {
                 while !Task.isCancelled { try? await Task.sleep(for: .milliseconds(5)) }
                 continuation.finish(throwing: RuntimeConnectionInterrupted())
             case .succeed:
-                if case .environmentStatus(let id) = request {
+                switch request {
+                case .environmentStatus(let id):
                     continuation.yield(.status(statuses[id] ?? EnvironmentStatus(environmentID: id, vm: .notFound, readiness: .checking)))
-                } else {
+                case .listEnvironments:
+                    continuation.yield(.environments(environments))
+                default:
                     continuation.yield(.runtimeVersion(versionInfo))
                 }
                 continuation.finish()
@@ -324,7 +333,7 @@ public actor FakeRuntimeBackend: RuntimeBackend {
         switch request {
         case .startEnvironment(let environment, _), .stopEnvironment(let environment, _), .importXcode(let environment, _):
             statuses[environment]?.inFlightOperation = id
-        case .runtimeVersion, .environmentStatus, .cancelOperation:
+        case .runtimeVersion, .listEnvironments, .environmentStatus, .cancelOperation:
             break
         }
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -24,7 +24,7 @@ public enum RequestValidator: Sendable {
             throw .protocolMismatch(client: envelope.protocolVersion, service: .current)
         }
         switch envelope.request {
-        case .runtimeVersion, .environmentStatus, .cancelOperation:
+        case .runtimeVersion, .listEnvironments, .environmentStatus, .cancelOperation:
             break
         case .startEnvironment(_, let options):
             guard options.ipWait >= .zero, options.ipWait <= maximumIPWait else {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -5,6 +5,8 @@ import Foundation
 public enum RuntimeEvent: Codable, Hashable, Sendable {
     /// The reply to `runtimeVersion`.
     case runtimeVersion(RuntimeVersionInfo)
+    /// The reply to `listEnvironments`.
+    case environments([DevelopmentEnvironment])
     /// The request was journaled and is now in flight.
     case accepted(OperationID)
     case progress(OperationID, ProgressPhase)
@@ -17,6 +19,7 @@ public enum RuntimeEvent: Codable, Hashable, Sendable {
     public var caseName: String {
         switch self {
         case .runtimeVersion: "runtimeVersion"
+        case .environments: "environments"
         case .accepted: "accepted"
         case .progress: "progress"
         case .log: "log"
@@ -152,6 +155,8 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
     /// Only this type sets it, and only through `sanitizedForWire()`: a raw probe value can
     /// never be assigned into a status and encoded unchanged.
     public private(set) var observed: ObservedTuple
+    /// The guest's current address, when it is running and reachable. Not persistent identity.
+    public var guestAddress: GuestIPAddress?
     public var reconciledAt: Date?
 
     public init(
@@ -160,6 +165,7 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
         readiness: Readiness,
         inFlightOperation: OperationID? = nil,
         observed: ObservedTuple = ObservedTuple(),
+        guestAddress: GuestIPAddress? = nil,
         reconciledAt: Date? = nil
     ) {
         self.environmentID = environmentID
@@ -169,6 +175,7 @@ public struct EnvironmentStatus: Codable, Hashable, Sendable {
         // Observations come from guest and CLI probes: every string is bounded and redacted
         // before it crosses XPC, at construction and again when decoded.
         self.observed = observed.sanitizedForWire()
+        self.guestAddress = guestAddress
         self.reconciledAt = reconciledAt
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -12,8 +12,10 @@ public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStri
     /// History: 1 was the initial contract; 2 added `InvalidRequestReason.tooManyInFlight`;
     /// 3 made `TartRuntimeInfo.version` optional, added its `problem`, and added the storage
     /// error, so an older peer would fail to decode a reply instead of being told what
-    /// happened, and would read `verified` with the wrong meaning.
-    public static let current = RuntimeProtocolVersion(3)
+    /// happened, and would read `verified` with the wrong meaning; 4 added the
+    /// `listEnvironments` request, the `environments` event, `EnvironmentStatus.guestAddress`,
+    /// and the lifecycle's own error cases, none of which a version-3 peer can decode.
+    public static let current = RuntimeProtocolVersion(4)
 
     public static func < (lhs: RuntimeProtocolVersion, rhs: RuntimeProtocolVersion) -> Bool {
         lhs.rawValue < rhs.rawValue

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -7,6 +7,9 @@ import Foundation
 /// (MVP-PLAN.md §3, "Sandbox and XPC boundary").
 public enum RuntimeRequest: Codable, Hashable, Sendable {
     case runtimeVersion
+    /// The environments the runtime knows about, from its own state. The GUI cannot read the
+    /// runtime's storage itself (MVP-PLAN.md §3, "Local storage").
+    case listEnvironments
     case environmentStatus(EnvironmentID)
     case startEnvironment(EnvironmentID, StartOptions)
     case stopEnvironment(EnvironmentID, StopMode)
@@ -16,6 +19,7 @@ public enum RuntimeRequest: Codable, Hashable, Sendable {
     public var caseName: String {
         switch self {
         case .runtimeVersion: "runtimeVersion"
+        case .listEnvironments: "listEnvironments"
         case .environmentStatus: "environmentStatus"
         case .startEnvironment: "startEnvironment"
         case .stopEnvironment: "stopEnvironment"
@@ -33,7 +37,7 @@ public enum RuntimeRequest: Codable, Hashable, Sendable {
     /// twice cannot leave the host anywhere asking once would not.
     public var mutatesHost: Bool {
         switch self {
-        case .runtimeVersion, .environmentStatus, .cancelOperation: false
+        case .runtimeVersion, .listEnvironments, .environmentStatus, .cancelOperation: false
         case .startEnvironment, .stopEnvironment, .importXcode: true
         }
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -27,6 +27,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     case toolMismatch(tool: SanitizedText, found: SanitizedText?, expected: SanitizedText)
     case xcodeComponentsIncomplete(missing: MissingComponents)
     case vmSlotUnavailable(maximum: Int)
+    case environmentNotFound(EnvironmentID)
+    case environmentAlreadyRunning(EnvironmentID)
+    case operationInFlight(OperationID)
     case operationOutcomeUnknown(OperationID)
     case unauthorizedCaller
     case protocolMismatch(client: Int, service: Int)
@@ -100,7 +103,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .guestNotReachable, .hostKeyChanged: .guest
         case .credentialsLocked, .loginExpired: .credentials
         case .toolMismatch, .xcodeComponentsIncomplete: .tools
-        case .vmSlotUnavailable, .operationOutcomeUnknown: .workflow
+        case .vmSlotUnavailable, .environmentNotFound, .environmentAlreadyRunning, .operationInFlight, .operationOutcomeUnknown: .workflow
         case .unauthorizedCaller, .protocolMismatch, .invalidRequest: .ipc
         case .canceled: .user
         }
@@ -150,6 +153,12 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             "Xcode is installed on the development Mac but is missing required components: \(Self.list(missing))."
         case .vmSlotUnavailable(let maximum):
             "Guesthouse manages at most \(maximum) development Macs, including stopped and preserved ones. Export any unpublished work from one you no longer need, then delete it to make room."
+        case .environmentNotFound(let id):
+            "No development Mac with the identifier \(id) is registered on this Mac."
+        case .environmentAlreadyRunning(let id):
+            "The development Mac \(id.tartVMName) is already running."
+        case .operationInFlight:
+            "Another operation is still running. Guesthouse runs one lifecycle operation at a time."
         case .operationOutcomeUnknown:
             "Guesthouse lost contact with its runtime before this operation reported a result. The operation may or may not have completed."
         case .unauthorizedCaller:
@@ -186,6 +195,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .toolMismatch: [.repair(.tools), .openConsole, .exportWork, .cancel]
         case .xcodeComponentsIncomplete: [.repair(.xcodeComponents), .openConsole, .exportWork, .cancel]
         case .vmSlotUnavailable: [.exportWork, .deleteEnvironment, .cancel]
+        case .environmentNotFound: [.inspectState, .cancel]
+        case .environmentAlreadyRunning: [.inspectState, .cancel]
+        case .operationInFlight: [.inspectState, .cancel]
         case .operationOutcomeUnknown: [.inspectState, .cancel]
         case .unauthorizedCaller: [.cancel]
         case .protocolMismatch: [.reinstallApp, .cancel]
@@ -227,6 +239,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .toolMismatch: "toolMismatch"
         case .xcodeComponentsIncomplete: "xcodeComponentsIncomplete"
         case .vmSlotUnavailable: "vmSlotUnavailable"
+        case .environmentNotFound: "environmentNotFound"
+        case .environmentAlreadyRunning: "environmentAlreadyRunning"
+        case .operationInFlight: "operationInFlight"
         case .operationOutcomeUnknown: "operationOutcomeUnknown"
         case .unauthorizedCaller: "unauthorizedCaller"
         case .protocolMismatch: "protocolMismatch"

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -128,8 +128,6 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             "This Mac has \(found.value); Guesthouse needs \(required.value). Development Macs cannot run here."
         case .unsupportedHost(.notAppleSilicon):
             "This Mac has an Intel processor. Guesthouse needs an Apple silicon Mac to run a macOS virtual machine."
-        case .unsupportedHost(.wrongArchitecture(let found, let required)):
-            "This Mac's processor is \(found.value). Guesthouse needs \(required) for this configuration."
         case .unsupportedHost(.architectureUnknown):
             "Guesthouse could not determine this Mac's processor type. Check this Mac again; if it keeps failing, export diagnostics."
         case .unsupportedHost(.macOSTooOld(let found, let minimum)):

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -11,13 +11,14 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     case insufficientDisk(requiredBytes: UInt64, availableBytes: UInt64, volumePath: SanitizedText)
     case downloadVerificationFailed(artifact: SanitizedText, check: VerificationCheck)
     case runtimeMissing
-    /// The installed runtime bundle failed verification and will not be executed.
-    /// Guesthouse's own storage could not be used: the location is missing, unsafe, or not
-    /// writable. Distinct from a missing runtime, which reinstalling Tart would fix.
+    /// The service is still bringing up its lifecycle after launch.
+    case runtimeStarting
+    /// The service's saved state could not be loaded or written.
     case runtimeStateUnavailable(reason: SanitizedText)
     /// Guesthouse's storage location itself could not be used. Carries which kind of problem
     /// it is, so the GUI offers what actually helps rather than a generic check.
     case runtimeStorageUnavailable(reason: SanitizedText, problem: StorageProblem)
+    /// The installed runtime bundle failed verification and will not be executed.
     case runtimeVerificationFailed(check: RuntimeVerificationCheck)
     case runtimeIncompatible(found: SanitizedText?, required: SanitizedText)
     case guestNotReachable(EnvironmentID)
@@ -29,6 +30,14 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     case vmSlotUnavailable(maximum: Int)
     case environmentNotFound(EnvironmentID)
     case environmentAlreadyRunning(EnvironmentID)
+    /// One VM at a time: another environment is running.
+    case anotherEnvironmentRunning(EnvironmentID)
+    /// The environment is preserved after a failed repair or export and must be repaired first.
+    case environmentPreserved(EnvironmentID)
+    /// A VM with the environment's name is running but Guesthouse cannot prove it started it.
+    case vmOwnershipUncertain(EnvironmentID)
+    /// The guest did not shut down within the graceful deadline; it is still running.
+    case gracefulStopTimedOut(EnvironmentID)
     case operationInFlight(OperationID)
     case operationOutcomeUnknown(OperationID)
     case unauthorizedCaller
@@ -99,7 +108,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         switch self {
         case .unsupportedHost: .host
         case .insufficientDisk, .runtimeStateUnavailable, .runtimeStorageUnavailable: .storage
-        case .downloadVerificationFailed, .runtimeMissing, .runtimeVerificationFailed, .runtimeIncompatible: .runtime
+        case .downloadVerificationFailed, .runtimeMissing, .runtimeStarting, .runtimeVerificationFailed, .runtimeIncompatible: .runtime
+        case .anotherEnvironmentRunning, .environmentPreserved: .workflow
+        case .vmOwnershipUncertain, .gracefulStopTimedOut: .guest
         case .guestNotReachable, .hostKeyChanged: .guest
         case .credentialsLocked, .loginExpired: .credentials
         case .toolMismatch, .xcodeComponentsIncomplete: .tools
@@ -117,6 +128,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             "This Mac has \(found.value); Guesthouse needs \(required.value). Development Macs cannot run here."
         case .unsupportedHost(.notAppleSilicon):
             "This Mac has an Intel processor. Guesthouse needs an Apple silicon Mac to run a macOS virtual machine."
+        case .unsupportedHost(.wrongArchitecture(let found, let required)):
+            "This Mac's processor is \(found.value). Guesthouse needs \(required) for this configuration."
         case .unsupportedHost(.architectureUnknown):
             "Guesthouse could not determine this Mac's processor type. Check this Mac again; if it keeps failing, export diagnostics."
         case .unsupportedHost(.macOSTooOld(let found, let minimum)):
@@ -131,8 +144,18 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             "The virtual machine runtime is not installed."
         case .runtimeStorageUnavailable(let reason, _):
             reason.value
+        case .runtimeStarting:
+            "The Guesthouse runtime is still starting. Try again in a moment."
         case .runtimeStateUnavailable(let reason):
             "Guesthouse's saved state could not be used (\(reason.value)). Guesthouse will inspect the actual virtual machines before offering anything; if this persists, check the storage location in Settings."
+        case .anotherEnvironmentRunning(let id):
+            "Another development Mac (\(id.tartVMName)) is running. Guesthouse runs one development Mac at a time until resource validation allows two; stop it first."
+        case .environmentPreserved(let id):
+            "The development Mac \(id.tartVMName) is preserved after a failed repair or an incomplete export, so it will not start until it is repaired. Export any unpublished work first."
+        case .vmOwnershipUncertain(let id):
+            "A virtual machine named \(id.tartVMName) is running, but Guesthouse cannot prove that it started it. Nothing will be started or stopped until this is inspected; open the console to see what is running."
+        case .gracefulStopTimedOut(let id):
+            "The development Mac \(id.tartVMName) did not shut down within the time allowed and is still running. Try again, open its console to finish what it is doing, or force-stop it (unsaved work inside can be lost)."
         case .runtimeVerificationFailed(let check):
             "The installed virtual machine runtime failed its \(Self.describe(check)) check and will not be run. Repair reinstalls the tested version."
         case .runtimeIncompatible(let found, let required):
@@ -181,10 +204,15 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .insufficientDisk: [.freeDiskSpace, .retry, .openSettings, .cancel]
         case .downloadVerificationFailed: [.retry, .cancel]
         case .runtimeMissing: [.repair(.runtime), .cancel]
+        case .runtimeStarting: [.retry, .cancel]
         case .runtimeStateUnavailable: [.inspectState, .openSettings, .cancel]
         // The storage error's own actions, kept: freeing space and retrying are what help.
         case .runtimeStorageUnavailable(_, .unwritable): [.freeDiskSpace, .retry, .cancel]
         case .runtimeStorageUnavailable(_, .unsafeLocation): [.cancel]
+        case .anotherEnvironmentRunning: [.cancel]
+        case .environmentPreserved: [.repair(.tools), .exportWork, .cancel]
+        case .vmOwnershipUncertain: [.inspectState, .openConsole, .cancel]
+        case .gracefulStopTimedOut: [.retry, .openConsole, .cancel]
         case .runtimeVerificationFailed: [.repair(.runtime), .cancel]
         case .runtimeIncompatible: [.repair(.runtime), .exportWork, .cancel]
         case .guestNotReachable: [.inspectState, .retry, .openConsole, .cancel]
@@ -228,8 +256,13 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .insufficientDisk: "insufficientDisk"
         case .downloadVerificationFailed: "downloadVerificationFailed"
         case .runtimeMissing: "runtimeMissing"
+        case .runtimeStarting: "runtimeStarting"
         case .runtimeStateUnavailable: "runtimeStateUnavailable"
         case .runtimeStorageUnavailable: "runtimeStorageUnavailable"
+        case .anotherEnvironmentRunning: "anotherEnvironmentRunning"
+        case .environmentPreserved: "environmentPreserved"
+        case .vmOwnershipUncertain: "vmOwnershipUncertain"
+        case .gracefulStopTimedOut: "gracefulStopTimedOut"
         case .runtimeVerificationFailed: "runtimeVerificationFailed"
         case .runtimeIncompatible: "runtimeIncompatible"
         case .guestNotReachable: "guestNotReachable"

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
@@ -48,6 +48,8 @@ public struct JournalRecord: Codable, Hashable, Sendable {
         /// nothing: `completed` would claim it succeeded, and every "unknown" outcome leaves the
         /// environment blocked against the new operation recovery is there to allow.
         case notApplied
+        /// After a relaunch the coordinator inspected the actual state and closed the operation.
+        case reconciled
     }
 
     /// Whether this build can read a record written in `format`.
@@ -94,7 +96,7 @@ public struct JournalRecord: Codable, Hashable, Sendable {
         switch outcome {
         case .started, .checkpoint, .unknown: true
         case .failed(.operationOutcomeUnknown), .failed(.canceled): true
-        case .completed, .notApplied, .failed: false
+        case .completed, .notApplied, .failed, .reconciled: false
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
@@ -32,7 +32,12 @@ public enum JournalOperation: Codable, Hashable, Sendable, CaseIterable {
 /// whole journal.
 public struct JournalRecord: Codable, Hashable, Sendable {
     /// The record format this build writes and the newest it can read.
-    public static let currentFormat = 1
+    ///
+    /// History: 1 was the initial format; 2 added the `reconciled` outcome and the lifecycle's
+    /// error cases inside `failed`, neither of which a format-1 reader can decode. A record
+    /// this build writes is therefore refused by name as a newer format rather than making the
+    /// previous build report the whole journal corrupt.
+    public static let currentFormat = 2
 
     public enum Outcome: Codable, Hashable, Sendable {
         /// The operation was accepted. It is in flight until a later record says otherwise.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/JournalRecord.swift
@@ -118,7 +118,10 @@ public struct JournalRecord: Codable, Hashable, Sendable {
         case .failed(.guestNotReachable(let reported)), .failed(.hostKeyChanged(let reported)):
             reported == environmentID
         case .checkpoint(let reached):
-            operation == .provision(stage: reached)
+            // A provisioning record must name the stage it reached. Other operations reach
+            // checkpoints too — a start is journaled once the VM is supervised — and their
+            // kind says nothing about which stage that was.
+            if case .provision(let stage) = operation { stage == reached } else { true }
         default:
             true
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/StateStore.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Persistence/StateStore.swift
@@ -150,8 +150,7 @@ public actor StateStore {
     // MARK: - Journal
 
     /// Appends a `started` record and returns its id only once the record is on disk.
-    public func begin(_ operation: JournalOperation, for environmentID: EnvironmentID, at timestamp: Date = Date()) throws -> OperationID {
-        let id = OperationID()
+    public func begin(_ operation: JournalOperation, for environmentID: EnvironmentID, id: OperationID = OperationID(), at timestamp: Date = Date()) throws -> OperationID {
         try append(JournalRecord(id: id, environmentID: environmentID, operation: operation, timestamp: timestamp, outcome: .started))
         return id
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Processes/ProcessIdentity.swift
@@ -88,6 +88,10 @@ public enum OwnershipVerdict: Hashable, Sendable {
         /// The recorded process exists but could not be read from the process table (for
         /// example it now belongs to another user), so it cannot be matched or ruled out.
         case processUnobservable
+        /// The process ended but its durable record could not be removed. The stored PID
+        /// outlives the process it describes, so whatever reuses that PID would be reconciled
+        /// against it; the environment is not free until the record is gone.
+        case identityNotForgotten
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -8,7 +8,7 @@
       "codexDesktopVersion": "TBD",
       "codexDesktopBuild": "TBD",
       "codexDesktopPath": "TBD",
-      "runtimeProtocolVersion": 3,
+      "runtimeProtocolVersion": 4,
       "tartVersion": "2.36.0",
       "guestMacOSBuild": "25F84",
       "xcodeBuild": "17F113",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeContractTests.swift
@@ -8,6 +8,7 @@ import Testing
 
     static let requests: [RuntimeRequest] = [
         .runtimeVersion,
+        .listEnvironments,
         .environmentStatus(environment),
         .startEnvironment(environment, StartOptions()),
         .startEnvironment(environment, StartOptions(console: .native, ipWait: .seconds(120))),
@@ -20,6 +21,7 @@ import Testing
 
     static let events: [RuntimeEvent] = [
         .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12", tart: .init(version: "2.36.0", verified: true))),
+        .environments([DevelopmentEnvironment(name: "Dev", createdAt: Date(timeIntervalSince1970: 1_800_000_000))]),
         .accepted(operation),
         .progress(operation, ProgressPhase(kind: .waitingForNetwork, fraction: 0.5)),
         .progress(operation, ProgressPhase(kind: .copying, fraction: nil, cancelable: false)),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Errors/GuesthouseErrorTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Errors/GuesthouseErrorTests.swift
@@ -15,6 +15,8 @@ import Testing
         .runtimeStateUnavailable(reason: "the operation journal could not be opened"),
         .runtimeStorageUnavailable(reason: "the storage folder is full", problem: .unwritable),
         .runtimeStorageUnavailable(reason: "a containing folder can be changed by other users", problem: .unsafeLocation),
+        .runtimeStarting,
+        .runtimeStateUnavailable(reason: "disk full"),
         .runtimeVerificationFailed(check: .signature),
         .runtimeIncompatible(found: "2.30.0", required: "2.36.0"),
         .guestNotReachable(EnvironmentID()),
@@ -34,6 +36,7 @@ import Testing
         .protocolMismatch(client: 2, service: 1),
         .invalidRequest(.pathEscapesAllowedRoot),
         .canceled,
+        .anotherEnvironmentRunning(EnvironmentID()), .environmentPreserved(EnvironmentID()), .vmOwnershipUncertain(EnvironmentID()), .gracefulStopTimedOut(EnvironmentID()),
     ]
 
     static let expectedCaseNames: Set<String> = [
@@ -43,6 +46,7 @@ import Testing
         "loginExpired", "toolMismatch", "xcodeComponentsIncomplete", "vmSlotUnavailable",
         "operationOutcomeUnknown", "unauthorizedCaller", "protocolMismatch", "invalidRequest",
         "canceled", "environmentNotFound", "environmentAlreadyRunning", "operationInFlight",
+        "runtimeStarting", "runtimeStateUnavailable", "anotherEnvironmentRunning", "environmentPreserved", "vmOwnershipUncertain", "gracefulStopTimedOut",
     ]
 
     @Test func samplesCoverEveryCase() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Errors/GuesthouseErrorTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Errors/GuesthouseErrorTests.swift
@@ -26,6 +26,9 @@ import Testing
         .toolMismatch(tool: "codex", found: nil, expected: "0.50.0"),
         .xcodeComponentsIncomplete(missing: ["iOS 26.4 Simulator"]),
         .vmSlotUnavailable(maximum: 2),
+        .environmentNotFound(EnvironmentID()),
+        .environmentAlreadyRunning(EnvironmentID()),
+        .operationInFlight(OperationID()),
         .operationOutcomeUnknown(OperationID()),
         .unauthorizedCaller,
         .protocolMismatch(client: 2, service: 1),
@@ -39,7 +42,7 @@ import Testing
         "runtimeVerificationFailed", "runtimeIncompatible", "guestNotReachable", "hostKeyChanged", "credentialsLocked",
         "loginExpired", "toolMismatch", "xcodeComponentsIncomplete", "vmSlotUnavailable",
         "operationOutcomeUnknown", "unauthorizedCaller", "protocolMismatch", "invalidRequest",
-        "canceled",
+        "canceled", "environmentNotFound", "environmentAlreadyRunning", "operationInFlight",
     ]
 
     @Test func samplesCoverEveryCase() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Persistence/StateStoreHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Persistence/StateStoreHardeningTests.swift
@@ -432,14 +432,17 @@ import Testing
         _ = try await store.begin(.startEnvironment, for: environment)
         let future = JournalRecord(id: OperationID(), environmentID: environment, operation: .stopEnvironment, timestamp: Date(), outcome: .started)
         var text = String(decoding: try JSONEncoder().encode(future), as: UTF8.self)
-        text = text.replacingOccurrences(of: "\"format\":1", with: "\"format\":2")
+        // One past what this build writes: a format from a newer Guesthouse, whatever the
+        // current number happens to be.
+        let unreadable = JournalRecord.currentFormat + 1
+        text = text.replacingOccurrences(of: "\"format\":\(JournalRecord.currentFormat)", with: "\"format\":\(unreadable)")
         let handle = try FileHandle(forWritingTo: await store.journalURL)
         try handle.seekToEnd()
         try handle.write(contentsOf: Data((text + "\n").utf8))
         try handle.close()
         let reopened = try StateStore(rootURL: root)
-        await #expect(throws: StateStoreError.unsupportedJournalFormat(line: 2, format: 2)) { try await reopened.replay() }
-        #expect(StateStoreError.unsupportedJournalFormat(line: 2, format: 2).recoveryActions.contains(.reinstallApp))
+        await #expect(throws: StateStoreError.unsupportedJournalFormat(line: 2, format: unreadable)) { try await reopened.replay() }
+        #expect(StateStoreError.unsupportedJournalFormat(line: 2, format: unreadable).recoveryActions.contains(.reinstallApp))
     }
 
     /// Formats start at 1, so a record declaring zero or a negative one came from damage rather

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Persistence/StateStoreHardeningTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Persistence/StateStoreHardeningTests.swift
@@ -111,10 +111,18 @@ import Testing
         let environment = EnvironmentID()
         let id = try await store.begin(.startEnvironment, for: environment)
         let record = JournalRecord(id: id, environmentID: environment, operation: .startEnvironment, timestamp: Date(), outcome: .completed)
+        let current = JournalRecord.currentFormat
         var json = String(decoding: try JSONEncoder().encode(record), as: UTF8.self)
-        #expect(json.contains("\"format\":1"))
-        json = json.replacingOccurrences(of: "\"format\":1", with: "\"format\":2")
+        #expect(json.contains("\"format\":\(current)"), "a record this build writes carries this build's format")
+        // A record from a later build is refused by name, so the journal is never reported as
+        // corrupt when the only problem is that it is newer.
+        json = json.replacingOccurrences(of: "\"format\":\(current)", with: "\"format\":\(current + 1)")
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(JournalRecord.self, from: Data(json.utf8)) }
+        // Every format this build claims to read still decodes.
+        for older in 1..<current {
+            let downgraded = json.replacingOccurrences(of: "\"format\":\(current + 1)", with: "\"format\":\(older)")
+            #expect(throws: Never.self) { try JSONDecoder().decode(JournalRecord.self, from: Data(downgraded.utf8)) }
+        }
     }
 
     @Test func migrationsMustAdvanceExactlyOneVersion() {

--- a/Packages/GuesthouseRuntimeKit/Package.swift
+++ b/Packages/GuesthouseRuntimeKit/Package.swift
@@ -33,9 +33,13 @@ let package = Package(
             ],
             swiftSettings: kitSwiftSettings
         ),
+        .executableTarget(
+            name: "GuesthouseKitTestHelper",
+            path: "Sources/GuesthouseKitTestHelper"
+        ),
         .testTarget(
             name: "GuesthouseRuntimeKitTests",
-            dependencies: ["GuesthouseRuntimeKit"],
+            dependencies: ["GuesthouseRuntimeKit", "GuesthouseKitTestHelper"],
             swiftSettings: kitSwiftSettings
         ),
     ],

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseKitTestHelper/main.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseKitTestHelper/main.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+// A test fixture that stands in for a long-running VM process: it accepts any arguments,
+// never touches them (so an arguments digest taken at launch still matches later; `yes`,
+// for example, rewrites its argv), and ends on SIGTERM like Tart does.
+while true {
+    sleep(3600)
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -30,9 +30,6 @@ public actor EnvironmentLifecycle {
         let token: OperationSupervisor.Token
         let identity: ProcessIdentity
         var address: GuestIPAddress?
-
-        /// Asked of the kernel, not inferred: a process that died a moment ago is not running.
-        var isAlive: Bool { kill(pid, 0) == 0 }
     }
 
     private struct InFlight {
@@ -40,6 +37,9 @@ public actor EnvironmentLifecycle {
         let environment: EnvironmentID
         /// `nil` while the slot is reserved but the operation has not been journaled yet.
         var task: Task<Void, Never>?
+        /// The phase last reported; cancellation is deferred while it is not cancelable.
+        var phase: ProgressPhase?
+        var cancelRequested = false
     }
 
     private let deps: Dependencies
@@ -137,7 +137,18 @@ public actor EnvironmentLifecycle {
         guard supervised[id] == nil, let identity = await deps.supervisor.identity(for: id) else { return }
         let token = deps.supervisor.hold("vm \(identity.vmName) (adopted)")
         supervised[id] = Supervised(run: nil, pid: live.pid, token: token, identity: identity, address: nil)
-        watchExit(pid: live.pid, environment: id)
+        watchExit(identity: identity, environment: id)
+        // A recovered VM is only usable with its address; it is looked up now and again on
+        // every status read until it is known.
+        if let address = try? await deps.backend.ip(vmName: identity.vmName, wait: .seconds(1)) {
+            supervised[id]?.address = address
+        }
+    }
+
+    /// Asked of the kernel each time, and matched against the recorded identity, so a PID
+    /// reused after the process died is never taken for the VM.
+    private func isAlive(_ live: Supervised) -> Bool {
+        deps.supervisor.verify(live.identity) != nil
     }
 
     // MARK: - Queries
@@ -150,13 +161,22 @@ public actor EnvironmentLifecycle {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else {
             throw GuesthouseError.environmentNotFound(id)
         }
+        // Inspection is how an uncertain verdict clears: the process table and inventory are
+        // read again now, so an inventory that was unreadable at launch does not block the
+        // environment until the service restarts.
+        if case .uncertain? = verdicts[id], inFlight == nil {
+            await reconcile()
+        }
         let inventory = try await deps.backend.list()
         let vm: EnvironmentStatus.VMState
         var readiness: EnvironmentStatus.Readiness
-        if let live = supervised[id], live.isAlive {
+        if let live = supervised[id], isAlive(live) {
             vm = .running
+            if live.address == nil, let address = try? await deps.backend.ip(vmName: environment.tartVMName, wait: .seconds(1)) {
+                supervised[id]?.address = address
+            }
             // Running without a confirmed address is not ready: nothing guest-dependent works.
-            readiness = live.address != nil ? .ready : .needsAttention(.guestNotReachable(id))
+            readiness = supervised[id]?.address != nil ? .ready : .needsAttention(.guestNotReachable(id))
         } else if case .uncertain(let reason)? = verdicts[id] {
             vm = .uncertain(reason: Self.describe(reason))
             readiness = .needsAttention(.vmOwnershipUncertain(id))
@@ -234,7 +254,7 @@ public actor EnvironmentLifecycle {
         let id = environment.id
         let arguments = TartBackend.runArguments(vmName: environment.tartVMName, console: options.console)
         do {
-            events(.progress(operation, ProgressPhase(kind: .startingVM, cancelable: false)))
+            report(operation, ProgressPhase(kind: .startingVM, cancelable: false), events)
             let run = try await deps.backend.run(vmName: environment.tartVMName, console: options.console)
             drainOutput(of: run)
             let identity: ProcessIdentity
@@ -250,10 +270,12 @@ public actor EnvironmentLifecycle {
             let vmToken = deps.supervisor.hold("vm \(environment.tartVMName)")
             supervised[id] = Supervised(run: run, pid: run.processIdentifier, token: vmToken, identity: identity, address: nil)
             verdicts[id] = nil
-            try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .checkpoint(.runtimeReady)))
+            // Watched before anything else can fail: a checkpoint that cannot be written
+            // fails the operation, but the process is supervised either way.
             watchExit(of: run, environment: id)
+            try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .checkpoint(.runtimeReady)))
 
-            events(.progress(operation, ProgressPhase(kind: .waitingForNetwork)))
+            report(operation, ProgressPhase(kind: .waitingForNetwork), events)
             let address = try await deps.backend.ip(vmName: environment.tartVMName, wait: options.ipWait)
             supervised[id]?.address = address
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .completed))
@@ -301,20 +323,30 @@ public actor EnvironmentLifecycle {
         do {
             switch mode {
             case .graceful(let deadline):
-                events(.progress(operation, ProgressPhase(kind: .stoppingVM, cancelable: false)))
+                report(operation, ProgressPhase(kind: .stoppingVM, cancelable: false), events)
                 do {
                     try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
                 } catch TartInvocationError.timedOut {
                     throw GuesthouseError.gracefulStopTimedOut(id)
+                } catch TartInvocationError.failed(.notRunning) {
+                    // Already stopped, or exited between the status read and the request: the
+                    // requested state is reached once the inventory confirms it.
+                    let inventory = try await deps.backend.list()
+                    if inventory.contains(where: { $0.name == environment.tartVMName && $0.running }) {
+                        throw TartInvocationError.failed(.notRunning)
+                    }
                 }
                 if let live = supervised[id], let run = live.run {
                     _ = await run.exit()
                 }
             case .force:
-                events(.progress(operation, ProgressPhase(kind: .forceStoppingVM, cancelable: false)))
+                report(operation, ProgressPhase(kind: .forceStoppingVM, cancelable: false), events)
                 if let live = supervised[id], let run = live.run {
                     run.terminate(gracePeriod: .seconds(5))
                     _ = await run.exit()
+                } else if let live = supervised[id] {
+                    // An adopted survivor has no run to end; its process is signaled directly.
+                    try await terminateAdopted(live, environment: id)
                 } else {
                     try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
                 }
@@ -334,11 +366,45 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    /// Cancels the in-flight operation if it is the one named. Phases marked non-cancelable
-    /// still run to their next checkpoint before the cancellation takes effect.
+    /// Cancels the in-flight operation if it is the one named. While the reported phase is
+    /// not cancelable the request is deferred to the next phase that is; an operation whose
+    /// remaining phases are all protected (a stop) runs to its end and reports its real
+    /// outcome, so a second stop is never attempted over an unknown one.
     public func cancel(_ operation: OperationID) {
-        guard let inFlight, inFlight.id == operation else { return }
-        inFlight.task?.cancel()
+        guard let current = inFlight, current.id == operation else { return }
+        if let phase = current.phase, !phase.cancelable {
+            inFlight?.cancelRequested = true
+            return
+        }
+        current.task?.cancel()
+    }
+
+    /// Reports a phase and honors a cancellation deferred by a protected phase before it.
+    private func report(_ operation: OperationID, _ phase: ProgressPhase, _ events: EventSink) {
+        inFlight?.phase = phase
+        events(.progress(operation, phase))
+        if phase.cancelable, inFlight?.cancelRequested == true {
+            inFlight?.task?.cancel()
+        }
+    }
+
+    /// Ends an adopted process with SIGTERM, then SIGKILL after five seconds. The identity is
+    /// verified before every signal: a PID that changed hands is left alone.
+    private func terminateAdopted(_ live: Supervised, environment: EnvironmentID) async throws {
+        guard deps.supervisor.verify(live.identity) != nil else { return }
+        kill(live.pid, SIGTERM)
+        for _ in 0..<50 where deps.supervisor.verify(live.identity) != nil {
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        if deps.supervisor.verify(live.identity) != nil {
+            kill(live.pid, SIGKILL)
+            for _ in 0..<50 where deps.supervisor.verify(live.identity) != nil {
+                try await Task.sleep(for: .milliseconds(100))
+            }
+        }
+        guard deps.supervisor.verify(live.identity) == nil else {
+            throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText("the virtual machine process did not end", limit: 200))
+        }
     }
 
     // MARK: - Internals
@@ -366,12 +432,15 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    private func watchExit(pid: Int32, environment: EnvironmentID) {
+    /// Polls an adopted process by identity, not by PID alone: once the PID no longer
+    /// carries the recorded start time, executable, and arguments, the VM process is gone.
+    private func watchExit(identity: ProcessIdentity, environment: EnvironmentID) {
+        let supervisor = deps.supervisor
         Task { [weak self] in
-            while kill(pid, 0) == 0 {
+            while supervisor.verify(identity) != nil {
                 try? await Task.sleep(for: .seconds(2))
             }
-            await self?.processExited(environment, pid: pid)
+            await self?.processExited(environment, pid: identity.pid)
         }
     }
 
@@ -391,7 +460,16 @@ public actor EnvironmentLifecycle {
     /// Journals the failure under the operation's own kind (the journal refuses a record whose
     /// kind differs from its `started` record), then reports it.
     private func fail(_ operation: OperationID, kind: JournalOperation, environment: EnvironmentID, with error: GuesthouseError, events: EventSink) async {
-        try? await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
+        do {
+            try await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
+        } catch {
+            // The journal still says "in flight". Until the actual state is inspected the
+            // environment stays blocked and the client is told the outcome is unknown, not
+            // that the operation failed: an unrecorded result must not license a retry.
+            unresolved[environment] = JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .started)
+            events(.failed(operation, .operationOutcomeUnknown(operation)))
+            return
+        }
         events(.failed(operation, error))
     }
 
@@ -409,6 +487,9 @@ public actor EnvironmentLifecycle {
         case .multipleCandidates: "more than one process matches the record"
         case .unrecordedLaunch: "the virtual machine is running but no launch was recorded"
         case .inventoryUnavailable: "the virtual machine inventory could not be read"
+        case .anotherProcessClaimsVM: "another process claims the virtual machine"
+        case .recordInconsistent: "the recorded process names a different virtual machine"
+        case .processUnobservable: "the recorded process exists but could not be read"
         }
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -50,6 +50,14 @@ public actor EnvironmentLifecycle {
     private var unresolved: [EnvironmentID: JournalRecord] = [:]
     private var inFlight: InFlight?
     private var reconciledAt: Date?
+    /// Set while an inventory failure has kept adoption from running, so a later listing tries
+    /// again instead of hiding a hand-created VM for the rest of the service's life.
+    private var adoptionPending = true
+
+    /// How long a terminal event may wait for the courtesy status that precedes it. The
+    /// operation is already durable by then, and a `tart list` that hangs must not keep the
+    /// client believing the work is still in flight (MVP-PLAN.md §2).
+    static let statusRefreshBudget = Duration.seconds(2)
 
     public init(dependencies: Dependencies) {
         deps = dependencies
@@ -77,8 +85,16 @@ public actor EnvironmentLifecycle {
         // launch: reconciliation marks the saved environments uncertain and inspection reads
         // the inventory again, whereas a throw here leaves the service permanently failed and
         // unable to answer even a status request (MVP-PLAN.md §4).
-        guard let inventory = try? await deps.backend.list() else { return }
-        let known = Set(snapshot.environments.map(\.id))
+        guard let inventory = try? await deps.backend.list() else {
+            adoptionPending = true
+            return
+        }
+        try await adopt(inventory)
+    }
+
+    private func adopt(_ inventory: [TartVMInfo]) async throws {
+        adoptionPending = false
+        var known = Set(snapshot.environments.map(\.id))
         var changed = false
         for vm in inventory where vm.source == .local {
             guard let id = Self.managedEnvironment(named: vm.name), !known.contains(id) else { continue }
@@ -87,6 +103,9 @@ public actor EnvironmentLifecycle {
             } catch {
                 continue
             }
+            // The CLI's output is untrusted: a name it repeats must adopt one environment, not
+            // append a second record that makes every later snapshot save fail.
+            known.insert(id)
             snapshot.environments.append(DevelopmentEnvironment(id: id, name: vm.name, createdAt: Date()))
             changed = true
         }
@@ -101,6 +120,17 @@ public actor EnvironmentLifecycle {
         else { return nil }
         let id = EnvironmentID(uuid: uuid)
         return id.tartVMName == name ? id : nil
+    }
+
+    /// The registered VM's own entry in a `tart list`, which can only be a local one.
+    ///
+    /// Adoption manages local bundles alone, and an environment is registered against the
+    /// bundle in `TART_HOME`. An OCI entry carrying the same name is a pulled image, not that
+    /// bundle: matching on the name alone would let a registered bundle be deleted and the
+    /// start still journal and launch, against an image Tart may go and fetch rather than
+    /// against the VM the environment was registered with (MVP-PLAN.md §4).
+    static func localVM(named name: String, in inventory: [TartVMInfo]) -> TartVMInfo? {
+        inventory.first { $0.name == name && $0.source == .local }
     }
 
     /// Re-derives ownership of every environment from the live process table and the VM
@@ -131,11 +161,12 @@ public actor EnvironmentLifecycle {
                 }
             case .ownedRunning(let live):
                 await adoptSurvivor(id, live: live)
-                // A running VM settles an interrupted start. It does not settle an interrupted
-                // stop: the `tart stop` an interrupted service left behind, and the guest
-                // shutdown it asked for, can still finish afterwards, so that operation's
-                // outcome is not established by this observation (MVP-PLAN.md §3).
-                if unresolved[id]?.operation != .stopEnvironment {
+                // A running VM settles an interrupted start and nothing else. The `tart stop` an
+                // interrupted service left behind, and the guest shutdown it asked for, can
+                // still finish afterwards; an interrupted import, provisioning, export, delete
+                // or repair changed things a running VM says nothing about. Each of those waits
+                // for its own state-specific check (MVP-PLAN.md §3).
+                if unresolved[id]?.operation == .startEnvironment {
                     await settleInterruptedOperation(id)
                 }
             case .uncertain:
@@ -144,6 +175,10 @@ public actor EnvironmentLifecycle {
         }
         self.verdicts = verdicts
         if inventory != nil {
+            // A readable inventory with no verdict and no supervised process establishes that
+            // no VM of ours is running, which settles a start or a stop and nothing else:
+            // `settledByVMState` keeps every other kind of record unresolved until the check
+            // that inspects what it actually changed can answer for it.
             for id in unresolved.keys where verdicts[id] == nil && supervised[id] == nil {
                 await settleInterruptedOperation(id)
             }
@@ -151,8 +186,47 @@ public actor EnvironmentLifecycle {
         reconciledAt = Date()
     }
 
+    /// Whether observing the VM itself establishes this operation's outcome.
+    ///
+    /// Starting and stopping a VM are exactly the operations the VM's own state answers for. An
+    /// import, a provisioning stage, an export, a delete, or a repair changed the filesystem or
+    /// the guest, and a VM that is running or absent says nothing about how far any of them
+    /// got; each waits for the check that inspects what it actually touched (MVP-PLAN.md §3).
+    static func settledByVMState(_ operation: JournalOperation) -> Bool {
+        switch operation {
+        case .startEnvironment, .stopEnvironment: true
+        case .provision, .importXcode, .deleteEnvironment, .exportWork, .repair: false
+        }
+    }
+
+    /// Settles a journal `begin` whose failure does not say whether the record landed.
+    ///
+    /// `begin` synchronizes the `started` line before the journal's own directory entry, so a
+    /// failure at that second step throws over a record a later read in this same service sees.
+    /// Left alone, nothing here would track it: status would report the environment ready while
+    /// the store refuses every later mutation for it as `operationUnresolved`, and no inspection
+    /// would try to settle it until the service restarted. Nothing had run when the write
+    /// failed — the launch and the signal both come after it — so a record that did land is
+    /// closed as `notApplied`, which is the truthful terminal outcome for a mutation that never
+    /// took effect; when even that cannot be written, the operation is held as unresolved so
+    /// the next inspection can settle it (MVP-PLAN.md §3).
+    func reconcileIndeterminateBegin(_ operation: OperationID, kind: JournalOperation, environment: EnvironmentID) async {
+        // A journal that cannot be read now leaves the same unknown, and the environment has to
+        // carry it: reporting nothing would license the very blind retry the journal prevents.
+        guard let replay = try? await deps.store.replay() else {
+            unresolved[environment] = JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .started)
+            return
+        }
+        guard let record = replay.inFlight[operation] else { return }
+        do {
+            try await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .notApplied))
+        } catch {
+            unresolved[environment] = record
+        }
+    }
+
     private func settleInterruptedOperation(_ id: EnvironmentID) async {
-        guard let record = unresolved[id] else { return }
+        guard let record = unresolved[id], Self.settledByVMState(record.operation) else { return }
         do {
             try await deps.store.append(JournalRecord(id: record.id, environmentID: id, operation: record.operation, timestamp: Date(), outcome: .reconciled))
             unresolved[id] = nil
@@ -186,8 +260,18 @@ public actor EnvironmentLifecycle {
 
     // MARK: - Queries
 
-    public func environments() -> [DevelopmentEnvironment] {
-        snapshot.environments
+    public func environments() async throws -> [DevelopmentEnvironment] {
+        // A hand-created VM that an unreadable inventory hid at launch is adopted on the next
+        // listing. Without this it would stay invisible — never listed, so never inspected and
+        // never reconciled — until the service process happened to restart (MVP-PLAN.md §4).
+        //
+        // An inventory that still cannot be read is reported rather than swallowed. The launch
+        // deliberately survives it, but a listing that could not be completed is not a list:
+        // answering with the snapshot alone would present "we could not look" as "there is
+        // nothing", and the user would never be offered the repair or the state inspection the
+        // failure carries.
+        if adoptionPending { try await adopt(self.inventory()) }
+        return snapshot.environments
     }
 
     public func status(of id: EnvironmentID) async throws -> EnvironmentStatus {
@@ -203,32 +287,8 @@ public actor EnvironmentLifecycle {
             await reconcile()
         }
         let inventory = try await self.inventory()
-        let vm: EnvironmentStatus.VMState
-        var readiness: EnvironmentStatus.Readiness
-        if let live = supervised[id], isAlive(live) {
-            vm = .running
-            // Asked again on every inspection rather than cached once: Tart's NAT address can
-            // change while the same VM process lives, most visibly after the host sleeps, and
-            // a stale address sends SSH and Screen Sharing to the wrong endpoint (§4).
-            supervised[id]?.address = try? await deps.backend.ip(vmName: environment.tartVMName, wait: .seconds(0))
-            // Running without a confirmed address is not ready: nothing guest-dependent works.
-            readiness = supervised[id]?.address != nil ? .ready : .needsAttention(.guestNotReachable(id))
-        } else if case .uncertain(let reason)? = verdicts[id] {
-            vm = .uncertain(reason: SanitizedText(Self.describe(reason), limit: 200))
-            readiness = .needsAttention(.vmOwnershipUncertain(id))
-        } else if let info = inventory.first(where: { $0.name == environment.tartVMName }) {
-            if info.running {
-                // Running according to Tart with no supervised process and no owned verdict.
-                vm = .uncertain(reason: "running without a recorded owner")
-                readiness = .needsAttention(.vmOwnershipUncertain(id))
-            } else {
-                vm = .stopped
-                readiness = .ready
-            }
-        } else {
-            vm = .notFound
-            readiness = .needsAttention(.environmentNotFound(id))
-        }
+        let (vm, initialReadiness) = try await vmState(of: environment, inventory: inventory)
+        var readiness = initialReadiness
         // A preserved slot is reported as such, so the GUI does not offer a start the
         // lifecycle would refuse.
         if snapshot.slots.state(of: id) == .preserved {
@@ -239,14 +299,79 @@ public actor EnvironmentLifecycle {
         if let record = unresolved[id] {
             readiness = .needsAttention(.operationOutcomeUnknown(record.id))
         }
+        // The address the field promises is one a guest connection can be made to, so it is
+        // answered from the state just computed rather than from the supervised entry alone. A
+        // VM that exited moments ago is observed as absent and reported stopped while its entry
+        // still holds the address it had until the exit watcher runs, and handing that out
+        // would point SSH and Screen Sharing at an endpoint this VM no longer owns (§4).
+        let address: GuestIPAddress? = if case .running = vm { supervised[id]?.address } else { nil }
         return EnvironmentStatus(
             environmentID: id,
             vm: vm,
             readiness: readiness,
             inFlightOperation: inFlight?.environment == id ? inFlight?.id : nil,
-            guestAddress: supervised[id]?.address,
+            guestAddress: address,
             reconciledAt: reconciledAt
         )
+    }
+
+    /// What the VM is doing, and what that asks of the user.
+    ///
+    /// The supervised process is asked of the kernel rather than remembered, and a process
+    /// table that declines to describe it is uncertainty, never an exit: reporting "cannot be
+    /// read" as "stopped" would show a VM that may still be running as available and license a
+    /// start over it (MVP-PLAN.md §4).
+    private func vmState(of environment: DevelopmentEnvironment, inventory: [TartVMInfo]) async throws -> (EnvironmentStatus.VMState, EnvironmentStatus.Readiness) {
+        let id = environment.id
+        switch supervised[id].map({ deps.supervisor.observe($0.identity) }) ?? .absent {
+        case .present:
+            // Asked again on every inspection rather than cached once: Tart's NAT address can
+            // change while the same VM process lives, most visibly after the host sleeps, and
+            // a stale address sends SSH and Screen Sharing to the wrong endpoint (§4).
+            let address: GuestIPAddress?
+            do {
+                address = try await deps.backend.ip(vmName: environment.tartVMName, wait: .seconds(0))
+            } catch TartInvocationError.runtimeReplaced {
+                // The inventory above proved the runtime a moment ago; it can be replaced
+                // between that and this probe. Guesthouse then refused to execute it and no
+                // guest was contacted, so swallowing this would send the user to inspect a
+                // guest that was never asked, instead of to repair the runtime (§3).
+                throw GuesthouseError.runtimeVerificationFailed(check: .signature)
+            } catch is ProcessLaunchError {
+                // Same window, and the same distinction: the runtime program could not be
+                // started at all, which reinstalling it repairs.
+                throw GuesthouseError.runtimeMissing
+            } catch {
+                // Everything else this probe reports — a timeout, no lease yet, a VM Tart says
+                // is not running — is about the guest, and is the readiness below.
+                address = nil
+            }
+            // The lookup suspends. A VM that ended while it was in flight was released by its
+            // exit watcher, and an address is no evidence about a process that is gone, so the
+            // answer is recomputed from what is true now.
+            guard let current = supervised[id], case .present = deps.supervisor.observe(current.identity) else { break }
+            supervised[id]?.address = address
+            // Running without a confirmed address is not ready: nothing guest-dependent works.
+            return (.running, address != nil ? .ready : .needsAttention(.guestNotReachable(id)))
+        case .unavailable:
+            return (
+                .uncertain(reason: SanitizedText(Self.describe(.processUnobservable), limit: 200)),
+                .needsAttention(.vmOwnershipUncertain(id))
+            )
+        case .absent:
+            break
+        }
+        if case .uncertain(let reason)? = verdicts[id] {
+            return (.uncertain(reason: SanitizedText(Self.describe(reason), limit: 200)), .needsAttention(.vmOwnershipUncertain(id)))
+        }
+        guard let info = Self.localVM(named: environment.tartVMName, in: inventory) else {
+            return (.notFound, .needsAttention(.environmentNotFound(id)))
+        }
+        // Running according to Tart with no supervised process and no owned verdict.
+        guard !info.running else {
+            return (.uncertain(reason: "running without a recorded owner"), .needsAttention(.vmOwnershipUncertain(id)))
+        }
+        return (.stopped, .ready)
     }
 
     // MARK: - Operations
@@ -257,6 +382,14 @@ public actor EnvironmentLifecycle {
     public func start(_ id: EnvironmentID, options: StartOptions, events: @escaping EventSink) async throws -> OperationID {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
         try refuseIfBlocked(id)
+        // Any slot whose ownership is unknown may still have a VM running: its recorded process
+        // could not be read, or its inventory could not be. Starting a second VM over that is
+        // what the one-running-VM invariant forbids (MVP-PLAN.md §4).
+        if let other = verdicts.keys.sorted(by: { $0.tartVMName < $1.tartVMName }).first(where: { key in
+            if case .uncertain? = verdicts[key] { return key != id } else { return false }
+        }) {
+            throw GuesthouseError.vmOwnershipUncertain(other)
+        }
         guard snapshot.slots.state(of: id) == .active else { throw GuesthouseError.environmentPreserved(id) }
         if supervised[id] != nil { throw GuesthouseError.environmentAlreadyRunning(id) }
         if let other = supervised.keys.first(where: { $0 != id }) { throw GuesthouseError.anotherEnvironmentRunning(other) }
@@ -265,36 +398,90 @@ public actor EnvironmentLifecycle {
         // both pass the checks and launch two instances against one disk.
         let operation = OperationID()
         inFlight = InFlight(id: operation, environment: id, task: nil)
+        let inventory: [TartVMInfo]
         do {
-            let inventory = try await self.inventory()
-            if let info = inventory.first(where: { $0.name == environment.tartVMName }), info.running {
-                throw GuesthouseError.environmentAlreadyRunning(id)
+            inventory = try await self.inventory()
+            // A registered VM whose bundle is gone from the store cannot be started. Without
+            // this, `tart run` is launched, exits before its identity can be recorded, and the
+            // failure reads as unavailable saved state instead of the missing VM it is.
+            guard let info = Self.localVM(named: environment.tartVMName, in: inventory) else {
+                throw GuesthouseError.environmentNotFound(id)
             }
+            if info.running { throw GuesthouseError.environmentAlreadyRunning(id) }
             // Every running app-managed VM counts against the one-running-VM invariant,
             // including a `guesthouse-<uuid>` the snapshot does not know: adoption may have
             // found no free slot for it, but it is still one of ours and still running (§4).
-            if let other = inventory.filter(\.running).compactMap({ Self.managedEnvironment(named: $0.name) }).first(where: { $0 != id }) {
+            let runningManaged = inventory.filter(\.running).compactMap { Self.managedEnvironment(named: $0.name) }.filter { $0 != id }
+            // One that has no slot is ours by name only; nothing records that Guesthouse
+            // started it. It is reported as the uncertain ownership it is, which offers the
+            // inspection and the console the developer needs, rather than a "stop it first"
+            // for a VM `stop` would refuse as unregistered (§4).
+            if let unadopted = runningManaged.first(where: { other in !snapshot.environments.contains { $0.id == other } }) {
+                throw GuesthouseError.vmOwnershipUncertain(unadopted)
+            }
+            if let other = runningManaged.first {
                 throw GuesthouseError.anotherEnvironmentRunning(other)
             }
+            // The inventory alone cannot say the VM is free: a `tart run` for it may have
+            // spawned without having taken the lock yet. The process table is asked for
+            // claimants immediately before the journal entry, and again before the launch (§4).
+            try await refuseIfAnySlotIsClaimed(startingFor: id, inventory: inventory)
+        } catch {
+            inFlight = nil
+            throw error
+        }
+        do {
             _ = try await deps.store.begin(.startEnvironment, for: id, id: operation)
         } catch {
             inFlight = nil
+            await reconcileIndeterminateBegin(operation, kind: .startEnvironment, environment: id)
             throw error
         }
         let token = deps.supervisor.hold("startEnvironment \(operation)")
         inFlight?.task = Task { [weak self] () async -> Void in
             guard let self else { return }
-            await self.performStart(operation, environment: environment, options: options, token: token, events: events)
+            await self.performStart(operation, environment: environment, options: options, inventory: inventory, token: token, events: events)
         }
         return operation
     }
 
-    private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, token: OperationSupervisor.Token, events: EventSink) async {
+    /// Refuses a start while any registered slot has a claimant, or an ownership that cannot be
+    /// established.
+    ///
+    /// Every slot is scanned, not only the one being started: a `tart run` that has spawned but
+    /// not yet taken its lock is in no inventory, and it may be claiming any of them, so
+    /// launching over it would put two VMs on one disk and break the one-running-VM invariant
+    /// (MVP-PLAN.md §4). The scan reads the process table, which only answers for the instant
+    /// it was taken — callers repeat it after every suspension that precedes the launch.
+    private func refuseIfAnySlotIsClaimed(startingFor id: EnvironmentID, inventory: [TartVMInfo]) async throws {
+        let running = Set(inventory.filter(\.running).map(\.name))
+        let registered = Dictionary(uniqueKeysWithValues: snapshot.environments.map { ($0.id, $0) })
+        let fresh = await deps.supervisor.reconcile(environments: Array(registered.keys)) { other in
+            guard let environment = registered[other] else { return .absent }
+            return running.contains(environment.tartVMName) ? .present : .absent
+        }
+        // The environment being started is answered for first and the rest in a stable order,
+        // so one process table always produces the same refusal.
+        for other in fresh.keys.sorted(by: { ($0 == id ? "" : $0.tartVMName) < ($1 == id ? "" : $1.tartVMName) }) {
+            guard case .uncertain? = fresh[other] else { continue }
+            verdicts[other] = fresh[other]
+            throw GuesthouseError.vmOwnershipUncertain(other)
+        }
+    }
+
+    private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, inventory: [TartVMInfo], token: OperationSupervisor.Token, events: EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
         let arguments = TartBackend.runArguments(vmName: environment.tartVMName, console: options.console)
         do {
             report(operation, ProgressPhase(kind: .startingVM, cancelable: false), events)
+            // The claimant scan that preceded the journal entry was already stale when the
+            // awaited write returned: another `tart run` can have spawned in between and be
+            // taking the lock now. The process table is therefore read once more here, with
+            // nothing but the launch after it. The inventory is the one already fetched — a VM
+            // that took a lock since has a process this scan finds anyway, and a second `tart
+            // list` would let a hanging inventory hold up a launch it cannot inform.
+            try await refuseIfAnySlotIsClaimed(startingFor: id, inventory: inventory)
             let run = try await deps.backend.run(vmName: environment.tartVMName, console: options.console)
             drainOutput(of: run)
             let identity: ProcessIdentity
@@ -320,13 +507,22 @@ public actor EnvironmentLifecycle {
             // An address says nothing if the process that was to own it is gone: a VM that
             // exited while the lookup was suspended was released by its exit watcher, and a
             // start that ends with no running VM has not completed.
-            guard supervised[id]?.pid == run.processIdentifier else {
+            guard let live = supervised[id], live.pid == run.processIdentifier else {
                 throw GuesthouseError.guestNotReachable(id)
+            }
+            // The watcher is asynchronous and may not have noticed an exit yet, so the kernel
+            // is asked directly rather than trusting the entry that is still there. A process
+            // table that will not answer leaves the outcome unestablished, not complete (§4).
+            switch deps.supervisor.observe(live.identity) {
+            case .present: break
+            case .absent: throw GuesthouseError.guestNotReachable(id)
+            case .unavailable: throw GuesthouseError.operationOutcomeUnknown(operation)
             }
             supervised[id]?.address = address
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .completed))
-            // The operation is complete whatever a best-effort status refresh does now.
-            if let status = try? await status(of: id) { events(.status(status)) }
+            // The operation is complete whatever a best-effort status refresh does now, so the
+            // refresh is bounded: an inventory that hangs must not delay the terminal event.
+            if let status = await refreshedStatus(of: id) { events(.status(status)) }
             events(.completed(operation))
         } catch is CancellationError {
             await fail(operation, kind: .startEnvironment, environment: id, with: .canceled, events: events)
@@ -353,18 +549,25 @@ public actor EnvironmentLifecycle {
         // The slot is taken before the first suspension, so two stops cannot both pass the
         // ownership check and signal the same VM.
         inFlight = InFlight(id: operation, environment: id, task: nil)
-        let alreadyStopped: Bool
         do {
-            alreadyStopped = try await requireOwnershipToStop(environment)
+            // Proven here so a stop this service may not perform is refused before it is
+            // journaled; proven again in the task, because this answer is stale by then.
+            _ = try await requireOwnershipToStop(environment)
+        } catch {
+            inFlight = nil
+            throw error
+        }
+        do {
             _ = try await deps.store.begin(.stopEnvironment, for: id, id: operation)
         } catch {
             inFlight = nil
+            await reconcileIndeterminateBegin(operation, kind: .stopEnvironment, environment: id)
             throw error
         }
         let token = deps.supervisor.hold("stopEnvironment \(operation)")
         inFlight?.task = Task { [weak self] () async -> Void in
             guard let self else { return }
-            await self.performStop(operation, environment: environment, mode: mode, alreadyStopped: alreadyStopped, token: token, events: events)
+            await self.performStop(operation, environment: environment, mode: mode, token: token, events: events)
         }
         return operation
     }
@@ -379,27 +582,46 @@ public actor EnvironmentLifecycle {
     /// force-stop was confirmed, is not an ownership problem.
     private func requireOwnershipToStop(_ environment: DevelopmentEnvironment) async throws -> Bool {
         if let live = supervised[environment.id], isAlive(live) { return false }
-        if isOwned(verdicts[environment.id]) { return false }
+        // A verdict is one reconciliation's memory. The process it named can have exited since,
+        // and another launch can have taken the same VM name; authorizing a stop from the
+        // remembered verdict alone would let Guesthouse shut down a machine that is no longer
+        // the one it recorded, so the recorded identity is asked of the kernel again (§4).
+        if case .ownedRunning(let recorded)? = verdicts[environment.id],
+           let identity = await deps.supervisor.identity(for: environment.id),
+           identity.pid == recorded.pid,
+           deps.supervisor.verify(identity) != nil {
+            return false
+        }
         switch await observe(environment) {
         case .stopped: return true
         case .running, .unknown: throw GuesthouseError.vmOwnershipUncertain(environment.id)
         }
     }
 
-    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, alreadyStopped: Bool, token: OperationSupervisor.Token, events: EventSink) async {
+    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
         do {
+            // Ownership was proven before the journal write suspended, and that answer only
+            // described the instant it was taken: the owned process can have exited since and
+            // another launch taken the same VM name, and the observed stopped state can have
+            // become a running VM again. Both signals act by name or by PID, so ownership is
+            // established once more here, immediately before either of them, and an ownership
+            // that changed is reported as uncertain rather than stopped (MVP-PLAN.md §4).
+            let alreadyStopped = try await requireOwnershipToStop(environment)
             switch mode {
             case .graceful(let deadline):
                 report(operation, ProgressPhase(kind: .stoppingVM, cancelable: false), events)
                 if !alreadyStopped {
+                    // One deadline covers the whole graceful stop. `tart stop` and the wait for
+                    // the process hosting the VM share it, so a normal Quit never takes close
+                    // to twice what the caller asked for (MVP-PLAN.md §2).
+                    let end = ContinuousClock.now.advanced(by: deadline)
                     try await gracefulStop(operation, environment: environment, deadline: deadline)
                     // Tart's command has returned, but the process hosting the VM may still be
-                    // unwinding, and Quit waits for both. The wait is bounded by the deadline
-                    // the caller asked for: the run itself was launched with a year-long
-                    // timeout, so an unbounded wait here would never end (MVP-PLAN.md §2).
-                    guard await waitForVMProcess(of: id, within: deadline) else {
+                    // unwinding, and Quit waits for both. The run itself was launched with a
+                    // year-long timeout, so an unbounded wait here would never end.
+                    guard await waitForVMProcess(of: id, until: end) else {
                         throw GuesthouseError.operationOutcomeUnknown(operation)
                     }
                 }
@@ -413,7 +635,7 @@ public actor EnvironmentLifecycle {
                         // An adopted survivor has no run to end; its process is signaled directly.
                         try await terminateAdopted(live, operation: operation)
                     } else {
-                        try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
+                        try await endUnsupervisedVM(environment, operation: operation)
                     }
                 }
             }
@@ -421,7 +643,9 @@ public actor EnvironmentLifecycle {
                 throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText(Self.describe(failure), limit: 200))
             }
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .stopEnvironment, timestamp: Date(), outcome: .completed))
-            if let status = try? await status(of: id) { events(.status(status)) }
+            // The stop is already durable, so the courtesy status is bounded: an inventory that
+            // hangs must not hold Quit past the deadline for a stop that already succeeded.
+            if let status = await refreshedStatus(of: id) { events(.status(status)) }
             events(.completed(operation))
         } catch is CancellationError {
             await fail(operation, kind: .stopEnvironment, environment: id, with: .canceled, events: events)
@@ -429,6 +653,11 @@ public actor EnvironmentLifecycle {
             await fail(operation, kind: .stopEnvironment, environment: id, with: error, events: events)
         } catch let error as TartInvocationError {
             await fail(operation, kind: .stopEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
+        } catch is ProcessLaunchError {
+            // `tart` itself could not be launched, so nothing was asked of the VM. Guesthouse's
+            // saved state is not involved, and reinstalling the runtime — not inspecting
+            // state — is what helps, exactly as on the start path.
+            await fail(operation, kind: .stopEnvironment, environment: id, with: .runtimeMissing, events: events)
         } catch {
             await fail(operation, kind: .stopEnvironment, environment: id, with: .runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200)), events: events)
         }
@@ -445,7 +674,13 @@ public actor EnvironmentLifecycle {
         do {
             try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
         } catch TartInvocationError.timedOut {
-            switch await observe(environment) {
+            // The caller's whole budget is spent by definition on this branch, and when the
+            // supervised process is already gone `observe` falls through to `tart list`, whose
+            // own timeout is longer than a graceful stop's entire deadline: a Quit would sit
+            // tens of seconds past what the user asked for. The read gets a short courtesy
+            // window instead, and one that does not answer inside it is the unknown outcome
+            // this branch already reports for a state it cannot read (MVP-PLAN.md §2).
+            switch await observe(environment, within: Self.statusRefreshBudget) {
             case .running: throw GuesthouseError.gracefulStopTimedOut(environment.id)
             case .stopped: return
             case .unknown: throw GuesthouseError.operationOutcomeUnknown(operation)
@@ -467,18 +702,50 @@ public actor EnvironmentLifecycle {
     /// A run this service launched and a survivor adopted after a relaunch are waited for the
     /// same way — by asking the kernel about the recorded identity — so an adopted VM's Tart
     /// process is waited for too, and only a definite absence counts as an exit (§4).
-    private func waitForVMProcess(of id: EnvironmentID, within deadline: Duration) async -> Bool {
+    private func waitForVMProcess(of id: EnvironmentID, until end: ContinuousClock.Instant) async -> Bool {
         guard let live = supervised[id] else { return true }
         let identity = live.identity
-        return await poll(until: deadline) { deps.supervisor.observe(identity) == .absent }
+        return await poll(until: end) { deps.supervisor.observe(identity) == .absent }
     }
 
-    private func poll(until deadline: Duration, _ finished: () -> Bool) async -> Bool {
-        let end = ContinuousClock.now.advanced(by: deadline)
+    private func poll(until end: ContinuousClock.Instant, _ finished: () -> Bool) async -> Bool {
         while true {
             if finished() { return true }
             if ContinuousClock.now >= end { return false }
             try? await Task.sleep(for: .milliseconds(50))
+        }
+    }
+
+    /// Ends the VM for a force stop when no supervised process is left to signal.
+    ///
+    /// The supervised process can have exited between the ownership preflight and this task,
+    /// in which case the requested stopped state is already reached and no command is needed:
+    /// `tart stop` would answer `notRunning`, and that would be reported as a failure for a
+    /// stop that succeeded (MVP-PLAN.md §2, Quit).
+    func endUnsupervisedVM(_ environment: DevelopmentEnvironment, operation: OperationID) async throws {
+        switch await observe(environment) {
+        case .stopped: return
+        case .running: try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
+        case .unknown: throw GuesthouseError.operationOutcomeUnknown(operation)
+        }
+    }
+
+    /// A status read that gives up at `statusRefreshBudget`, for the courtesy refresh that
+    /// precedes a terminal event. The operation it follows is already journaled, so a `tart
+    /// list` that never answers must cost the client nothing.
+    private func refreshedStatus(of id: EnvironmentID) async -> EnvironmentStatus? {
+        await withTaskGroup(of: EnvironmentStatus?.self) { group in
+            group.addTask { [weak self] in
+                guard let self else { return nil }
+                return try? await self.status(of: id)
+            }
+            group.addTask {
+                try? await Task.sleep(for: Self.statusRefreshBudget)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
         }
     }
 
@@ -495,7 +762,25 @@ public actor EnvironmentLifecycle {
             }
         }
         guard let inventory = try? await deps.backend.list() else { return .unknown }
-        return inventory.contains { $0.name == environment.tartVMName && $0.running } ? .running : .stopped
+        return Self.localVM(named: environment.tartVMName, in: inventory)?.running == true ? .running : .stopped
+    }
+
+    /// `observe`, giving up at `budget` with `.unknown`. Cancelling the group ends the query
+    /// process too, so the wait really is bounded rather than merely abandoned.
+    private func observe(_ environment: DevelopmentEnvironment, within budget: Duration) async -> VMObservation {
+        await withTaskGroup(of: VMObservation.self) { group in
+            group.addTask { [weak self] in
+                guard let self else { return .unknown }
+                return await self.observe(environment)
+            }
+            group.addTask {
+                try? await Task.sleep(for: budget)
+                return .unknown
+            }
+            let first = await group.next() ?? .unknown
+            group.cancelAll()
+            return first
+        }
     }
 
     /// Cancels the in-flight operation if it is the one named. While the reported phase is
@@ -504,7 +789,11 @@ public actor EnvironmentLifecycle {
     /// outcome, so a second stop is never attempted over an unknown one.
     public func cancel(_ operation: OperationID) {
         guard let current = inFlight, current.id == operation else { return }
-        if let phase = current.phase, !phase.cancelable {
+        // No phase yet means the operation has not reported one. Its first phase is a protected
+        // one for both start and stop, and the task may not even exist yet, so cancelling here
+        // would either be dropped or land on a task about to begin mutating; the request is
+        // deferred to the next cancelable phase instead.
+        guard let phase = current.phase, phase.cancelable else {
             inFlight?.cancelRequested = true
             return
         }
@@ -622,9 +911,14 @@ public actor EnvironmentLifecycle {
             try await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
             // A recorded outcome that is itself unknown settles nothing: the environment stays
             // blocked, and status keeps asking for inspection, until actual state says what
-            // the mutation did. The journal agrees; `leavesInFlight` reads it the same way.
-            if case .operationOutcomeUnknown = error {
+            // the mutation did. A cancellation is the same — the work may have been half done
+            // when the task stopped — and `JournalRecord.leavesInFlight` reads both that way,
+            // so both are tracked here or only a service restart would rediscover them.
+            switch error {
+            case .operationOutcomeUnknown, .canceled:
                 unresolved[environment] = JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .started)
+            default:
+                break
             }
         } catch {
             // The journal still says "in flight". Until the actual state is inspected the
@@ -637,10 +931,10 @@ public actor EnvironmentLifecycle {
         events(.failed(operation, error))
     }
 
-    private func isOwned(_ verdict: OwnershipVerdict?) -> Bool {
-        if case .ownedRunning? = verdict { return true }
-        return false
-    }
+    /// Test seams: what the lifecycle is doing right now, before any progress has been
+    /// reported for it.
+    var inFlightOperationID: OperationID? { inFlight?.id }
+    var inFlightPhase: ProgressPhase? { inFlight?.phase }
 
     static func describe(_ reason: OwnershipVerdict.UncertaintyReason) -> String {
         switch reason {
@@ -676,6 +970,11 @@ public actor EnvironmentLifecycle {
             return try await deps.backend.list()
         } catch let error as TartInvocationError {
             throw Self.mapInventory(error)
+        } catch is ProcessLaunchError {
+            // The runtime program itself could not be started, which reinstalling it repairs.
+            // Guesthouse's saved state is not involved, so it must not be what the user is
+            // sent to inspect.
+            throw GuesthouseError.runtimeMissing
         }
     }
 
@@ -683,16 +982,20 @@ public actor EnvironmentLifecycle {
     /// answers for commands addressed at one VM.
     public static func mapInventory(_ error: TartInvocationError) -> GuesthouseError {
         switch error {
-        case .unparseableOutput: .runtimeIncompatible(found: nil, required: TartPin.releaseTag)
+        case .unparseableOutput: .runtimeIncompatible(found: nil, required: SanitizedText(TartPin.releaseTag))
         case .timedOut: .runtimeStateUnavailable(reason: SanitizedText("the list of virtual machines did not answer in time", limit: 200))
+        case .runtimeReplaced: .runtimeVerificationFailed(check: .signature)
         case .failed: .runtimeStateUnavailable(reason: SanitizedText("the list of virtual machines could not be read", limit: 200))
         }
     }
 
     public static func map(_ error: TartInvocationError, environment: EnvironmentID) -> GuesthouseError {
         switch error {
-        case .unparseableOutput: .runtimeIncompatible(found: nil, required: TartPin.releaseTag)
+        case .unparseableOutput: .runtimeIncompatible(found: nil, required: SanitizedText(TartPin.releaseTag))
         case .timedOut: .guestNotReachable(environment)
+        // Guesthouse refused to execute a host runtime that is no longer the verified file.
+        // Nothing was run and no guest was probed; reinstalling the runtime is what helps.
+        case .runtimeReplaced: .runtimeVerificationFailed(check: .signature)
         case .failed(let failure):
             switch failure {
             case .vmNotFound: .environmentNotFound(environment)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -73,12 +73,15 @@ public actor EnvironmentLifecycle {
     /// adopted into a free slot. This is how a VM created by hand for phase 0 becomes an
     /// environment; nothing is created here.
     public func adoptExistingVMs() async throws {
+        // An inventory that cannot be read adopts nothing, and is not a reason to fail the
+        // launch: reconciliation marks the saved environments uncertain and inspection reads
+        // the inventory again, whereas a throw here leaves the service permanently failed and
+        // unable to answer even a status request (MVP-PLAN.md §4).
+        guard let inventory = try? await deps.backend.list() else { return }
         let known = Set(snapshot.environments.map(\.id))
         var changed = false
-        for vm in try await deps.backend.list() where vm.source == .local {
-            guard vm.name.hasPrefix("guesthouse-"), let uuid = UUID(uuidString: String(vm.name.dropFirst("guesthouse-".count))) else { continue }
-            let id = EnvironmentID(uuid: uuid)
-            guard id.tartVMName == vm.name, !known.contains(id) else { continue }
+        for vm in inventory where vm.source == .local {
+            guard let id = Self.managedEnvironment(named: vm.name), !known.contains(id) else { continue }
             do {
                 try snapshot.slots.reserve(id)
             } catch {
@@ -88,6 +91,16 @@ public actor EnvironmentLifecycle {
             changed = true
         }
         if changed { try await deps.store.saveSnapshot(snapshot) }
+    }
+
+    /// The environment a `guesthouse-<uuid>` VM name identifies, or `nil` for a VM this app
+    /// does not manage. The name must round-trip, so a look-alike is never taken for ours.
+    static func managedEnvironment(named name: String) -> EnvironmentID? {
+        guard name.hasPrefix("guesthouse-"),
+              let uuid = UUID(uuidString: String(name.dropFirst("guesthouse-".count)))
+        else { return nil }
+        let id = EnvironmentID(uuid: uuid)
+        return id.tartVMName == name ? id : nil
     }
 
     /// Re-derives ownership of every environment from the live process table and the VM
@@ -107,12 +120,24 @@ public actor EnvironmentLifecycle {
         for (id, verdict) in verdicts {
             switch verdict {
             case .exited:
-                try? await deps.supervisor.forget(id)
-                verdicts[id] = nil
-                await settleInterruptedOperation(id)
+                do {
+                    try await deps.supervisor.forget(id)
+                    verdicts[id] = nil
+                    await settleInterruptedOperation(id)
+                } catch {
+                    // The record outlives the process it describes; until it can be removed
+                    // the environment is uncertain rather than free.
+                    verdicts[id] = .uncertain(.identityNotForgotten)
+                }
             case .ownedRunning(let live):
                 await adoptSurvivor(id, live: live)
-                await settleInterruptedOperation(id)
+                // A running VM settles an interrupted start. It does not settle an interrupted
+                // stop: the `tart stop` an interrupted service left behind, and the guest
+                // shutdown it asked for, can still finish afterwards, so that operation's
+                // outcome is not established by this observation (MVP-PLAN.md §3).
+                if unresolved[id]?.operation != .stopEnvironment {
+                    await settleInterruptedOperation(id)
+                }
             case .uncertain:
                 break
             }
@@ -127,8 +152,16 @@ public actor EnvironmentLifecycle {
     }
 
     private func settleInterruptedOperation(_ id: EnvironmentID) async {
-        guard let record = unresolved.removeValue(forKey: id) else { return }
-        try? await deps.store.append(JournalRecord(id: record.id, environmentID: id, operation: record.operation, timestamp: Date(), outcome: .reconciled))
+        guard let record = unresolved[id] else { return }
+        do {
+            try await deps.store.append(JournalRecord(id: record.id, environmentID: id, operation: record.operation, timestamp: Date(), outcome: .reconciled))
+            unresolved[id] = nil
+        } catch {
+            // The durable journal still says the mutation is in flight. Forgetting it here
+            // would report the environment as settled while storage contradicts that, and
+            // nothing short of a restart could clear it; the entry is kept so the next
+            // inspection settles it once the journal is writable again.
+        }
     }
 
     /// A process proven ours after a relaunch is supervised again: a transaction is held and
@@ -161,24 +194,27 @@ public actor EnvironmentLifecycle {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else {
             throw GuesthouseError.environmentNotFound(id)
         }
-        // Inspection is how an uncertain verdict clears: the process table and inventory are
-        // read again now, so an inventory that was unreadable at launch does not block the
-        // environment until the service restarts.
-        if case .uncertain? = verdicts[id], inFlight == nil {
+        // Inspection is how an uncertain verdict and an unsettled operation clear: the process
+        // table and inventory are read again now, so neither an inventory that was unreadable
+        // at launch nor a terminal record that could not be written blocks the environment
+        // until the service restarts.
+        let uncertain: Bool = if case .uncertain? = verdicts[id] { true } else { false }
+        if inFlight == nil, uncertain || unresolved[id] != nil {
             await reconcile()
         }
-        let inventory = try await deps.backend.list()
+        let inventory = try await self.inventory()
         let vm: EnvironmentStatus.VMState
         var readiness: EnvironmentStatus.Readiness
         if let live = supervised[id], isAlive(live) {
             vm = .running
-            if live.address == nil, let address = try? await deps.backend.ip(vmName: environment.tartVMName, wait: .seconds(1)) {
-                supervised[id]?.address = address
-            }
+            // Asked again on every inspection rather than cached once: Tart's NAT address can
+            // change while the same VM process lives, most visibly after the host sleeps, and
+            // a stale address sends SSH and Screen Sharing to the wrong endpoint (§4).
+            supervised[id]?.address = try? await deps.backend.ip(vmName: environment.tartVMName, wait: .seconds(0))
             // Running without a confirmed address is not ready: nothing guest-dependent works.
             readiness = supervised[id]?.address != nil ? .ready : .needsAttention(.guestNotReachable(id))
         } else if case .uncertain(let reason)? = verdicts[id] {
-            vm = .uncertain(reason: Self.describe(reason))
+            vm = .uncertain(reason: SanitizedText(Self.describe(reason), limit: 200))
             readiness = .needsAttention(.vmOwnershipUncertain(id))
         } else if let info = inventory.first(where: { $0.name == environment.tartVMName }) {
             if info.running {
@@ -193,13 +229,15 @@ public actor EnvironmentLifecycle {
             vm = .notFound
             readiness = .needsAttention(.environmentNotFound(id))
         }
-        if let record = unresolved[id] {
-            readiness = .needsAttention(.operationOutcomeUnknown(record.id))
-        }
         // A preserved slot is reported as such, so the GUI does not offer a start the
         // lifecycle would refuse.
         if snapshot.slots.state(of: id) == .preserved {
             readiness = .needsAttention(.environmentPreserved(id))
+        }
+        // An operation whose outcome is unknown outranks preservation: it is what has to be
+        // inspected first, and it is what `refuseIfBlocked` will refuse a repair over (§3).
+        if let record = unresolved[id] {
+            readiness = .needsAttention(.operationOutcomeUnknown(record.id))
         }
         return EnvironmentStatus(
             environmentID: id,
@@ -228,13 +266,15 @@ public actor EnvironmentLifecycle {
         let operation = OperationID()
         inFlight = InFlight(id: operation, environment: id, task: nil)
         do {
-            let inventory = try await deps.backend.list()
+            let inventory = try await self.inventory()
             if let info = inventory.first(where: { $0.name == environment.tartVMName }), info.running {
                 throw GuesthouseError.environmentAlreadyRunning(id)
             }
-            let runningNames = Set(inventory.filter(\.running).map(\.name))
-            if let other = snapshot.environments.first(where: { $0.id != id && runningNames.contains($0.tartVMName) }) {
-                throw GuesthouseError.anotherEnvironmentRunning(other.id)
+            // Every running app-managed VM counts against the one-running-VM invariant,
+            // including a `guesthouse-<uuid>` the snapshot does not know: adoption may have
+            // found no free slot for it, but it is still one of ours and still running (§4).
+            if let other = inventory.filter(\.running).compactMap({ Self.managedEnvironment(named: $0.name) }).first(where: { $0 != id }) {
+                throw GuesthouseError.anotherEnvironmentRunning(other)
             }
             _ = try await deps.store.begin(.startEnvironment, for: id, id: operation)
         } catch {
@@ -277,6 +317,12 @@ public actor EnvironmentLifecycle {
 
             report(operation, ProgressPhase(kind: .waitingForNetwork), events)
             let address = try await deps.backend.ip(vmName: environment.tartVMName, wait: options.ipWait)
+            // An address says nothing if the process that was to own it is gone: a VM that
+            // exited while the lookup was suspended was released by its exit watcher, and a
+            // start that ends with no running VM has not completed.
+            guard supervised[id]?.pid == run.processIdentifier else {
+                throw GuesthouseError.guestNotReachable(id)
+            }
             supervised[id]?.address = address
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .completed))
             // The operation is complete whatever a best-effort status refresh does now.
@@ -288,22 +334,28 @@ public actor EnvironmentLifecycle {
             await fail(operation, kind: .startEnvironment, environment: id, with: error, events: events)
         } catch let error as TartInvocationError {
             await fail(operation, kind: .startEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
+        } catch is ProcessLaunchError {
+            // The runtime program itself could not be started. Guesthouse's saved state is not
+            // involved, and reinstalling the runtime — not inspecting state — is what helps.
+            await fail(operation, kind: .startEnvironment, environment: id, with: .runtimeMissing, events: events)
         } catch {
             await fail(operation, kind: .startEnvironment, environment: id, with: .runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200)), events: events)
         }
     }
 
-    /// Graceful stop through Tart, or the explicitly warned force-stop. Force-stopping needs
-    /// ownership evidence: a supervised process or an owned reconciliation verdict.
+    /// Graceful stop through Tart, or the explicitly warned force-stop. Either way the VM must
+    /// be proven ours: a supervised process or an owned reconciliation verdict, or an
+    /// inventory that says nothing by that name is running.
     public func stop(_ id: EnvironmentID, mode: StopMode, events: @escaping EventSink) async throws -> OperationID {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
         try refuseIfBlocked(id)
-        if mode == .force, supervised[id] == nil, !isOwned(verdicts[id]) {
-            throw GuesthouseError.vmOwnershipUncertain(id)
-        }
         let operation = OperationID()
+        // The slot is taken before the first suspension, so two stops cannot both pass the
+        // ownership check and signal the same VM.
         inFlight = InFlight(id: operation, environment: id, task: nil)
+        let alreadyStopped: Bool
         do {
+            alreadyStopped = try await requireOwnershipToStop(environment)
             _ = try await deps.store.begin(.stopEnvironment, for: id, id: operation)
         } catch {
             inFlight = nil
@@ -312,46 +364,62 @@ public actor EnvironmentLifecycle {
         let token = deps.supervisor.hold("stopEnvironment \(operation)")
         inFlight?.task = Task { [weak self] () async -> Void in
             guard let self else { return }
-            await self.performStop(operation, environment: environment, mode: mode, token: token, events: events)
+            await self.performStop(operation, environment: environment, mode: mode, alreadyStopped: alreadyStopped, token: token, events: events)
         }
         return operation
     }
 
-    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: EventSink) async {
+    /// Both modes act on the VM by name or by PID, so neither may run against a machine this
+    /// service cannot prove it started: an app-named VM someone else launched since the last
+    /// reconciliation has no verdict of its own, and a graceful `tart stop <name>` would shut
+    /// it down all the same (MVP-PLAN.md §4).
+    ///
+    /// Returns whether the requested stopped state is already reached, which needs no signal:
+    /// a guest that finished shutting down after a graceful timeout, but before the warned
+    /// force-stop was confirmed, is not an ownership problem.
+    private func requireOwnershipToStop(_ environment: DevelopmentEnvironment) async throws -> Bool {
+        if let live = supervised[environment.id], isAlive(live) { return false }
+        if isOwned(verdicts[environment.id]) { return false }
+        switch await observe(environment) {
+        case .stopped: return true
+        case .running, .unknown: throw GuesthouseError.vmOwnershipUncertain(environment.id)
+        }
+    }
+
+    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, alreadyStopped: Bool, token: OperationSupervisor.Token, events: EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
         do {
             switch mode {
             case .graceful(let deadline):
                 report(operation, ProgressPhase(kind: .stoppingVM, cancelable: false), events)
-                do {
-                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
-                } catch TartInvocationError.timedOut {
-                    throw GuesthouseError.gracefulStopTimedOut(id)
-                } catch TartInvocationError.failed(.notRunning) {
-                    // Already stopped, or exited between the status read and the request: the
-                    // requested state is reached once the inventory confirms it.
-                    let inventory = try await deps.backend.list()
-                    if inventory.contains(where: { $0.name == environment.tartVMName && $0.running }) {
-                        throw TartInvocationError.failed(.notRunning)
+                if !alreadyStopped {
+                    try await gracefulStop(operation, environment: environment, deadline: deadline)
+                    // Tart's command has returned, but the process hosting the VM may still be
+                    // unwinding, and Quit waits for both. The wait is bounded by the deadline
+                    // the caller asked for: the run itself was launched with a year-long
+                    // timeout, so an unbounded wait here would never end (MVP-PLAN.md §2).
+                    guard await waitForVMProcess(of: id, within: deadline) else {
+                        throw GuesthouseError.operationOutcomeUnknown(operation)
                     }
-                }
-                if let live = supervised[id], let run = live.run {
-                    _ = await run.exit()
                 }
             case .force:
                 report(operation, ProgressPhase(kind: .forceStoppingVM, cancelable: false), events)
-                if let live = supervised[id], let run = live.run {
-                    run.terminate(gracePeriod: .seconds(5))
-                    _ = await run.exit()
-                } else if let live = supervised[id] {
-                    // An adopted survivor has no run to end; its process is signaled directly.
-                    try await terminateAdopted(live, environment: id)
-                } else {
-                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
+                if !alreadyStopped {
+                    if let live = supervised[id], let run = live.run {
+                        run.terminate(gracePeriod: .seconds(5))
+                        _ = await run.exit()
+                    } else if let live = supervised[id] {
+                        // An adopted survivor has no run to end; its process is signaled directly.
+                        try await terminateAdopted(live, operation: operation)
+                    } else {
+                        try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
+                    }
                 }
             }
-            await release(id)
+            if let failure = await release(id) {
+                throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText(Self.describe(failure), limit: 200))
+            }
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .stopEnvironment, timestamp: Date(), outcome: .completed))
             if let status = try? await status(of: id) { events(.status(status)) }
             events(.completed(operation))
@@ -364,6 +432,70 @@ public actor EnvironmentLifecycle {
         } catch {
             await fail(operation, kind: .stopEnvironment, environment: id, with: .runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200)), events: events)
         }
+    }
+
+    /// Asks Tart to shut the guest down, then establishes what actually happened.
+    ///
+    /// A deadline that expires ends the `tart stop` command while the guest may still be
+    /// completing the shutdown it was already asked for, so nothing terminal is recorded from
+    /// the timeout alone: a VM still running is the reported timeout, a VM that is gone is a
+    /// stop that completed late, and a state that cannot be read leaves the outcome unknown
+    /// rather than unblocking the environment for a retry or a force-stop (MVP-PLAN.md §3).
+    private func gracefulStop(_ operation: OperationID, environment: DevelopmentEnvironment, deadline: Duration) async throws {
+        do {
+            try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
+        } catch TartInvocationError.timedOut {
+            switch await observe(environment) {
+            case .running: throw GuesthouseError.gracefulStopTimedOut(environment.id)
+            case .stopped: return
+            case .unknown: throw GuesthouseError.operationOutcomeUnknown(operation)
+            }
+        } catch TartInvocationError.failed(.notRunning) {
+            // Already stopped, or exited between the ownership check and the request: the
+            // requested state is reached once the VM itself confirms it.
+            switch await observe(environment) {
+            case .stopped: return
+            case .running: throw TartInvocationError.failed(.notRunning)
+            case .unknown: throw GuesthouseError.operationOutcomeUnknown(operation)
+            }
+        }
+    }
+
+    /// Waits for the process hosting the VM to end, giving up at `deadline`. `false` means the
+    /// wait expired with the process still there, which leaves the outcome unestablished.
+    ///
+    /// A run this service launched and a survivor adopted after a relaunch are waited for the
+    /// same way — by asking the kernel about the recorded identity — so an adopted VM's Tart
+    /// process is waited for too, and only a definite absence counts as an exit (§4).
+    private func waitForVMProcess(of id: EnvironmentID, within deadline: Duration) async -> Bool {
+        guard let live = supervised[id] else { return true }
+        let identity = live.identity
+        return await poll(until: deadline) { deps.supervisor.observe(identity) == .absent }
+    }
+
+    private func poll(until deadline: Duration, _ finished: () -> Bool) async -> Bool {
+        let end = ContinuousClock.now.advanced(by: deadline)
+        while true {
+            if finished() { return true }
+            if ContinuousClock.now >= end { return false }
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+    }
+
+    /// Whether the VM is running, answered from the supervised process first and the inventory
+    /// otherwise. `unknown` when neither can say, which is never treated as "stopped".
+    private enum VMObservation { case running, stopped, unknown }
+
+    private func observe(_ environment: DevelopmentEnvironment) async -> VMObservation {
+        if let live = supervised[environment.id] {
+            switch deps.supervisor.observe(live.identity) {
+            case .present: return .running
+            case .unavailable: return .unknown
+            case .absent: break
+            }
+        }
+        guard let inventory = try? await deps.backend.list() else { return .unknown }
+        return inventory.contains { $0.name == environment.tartVMName && $0.running } ? .running : .stopped
     }
 
     /// Cancels the in-flight operation if it is the one named. While the reported phase is
@@ -388,22 +520,32 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    /// Ends an adopted process with SIGTERM, then SIGKILL after five seconds. The identity is
-    /// verified before every signal: a PID that changed hands is left alone.
-    private func terminateAdopted(_ live: Supervised, environment: EnvironmentID) async throws {
-        guard deps.supervisor.verify(live.identity) != nil else { return }
-        kill(live.pid, SIGTERM)
-        for _ in 0..<50 where deps.supervisor.verify(live.identity) != nil {
-            try await Task.sleep(for: .milliseconds(100))
-        }
-        if deps.supervisor.verify(live.identity) != nil {
-            kill(live.pid, SIGKILL)
-            for _ in 0..<50 where deps.supervisor.verify(live.identity) != nil {
+    /// Ends an adopted process with SIGTERM, then SIGKILL after five seconds.
+    ///
+    /// The identity is observed again before every signal, so a PID that changed hands is left
+    /// alone and a process the kernel will not describe is never signaled. A process that
+    /// cannot be read at the end is neither proven gone nor proven alive, so the stop reports
+    /// an unknown outcome instead of a success it did not establish (§4).
+    private func terminateAdopted(_ live: Supervised, operation: OperationID) async throws {
+        if case .present = deps.supervisor.observe(live.identity) {
+            kill(live.pid, SIGTERM)
+            for _ in 0..<50 where deps.supervisor.observe(live.identity) != .absent {
                 try await Task.sleep(for: .milliseconds(100))
             }
         }
-        guard deps.supervisor.verify(live.identity) == nil else {
+        if case .present = deps.supervisor.observe(live.identity) {
+            kill(live.pid, SIGKILL)
+            for _ in 0..<50 where deps.supervisor.observe(live.identity) != .absent {
+                try await Task.sleep(for: .milliseconds(100))
+            }
+        }
+        switch deps.supervisor.observe(live.identity) {
+        case .absent:
+            return
+        case .present:
             throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText("the virtual machine process did not end", limit: 200))
+        case .unavailable:
+            throw GuesthouseError.operationOutcomeUnknown(operation)
         }
     }
 
@@ -432,12 +574,14 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    /// Polls an adopted process by identity, not by PID alone: once the PID no longer
-    /// carries the recorded start time, executable, and arguments, the VM process is gone.
+    /// Polls an adopted process by identity, not by PID alone: once the PID no longer carries
+    /// the recorded start time, executable, and arguments, the VM process is gone. Only a
+    /// definite absence ends the watch — a process table that declines to describe the process
+    /// is not evidence that it exited, and releasing here would abandon a running VM (§4).
     private func watchExit(identity: ProcessIdentity, environment: EnvironmentID) {
         let supervisor = deps.supervisor
         Task { [weak self] in
-            while supervisor.verify(identity) != nil {
+            while supervisor.observe(identity) != .absent {
                 try? await Task.sleep(for: .seconds(2))
             }
             await self?.processExited(environment, pid: identity.pid)
@@ -449,12 +593,26 @@ public actor EnvironmentLifecycle {
         await release(id)
     }
 
-    private func release(_ id: EnvironmentID) async {
+    /// Ends supervision of an environment, and returns the failure that kept its durable
+    /// identity on disk, if any.
+    ///
+    /// The identity is removed before the in-memory state is cleared. A dead PID left in
+    /// `processes.json` is reconciled against whatever reuses that PID after a relaunch, so an
+    /// environment whose record could not be removed is left uncertain rather than free, and a
+    /// caller reporting an operation's outcome must not call it completed (MVP-PLAN.md §4).
+    @discardableResult
+    private func release(_ id: EnvironmentID) async -> (any Error)? {
+        var failure: (any Error)?
+        do {
+            try await deps.supervisor.forget(id)
+        } catch {
+            failure = error
+        }
         if let live = supervised.removeValue(forKey: id) {
             live.token.end()
         }
-        try? await deps.supervisor.forget(id)
-        verdicts[id] = nil
+        verdicts[id] = failure == nil ? nil : .uncertain(.identityNotForgotten)
+        return failure
     }
 
     /// Journals the failure under the operation's own kind (the journal refuses a record whose
@@ -462,6 +620,12 @@ public actor EnvironmentLifecycle {
     private func fail(_ operation: OperationID, kind: JournalOperation, environment: EnvironmentID, with error: GuesthouseError, events: EventSink) async {
         do {
             try await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
+            // A recorded outcome that is itself unknown settles nothing: the environment stays
+            // blocked, and status keeps asking for inspection, until actual state says what
+            // the mutation did. The journal agrees; `leavesInFlight` reads it the same way.
+            if case .operationOutcomeUnknown = error {
+                unresolved[environment] = JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .started)
+            }
         } catch {
             // The journal still says "in flight". Until the actual state is inspected the
             // environment stays blocked and the client is told the outcome is unknown, not
@@ -491,6 +655,7 @@ public actor EnvironmentLifecycle {
         case .recordInconsistent: "the recorded process names a different virtual machine"
         case .processUnobservable: "the recorded process exists but could not be read"
         case .vmNameUnconfirmed: "the running process does not name this virtual machine"
+        case .identityNotForgotten: "the record of the virtual machine's process could not be removed"
         }
     }
 
@@ -501,6 +666,27 @@ public actor EnvironmentLifecycle {
         if let error = error as? StateStoreError { return error.userMessage }
         let text = String(describing: error)
         return String(text.prefix { $0 != "(" && $0 != ":" })
+    }
+
+    /// The VM inventory, with its failures named as inventory failures. `tart list` runs on
+    /// the host and probes no guest network, so a hung or failing one is a runtime and state
+    /// availability problem, never a guest that cannot be reached.
+    private func inventory() async throws -> [TartVMInfo] {
+        do {
+            return try await deps.backend.list()
+        } catch let error as TartInvocationError {
+            throw Self.mapInventory(error)
+        }
+    }
+
+    /// How an inventory command's failure reads to the user, as distinct from `map`, which
+    /// answers for commands addressed at one VM.
+    public static func mapInventory(_ error: TartInvocationError) -> GuesthouseError {
+        switch error {
+        case .unparseableOutput: .runtimeIncompatible(found: nil, required: TartPin.releaseTag)
+        case .timedOut: .runtimeStateUnavailable(reason: SanitizedText("the list of virtual machines did not answer in time", limit: 200))
+        case .failed: .runtimeStateUnavailable(reason: SanitizedText("the list of virtual machines could not be read", limit: 200))
+        }
     }
 
     public static func map(_ error: TartInvocationError, environment: EnvironmentID) -> GuesthouseError {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -31,10 +31,8 @@ public actor EnvironmentLifecycle {
         let identity: ProcessIdentity
         var address: GuestIPAddress?
 
-        var isAlive: Bool {
-            if let run { return run.processIdentifier > 0 }
-            return kill(pid, 0) == 0
-        }
+        /// Asked of the kernel, not inferred: a process that died a moment ago is not running.
+        var isAlive: Bool { kill(pid, 0) == 0 }
     }
 
     private struct InFlight {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -1,10 +1,13 @@
+import Darwin
 import Foundation
 import GuesthouseCore
 
-/// Start, stop, and status for the app-managed VMs, with one lifecycle operation in flight at
-/// a time (MVP-PLAN.md §10, Phase 1). Every step is journaled before it is reported, every
-/// running VM process is supervised with a held transaction, and a start is refused whenever
-/// ownership of the VM is uncertain (§4).
+/// Start, stop, and status for the app-managed VMs, with one lifecycle operation and one
+/// running VM at a time (MVP-PLAN.md §4, §6, §10 Phase 1). Every step is journaled before it
+/// is reported, every running VM process is supervised with a held transaction, an
+/// interrupted operation found in the journal at launch blocks its environment until the
+/// actual state settles it, and nothing is started or stopped while ownership of the VM is
+/// uncertain (§4).
 public actor EnvironmentLifecycle {
     public typealias EventSink = @Sendable (RuntimeEvent) -> Void
 
@@ -21,22 +24,32 @@ public actor EnvironmentLifecycle {
     }
 
     private struct Supervised {
-        let run: ProcessRun
+        /// `nil` for a survivor adopted after a relaunch; its exit is polled instead.
+        let run: ProcessRun?
+        let pid: Int32
         let token: OperationSupervisor.Token
         let identity: ProcessIdentity
         var address: GuestIPAddress?
+
+        var isAlive: Bool {
+            if let run { return run.processIdentifier > 0 }
+            return kill(pid, 0) == 0
+        }
     }
 
     private struct InFlight {
         let id: OperationID
         let environment: EnvironmentID
-        let task: Task<Void, Never>
+        /// `nil` while the slot is reserved but the operation has not been journaled yet.
+        var task: Task<Void, Never>?
     }
 
     private let deps: Dependencies
     private var snapshot: EnvironmentsSnapshot = .empty
     private var supervised: [EnvironmentID: Supervised] = [:]
     private var verdicts: [EnvironmentID: OwnershipVerdict] = [:]
+    /// Journal records an interrupted service left in flight, until the actual state settles them.
+    private var unresolved: [EnvironmentID: JournalRecord] = [:]
     private var inFlight: InFlight?
     private var reconciledAt: Date?
 
@@ -46,11 +59,15 @@ public actor EnvironmentLifecycle {
 
     // MARK: - Launch
 
-    /// Loads state, adopts app-managed VMs found in the store, and reconciles recorded
-    /// processes. Call once when the service starts.
+    /// Loads state, adopts app-managed VMs found in the store, replays the journal, and
+    /// reconciles recorded processes. Call once when the service starts.
     public func prepare() async throws {
         snapshot = try await deps.store.loadSnapshot()
         try await adoptExistingVMs()
+        let replay = try await deps.store.replay()
+        for record in replay.inFlight.values {
+            unresolved[record.environmentID] = record
+        }
         await reconcile()
     }
 
@@ -75,15 +92,54 @@ public actor EnvironmentLifecycle {
         if changed { try await deps.store.saveSnapshot(snapshot) }
     }
 
-    /// Re-derives ownership of every recorded process from the live process table and the
-    /// VM inventory. An `uncertain` verdict blocks `start` until a repair clears it.
+    /// Re-derives ownership of every environment from the live process table and the VM
+    /// inventory. A confirmed exit forgets the identity and settles an interrupted operation;
+    /// an owned survivor is adopted back under supervision; an `uncertain` verdict blocks
+    /// start and stop until a repair clears it. An unreadable inventory makes everything
+    /// uncertain rather than assumed absent.
     public func reconcile() async {
-        let running = Set((try? await deps.backend.list())?.filter(\.running).map(\.name) ?? [])
+        let inventory = try? await deps.backend.list()
+        let running = Set(inventory?.filter(\.running).map(\.name) ?? [])
         let byEnvironment = Dictionary(uniqueKeysWithValues: snapshot.environments.map { ($0.id, $0) })
-        verdicts = await deps.supervisor.reconcile { id in
-            byEnvironment[id].map { running.contains($0.tartVMName) }
+        var verdicts = await deps.supervisor.reconcile(environments: Array(byEnvironment.keys)) { id in
+            guard inventory != nil else { return .unknown }
+            guard let environment = byEnvironment[id] else { return .absent }
+            return running.contains(environment.tartVMName) ? .present : .absent
+        }
+        for (id, verdict) in verdicts {
+            switch verdict {
+            case .exited:
+                try? await deps.supervisor.forget(id)
+                verdicts[id] = nil
+                await settleInterruptedOperation(id)
+            case .ownedRunning(let live):
+                await adoptSurvivor(id, live: live)
+                await settleInterruptedOperation(id)
+            case .uncertain:
+                break
+            }
+        }
+        self.verdicts = verdicts
+        if inventory != nil {
+            for id in unresolved.keys where verdicts[id] == nil && supervised[id] == nil {
+                await settleInterruptedOperation(id)
+            }
         }
         reconciledAt = Date()
+    }
+
+    private func settleInterruptedOperation(_ id: EnvironmentID) async {
+        guard let record = unresolved.removeValue(forKey: id) else { return }
+        try? await deps.store.append(JournalRecord(id: record.id, environmentID: id, operation: record.operation, timestamp: Date(), outcome: .reconciled))
+    }
+
+    /// A process proven ours after a relaunch is supervised again: a transaction is held and
+    /// its exit is watched, so the service does not idle out with the VM running.
+    private func adoptSurvivor(_ id: EnvironmentID, live: LiveProcess) async {
+        guard supervised[id] == nil, let identity = await deps.supervisor.identity(for: id) else { return }
+        let token = deps.supervisor.hold("vm \(identity.vmName) (adopted)")
+        supervised[id] = Supervised(run: nil, pid: live.pid, token: token, identity: identity, address: nil)
+        watchExit(pid: live.pid, environment: id)
     }
 
     // MARK: - Queries
@@ -98,20 +154,29 @@ public actor EnvironmentLifecycle {
         }
         let inventory = try await deps.backend.list()
         let vm: EnvironmentStatus.VMState
-        if let live = supervised[id], live.run.processIdentifier > 0, verdicts[id] == nil || isOwned(verdicts[id]) {
+        var readiness: EnvironmentStatus.Readiness
+        if let live = supervised[id], live.isAlive {
             vm = .running
+            // Running without a confirmed address is not ready: nothing guest-dependent works.
+            readiness = live.address != nil ? .ready : .needsAttention(.guestNotReachable(id))
         } else if case .uncertain(let reason)? = verdicts[id] {
-            vm = .uncertain(reason: String(describing: reason))
+            vm = .uncertain(reason: Self.describe(reason))
+            readiness = .needsAttention(.vmOwnershipUncertain(id))
         } else if let info = inventory.first(where: { $0.name == environment.tartVMName }) {
-            vm = info.running ? .running : .stopped
+            if info.running {
+                // Running according to Tart with no supervised process and no owned verdict.
+                vm = .uncertain(reason: "running without a recorded owner")
+                readiness = .needsAttention(.vmOwnershipUncertain(id))
+            } else {
+                vm = .stopped
+                readiness = .ready
+            }
         } else {
             vm = .notFound
+            readiness = .needsAttention(.environmentNotFound(id))
         }
-        let readiness: EnvironmentStatus.Readiness
-        switch vm {
-        case .uncertain: readiness = .needsAttention(.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()))
-        case .notFound: readiness = .needsAttention(.environmentNotFound(id))
-        case .running, .stopped: readiness = .ready
+        if let record = unresolved[id] {
+            readiness = .needsAttention(.operationOutcomeUnknown(record.id))
         }
         return EnvironmentStatus(
             environmentID: id,
@@ -130,32 +195,57 @@ public actor EnvironmentLifecycle {
     /// result arrive through `events`.
     public func start(_ id: EnvironmentID, options: StartOptions, events: @escaping EventSink) async throws -> OperationID {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
-        if let inFlight { throw GuesthouseError.operationInFlight(inFlight.id) }
-        if case .uncertain? = verdicts[id] { throw GuesthouseError.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()) }
+        try refuseIfBlocked(id)
+        guard snapshot.slots.state(of: id) == .active else { throw GuesthouseError.environmentPreserved(id) }
         if supervised[id] != nil { throw GuesthouseError.environmentAlreadyRunning(id) }
-        if let info = try await deps.backend.list().first(where: { $0.name == environment.tartVMName }), info.running {
-            throw GuesthouseError.environmentAlreadyRunning(id)
-        }
+        if let other = supervised.keys.first(where: { $0 != id }) { throw GuesthouseError.anotherEnvironmentRunning(other) }
 
-        let operation = try await deps.store.begin(.startEnvironment, for: id)
+        // The slot is taken before the first suspension, so two simultaneous starts cannot
+        // both pass the checks and launch two instances against one disk.
+        let operation = OperationID()
+        inFlight = InFlight(id: operation, environment: id, task: nil)
+        do {
+            let inventory = try await deps.backend.list()
+            if let info = inventory.first(where: { $0.name == environment.tartVMName }), info.running {
+                throw GuesthouseError.environmentAlreadyRunning(id)
+            }
+            let runningNames = Set(inventory.filter(\.running).map(\.name))
+            if let other = snapshot.environments.first(where: { $0.id != id && runningNames.contains($0.tartVMName) }) {
+                throw GuesthouseError.anotherEnvironmentRunning(other.id)
+            }
+            _ = try await deps.store.begin(.startEnvironment, for: id, id: operation)
+        } catch {
+            inFlight = nil
+            throw error
+        }
         let token = deps.supervisor.hold("startEnvironment \(operation)")
-        let task = Task { [weak self] () async -> Void in
+        inFlight?.task = Task { [weak self] () async -> Void in
             guard let self else { return }
             await self.performStart(operation, environment: environment, options: options, token: token, events: events)
         }
-        inFlight = InFlight(id: operation, environment: id, task: task)
         return operation
     }
 
     private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, token: OperationSupervisor.Token, events: EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
+        let arguments = TartBackend.runArguments(vmName: environment.tartVMName, console: options.console)
         do {
             events(.progress(operation, ProgressPhase(kind: .startingVM, cancelable: false)))
             let run = try await deps.backend.run(vmName: environment.tartVMName, console: options.console)
-            let identity = try await deps.supervisor.recordLaunch(pid: run.processIdentifier, executable: deps.backend.bundle.executable, arguments: ["run", environment.tartVMName], vmName: environment.tartVMName, environment: id)
+            drainOutput(of: run)
+            let identity: ProcessIdentity
+            do {
+                identity = try await deps.supervisor.recordLaunch(pid: run.processIdentifier, executable: deps.backend.bundle.executable, arguments: arguments, vmName: environment.tartVMName, environment: id)
+            } catch {
+                // Without a durable identity the VM would be an orphan after a relaunch: it is
+                // ended before the failure is reported.
+                run.terminate(gracePeriod: .seconds(30))
+                _ = await run.exit()
+                throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200))
+            }
             let vmToken = deps.supervisor.hold("vm \(environment.tartVMName)")
-            supervised[id] = Supervised(run: run, token: vmToken, identity: identity, address: nil)
+            supervised[id] = Supervised(run: run, pid: run.processIdentifier, token: vmToken, identity: identity, address: nil)
             verdicts[id] = nil
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .checkpoint(.runtimeReady)))
             watchExit(of: run, environment: id)
@@ -164,7 +254,8 @@ public actor EnvironmentLifecycle {
             let address = try await deps.backend.ip(vmName: environment.tartVMName, wait: options.ipWait)
             supervised[id]?.address = address
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .completed))
-            events(.status(try await status(of: id)))
+            // The operation is complete whatever a best-effort status refresh does now.
+            if let status = try? await status(of: id) { events(.status(status)) }
             events(.completed(operation))
         } catch is CancellationError {
             await fail(operation, kind: .startEnvironment, environment: id, with: .canceled, events: events)
@@ -173,22 +264,31 @@ public actor EnvironmentLifecycle {
         } catch let error as TartInvocationError {
             await fail(operation, kind: .startEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
         } catch {
-            await fail(operation, kind: .startEnvironment, environment: id, with: .guestNotReachable(id), events: events)
+            await fail(operation, kind: .startEnvironment, environment: id, with: .runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200)), events: events)
         }
     }
 
-    /// Graceful stop through Tart, then a warned force-stop only when the request says so.
+    /// Graceful stop through Tart, or the explicitly warned force-stop. Force-stopping needs
+    /// ownership evidence: a supervised process or an owned reconciliation verdict.
     public func stop(_ id: EnvironmentID, mode: StopMode, events: @escaping EventSink) async throws -> OperationID {
         guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
-        if let inFlight { throw GuesthouseError.operationInFlight(inFlight.id) }
-        if case .uncertain? = verdicts[id] { throw GuesthouseError.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()) }
-        let operation = try await deps.store.begin(.stopEnvironment, for: id)
+        try refuseIfBlocked(id)
+        if mode == .force, supervised[id] == nil, !isOwned(verdicts[id]) {
+            throw GuesthouseError.vmOwnershipUncertain(id)
+        }
+        let operation = OperationID()
+        inFlight = InFlight(id: operation, environment: id, task: nil)
+        do {
+            _ = try await deps.store.begin(.stopEnvironment, for: id, id: operation)
+        } catch {
+            inFlight = nil
+            throw error
+        }
         let token = deps.supervisor.hold("stopEnvironment \(operation)")
-        let task = Task { [weak self] () async -> Void in
+        inFlight?.task = Task { [weak self] () async -> Void in
             guard let self else { return }
             await self.performStop(operation, environment: environment, mode: mode, token: token, events: events)
         }
-        inFlight = InFlight(id: operation, environment: id, task: task)
         return operation
     }
 
@@ -199,22 +299,26 @@ public actor EnvironmentLifecycle {
             switch mode {
             case .graceful(let deadline):
                 events(.progress(operation, ProgressPhase(kind: .stoppingVM, cancelable: false)))
-                try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
-                if let live = supervised[id] {
-                    _ = await live.run.exit()
+                do {
+                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
+                } catch TartInvocationError.timedOut {
+                    throw GuesthouseError.gracefulStopTimedOut(id)
+                }
+                if let live = supervised[id], let run = live.run {
+                    _ = await run.exit()
                 }
             case .force:
                 events(.progress(operation, ProgressPhase(kind: .forceStoppingVM, cancelable: false)))
-                if let live = supervised[id] {
-                    live.run.terminate(gracePeriod: .seconds(5))
-                    _ = await live.run.exit()
+                if let live = supervised[id], let run = live.run {
+                    run.terminate(gracePeriod: .seconds(5))
+                    _ = await run.exit()
                 } else {
-                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(1))
+                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
                 }
             }
             await release(id)
             try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .stopEnvironment, timestamp: Date(), outcome: .completed))
-            events(.status(try await status(of: id)))
+            if let status = try? await status(of: id) { events(.status(status)) }
             events(.completed(operation))
         } catch is CancellationError {
             await fail(operation, kind: .stopEnvironment, environment: id, with: .canceled, events: events)
@@ -223,7 +327,7 @@ public actor EnvironmentLifecycle {
         } catch let error as TartInvocationError {
             await fail(operation, kind: .stopEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
         } catch {
-            await fail(operation, kind: .stopEnvironment, environment: id, with: .guestNotReachable(id), events: events)
+            await fail(operation, kind: .stopEnvironment, environment: id, with: .runtimeStateUnavailable(reason: SanitizedText(Self.describe(error), limit: 200)), events: events)
         }
     }
 
@@ -231,20 +335,45 @@ public actor EnvironmentLifecycle {
     /// still run to their next checkpoint before the cancellation takes effect.
     public func cancel(_ operation: OperationID) {
         guard let inFlight, inFlight.id == operation else { return }
-        inFlight.task.cancel()
+        inFlight.task?.cancel()
     }
 
     // MARK: - Internals
 
-    private func watchExit(of run: ProcessRun, environment: EnvironmentID) {
-        Task { [weak self] in
-            _ = await run.exit()
-            await self?.processExited(environment, run: run)
+    /// The checks every operation shares: one at a time, no interrupted operation left
+    /// unresolved, and no uncertain ownership.
+    private func refuseIfBlocked(_ id: EnvironmentID) throws {
+        if let inFlight { throw GuesthouseError.operationInFlight(inFlight.id) }
+        if let record = unresolved[id] { throw GuesthouseError.operationOutcomeUnknown(record.id) }
+        if case .uncertain? = verdicts[id] { throw GuesthouseError.vmOwnershipUncertain(id) }
+    }
+
+    /// Tart's output over a VM's lifetime is already redacted and is not kept: the stream is
+    /// consumed so the bounded buffer never fills.
+    private func drainOutput(of run: ProcessRun) {
+        Task.detached {
+            for await _ in run.output {}
         }
     }
 
-    private func processExited(_ id: EnvironmentID, run: ProcessRun) async {
-        guard let live = supervised[id], live.run === run else { return }
+    private func watchExit(of run: ProcessRun, environment: EnvironmentID) {
+        Task { [weak self] in
+            _ = await run.exit()
+            await self?.processExited(environment, pid: run.processIdentifier)
+        }
+    }
+
+    private func watchExit(pid: Int32, environment: EnvironmentID) {
+        Task { [weak self] in
+            while kill(pid, 0) == 0 {
+                try? await Task.sleep(for: .seconds(2))
+            }
+            await self?.processExited(environment, pid: pid)
+        }
+    }
+
+    private func processExited(_ id: EnvironmentID, pid: Int32) async {
+        guard let live = supervised[id], live.pid == pid else { return }
         await release(id)
     }
 
@@ -268,13 +397,31 @@ public actor EnvironmentLifecycle {
         return false
     }
 
-    private func supervisedOperation(for id: EnvironmentID) -> OperationID? {
-        inFlight?.environment == id ? inFlight?.id : nil
+    static func describe(_ reason: OwnershipVerdict.UncertaintyReason) -> String {
+        switch reason {
+        case .pidReusedByAnotherProcess: "the recorded process id now belongs to another process"
+        case .executableMismatch: "the recorded process runs a different program"
+        case .argumentsMismatch: "the recorded process runs with different arguments"
+        case .lockHeldWithoutProcess: "the virtual machine is locked but no recorded process holds it"
+        case .multipleCandidates: "more than one process matches the record"
+        case .unrecordedLaunch: "the virtual machine is running but no launch was recorded"
+        case .inventoryUnavailable: "the virtual machine inventory could not be read"
+        }
     }
 
-    static func map(_ error: TartInvocationError, environment: EnvironmentID) -> GuesthouseError {
+    /// Error text safe for a user-facing reason: the error's case name only.
+    static func describe(_ error: any Error) -> String {
+        if let error = error as? SupervisionError { return error.userMessage }
+        if let error = error as? ProcessIdentityStoreError { return error.userMessage }
+        if let error = error as? StateStoreError { return error.userMessage }
+        let text = String(describing: error)
+        return String(text.prefix { $0 != "(" && $0 != ":" })
+    }
+
+    public static func map(_ error: TartInvocationError, environment: EnvironmentID) -> GuesthouseError {
         switch error {
-        case .unparseableOutput: .toolMismatch(tool: "tart", found: nil, expected: TartPin.releaseTag)
+        case .unparseableOutput: .runtimeIncompatible(found: nil, required: TartPin.releaseTag)
+        case .timedOut: .guestNotReachable(environment)
         case .failed(let failure):
             switch failure {
             case .vmNotFound: .environmentNotFound(environment)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -490,6 +490,7 @@ public actor EnvironmentLifecycle {
         case .anotherProcessClaimsVM: "another process claims the virtual machine"
         case .recordInconsistent: "the recorded process names a different virtual machine"
         case .processUnobservable: "the recorded process exists but could not be read"
+        case .vmNameUnconfirmed: "the running process does not name this virtual machine"
         }
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -1,0 +1,288 @@
+import Foundation
+import GuesthouseCore
+
+/// Start, stop, and status for the app-managed VMs, with one lifecycle operation in flight at
+/// a time (MVP-PLAN.md §10, Phase 1). Every step is journaled before it is reported, every
+/// running VM process is supervised with a held transaction, and a start is refused whenever
+/// ownership of the VM is uncertain (§4).
+public actor EnvironmentLifecycle {
+    public typealias EventSink = @Sendable (RuntimeEvent) -> Void
+
+    public struct Dependencies: Sendable {
+        public var backend: TartBackend
+        public var supervisor: OperationSupervisor
+        public var store: StateStore
+
+        public init(backend: TartBackend, supervisor: OperationSupervisor, store: StateStore) {
+            self.backend = backend
+            self.supervisor = supervisor
+            self.store = store
+        }
+    }
+
+    private struct Supervised {
+        let run: ProcessRun
+        let token: OperationSupervisor.Token
+        let identity: ProcessIdentity
+        var address: GuestIPAddress?
+    }
+
+    private struct InFlight {
+        let id: OperationID
+        let environment: EnvironmentID
+        let task: Task<Void, Never>
+    }
+
+    private let deps: Dependencies
+    private var snapshot: EnvironmentsSnapshot = .empty
+    private var supervised: [EnvironmentID: Supervised] = [:]
+    private var verdicts: [EnvironmentID: OwnershipVerdict] = [:]
+    private var inFlight: InFlight?
+    private var reconciledAt: Date?
+
+    public init(dependencies: Dependencies) {
+        deps = dependencies
+    }
+
+    // MARK: - Launch
+
+    /// Loads state, adopts app-managed VMs found in the store, and reconciles recorded
+    /// processes. Call once when the service starts.
+    public func prepare() async throws {
+        snapshot = try await deps.store.loadSnapshot()
+        try await adoptExistingVMs()
+        await reconcile()
+    }
+
+    /// Any VM in `TART_HOME` named `guesthouse-<uuid>` that the snapshot does not know is
+    /// adopted into a free slot. This is how a VM created by hand for phase 0 becomes an
+    /// environment; nothing is created here.
+    public func adoptExistingVMs() async throws {
+        let known = Set(snapshot.environments.map(\.id))
+        var changed = false
+        for vm in try await deps.backend.list() where vm.source == .local {
+            guard vm.name.hasPrefix("guesthouse-"), let uuid = UUID(uuidString: String(vm.name.dropFirst("guesthouse-".count))) else { continue }
+            let id = EnvironmentID(uuid: uuid)
+            guard id.tartVMName == vm.name, !known.contains(id) else { continue }
+            do {
+                try snapshot.slots.reserve(id)
+            } catch {
+                continue
+            }
+            snapshot.environments.append(DevelopmentEnvironment(id: id, name: vm.name, createdAt: Date()))
+            changed = true
+        }
+        if changed { try await deps.store.saveSnapshot(snapshot) }
+    }
+
+    /// Re-derives ownership of every recorded process from the live process table and the
+    /// VM inventory. An `uncertain` verdict blocks `start` until a repair clears it.
+    public func reconcile() async {
+        let running = Set((try? await deps.backend.list())?.filter(\.running).map(\.name) ?? [])
+        let byEnvironment = Dictionary(uniqueKeysWithValues: snapshot.environments.map { ($0.id, $0) })
+        verdicts = await deps.supervisor.reconcile { id in
+            byEnvironment[id].map { running.contains($0.tartVMName) }
+        }
+        reconciledAt = Date()
+    }
+
+    // MARK: - Queries
+
+    public func environments() -> [DevelopmentEnvironment] {
+        snapshot.environments
+    }
+
+    public func status(of id: EnvironmentID) async throws -> EnvironmentStatus {
+        guard let environment = snapshot.environments.first(where: { $0.id == id }) else {
+            throw GuesthouseError.environmentNotFound(id)
+        }
+        let inventory = try await deps.backend.list()
+        let vm: EnvironmentStatus.VMState
+        if let live = supervised[id], live.run.processIdentifier > 0, verdicts[id] == nil || isOwned(verdicts[id]) {
+            vm = .running
+        } else if case .uncertain(let reason)? = verdicts[id] {
+            vm = .uncertain(reason: String(describing: reason))
+        } else if let info = inventory.first(where: { $0.name == environment.tartVMName }) {
+            vm = info.running ? .running : .stopped
+        } else {
+            vm = .notFound
+        }
+        let readiness: EnvironmentStatus.Readiness
+        switch vm {
+        case .uncertain: readiness = .needsAttention(.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()))
+        case .notFound: readiness = .needsAttention(.environmentNotFound(id))
+        case .running, .stopped: readiness = .ready
+        }
+        return EnvironmentStatus(
+            environmentID: id,
+            vm: vm,
+            readiness: readiness,
+            inFlightOperation: inFlight?.environment == id ? inFlight?.id : nil,
+            guestAddress: supervised[id]?.address,
+            reconciledAt: reconciledAt
+        )
+    }
+
+    // MARK: - Operations
+
+    /// Journals, launches, supervises, and waits for the guest's address. Returns the
+    /// operation id once the journal has it and the launch is under way; progress and the
+    /// result arrive through `events`.
+    public func start(_ id: EnvironmentID, options: StartOptions, events: @escaping EventSink) async throws -> OperationID {
+        guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
+        if let inFlight { throw GuesthouseError.operationInFlight(inFlight.id) }
+        if case .uncertain? = verdicts[id] { throw GuesthouseError.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()) }
+        if supervised[id] != nil { throw GuesthouseError.environmentAlreadyRunning(id) }
+        if let info = try await deps.backend.list().first(where: { $0.name == environment.tartVMName }), info.running {
+            throw GuesthouseError.environmentAlreadyRunning(id)
+        }
+
+        let operation = try await deps.store.begin(.startEnvironment, for: id)
+        let token = deps.supervisor.hold("startEnvironment \(operation)")
+        let task = Task { [weak self] () async -> Void in
+            guard let self else { return }
+            await self.performStart(operation, environment: environment, options: options, token: token, events: events)
+        }
+        inFlight = InFlight(id: operation, environment: id, task: task)
+        return operation
+    }
+
+    private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, token: OperationSupervisor.Token, events: EventSink) async {
+        defer { token.end(); inFlight = nil }
+        let id = environment.id
+        do {
+            events(.progress(operation, ProgressPhase(kind: .startingVM, cancelable: false)))
+            let run = try await deps.backend.run(vmName: environment.tartVMName, console: options.console)
+            let identity = try await deps.supervisor.recordLaunch(pid: run.processIdentifier, executable: deps.backend.bundle.executable, arguments: ["run", environment.tartVMName], vmName: environment.tartVMName, environment: id)
+            let vmToken = deps.supervisor.hold("vm \(environment.tartVMName)")
+            supervised[id] = Supervised(run: run, token: vmToken, identity: identity, address: nil)
+            verdicts[id] = nil
+            try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .checkpoint(.runtimeReady)))
+            watchExit(of: run, environment: id)
+
+            events(.progress(operation, ProgressPhase(kind: .waitingForNetwork)))
+            let address = try await deps.backend.ip(vmName: environment.tartVMName, wait: options.ipWait)
+            supervised[id]?.address = address
+            try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .startEnvironment, timestamp: Date(), outcome: .completed))
+            events(.status(try await status(of: id)))
+            events(.completed(operation))
+        } catch is CancellationError {
+            await fail(operation, kind: .startEnvironment, environment: id, with: .canceled, events: events)
+        } catch let error as GuesthouseError {
+            await fail(operation, kind: .startEnvironment, environment: id, with: error, events: events)
+        } catch let error as TartInvocationError {
+            await fail(operation, kind: .startEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
+        } catch {
+            await fail(operation, kind: .startEnvironment, environment: id, with: .guestNotReachable(id), events: events)
+        }
+    }
+
+    /// Graceful stop through Tart, then a warned force-stop only when the request says so.
+    public func stop(_ id: EnvironmentID, mode: StopMode, events: @escaping EventSink) async throws -> OperationID {
+        guard let environment = snapshot.environments.first(where: { $0.id == id }) else { throw GuesthouseError.environmentNotFound(id) }
+        if let inFlight { throw GuesthouseError.operationInFlight(inFlight.id) }
+        if case .uncertain? = verdicts[id] { throw GuesthouseError.operationOutcomeUnknown(supervisedOperation(for: id) ?? OperationID()) }
+        let operation = try await deps.store.begin(.stopEnvironment, for: id)
+        let token = deps.supervisor.hold("stopEnvironment \(operation)")
+        let task = Task { [weak self] () async -> Void in
+            guard let self else { return }
+            await self.performStop(operation, environment: environment, mode: mode, token: token, events: events)
+        }
+        inFlight = InFlight(id: operation, environment: id, task: task)
+        return operation
+    }
+
+    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: EventSink) async {
+        defer { token.end(); inFlight = nil }
+        let id = environment.id
+        do {
+            switch mode {
+            case .graceful(let deadline):
+                events(.progress(operation, ProgressPhase(kind: .stoppingVM, cancelable: false)))
+                try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
+                if let live = supervised[id] {
+                    _ = await live.run.exit()
+                }
+            case .force:
+                events(.progress(operation, ProgressPhase(kind: .forceStoppingVM, cancelable: false)))
+                if let live = supervised[id] {
+                    live.run.terminate(gracePeriod: .seconds(5))
+                    _ = await live.run.exit()
+                } else {
+                    try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(1))
+                }
+            }
+            await release(id)
+            try await deps.store.append(JournalRecord(id: operation, environmentID: id, operation: .stopEnvironment, timestamp: Date(), outcome: .completed))
+            events(.status(try await status(of: id)))
+            events(.completed(operation))
+        } catch is CancellationError {
+            await fail(operation, kind: .stopEnvironment, environment: id, with: .canceled, events: events)
+        } catch let error as GuesthouseError {
+            await fail(operation, kind: .stopEnvironment, environment: id, with: error, events: events)
+        } catch let error as TartInvocationError {
+            await fail(operation, kind: .stopEnvironment, environment: id, with: Self.map(error, environment: id), events: events)
+        } catch {
+            await fail(operation, kind: .stopEnvironment, environment: id, with: .guestNotReachable(id), events: events)
+        }
+    }
+
+    /// Cancels the in-flight operation if it is the one named. Phases marked non-cancelable
+    /// still run to their next checkpoint before the cancellation takes effect.
+    public func cancel(_ operation: OperationID) {
+        guard let inFlight, inFlight.id == operation else { return }
+        inFlight.task.cancel()
+    }
+
+    // MARK: - Internals
+
+    private func watchExit(of run: ProcessRun, environment: EnvironmentID) {
+        Task { [weak self] in
+            _ = await run.exit()
+            await self?.processExited(environment, run: run)
+        }
+    }
+
+    private func processExited(_ id: EnvironmentID, run: ProcessRun) async {
+        guard let live = supervised[id], live.run === run else { return }
+        await release(id)
+    }
+
+    private func release(_ id: EnvironmentID) async {
+        if let live = supervised.removeValue(forKey: id) {
+            live.token.end()
+        }
+        try? await deps.supervisor.forget(id)
+        verdicts[id] = nil
+    }
+
+    /// Journals the failure under the operation's own kind (the journal refuses a record whose
+    /// kind differs from its `started` record), then reports it.
+    private func fail(_ operation: OperationID, kind: JournalOperation, environment: EnvironmentID, with error: GuesthouseError, events: EventSink) async {
+        try? await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
+        events(.failed(operation, error))
+    }
+
+    private func isOwned(_ verdict: OwnershipVerdict?) -> Bool {
+        if case .ownedRunning? = verdict { return true }
+        return false
+    }
+
+    private func supervisedOperation(for id: EnvironmentID) -> OperationID? {
+        inFlight?.environment == id ? inFlight?.id : nil
+    }
+
+    static func map(_ error: TartInvocationError, environment: EnvironmentID) -> GuesthouseError {
+        switch error {
+        case .unparseableOutput: .toolMismatch(tool: "tart", found: nil, expected: TartPin.releaseTag)
+        case .failed(let failure):
+            switch failure {
+            case .vmNotFound: .environmentNotFound(environment)
+            case .alreadyRunning, .lockHeld: .environmentAlreadyRunning(environment)
+            case .noIPAddress, .notRunning: .guestNotReachable(environment)
+            case .virtualMachineLimitExceeded: .vmSlotUnavailable(maximum: VMSlotInventory.maximumSlots)
+            case .requiresStoppedVM, .directoryAlreadyInitialized, .diskInUse, .unknown: .guestNotReachable(environment)
+            }
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -176,6 +176,11 @@ public actor EnvironmentLifecycle {
         if let record = unresolved[id] {
             readiness = .needsAttention(.operationOutcomeUnknown(record.id))
         }
+        // A preserved slot is reported as such, so the GUI does not offer a start the
+        // lifecycle would refuse.
+        if snapshot.slots.state(of: id) == .preserved {
+            readiness = .needsAttention(.environmentPreserved(id))
+        }
         return EnvironmentStatus(
             environmentID: id,
             vm: vm,

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/LiveProcessEnumerator.swift
@@ -86,6 +86,11 @@ public struct LiveProcessEnumerator: Sendable {
     public func observe(pid: Int32) -> Observation {
         guard pid > 0 else { return .absent }
         if kill(pid, 0) != 0, errno == ESRCH { return .absent }
+        // A process that has exited but not been reaped still answers `kill(pid, 0)`, and its
+        // arguments are gone with it. That is an exit, not an unreadable process, and the same
+        // goes for a PID that now belongs to another account: neither can be the VM we started.
+        guard let state = processInfo(pid: pid) else { return .unavailable(reason: "process state unreadable") }
+        guard Self.isOwnedAndRunning(state) else { return .absent }
         guard let first = startTime(pid: pid) else { return .unavailable(reason: "start time unreadable") }
         guard let path = executablePath(pid: pid) else { return .unavailable(reason: "executable path unreadable") }
         guard let arguments = kernel.arguments(pid) else { return .unavailable(reason: "arguments unreadable") }
@@ -100,35 +105,71 @@ public struct LiveProcessEnumerator: Sendable {
         return .present(LiveProcess(pid: pid, startTime: first, executablePath: path, argumentsDigest: Self.digest(of: arguments), claimedVMName: Self.claimedVMName(in: arguments)))
     }
 
+    /// How long the scan gives a process that is exec'ing to publish its arguments, and how
+    /// many times it asks again. Both are spent once per scan and only when something could
+    /// not be described, which is rare; the window itself is measured in microseconds.
+    static let settleInterval: UInt32 = 5_000
+    static let settleAttempts = 3
+
     /// Every readable process whose arguments name `vmName`, and whether any process could
     /// not be read. Used to notice a launch that has not taken the VM's lock yet.
     public func claimants(ofVM vmName: String) -> Candidates {
         var found: [LiveProcess] = []
         var unreadable = false
         guard let candidates = kernel.pids() else { return Candidates(processes: found, unreadable: true) }
-        for candidate in candidates {
-            guard let arguments = kernel.arguments(candidate) else {
-                // A running process of this user's whose arguments the kernel declined to
-                // describe could be the launch that has not taken the VM's lock yet. One that
-                // belongs to somebody else, or that has already exited, never could be: the
-                // service launches Tart as this user, and those failures are the ordinary
-                // answer for every other process on the Mac. An ownership lookup the kernel
-                // also refused says nothing either way, and reading that as somebody else's
-                // process would turn an interrupted start into a free environment.
-                switch ownership(of: candidate) {
-                case .own, .unavailable: unreadable = true
-                case .notOurs: break
-                }
-                continue
-            }
-            guard Self.claimedVMName(in: arguments) == vmName else { continue }
-            switch observe(pid: candidate) {
+        func consider(_ pid: Int32, arguments: [String]) {
+            guard Self.claimedVMName(in: arguments) == vmName else { return }
+            switch observe(pid: pid) {
             case .present(let process): found.append(process)
             case .unavailable: unreadable = true
             case .absent: break
             }
         }
-        return Candidates(processes: found, unreadable: unreadable)
+        // A running process of this user's whose arguments the kernel declined to describe
+        // could be the launch that has not taken the VM's lock yet, so it is asked again
+        // below rather than dismissed. One that belongs to somebody else, or that has exited
+        // or begun exiting, never could be: the service launches Tart as this user, and those
+        // failures are the ordinary answer for every other process on the Mac.
+        var undescribed: [Int32] = []
+        for candidate in candidates {
+            if let arguments = kernel.arguments(candidate) {
+                consider(candidate, arguments: arguments)
+            } else {
+                switch ownership(of: candidate) {
+                case .own: undescribed.append(candidate)
+                // The kernel would not say whose it is, so the scan cannot claim to be complete.
+                case .unavailable: unreadable = true
+                case .notOurs: break
+                }
+            }
+        }
+        // `proc_listallpids` reports a process from the moment it is created, but the kernel
+        // only publishes its argument vector part-way through `exec`; for that window — under
+        // a millisecond — it answers exactly as it does for a process it will never describe.
+        // A Mac is always starting something, so a single read is not evidence that a process
+        // is unidentifiable: whatever the first pass could not describe is asked again once it
+        // has had time to settle, and only silence that outlasts that is reported as silence.
+        // Without this, an unrelated program the Mac happened to be launching would leave the
+        // environment `uncertain` and refuse to start it.
+        for _ in 0..<Self.settleAttempts where !undescribed.isEmpty {
+            usleep(Self.settleInterval)
+            var stillUndescribed: [Int32] = []
+            for candidate in undescribed {
+                // It may have finished exiting while the scan settled; then it never held the VM.
+                switch ownership(of: candidate) {
+                case .own: break
+                case .unavailable: unreadable = true; continue
+                case .notOurs: continue
+                }
+                guard let arguments = kernel.arguments(candidate) else {
+                    stillUndescribed.append(candidate)
+                    continue
+                }
+                consider(candidate, arguments: arguments)
+            }
+            undescribed = stillUndescribed
+        }
+        return Candidates(processes: found, unreadable: unreadable || !undescribed.isEmpty)
     }
 
     /// The identity of one running process, or `nil` if it does not exist or cannot be read.
@@ -185,8 +226,19 @@ public struct LiveProcessEnumerator: Sendable {
             // A PID that is simply gone answers `ESRCH`; anything else is a refusal.
             return kill(pid, 0) != 0 && errno == ESRCH ? .notOurs : .unavailable
         }
-        let mine = info.kp_eproc.e_ucred.cr_uid == getuid() && info.kp_proc.p_stat != Int8(SZOMB)
-        return mine ? .own : .notOurs
+        return Self.isOwnedAndRunning(info) ? .own : .notOurs
+    }
+
+    /// Whether `info` describes a running process this user owns. Every process belonging to
+    /// another account is excluded, and so is one that has exited: a zombie, and equally one
+    /// that has only begun exiting. Both have left user space for good, both have already lost
+    /// the argument vector that would identify them, and neither will ever take a VM's lock.
+    /// Testing for `SZOMB` alone would race the teardown, and lose that race often enough to
+    /// read the ordinary end of an unrelated program as a process that cannot be identified.
+    static func isOwnedAndRunning(_ info: kinfo_proc) -> Bool {
+        info.kp_eproc.e_ucred.cr_uid == getuid()
+            && info.kp_proc.p_stat != Int8(SZOMB)
+            && info.kp_proc.p_flag & P_WEXIT == 0
     }
 
     func executablePath(pid: Int32) -> String? {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -100,14 +100,37 @@ public final class OperationSupervisor: Sendable {
         await store.identity(for: environment)
     }
 
+    /// What the process table says about a recorded identity. `absent` is proof the recorded
+    /// process is gone; `unavailable` is the process table declining to answer, which is not
+    /// the same thing and must never end supervision (MVP-PLAN.md §4).
+    public enum IdentityObservation: Hashable, Sendable {
+        case present(LiveProcess)
+        case absent
+        case unavailable
+    }
+
+    /// Observes `identity` against the live process table. A PID that now carries a different
+    /// start time, executable, or arguments belongs to another process, which proves the
+    /// recorded one exited; a PID that exists but cannot be read proves nothing.
+    public func observe(_ identity: ProcessIdentity) -> IdentityObservation {
+        switch enumerator.observe(pid: identity.pid) {
+        case .absent:
+            .absent
+        case .unavailable:
+            .unavailable
+        case .present(let live):
+            live.startTime == identity.startTime
+                && live.executablePath == identity.executablePath
+                && live.argumentsDigest == identity.argumentsDigest
+                ? .present(live) : .absent
+        }
+    }
+
     /// The live process that is exactly `identity` (same PID, start time, executable, and
     /// arguments), or `nil`: a PID that now belongs to another process is never a match.
+    /// A caller that must tell "gone" from "unreadable" uses `observe` instead.
     public func verify(_ identity: ProcessIdentity) -> LiveProcess? {
-        guard let live = enumerator.live(pid: identity.pid),
-              live.startTime == identity.startTime,
-              live.executablePath == identity.executablePath,
-              live.argumentsDigest == identity.argumentsDigest
-        else { return nil }
+        guard case .present(let live) = observe(identity) else { return nil }
         return live
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GuesthouseCore
 import Synchronization
@@ -66,7 +67,10 @@ public final class OperationSupervisor: Sendable {
         guard let live = enumerator.live(pid: pid) else {
             throw SupervisionError.processNotObservable(pid: pid)
         }
-        guard live.executablePath == executable.path, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
+        // The kernel reports the real path (`/private/var/…`, not `/var/…`); the recorded path
+        // is the same form, so the reconciler compares like with like.
+        let resolvedExecutable = Self.realPath(of: executable)
+        guard live.executablePath == resolvedExecutable, live.argumentsDigest == LiveProcessEnumerator.digest(of: arguments) else {
             throw SupervisionError.processMismatch(pid: pid)
         }
         // The process must name the VM the caller says it launched, and that VM must be the
@@ -81,7 +85,7 @@ public final class OperationSupervisor: Sendable {
         let identity = ProcessIdentity(
             pid: pid,
             startTime: live.startTime,
-            executablePath: executable.path,
+            executablePath: resolvedExecutable,
             argumentsDigest: LiveProcessEnumerator.digest(of: arguments),
             vmName: vmName,
             environmentID: environment,
@@ -89,6 +93,11 @@ public final class OperationSupervisor: Sendable {
         )
         try await store.record(identity)
         return identity
+    }
+
+    /// The recorded identity for an environment, if any.
+    public func identity(for environment: EnvironmentID) async -> ProcessIdentity? {
+        await store.identity(for: environment)
     }
 
     /// Forgets a process that is confirmed gone.
@@ -185,6 +194,16 @@ public final class OperationSupervisor: Sendable {
     /// recorded identity against a supplied observation.
     public static func verdict(recorded: ProcessIdentity, observed: [LiveProcess], vmLockPresent: Bool) -> OwnershipVerdict {
         ProcessReconciler.reconcile(recorded: recorded, observed: observed, vmLockPresent: vmLockPresent)
+    }
+}
+
+extension OperationSupervisor {
+    /// `realpath(3)`: every symbolic link resolved, including the `/var` → `/private/var`
+    /// prefix that Foundation's URL resolution keeps.
+    static func realPath(of url: URL) -> String {
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        guard let resolved = realpath(url.path, &buffer) else { return url.path }
+        return String(cString: resolved)
     }
 }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Supervision/OperationSupervisor.swift
@@ -100,6 +100,17 @@ public final class OperationSupervisor: Sendable {
         await store.identity(for: environment)
     }
 
+    /// The live process that is exactly `identity` (same PID, start time, executable, and
+    /// arguments), or `nil`: a PID that now belongs to another process is never a match.
+    public func verify(_ identity: ProcessIdentity) -> LiveProcess? {
+        guard let live = enumerator.live(pid: identity.pid),
+              live.startTime == identity.startTime,
+              live.executablePath == identity.executablePath,
+              live.argumentsDigest == identity.argumentsDigest
+        else { return nil }
+        return live
+    }
+
     /// Forgets a process that is confirmed gone.
     public func forget(_ environment: EnvironmentID) async throws {
         try await store.remove(environment)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -169,9 +169,7 @@ public struct TartBackend: Sendable {
         // A truncated capture is not a complete answer: a parser must see all of stdout
         // before its result is trusted as the runtime's own.
         guard !exit.outputTruncated else { throw TartInvocationError.unparseableOutput }
-        return Captured(stdout: stdout.joined(separator: "
-"), stderr: stderr.joined(separator: "
-"))
+        return Captured(stdout: stdout.joined(separator: "\n"), stderr: stderr.joined(separator: "\n"))
     }
 
     static func exitStatus(_ exit: ProcessExit) -> Int32 {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -143,32 +143,36 @@ public struct TartBackend: Sendable {
         ))
         // A canceled operation ends the query process too, so a start canceled while waiting
         // for the address does not keep `tart ip` waiting for its own timeout.
-        let (stdout, stderr, exit) = await withTaskCancellationHandler {
+        let (stdout, stderr, exit, recordLimitReached) = await withTaskCancellationHandler {
             var stdout: [String] = []
             var stderr: [String] = []
+            var reachedLimit = false
             for await line in run.output {
                 // A command whose output is parsed is bounded by record count as well as by
                 // the runner's byte cap: empty records cost no bytes but still cost memory.
-                guard stdout.count + stderr.count < Self.maximumCapturedRecords else { break }
+                guard stdout.count + stderr.count < Self.maximumCapturedRecords else {
+                    reachedLimit = true
+                    break
+                }
                 switch line {
                 case .stdout(let text): stdout.append(text.text)
                 case .stderr(let text): stderr.append(text.text)
                 }
             }
-            return (stdout, stderr, await run.exit())
+            return (stdout, stderr, await run.exit(), reachedLimit)
         } onCancel: {
             run.terminate(gracePeriod: .seconds(1))
         }
         if Task.isCancelled { throw CancellationError() }
         if exit.timedOut { throw TartInvocationError.timedOut }
-        // A truncated capture is not a complete answer: a parser must see all of stdout
-        // before its result is trusted as the runtime's own.
         guard exit.succeeded else {
             throw TartInvocationError.failed(TartErrorClassifier.classify(stderr: stderr.joined(separator: "\n"), exitStatus: Self.exitStatus(exit)))
         }
-        // A truncated capture is not a complete answer: a parser must see all of stdout
-        // before its result is trusted as the runtime's own.
-        guard !exit.outputTruncated else { throw TartInvocationError.unparseableOutput }
+        // A truncated capture is not a complete answer: a parser must see all of stdout before
+        // its result is trusted as the runtime's own. The record cap counts as truncation even
+        // when the bytes stayed under the runner's limit, because a parseable prefix of an
+        // unread answer is exactly the case a byte count cannot notice.
+        guard !exit.outputTruncated, !recordLimitReached else { throw TartInvocationError.unparseableOutput }
         return Captured(stdout: stdout.joined(separator: "\n"), stderr: stderr.joined(separator: "\n"))
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -20,9 +20,6 @@ public struct TartBackend: Sendable {
         self.verifiedBundle = verifiedBundle
     }
 
-    /// The most records a parsed command may produce before its output is refused.
-    static let maximumCapturedRecords = 512
-
     /// Refuses to launch when the bundle is not the one that passed verification.
     func requireVerifiedBundle() throws {
         guard let verifiedBundle else { return }
@@ -85,9 +82,20 @@ public struct TartBackend: Sendable {
     }
 
     /// `tart ip <vm> --wait <seconds>`: the guest's address once it has one.
+    ///
+    /// The caller's wait bounds the whole invocation, not only Tart's own waiting: the command
+    /// is ended at that deadline and reaped inside a short grace period. A fifteen-second slack
+    /// and the runner's five-second default grace used to turn the status probe's zero-second
+    /// lookup into twenty seconds of blocked inspection, and a ninety-second start into a
+    /// hundred and ten (MVP-PLAN.md §2). A short floor is kept so a probe that asks for no
+    /// waiting can still be answered by a Tart that already knows the address.
     public func ip(vmName: String, wait: Duration) async throws -> GuestIPAddress {
         let seconds = max(0, Int(wait.components.seconds))
-        let output = try await capture(["ip", vmName, "--wait", String(seconds)], timeout: wait + .seconds(15))
+        let output = try await capture(
+            ["ip", vmName, "--wait", String(seconds)],
+            timeout: max(wait, Self.minimumIPDeadline),
+            terminationGracePeriod: Self.ipTerminationGrace
+        )
         do {
             return try TartIPParser.parse(output.stdout)
         } catch {
@@ -127,6 +135,12 @@ public struct TartBackend: Sendable {
 
     static let neverForceSeconds = 86_400
 
+    /// The least an address lookup is given, so a zero-wait probe can still be answered.
+    static let minimumIPDeadline = Duration.seconds(2)
+    /// How long a timed-out address lookup may take to be reaped, counted on top of its
+    /// deadline. Deliberately far below the runner's five-second default.
+    static let ipTerminationGrace = Duration.milliseconds(500)
+
     // MARK: - Helpers
 
     struct Captured {
@@ -134,12 +148,13 @@ public struct TartBackend: Sendable {
         let stderr: String
     }
 
-    private func capture(_ arguments: [String], timeout: Duration) async throws -> Captured {
+    private func capture(_ arguments: [String], timeout: Duration, terminationGracePeriod: Duration = .seconds(5)) async throws -> Captured {
         let run = try await launch(ProcessInvocation(
             executable: bundle.executable,
             arguments: arguments,
             environment: storage.environmentForTart(),
-            timeout: timeout
+            timeout: timeout,
+            terminationGracePeriod: terminationGracePeriod
         ))
         // A canceled operation ends the query process too, so a start canceled while waiting
         // for the address does not keep `tart ip` waiting for its own timeout.

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -1,9 +1,8 @@
 import Foundation
 import GuesthouseCore
 
-/// Runs the verified Tart bundle with `TART_HOME` pinned to the VM store.
-///
-/// Only `version()` exists here; inventory, IP discovery, and lifecycle arrive with #25.
+/// Runs the verified Tart bundle with `TART_HOME` pinned to the VM store. The service, never
+/// the client, chooses every executable path and flag here (MVP-PLAN.md §3).
 public struct TartBackend: Sendable {
     public let bundle: TartBundle
     public let storage: RuntimeStorage
@@ -62,11 +61,72 @@ public struct TartBackend: Sendable {
     /// `tart --version`, parsed strictly. Anything unparseable is reported as a failure, never
     /// guessed.
     public func version() async throws -> TartVersion {
+        try requireVerifiedExecutable()
+        let output = try await capture(["--version"], timeout: .seconds(15))
+        // The parser's contract is one line, and it splits on newlines where `split` drops
+        // empty subsequences: a leading or extra blank record would be parsed away and drifted
+        // output read as the pin. The capture itself has to be that one line.
+        guard !output.stdout.contains("\n"), let version = TartVersion(parsing: output.stdout) else {
+            throw TartInvocationError.unparseableOutput
+        }
+        return version
+    }
+
+    /// `tart list --format json`: the inventory of the app-managed store only.
+    public func list() async throws -> [TartVMInfo] {
+        let output = try await capture(["list", "--format", "json"], timeout: .seconds(30))
+        do {
+            return try TartListParser.parse(output.stdout)
+        } catch {
+            throw TartInvocationError.unparseableOutput
+        }
+    }
+
+    /// `tart ip <vm> --wait <seconds>`: the guest's address once it has one.
+    public func ip(vmName: String, wait: Duration) async throws -> GuestIPAddress {
+        let seconds = max(0, Int(wait.components.seconds))
+        let output = try await capture(["ip", vmName, "--wait", String(seconds)], timeout: wait + .seconds(15))
+        do {
+            return try TartIPParser.parse(output.stdout)
+        } catch {
+            throw TartInvocationError.unparseableOutput
+        }
+    }
+
+    /// `tart run <vm>`, headless unless the native console is requested. The returned run
+    /// lives as long as the VM; the caller supervises it.
+    public func run(vmName: String, console: StartOptions.ConsoleMode) async throws -> ProcessRun {
+        var arguments = ["run", vmName]
+        if console == .headless { arguments.append("--no-graphics") }
+        return try await launch(ProcessInvocation(
+            executable: bundle.executable,
+            arguments: arguments,
+            environment: storage.environmentForTart(),
+            timeout: .seconds(60 * 60 * 24 * 365),
+            terminationGracePeriod: .seconds(30)
+        ))
+    }
+
+    /// `tart stop <vm> --timeout <seconds>`: graceful shutdown, then Tart's own force after
+    /// the deadline.
+    public func stop(vmName: String, deadline: Duration) async throws {
+        let seconds = max(1, Int(deadline.components.seconds))
+        _ = try await capture(["stop", vmName, "--timeout", String(seconds)], timeout: deadline + .seconds(30))
+    }
+
+    // MARK: - Helpers
+
+    struct Captured {
+        let stdout: String
+        let stderr: String
+    }
+
+    private func capture(_ arguments: [String], timeout: Duration) async throws -> Captured {
         let run = try await launch(ProcessInvocation(
             executable: bundle.executable,
-            arguments: ["--version"],
+            arguments: arguments,
             environment: storage.environmentForTart(),
-            timeout: .seconds(15)
+            timeout: timeout
         ))
         var stdout: [String] = []
         var stderr: [String] = []
@@ -85,21 +145,15 @@ public struct TartBackend: Sendable {
         }
         let exit = await run.exit()
         guard exit.succeeded else {
-            throw TartInvocationError.failed(TartErrorClassifier.classify(stderr: stderr.joined(separator: "\n"), exitStatus: exitStatus(exit)))
+            throw TartInvocationError.failed(TartErrorClassifier.classify(stderr: stderr.joined(separator: "\n"), exitStatus: Self.exitStatus(exit)))
         }
-        // A truncated capture is not a complete answer: the parser must see all of stdout
-        // before a version is accepted as the runtime's own.
+        // A truncated capture is not a complete answer: a parser must see all of stdout
+        // before its result is trusted as the runtime's own.
         guard !exit.outputTruncated, !truncatedRecords else { throw TartInvocationError.unparseableOutput }
-        // The parser's contract is one line, but it splits on newlines and `split` drops empty
-        // subsequences, so a leading or extra blank record would be parsed away and drifted
-        // output read as the pin. The capture itself has to be that one line.
-        guard stdout.count == 1, let version = TartVersion(parsing: stdout[0]) else {
-            throw TartInvocationError.unparseableOutput
-        }
-        return version
+        return Captured(stdout: stdout.joined(separator: "\n"), stderr: stderr.joined(separator: "\n"))
     }
 
-    private func exitStatus(_ exit: ProcessExit) -> Int32 {
+    static func exitStatus(_ exit: ProcessExit) -> Int32 {
         switch exit.reason {
         case .status(let status): status
         case .signal(let signal): 128 + signal

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -20,6 +20,9 @@ public struct TartBackend: Sendable {
         self.verifiedBundle = verifiedBundle
     }
 
+    /// The most records a parsed command may produce before its output is refused.
+    static let maximumCapturedRecords = 512
+
     /// Refuses to launch when the bundle is not the one that passed verification.
     func requireVerifiedBundle() throws {
         guard let verifiedBundle else { return }
@@ -61,7 +64,6 @@ public struct TartBackend: Sendable {
     /// `tart --version`, parsed strictly. Anything unparseable is reported as a failure, never
     /// guessed.
     public func version() async throws -> TartVersion {
-        try requireVerifiedExecutable()
         let output = try await capture(["--version"], timeout: .seconds(15))
         // The parser's contract is one line, and it splits on newlines where `split` drops
         // empty subsequences: a leading or extra blank record would be parsed away and drifted
@@ -100,19 +102,30 @@ public struct TartBackend: Sendable {
         if console == .headless { arguments.append("--no-graphics") }
         return try await launch(ProcessInvocation(
             executable: bundle.executable,
-            arguments: arguments,
+            arguments: Self.runArguments(vmName: vmName, console: console),
             environment: storage.environmentForTart(),
             timeout: .seconds(60 * 60 * 24 * 365),
             terminationGracePeriod: .seconds(30)
         ))
     }
 
-    /// `tart stop <vm> --timeout <seconds>`: graceful shutdown, then Tart's own force after
-    /// the deadline.
-    public func stop(vmName: String, deadline: Duration) async throws {
-        let seconds = max(1, Int(deadline.components.seconds))
-        _ = try await capture(["stop", vmName, "--timeout", String(seconds)], timeout: deadline + .seconds(30))
+    /// The exact argument vector `run` uses, recorded with the process identity so a survivor
+    /// is recognized after a relaunch.
+    public static func runArguments(vmName: String, console: StartOptions.ConsoleMode) -> [String] {
+        var arguments = ["run", vmName]
+        if console == .headless { arguments.append("--no-graphics") }
+        return arguments
     }
+
+    /// `tart stop <vm>`: a graceful shutdown that waits up to `deadline`. Tart's own `--timeout`
+    /// escalates to a force-stop, so it is set far beyond the deadline; when the deadline
+    /// passes, the stop command is ended and `TartInvocationError.timedOut` is thrown with the
+    /// guest still running. Force-stopping is a separate, warned path.
+    public func stop(vmName: String, deadline: Duration) async throws {
+        _ = try await capture(["stop", vmName, "--timeout", String(Self.neverForceSeconds)], timeout: deadline)
+    }
+
+    static let neverForceSeconds = 86_400
 
     // MARK: - Helpers
 
@@ -128,29 +141,37 @@ public struct TartBackend: Sendable {
             environment: storage.environmentForTart(),
             timeout: timeout
         ))
-        var stdout: [String] = []
-        var stderr: [String] = []
-        var truncatedRecords = false
-        for await line in run.output {
-            // A command whose output is parsed is bounded by record count as well as by the
-            // runner's byte cap: empty records cost no bytes but still cost memory.
-            guard stdout.count + stderr.count < Self.maximumCapturedRecords else {
-                truncatedRecords = true
-                break
+        // A canceled operation ends the query process too, so a start canceled while waiting
+        // for the address does not keep `tart ip` waiting for its own timeout.
+        let (stdout, stderr, exit) = await withTaskCancellationHandler {
+            var stdout: [String] = []
+            var stderr: [String] = []
+            for await line in run.output {
+                // A command whose output is parsed is bounded by record count as well as by
+                // the runner's byte cap: empty records cost no bytes but still cost memory.
+                guard stdout.count + stderr.count < Self.maximumCapturedRecords else { break }
+                switch line {
+                case .stdout(let text): stdout.append(text.text)
+                case .stderr(let text): stderr.append(text.text)
+                }
             }
-            switch line {
-            case .stdout(let text): stdout.append(text.text)
-            case .stderr(let text): stderr.append(text.text)
-            }
+            return (stdout, stderr, await run.exit())
+        } onCancel: {
+            run.terminate(gracePeriod: .seconds(1))
         }
-        let exit = await run.exit()
+        if Task.isCancelled { throw CancellationError() }
+        if exit.timedOut { throw TartInvocationError.timedOut }
+        // A truncated capture is not a complete answer: a parser must see all of stdout
+        // before its result is trusted as the runtime's own.
         guard exit.succeeded else {
             throw TartInvocationError.failed(TartErrorClassifier.classify(stderr: stderr.joined(separator: "\n"), exitStatus: Self.exitStatus(exit)))
         }
         // A truncated capture is not a complete answer: a parser must see all of stdout
         // before its result is trusted as the runtime's own.
-        guard !exit.outputTruncated, !truncatedRecords else { throw TartInvocationError.unparseableOutput }
-        return Captured(stdout: stdout.joined(separator: "\n"), stderr: stderr.joined(separator: "\n"))
+        guard !exit.outputTruncated else { throw TartInvocationError.unparseableOutput }
+        return Captured(stdout: stdout.joined(separator: "
+"), stderr: stderr.joined(separator: "
+"))
     }
 
     static func exitStatus(_ exit: ProcessExit) -> Int32 {
@@ -168,4 +189,6 @@ public enum TartInvocationError: Error, Hashable, Sendable {
     /// integrity failure is not an unknown version: the caller must report the bundle as
     /// unverified rather than as one that verified and then would not answer.
     case runtimeReplaced
+    /// The command did not finish within its deadline and was ended.
+    case timedOut
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -108,6 +108,7 @@ import Testing
         try snapshot.slots.markPreserved(environment)
         try await store.saveSnapshot(snapshot)
         try await lifecycle.prepare()
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.environmentPreserved(environment)))
         await #expect(throws: GuesthouseError.environmentPreserved(environment)) {
             _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
         }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -18,10 +18,11 @@ import Testing
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let store = try StateStore(rootURL: storage.url(for: .state))
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
-        // The fixture's executable is a copy of `yes`: it accepts any arguments and runs until
-        // ended, so `run` looks like a live VM process with the recorded identity.
+        // The fixture's executable is a link to `yes`: it accepts any arguments and runs until
+        // ended, so `run` looks like a live VM process with the recorded identity. (A copied
+        // system binary would be killed at launch: platform binaries only run in place.)
         try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/yes"), to: bundle.executable)
+        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: URL(fileURLWithPath: "/usr/bin/yes"))
         let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
         for identity in recordedIdentities { try await identities.record(identity) }
         let supervisor = OperationSupervisor(store: identities)
@@ -55,7 +56,7 @@ import Testing
         let interrupted = try await store.begin(.startEnvironment, for: environment)
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/yes"), to: bundle.executable)
+        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: URL(fileURLWithPath: "/usr/bin/yes"))
         let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
         let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
         try await lifecycle.prepare()

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -18,6 +18,10 @@ import Testing
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let store = try StateStore(rootURL: storage.url(for: .state))
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        // The fixture's executable is a copy of `yes`: it accepts any arguments and runs until
+        // ended, so `run` looks like a live VM process with the recorded identity.
+        try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/yes"), to: bundle.executable)
         let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
         for identity in recordedIdentities { try await identities.record(identity) }
         let supervisor = OperationSupervisor(store: identities)
@@ -42,6 +46,88 @@ import Testing
             try? await Task.sleep(for: .milliseconds(5))
         }
         return events.events
+    }
+
+    @Test func anInterruptedOperationIsSettledOnceTheVMIsConfirmedStopped() async throws {
+        let runner = tartLikeRunner()
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let store = try StateStore(rootURL: storage.url(for: .state))
+        let interrupted = try await store.begin(.startEnvironment, for: environment)
+        let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/usr/bin/yes"), to: bundle.executable)
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
+        let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
+        try await lifecycle.prepare()
+        let replay = try await store.replay()
+        #expect(replay.inFlight.isEmpty, "the interrupted start was closed by reconciliation")
+        #expect(replay.records.last?.id == interrupted)
+        #expect(replay.records.last?.outcome == .reconciled)
+        #expect(try await lifecycle.status(of: environment).readiness == .ready)
+    }
+
+    @Test func aRunningVMWithoutOwnershipEvidenceBlocksStartAndForceStop() async throws {
+        let runner = tartLikeRunner(running: true)
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let status = try await lifecycle.status(of: environment)
+        guard case .uncertain = status.vm else { Issue.record("expected uncertain, got \(status.vm)"); return }
+        #expect(status.readiness == .needsAttention(.vmOwnershipUncertain(environment)))
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        }
+    }
+
+    @Test func aSecondVMIsRefusedWhileOneRuns() async throws {
+        let other = EnvironmentID()
+        let runner = FakeProcessRunner(script: [
+            "list": .init(stdout: [listJSON(running: false, extra: [other.tartVMName])]),
+            "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.9"]), "stop": .init(),
+        ])
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        #expect(await lifecycle.environments().count == 2)
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        await #expect(throws: GuesthouseError.anotherEnvironmentRunning(environment)) {
+            _ = try await lifecycle.start(other, options: StartOptions()) { _ in }
+        }
+        await runner.finishHanging()
+    }
+
+    @Test func aPreservedEnvironmentIsRefused() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        var snapshot = try await store.loadSnapshot()
+        try snapshot.slots.markPreserved(environment)
+        try await store.saveSnapshot(snapshot)
+        try await lifecycle.prepare()
+        await #expect(throws: GuesthouseError.environmentPreserved(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+    }
+
+    @Test func aGracefulStopThatMissesItsDeadlineIsReportedNotForced() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("stop", .init(hangs: true))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .milliseconds(300))) { event in stopEvents.add(event) }
+        let seen = await collect(stopEvents)
+        #expect(seen.last == .failed(stop, .gracefulStopTimedOut(environment)))
+        #expect(try await lifecycle.status(of: environment).vm == .running, "the guest was not force-stopped")
+        let stopInvocation = await runner.invocations.last { $0.arguments.first == "stop" }
+        #expect(stopInvocation?.arguments == ["stop", environment.tartVMName, "--timeout", String(TartBackend.neverForceSeconds)])
+        await runner.finishHanging()
     }
 
     @Test func adoptsOnlyAppManagedVMsIntoFreeSlots() async throws {
@@ -139,7 +225,7 @@ import Testing
         #expect(seen.map(\.caseName) == ["progress", "status", "completed"])
         guard let statusEvent = seen.first(where: { if case .status = $0 { true } else { false } }), case .status(let status) = statusEvent else { Issue.record("no status in \(seen)"); return }
         #expect(status.vm == .stopped)
-        #expect(await runner.invocations.map(\.arguments).contains(["stop", environment.tartVMName, "--timeout", "20"]))
+        #expect(await runner.invocations.map(\.arguments).contains(["stop", environment.tartVMName, "--timeout", String(TartBackend.neverForceSeconds)]), "Tart's own force-stop is never reached by a graceful request")
         #expect(try await store.replay().inFlight.isEmpty)
         _ = stop
     }
@@ -165,7 +251,7 @@ import Testing
         try await lifecycle.prepare()
         let status = try await lifecycle.status(of: environment)
         guard case .uncertain = status.vm else { Issue.record("expected uncertain, got \(status.vm)"); return }
-        guard case .needsAttention(let error) = status.readiness, error.caseName == "operationOutcomeUnknown" else { Issue.record("expected needsAttention"); return }
+        #expect(status.readiness == .needsAttention(.vmOwnershipUncertain(environment)))
         await #expect(throws: GuesthouseError.self) {
             _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
         }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import GuesthouseCore
 import Synchronization
@@ -25,7 +26,7 @@ import Testing
 
     /// A lifecycle over storage the test already holds, so a snapshot or a journal record can
     /// be seeded before the service starts.
-    func makeLifecycle(runner: FakeProcessRunner, storage: RuntimeStorage, store: StateStore, recordedIdentities: [ProcessIdentity] = []) async throws -> EnvironmentLifecycle {
+    func makeLifecycle(runner: FakeProcessRunner, storage: RuntimeStorage, store: StateStore, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> EnvironmentLifecycle {
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         // The fixture's executable is a link to the test helper: it accepts any arguments,
         // leaves them untouched, and runs until ended, so `run` looks like a live VM process
@@ -35,13 +36,13 @@ import Testing
         try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: try TestHelper.executable())
         let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
         for identity in recordedIdentities { try await identities.record(identity) }
-        let supervisor = OperationSupervisor(store: identities)
+        let supervisor = OperationSupervisor(store: identities, enumerator: enumerator)
         return EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
     }
 
-    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = []) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
+    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
         let (storage, store) = try makeStorage()
-        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store, recordedIdentities: recordedIdentities)
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store, recordedIdentities: recordedIdentities, enumerator: enumerator)
         return (lifecycle, store, storage)
     }
 
@@ -88,13 +89,14 @@ import Testing
         ])
     }
 
-    func collect(_ events: EventCollector, until terminal: Int = 1) async -> [RuntimeEvent] {
-        for _ in 0..<400 {
+    func collect(_ events: EventCollector, deadline: Duration = .seconds(2)) async -> [RuntimeEvent] {
+        let end = ContinuousClock.now.advanced(by: deadline)
+        while true {
             let seen = events.events
             if seen.contains(where: { if case .completed = $0 { true } else if case .failed = $0 { true } else { false } }) { return seen }
+            if ContinuousClock.now >= end { return seen }
             try? await Task.sleep(for: .milliseconds(5))
         }
-        return events.events
     }
 
     @Test func anInterruptedOperationIsSettledOnceTheVMIsConfirmedStopped() async throws {
@@ -138,7 +140,7 @@ import Testing
         ])
         let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
         try await lifecycle.prepare()
-        #expect(await lifecycle.environments().count == 2)
+        #expect(try await lifecycle.environments().count == 2)
         let events = EventCollector()
         _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
         _ = await collect(events)
@@ -183,7 +185,7 @@ import Testing
     @Test func adoptsOnlyAppManagedVMsIntoFreeSlots() async throws {
         let (lifecycle, store, _) = try await makeLifecycle(runner: tartLikeRunner())
         try await lifecycle.prepare()
-        let environments = await lifecycle.environments()
+        let environments = try await lifecycle.environments()
         #expect(environments.map(\.id) == [environment])
         #expect(environments[0].name == environment.tartVMName)
         let snapshot = try await store.loadSnapshot()
@@ -444,8 +446,16 @@ import Testing
         let runner = tartLikeRunner()
         await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
         let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        // The launch survives it: the service still exists and can be asked again.
         try await lifecycle.prepare()
-        #expect(await lifecycle.environments().map(\.id) == [environment], "the saved environments are still served")
+        // The listing itself does not pretend to have succeeded. It could not be completed, so
+        // it reports the inventory failure with its recovery rather than a list that may be
+        // missing environments.
+        await #expect(throws: GuesthouseError.runtimeStateUnavailable(reason: SanitizedText("the list of virtual machines could not be read", limit: 200))) {
+            _ = try await lifecycle.environments()
+        }
+        await runner.set("list", .init(stdout: [listJSON(running: false)]))
+        #expect(try await lifecycle.environments().map(\.id) == [environment], "the saved environments are served once the inventory answers")
     }
 
     @Test func aReconciliationTheJournalCannotRecordStaysUnresolvedUntilStorageIsRepaired() async throws {
@@ -503,10 +513,15 @@ import Testing
         ])
         let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
         try await lifecycle.prepare()
-        #expect(await lifecycle.environments().count == 2, "the third VM found no free slot")
-        await #expect(throws: GuesthouseError.anotherEnvironmentRunning(unadopted)) {
+        #expect(try await lifecycle.environments().count == 2, "the third VM found no free slot")
+        // Nothing records that Guesthouse started it, and `stop` would refuse its unregistered
+        // id, so "stop it first" is not something the developer could act on: the blocker is
+        // reported as the uncertain ownership it is, with inspection and the console.
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(unadopted)) {
             _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
         }
+        #expect(GuesthouseError.vmOwnershipUncertain(unadopted).recoveryActions.contains(.inspectState))
+        #expect(GuesthouseError.vmOwnershipUncertain(unadopted).recoveryActions.contains(.openConsole))
     }
 
     @Test func statusRefreshesTheGuestAddressOnEveryInspection() async throws {
@@ -636,6 +651,557 @@ import Testing
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         let backend = TartBackend(bundle: bundle, storage: storage, runner: runner)
         await #expect(throws: TartInvocationError.unparseableOutput) { _ = try await backend.list() }
+    }
+
+    /// A live process that stands in for a `tart run <vm>` nobody adopted. It is spawned
+    /// outside `ProcessRunner` so nothing reaps it; the caller ends it.
+    func spawnClaimant(of vmName: String) throws -> pid_t {
+        let helper = try TestHelper.executable().path
+        var pid: pid_t = 0
+        var argv: [UnsafeMutablePointer<CChar>?] = [strdup(helper), strdup("run"), strdup(vmName), strdup("--no-graphics"), nil]
+        defer { for argument in argv { free(argument) } }
+        #expect(posix_spawn(&pid, helper, nil, nil, &argv, environ) == 0)
+        return pid
+    }
+
+    @Test func aStartIsRefusedWhenTheVMIsNoLongerInTheStore() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        // The registered VM's bundle was removed from TART_HOME, so the inventory no longer
+        // names it.
+        let runner = FakeProcessRunner(script: [
+            "list": .init(stdout: [#"[{"Source":"local","Name":"ubuntu","Disk":1,"Size":1,"Accessed":"2026-09-03T00:00:00Z","Running":false,"State":"stopped"}]"#]),
+            "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.7"]), "stop": .init(),
+        ])
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+        await #expect(throws: GuesthouseError.environmentNotFound(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "run" }), "a VM that is not there is never launched")
+        #expect(try await store.replay().inFlight.isEmpty, "nothing was journaled for a start that cannot happen")
+    }
+
+    @Test func aClaimantThatHasNotTakenTheLockRefusesTheStart() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        // A `tart run` for this VM that has spawned but has not taken the lock yet: the
+        // inventory still says stopped.
+        let claimant = try spawnClaimant(of: environment.tartVMName)
+        defer { kill(claimant, SIGKILL); waitpid(claimant, nil, 0) }
+        for _ in 0..<200 where LiveProcessEnumerator().live(pid: claimant) == nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "run" }), "two Tart processes never race for one disk")
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func anotherSlotWithUncertainOwnershipBlocksTheStart() async throws {
+        let other = EnvironmentID()
+        // The other slot's recorded process is alive and claims that slot's VM, but it does not
+        // match what was recorded for it, so its ownership is unresolved while the inventory
+        // says the VM is stopped.
+        let holder = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/perl"), arguments: ["-e", "sleep 43", "run", other.tartVMName], timeout: .seconds(20)))
+        defer { holder.terminate(gracePeriod: .milliseconds(100)) }
+        let mismatched = ProcessIdentity(pid: holder.processIdentifier, startTime: Date(timeIntervalSince1970: 0), executablePath: "/usr/bin/perl", argumentsDigest: "sha256:0", vmName: other.tartVMName, environmentID: other, recordedAt: Date(timeIntervalSince1970: 0))
+        let runner = FakeProcessRunner(script: [
+            "list": .init(stdout: [listJSON(running: false, extra: [other.tartVMName])]),
+            "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.7"]), "stop": .init(),
+        ])
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, recordedIdentities: [mismatched])
+        try await lifecycle.prepare()
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(other)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "run" }), "a slot that may still be running blocks the second VM")
+    }
+
+    @Test func aDuplicatedInventoryEntryIsAdoptedOnce() async throws {
+        // `tart list` is untrusted output: the same VM appearing twice must not produce two
+        // records, which would make every later snapshot save fail.
+        let repeated = "[" + [entryJSON(environment.tartVMName, running: false), entryJSON(environment.tartVMName, running: false)].joined(separator: ",") + "]"
+        let runner = FakeProcessRunner(script: [
+            "list": .init(stdout: [repeated]), "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.7"]), "stop": .init(),
+        ])
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        #expect(try await lifecycle.environments().map(\.id) == [environment])
+        #expect(try await store.loadSnapshot().environments.count == 1)
+    }
+
+    @Test func aVMHiddenByATransientInventoryFailureIsAdoptedOnTheNextListing() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        await #expect(throws: GuesthouseError.self, "an unreadable inventory reports the failure instead of an empty list") {
+            _ = try await lifecycle.environments()
+        }
+        await runner.set("list", .init(stdout: [listJSON(running: false)]))
+        #expect(try await lifecycle.environments().map(\.id) == [environment], "the next listing adopts what the failed one missed")
+    }
+
+    @Test func anInterruptedImportIsNotSettledByARunningVM() async throws {
+        let survivor = try await ProcessRunner().run(ProcessInvocation(executable: try TestHelper.executable(), arguments: ["run", environment.tartVMName, "--no-graphics"], timeout: .seconds(60)))
+        defer { survivor.terminate(gracePeriod: .milliseconds(100)) }
+        let live = try #require(LiveProcessEnumerator().live(pid: survivor.processIdentifier))
+        let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        let (storage, store) = try makeStorage()
+        let lifecycle = try await makeLifecycle(runner: tartLikeRunner(running: true), storage: storage, store: store, recordedIdentities: [identity])
+        // A workspace import was interrupted. A running VM says nothing about how far it got.
+        let interrupted = try await store.begin(.importXcode, for: environment)
+        try await lifecycle.prepare()
+        #expect(try await store.replay().inFlight[interrupted] != nil, "a running VM does not establish what an import changed")
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(interrupted)))
+    }
+
+    @Test func anInterruptedImportIsNotSettledByAStoppedVM() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        // A workspace import was interrupted. The VM being stopped, with no process of ours
+        // left, says nothing about what the import wrote into the guest.
+        let interrupted = try await store.begin(.importXcode, for: environment)
+        let lifecycle = try await makeLifecycle(runner: tartLikeRunner(running: false), storage: storage, store: store)
+        try await lifecycle.prepare()
+        #expect(try await store.replay().inFlight[interrupted] != nil, "an absent VM does not establish what an import changed")
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(interrupted)))
+    }
+
+    @Test func aClaimantOnAnotherSlotAppearingAfterReconciliationRefusesTheStart() async throws {
+        let other = EnvironmentID()
+        let runner = tartLikeRunner()
+        await runner.set("list", .init(stdout: [listJSON(running: false, extra: [other.tartVMName])]))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        #expect(try await lifecycle.environments().count == 2)
+        // The claimant appears after reconciliation, so no remembered verdict names it, and it
+        // has not taken its lock yet, so `tart list` still calls that VM stopped. Only a fresh
+        // process-table scan of every slot can see it.
+        let claimant = try spawnClaimant(of: other.tartVMName)
+        defer { kill(claimant, SIGKILL); waitpid(claimant, nil, 0) }
+        var seen = false
+        for _ in 0..<200 where !seen {
+            seen = LiveProcessEnumerator().live(pid: claimant) != nil
+            if !seen { try await Task.sleep(for: .milliseconds(5)) }
+        }
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(other)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "run" }), "no second VM is launched over a slot something else may be taking")
+    }
+
+    @Test func aStopThatCannotLaunchTheRuntimeAsksForRuntimeRepair() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        // The runtime is removed after the stop's ownership preflight has passed, so `tart
+        // stop` cannot be launched at all.
+        await runner.set("stop", .init(failsToLaunch: true))
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(2))) { event in events.add(event) }
+        let seen = await collect(events, deadline: .seconds(5))
+        #expect(seen.last == .failed(stop, .runtimeMissing), "reinstalling the runtime is what helps, not inspecting saved state")
+        #expect(GuesthouseError.runtimeMissing.recoveryActions.contains(.repair(.runtime)))
+        await runner.finishHanging()
+    }
+
+    @Test func anUnobservableSupervisedProcessIsUncertainNotStopped() async throws {
+        let claimant = try spawnClaimant(of: environment.tartVMName)
+        defer { kill(claimant, SIGKILL); waitpid(claimant, nil, 0) }
+        var live: LiveProcess?
+        for _ in 0..<200 where live == nil {
+            live = LiveProcessEnumerator().live(pid: claimant)
+            if live == nil { try await Task.sleep(for: .milliseconds(5)) }
+        }
+        let observed = try #require(live)
+        let identity = ProcessIdentity(pid: observed.pid, startTime: observed.startTime, executablePath: observed.executablePath, argumentsDigest: observed.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        // Tart's inventory says the VM is stopped, so nothing but the process table can say
+        // otherwise: reading the record as an exit would report the VM as available.
+        let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner(running: false), recordedIdentities: [identity])
+        try await lifecycle.prepare()
+        #expect(try await lifecycle.status(of: environment).vm == .running)
+        // The process is still there but the kernel declines to describe it: "cannot be read"
+        // must not be reported as "stopped". (An exited process is a different answer: it holds
+        // no VM, and reconciliation says so.)
+        let opaque = claimant
+        let blind = LiveProcessEnumerator(kernel: .init(
+            pids: { LiveProcessEnumerator.listAllPIDs() },
+            arguments: { pid in pid == opaque ? nil : LiveProcessEnumerator.readArguments(pid: pid) }
+        ))
+        guard case .unavailable = blind.observe(pid: claimant) else {
+            Issue.record("expected an undescribable process to be unreadable, got \(blind.observe(pid: claimant))")
+            return
+        }
+        let (blindLifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner(running: false), recordedIdentities: [identity], enumerator: blind)
+        try await blindLifecycle.prepare()
+        let status = try await blindLifecycle.status(of: environment)
+        guard case .uncertain = status.vm else { Issue.record("expected uncertain, got \(status.vm)"); return }
+        #expect(status.readiness == .needsAttention(.vmOwnershipUncertain(environment)))
+    }
+
+    @Test func aVMThatEndsWhileItsAddressIsLookedUpIsNotReportedRunning() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        // The inspection's own address lookup is slow enough for the VM to end while it is in
+        // flight; the answer that comes back describes a process that is gone.
+        await runner.set("ip", .init(stdout: ["192.168.64.7"], delay: .milliseconds(600)))
+        let inspection = Task { try await lifecycle.status(of: environment) }
+        try await Task.sleep(for: .milliseconds(150))
+        await runner.finishHanging(command: "run")
+        let status = try await inspection.value
+        #expect(status.vm == .stopped, "an address is no evidence that the VM is still running")
+    }
+
+    @Test func anOwnedVerdictIsRevalidatedBeforeAStopIsAuthorized() async throws {
+        let survivor = try await ProcessRunner().run(ProcessInvocation(executable: try TestHelper.executable(), arguments: ["run", environment.tartVMName, "--no-graphics"], timeout: .seconds(60)))
+        let live = try #require(LiveProcessEnumerator().live(pid: survivor.processIdentifier))
+        let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        let runner = tartLikeRunner(running: true)
+        // Adoption's address lookup is slow enough that the survivor's exit is noticed while
+        // reconciliation is still running, and the verdict it computed earlier is written back
+        // over the release: a remembered `ownedRunning` for a process that is gone.
+        await runner.set("ip", .init(stdout: ["192.168.64.7"], delay: .milliseconds(2_600)))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, recordedIdentities: [identity])
+        let prepared = Task { try await lifecycle.prepare() }
+        try await Task.sleep(for: .milliseconds(150))
+        survivor.terminate(gracePeriod: .milliseconds(100))
+        _ = await survivor.exit()
+        try await prepared.value
+        await runner.set("ip", .init(stdout: ["192.168.64.7"]))
+        // Something else may hold that VM name now, so the stop is refused rather than sending
+        // `tart stop` at a machine Guesthouse can no longer prove is its own.
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "stop" }))
+    }
+
+    @Test func aVMStartedAfterTheStopPreflightIsNotReportedAsStopped() async throws {
+        let runner = tartLikeRunner(running: false)
+        await runner.set("list", .init(stdout: [listJSON(running: false)], delay: .milliseconds(250)))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(5))) { event in events.add(event) }
+        // Between the preflight's observation and the journalled task, something starts the VM.
+        await runner.set("list", .init(stdout: [listJSON(running: true)], delay: .milliseconds(250)))
+        let seen = await collect(events, deadline: .seconds(10))
+        #expect(seen.last == .failed(stop, .vmOwnershipUncertain(environment)), "a stop never completes over a VM that is running again")
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func aForceStopWithNothingLeftToSignalDoesNotAskTartToStopAStoppedVM() async throws {
+        let runner = tartLikeRunner(running: false)
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let development = try #require(try await lifecycle.environments().first)
+        // The supervised process ended between the ownership preflight and this step, so the
+        // requested state is already reached; `tart stop` would answer `notRunning` and that
+        // would be reported as a failed stop.
+        try await lifecycle.endUnsupervisedVM(development, operation: OperationID())
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "stop" }))
+    }
+
+    @Test func theGracefulStopDeadlineCoversBothTheCommandAndTheProcessWait() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        // `tart stop` uses most of the deadline and the VM process never ends, so the wait for
+        // it gets what is left rather than a fresh deadline of its own.
+        await runner.set("stop", .init(delay: .milliseconds(800)))
+        let events = EventCollector()
+        let began = ContinuousClock.now
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(1))) { event in events.add(event) }
+        let seen = await collect(events, deadline: .seconds(10))
+        let elapsed = ContinuousClock.now - began
+        #expect(seen.last == .failed(stop, .operationOutcomeUnknown(stop)))
+        #expect(elapsed < .milliseconds(1_500), "one deadline covers the command and the wait, not one each (took \(elapsed))")
+        await runner.finishHanging()
+    }
+
+    @Test func aHangingStatusRefreshDoesNotHoldTheTerminalEvent() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        // The inventory stops answering. The stop itself still completes and is durable, so the
+        // client must not be left believing the operation is in flight.
+        await runner.set("list", .init(hangs: true))
+        let events = EventCollector()
+        let began = ContinuousClock.now
+        let stop = try await lifecycle.stop(environment, mode: .force) { event in events.add(event) }
+        let seen = await collect(events, deadline: .seconds(20))
+        let elapsed = ContinuousClock.now - began
+        #expect(seen.last == .completed(stop))
+        #expect(elapsed < .seconds(10), "the courtesy status is bounded (took \(elapsed))")
+        #expect(try await store.replay().inFlight.isEmpty)
+        await runner.finishHanging()
+    }
+
+    @Test func aHangingStatusRefreshDoesNotHoldTheStartsTerminalEvent() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let began = ContinuousClock.now
+        let start = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        // The address is found, the completed record is durable, and then the inventory hangs.
+        await runner.set("list", .init(hangs: true))
+        let seen = await collect(events, deadline: .seconds(20))
+        let elapsed = ContinuousClock.now - began
+        #expect(seen.last == .completed(start))
+        #expect(elapsed < .seconds(10), "the courtesy status is bounded (took \(elapsed))")
+        await runner.finishHanging()
+    }
+
+    @Test func aCancellationBeforeTheFirstProgressReportIsDeferred() async throws {
+        let runner = tartLikeRunner()
+        // The start's inventory read is slow, so the operation exists while no phase has been
+        // reported for it and its task has not been created: the window a cancellation must be
+        // held over rather than dropped or delivered into a protected phase.
+        await runner.set("list", .init(stdout: [listJSON(running: false)], delay: .milliseconds(500)))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let started = Task { try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(5))) { event in events.add(event) } }
+        var pending: OperationID?
+        for _ in 0..<200 where pending == nil {
+            pending = await lifecycle.inFlightOperationID
+            if pending == nil { try await Task.sleep(for: .milliseconds(2)) }
+        }
+        let operation = try #require(pending)
+        #expect(await lifecycle.inFlightPhase == nil, "no phase has been reported for it yet")
+        await lifecycle.cancel(operation)
+        #expect(try await started.value == operation)
+        let seen = await collect(events, deadline: .seconds(10))
+        #expect(seen.contains(.progress(operation, ProgressPhase(kind: .startingVM, cancelable: false))), "the protected phase still ran")
+        #expect(seen.last == .failed(operation, .canceled), "the deferred request was applied at the first cancelable phase")
+        await runner.finishHanging()
+    }
+
+    @Test func aCanceledOperationStaysUnresolvedUntilInspectionSettlesIt() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("ip", .init(hangs: true))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let start = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(30))) { event in events.add(event) }
+        for _ in 0..<400 where events.events.count < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        await lifecycle.cancel(start)
+        let seen = await collect(events, deadline: .seconds(10))
+        #expect(seen.last == .failed(start, .canceled))
+        #expect(try await store.replay().inFlight[start] != nil, "the journal reads a cancellation as still in flight")
+        // Inspection is what settles it. Without the environment being tracked as unresolved,
+        // nothing would reconcile and only a restart would rediscover the journal entry.
+        _ = try await lifecycle.status(of: environment)
+        #expect(try await store.replay().inFlight.isEmpty, "inspecting the actual state settles the canceled start")
+        await runner.finishHanging()
+    }
+
+    @Test func aRuntimeThatCannotBeLaunchedAsksForRuntimeRepair() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        // The bundle's executable is missing, so no process can be started at all.
+        let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
+        let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: ProcessRunner()), supervisor: supervisor, store: store))
+        try await lifecycle.prepare()
+        do {
+            _ = try await lifecycle.status(of: environment)
+            Issue.record("expected the runtime failure to be reported")
+        } catch let error as GuesthouseError {
+            #expect(error.caseName == "runtimeMissing", "reinstalling the runtime is what helps, not inspecting saved state")
+            #expect(error.recoveryActions.contains(.repair(.runtime)))
+        }
+    }
+
+    @Test func aReplacedRuntimeAsksForRuntimeRepairNotTheGuestNetwork() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: try TestHelper.executable())
+        // The identity recorded at verification is not the bundle that is there now.
+        let staleFile = TartBundle.FileIdentity(device: 1, inode: 2, size: 3, modified: timespec(tv_sec: 4, tv_nsec: 5), changed: timespec(tv_sec: 6, tv_nsec: 7))
+        let stale = TartBundle.BundleIdentity(directoryDevice: 1, directoryInode: 2, infoPlist: staleFile, executable: staleFile)
+        let backend = TartBackend(bundle: bundle, storage: storage, runner: tartLikeRunner(), verifiedBundle: stale)
+        await #expect(throws: TartInvocationError.runtimeReplaced) { _ = try await backend.list() }
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
+        let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: backend, supervisor: supervisor, store: store))
+        try await lifecycle.prepare()
+        do {
+            _ = try await lifecycle.status(of: environment)
+            Issue.record("expected the refusal to run a replaced runtime to be reported")
+        } catch let error as GuesthouseError {
+            #expect(error.caseName == "runtimeVerificationFailed", "Guesthouse refused to run the host runtime; no guest was probed")
+            #expect(error.recoveryActions.contains(.repair(.runtime)))
+        }
+        #expect(EnvironmentLifecycle.map(.runtimeReplaced, environment: environment).caseName == "runtimeVerificationFailed")
+    }
+
+    @Test func aHangingAddressLookupEndsWithinTheRequestedWait() async throws {
+        let (storage, store) = try makeStorage()
+        let runner = tartLikeRunner()
+        await runner.set("ip", .init(hangs: true))
+        _ = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        let backend = TartBackend(bundle: TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app")), storage: storage, runner: runner)
+        let began = ContinuousClock.now
+        await #expect(throws: TartInvocationError.timedOut) { _ = try await backend.ip(vmName: environment.tartVMName, wait: .seconds(2)) }
+        let waited = ContinuousClock.now - began
+        #expect(waited < .seconds(5), "the wait the caller asked for bounds the whole invocation (took \(waited))")
+        // The probe every status inspection makes asks for no guest wait at all.
+        let probeBegan = ContinuousClock.now
+        await #expect(throws: TartInvocationError.timedOut) { _ = try await backend.ip(vmName: environment.tartVMName, wait: .zero) }
+        let probed = ContinuousClock.now - probeBegan
+        #expect(probed < .seconds(5), "a zero-wait probe no longer costs twenty seconds (took \(probed))")
+        await runner.finishHanging()
+    }
+
+    /// Adoption manages local bundles alone, so a pulled image that happens to carry the
+    /// environment's name is not the bundle it was registered with. Matching on the name alone
+    /// would journal and launch a start against something Tart may go and fetch.
+    @Test func anOCIImageCarryingTheVMsNameIsNotTheRegisteredBundle() async throws {
+        let image = #"[{"Source":"OCI","Name":"\#(environment.tartVMName)","Disk":160,"Size":20,"Accessed":"2026-09-03T00:00:00Z","Running":false,"State":"stopped"}]"#
+        let runner = FakeProcessRunner(script: ["list": .init(stdout: [image]), "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.7"]), "stop": .init()])
+        let (storage, store) = try makeStorage()
+        // Registered while the local bundle existed; it has since been removed from the store.
+        try await seedSnapshot(in: store)
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+        #expect(try await lifecycle.status(of: environment).vm == .notFound)
+        await #expect(throws: GuesthouseError.environmentNotFound(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        #expect(try await store.replay().inFlight.isEmpty, "a start with no bundle to run is refused before it is journaled")
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "run" }))
+    }
+
+    /// The field promises an address a guest connection can be made to. A VM observed as no
+    /// longer running still has the address its supervised entry cached until the exit watcher
+    /// runs, and answering with that would point SSH and Screen Sharing at an endpoint this VM
+    /// no longer owns.
+    @Test func anAddressIsReportedOnlyForAVMThatIsRunning() async throws {
+        let real = LiveProcessEnumerator()
+        let unreadable = Mutex(false)
+        let enumerator = LiveProcessEnumerator(kernel: .init(
+            pids: real.kernel.pids,
+            arguments: { pid in unreadable.withLock { $0 } ? nil : real.kernel.arguments(pid) }
+        ))
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, enumerator: enumerator)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(3))) { event in events.add(event) }
+        _ = await collect(events)
+        #expect(try await lifecycle.status(of: environment).guestAddress?.rawValue == "192.168.64.7")
+        // The process table stops answering for the recorded process, which is the state a
+        // supervised VM that ended leaves behind until its exit is observed.
+        unreadable.withLock { $0 = true }
+        let status = try await lifecycle.status(of: environment)
+        #expect(status.vm != .running)
+        #expect(status.guestAddress == nil, "an address the VM may no longer own is not reported")
+        unreadable.withLock { $0 = false }
+        _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        try await waitUntilNotRunning(lifecycle)
+    }
+
+    /// The inventory proves the runtime, and the address probe then runs it again. A runtime
+    /// removed in between is a host failure with a repair, and reporting it as a guest that
+    /// cannot be reached would offer retry and guest inspection instead.
+    @Test func aRuntimeLostUnderTheAddressProbeAsksForRepairNotForTheGuest() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        #expect(try await lifecycle.status(of: environment).guestAddress?.rawValue == "192.168.64.7")
+        await runner.set("ip", .init(failsToLaunch: true))
+        await #expect(throws: GuesthouseError.runtimeMissing) { _ = try await lifecycle.status(of: environment) }
+        await runner.set("ip", .init(stdout: ["192.168.64.7"]))
+        _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        try await waitUntilNotRunning(lifecycle)
+    }
+
+    /// `tart stop` reaching its deadline spends the whole budget the caller gave. Establishing
+    /// what happened may need `tart list`, whose own timeout is longer than the graceful stop
+    /// itself, so that read is bounded: a Quit reports an outcome it will settle by inspection
+    /// rather than sitting tens of seconds past what the user asked for.
+    @Test func aStopWhoseDeadlinePassedDoesNotWaitOutAnUnboundedInventory() async throws {
+        let real = LiveProcessEnumerator()
+        let gone = Mutex(false)
+        // The recorded process reads back as another program's, which is what the kernel
+        // reports once the VM's own process has exited and its PID has been taken over: an
+        // exit, not an unreadable process, so the observation falls through to the inventory.
+        let enumerator = LiveProcessEnumerator(kernel: .init(
+            pids: real.kernel.pids,
+            arguments: { pid in gone.withLock { $0 } ? ["sleep", "600"] : real.kernel.arguments(pid) }
+        ))
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, enumerator: enumerator)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+
+        await runner.set("stop", .init(hangs: true))
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(1))) { event in stopEvents.add(event) }
+        // Once the task's own ownership check has passed, the VM's process leaves the table
+        // and the inventory stops answering promptly: this is the state that sends the
+        // post-timeout observation to `tart list`.
+        try await Task.sleep(for: .milliseconds(300))
+        gone.withLock { $0 = true }
+        await runner.set("list", .init(stdout: [listJSON(running: false, extra: ["ubuntu"])], delay: .seconds(8)))
+        let began = ContinuousClock.now
+        let seen = await collect(stopEvents, deadline: .seconds(15))
+        #expect(seen.last == .failed(stop, .operationOutcomeUnknown(stop)), "an inventory that will not answer in the courtesy window leaves the outcome unknown")
+        #expect(began.duration(to: .now) < .seconds(6), "the observation gave up long before the inventory's own timeout")
+        gone.withLock { $0 = false }
+        await runner.set("list", .init(stdout: [listJSON(running: false, extra: ["ubuntu"])]))
+        await runner.finishHanging()
+    }
+
+    /// `StateStore.begin` makes the `started` record durable before the journal's own directory
+    /// entry, so a failure at that second step throws over a record a later read in this same
+    /// service still sees. Nothing had run when it failed, so a record that did land is closed
+    /// rather than left in flight with nothing tracking it.
+    @Test func aJournalBeginThatMayHaveLandedIsSettledRatherThanLeftInFlight() async throws {
+        let runner = tartLikeRunner()
+        let (storage, store) = try makeStorage()
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+        // The record an indeterminate `begin` left behind.
+        let operation = try await store.begin(.startEnvironment, for: environment)
+        await lifecycle.reconcileIndeterminateBegin(operation, kind: .startEnvironment, environment: environment)
+        let replay = try await store.replay()
+        #expect(replay.inFlight.isEmpty, "the record that landed is closed as the mutation that never took effect")
+        #expect(replay.records.last?.outcome == .notApplied)
+        #expect(try await lifecycle.status(of: environment).readiness == .ready)
+
+        // A journal that cannot be read leaves the same unknown, and the environment has to
+        // carry it rather than report a readiness that would license a blind retry.
+        let second = try await store.begin(.stopEnvironment, for: environment)
+        let original = try breakJournal(in: storage)
+        await lifecycle.reconcileIndeterminateBegin(second, kind: .stopEnvironment, environment: environment)
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(second)))
+        try repairJournal(in: storage, with: original)
     }
 
     @Test func unknownEnvironmentIsRefused() async throws {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -1,0 +1,188 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.serialized) struct EnvironmentLifecycleTests {
+    let root = FileManager.default.temporaryDirectory.appending(path: "LifecycleTests-\(UUID().uuidString)")
+    let environment = EnvironmentID()
+
+    func listJSON(running: Bool, extra: [String] = []) -> String {
+        var entries = [#"{"Source":"local","Name":"\#(environment.tartVMName)","Disk":160,"Size":20,"Accessed":"2026-09-03T00:00:00Z","Running":\#(running),"State":"\#(running ? "running" : "stopped")"}"#]
+        entries += extra.map { #"{"Source":"local","Name":"\#($0)","Disk":1,"Size":1,"Accessed":"2026-09-03T00:00:00Z","Running":false,"State":"stopped"}"# }
+        return "[" + entries.joined(separator: ",") + "]"
+    }
+
+    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = []) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let store = try StateStore(rootURL: storage.url(for: .state))
+        let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
+        for identity in recordedIdentities { try await identities.record(identity) }
+        let supervisor = OperationSupervisor(store: identities)
+        let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
+        return (lifecycle, store, storage)
+    }
+
+    /// A runner that behaves like Tart for one VM: `list`, `run` (hangs until `stop`), `ip`, `stop`.
+    func tartLikeRunner(running: Bool = false, ip: String = "192.168.64.7") -> FakeProcessRunner {
+        FakeProcessRunner(script: [
+            "list": .init(stdout: [listJSON(running: running, extra: ["ubuntu"])]),
+            "run": .init(hangs: true),
+            "ip": .init(stdout: [ip]),
+            "stop": .init(),
+        ])
+    }
+
+    func collect(_ events: EventCollector, until terminal: Int = 1) async -> [RuntimeEvent] {
+        for _ in 0..<400 {
+            let seen = events.events
+            if seen.contains(where: { if case .completed = $0 { true } else if case .failed = $0 { true } else { false } }) { return seen }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        return events.events
+    }
+
+    @Test func adoptsOnlyAppManagedVMsIntoFreeSlots() async throws {
+        let (lifecycle, store, _) = try await makeLifecycle(runner: tartLikeRunner())
+        try await lifecycle.prepare()
+        let environments = await lifecycle.environments()
+        #expect(environments.map(\.id) == [environment])
+        #expect(environments[0].name == environment.tartVMName)
+        let snapshot = try await store.loadSnapshot()
+        #expect(snapshot.slots.state(of: environment) == .active)
+        #expect(snapshot.environments.count == 1)
+        let status = try await lifecycle.status(of: environment)
+        #expect(status.vm == .stopped)
+        #expect(status.readiness == .ready)
+        #expect(status.inFlightOperation == nil)
+    }
+
+    @Test func startJournalsBeforeReportingThenSupervisesAndResolvesTheAddress() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let operation = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(3))) { event in events.add(event) }
+        let replay = try await store.replay()
+        #expect(replay.inFlight[operation]?.outcome == .started, "the started record is durable before start() returns")
+
+        let seen = await collect(events)
+        #expect(seen.map(\.caseName) == ["progress", "progress", "status", "completed"])
+        guard let statusEvent = seen.first(where: { if case .status = $0 { true } else { false } }), case .status(let status) = statusEvent else { Issue.record("no status in \(seen)"); return }
+        #expect(status.vm == .running)
+        #expect(status.guestAddress?.rawValue == "192.168.64.7")
+        #expect(try await store.replay().inFlight.isEmpty, "completed is journaled")
+
+        let invocations = await runner.invocations.map(\.arguments)
+        #expect(invocations.contains(["run", environment.tartVMName, "--no-graphics"]))
+        #expect(invocations.contains(["ip", environment.tartVMName, "--wait", "3"]))
+        for invocation in await runner.invocations { #expect(invocation.environment.keys.sorted() == ["TART_HOME"]) }
+
+        await #expect(throws: GuesthouseError.environmentAlreadyRunning(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+    }
+
+    @Test func nativeConsoleOmitsNoGraphics() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(console: .native, ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        #expect(await runner.invocations.map(\.arguments).contains(["run", environment.tartVMName]))
+    }
+
+    @Test func secondOperationWhileOneIsInFlightIsRefused() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("ip", .init(hangs: true))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let operation = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(30))) { _ in }
+        try await Task.sleep(for: .milliseconds(50))
+        await #expect(throws: GuesthouseError.operationInFlight(operation)) {
+            _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        }
+        #expect(try await lifecycle.status(of: environment).inFlightOperation == operation)
+        await runner.finishHanging()
+    }
+
+    @Test func unreachableGuestFailsTheStartButKeepsSupervising() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("ip", .init(stderr: ["no IP address found, is your VM running?"], exit: ProcessExit(reason: .status(1))))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let operation = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        let seen = await collect(events)
+        #expect(seen.last == .failed(operation, .guestNotReachable(environment)))
+        #expect(try await store.replay().inFlight.isEmpty)
+        #expect(try await lifecycle.status(of: environment).vm == .running, "the VM process is still supervised")
+    }
+
+    @Test func gracefulStopWaitsForTheProcessAndReleasesTheSlotState() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(20))) { event in stopEvents.add(event) }
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(stopEvents.events.map(\.caseName) == ["progress"], "waits for the VM process to exit")
+        await runner.finishHanging()
+        let seen = await collect(stopEvents)
+        #expect(seen.map(\.caseName) == ["progress", "status", "completed"])
+        guard let statusEvent = seen.first(where: { if case .status = $0 { true } else { false } }), case .status(let status) = statusEvent else { Issue.record("no status in \(seen)"); return }
+        #expect(status.vm == .stopped)
+        #expect(await runner.invocations.map(\.arguments).contains(["stop", environment.tartVMName, "--timeout", "20"]))
+        #expect(try await store.replay().inFlight.isEmpty)
+        _ = stop
+    }
+
+    @Test func forceStopTerminatesTheSupervisedProcess() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let stopEvents = EventCollector()
+        _ = try await lifecycle.stop(environment, mode: .force) { event in stopEvents.add(event) }
+        let seen = await collect(stopEvents)
+        #expect(seen.map(\.caseName) == ["progress", "status", "completed"])
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "stop" }), "force stop does not go through tart stop while the process is supervised")
+    }
+
+    @Test func uncertainOwnershipBlocksStartUntilRepaired() async throws {
+        let runner = tartLikeRunner(running: true)
+        let stale = ProcessIdentity(pid: 2_000_000_000, startTime: Date(), executablePath: "/nowhere/tart", argumentsDigest: "sha256:x", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, recordedIdentities: [stale])
+        try await lifecycle.prepare()
+        let status = try await lifecycle.status(of: environment)
+        guard case .uncertain = status.vm else { Issue.record("expected uncertain, got \(status.vm)"); return }
+        guard case .needsAttention(let error) = status.readiness, error.caseName == "operationOutcomeUnknown" else { Issue.record("expected needsAttention"); return }
+        await #expect(throws: GuesthouseError.self) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+    }
+
+    @Test func unknownEnvironmentIsRefused() async throws {
+        let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner())
+        try await lifecycle.prepare()
+        let stranger = EnvironmentID()
+        await #expect(throws: GuesthouseError.environmentNotFound(stranger)) { _ = try await lifecycle.status(of: stranger) }
+        await #expect(throws: GuesthouseError.environmentNotFound(stranger)) { _ = try await lifecycle.start(stranger, options: StartOptions()) { _ in } }
+    }
+}
+
+/// Records events synchronously in delivery order; the sink closure calls `add` directly.
+final class EventCollector: Sendable {
+    private let storage = Mutex<[RuntimeEvent]>([])
+    var events: [RuntimeEvent] { storage.withLock { $0 } }
+    func add(_ event: RuntimeEvent) { storage.withLock { $0.append(event) } }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -8,15 +8,24 @@ import Testing
     let root = FileManager.default.temporaryDirectory.appending(path: "LifecycleTests-\(UUID().uuidString)")
     let environment = EnvironmentID()
 
+    func entryJSON(_ name: String, running: Bool) -> String {
+        #"{"Source":"local","Name":"\#(name)","Disk":160,"Size":20,"Accessed":"2026-09-03T00:00:00Z","Running":\#(running),"State":"\#(running ? "running" : "stopped")"}"#
+    }
+
     func listJSON(running: Bool, extra: [String] = []) -> String {
-        var entries = [#"{"Source":"local","Name":"\#(environment.tartVMName)","Disk":160,"Size":20,"Accessed":"2026-09-03T00:00:00Z","Running":\#(running),"State":"\#(running ? "running" : "stopped")"}"#]
+        var entries = [entryJSON(environment.tartVMName, running: running)]
         entries += extra.map { #"{"Source":"local","Name":"\#($0)","Disk":1,"Size":1,"Accessed":"2026-09-03T00:00:00Z","Running":false,"State":"stopped"}"# }
         return "[" + entries.joined(separator: ",") + "]"
     }
 
-    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = []) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
+    func makeStorage() throws -> (RuntimeStorage, StateStore) {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
-        let store = try StateStore(rootURL: storage.url(for: .state))
+        return (storage, try StateStore(rootURL: storage.url(for: .state)))
+    }
+
+    /// A lifecycle over storage the test already holds, so a snapshot or a journal record can
+    /// be seeded before the service starts.
+    func makeLifecycle(runner: FakeProcessRunner, storage: RuntimeStorage, store: StateStore, recordedIdentities: [ProcessIdentity] = []) async throws -> EnvironmentLifecycle {
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         // The fixture's executable is a link to the test helper: it accepts any arguments,
         // leaves them untouched, and runs until ended, so `run` looks like a live VM process
@@ -27,8 +36,46 @@ import Testing
         let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
         for identity in recordedIdentities { try await identities.record(identity) }
         let supervisor = OperationSupervisor(store: identities)
-        let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
+        return EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
+    }
+
+    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = []) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
+        let (storage, store) = try makeStorage()
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store, recordedIdentities: recordedIdentities)
         return (lifecycle, store, storage)
+    }
+
+    /// Saves the environment into the snapshot, so a test does not depend on adoption having
+    /// read the inventory.
+    func seedSnapshot(in store: StateStore) async throws {
+        var snapshot = try await store.loadSnapshot()
+        snapshot.environments.append(DevelopmentEnvironment(id: environment, name: environment.tartVMName, createdAt: Date()))
+        try snapshot.slots.reserve(environment)
+        try await store.saveSnapshot(snapshot)
+    }
+
+    /// Replaces the journal with a symbolic link, which the store refuses to open, and returns
+    /// what it held so the test can put it back.
+    func breakJournal(in storage: RuntimeStorage) throws -> Data {
+        let journal = storage.url(for: .state).appending(path: "journal.ndjson")
+        let original = try Data(contentsOf: journal)
+        try FileManager.default.removeItem(at: journal)
+        try FileManager.default.createSymbolicLink(at: journal, withDestinationURL: URL(fileURLWithPath: "/dev/null"))
+        return original
+    }
+
+    func repairJournal(in storage: RuntimeStorage, with original: Data) throws {
+        let journal = storage.url(for: .state).appending(path: "journal.ndjson")
+        try FileManager.default.removeItem(at: journal)
+        try original.write(to: journal)
+    }
+
+    /// Waits until the environment is no longer reported as running.
+    func waitUntilNotRunning(_ lifecycle: EnvironmentLifecycle) async throws {
+        for _ in 0..<400 {
+            if try await lifecycle.status(of: environment).vm != .running { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
     }
 
     /// A runner that behaves like Tart for one VM: `list`, `run` (hangs until `stop`), `ip`, `stop`.
@@ -172,6 +219,9 @@ import Testing
         await #expect(throws: GuesthouseError.environmentAlreadyRunning(environment)) {
             _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
         }
+        // The fake's `run` is a real child process that outlives the test until its own
+        // timeout; every test that starts one ends it.
+        await runner.finishHanging()
     }
 
     @Test func nativeConsoleOmitsNoGraphics() async throws {
@@ -182,6 +232,7 @@ import Testing
         _ = try await lifecycle.start(environment, options: StartOptions(console: .native, ipWait: .seconds(1))) { event in events.add(event) }
         _ = await collect(events)
         #expect(await runner.invocations.map(\.arguments).contains(["run", environment.tartVMName]))
+        await runner.finishHanging()
     }
 
     @Test func secondOperationWhileOneIsInFlightIsRefused() async throws {
@@ -209,6 +260,7 @@ import Testing
         #expect(seen.last == .failed(operation, .guestNotReachable(environment)))
         #expect(try await store.replay().inFlight.isEmpty)
         #expect(try await lifecycle.status(of: environment).vm == .running, "the VM process is still supervised")
+        await runner.finishHanging()
     }
 
     @Test func gracefulStopWaitsForTheProcessAndReleasesTheSlotState() async throws {
@@ -354,6 +406,236 @@ import Testing
             _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
         }
         _ = store
+    }
+
+    @Test func aGracefulStopOfAVMWithoutOwnershipEvidenceIsRefused() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        // Something outside Guesthouse started the app-named VM after the last reconciliation,
+        // so there is no verdict for it at all.
+        await runner.set("list", .init(stdout: [listJSON(running: true)]))
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(5))) { _ in }
+        }
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "stop" }), "a guest that is not ours is never shut down by name")
+    }
+
+    @Test func aForceStopCompletesWhenTheGuestAlreadyStopped() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        // The guest finishes shutting down before the warned force-stop is confirmed.
+        await runner.finishHanging()
+        try await waitUntilNotRunning(lifecycle)
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .force) { event in events.add(event) }
+        let seen = await collect(events)
+        #expect(seen.last == .completed(stop), "the requested stopped state was already reached")
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func anUnreadableInventoryAtLaunchDoesNotFailTheService() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        let runner = tartLikeRunner()
+        await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+        #expect(await lifecycle.environments().map(\.id) == [environment], "the saved environments are still served")
+    }
+
+    @Test func aReconciliationTheJournalCannotRecordStaysUnresolvedUntilStorageIsRepaired() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        let interrupted = try await store.begin(.startEnvironment, for: environment)
+        let runner = tartLikeRunner()
+        // Nothing settles while the inventory is unreadable.
+        await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+
+        let original = try breakJournal(in: storage)
+        await runner.set("list", .init(stdout: [listJSON(running: false)]))
+        await lifecycle.reconcile()
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(interrupted)),
+                "an unwritten terminal record leaves the operation in flight")
+
+        try repairJournal(in: storage, with: original)
+        #expect(try await lifecycle.status(of: environment).readiness == .ready, "inspection settles it once storage works, without a restart")
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func aPreservedEnvironmentStillAsksForTheUnknownOutcomeFirst() async throws {
+        let (storage, store) = try makeStorage()
+        try await seedSnapshot(in: store)
+        var snapshot = try await store.loadSnapshot()
+        try snapshot.slots.markPreserved(environment)
+        try await store.saveSnapshot(snapshot)
+        let interrupted = try await store.begin(.stopEnvironment, for: environment)
+        let runner = tartLikeRunner()
+        await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
+        let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        try await lifecycle.prepare()
+
+        _ = try breakJournal(in: storage)
+        await runner.set("list", .init(stdout: [listJSON(running: false)]))
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(interrupted)),
+                "preservation does not hide the operation that has to be inspected first")
+    }
+
+    @Test func aRunningAppManagedVMWithoutASlotRefusesAStart() async throws {
+        let filler = EnvironmentID()
+        let unadopted = EnvironmentID()
+        // The two slots are taken before the running VM is reached, so it is app-managed and
+        // running yet absent from the snapshot.
+        let inventory = [
+            entryJSON(environment.tartVMName, running: false),
+            entryJSON(filler.tartVMName, running: false),
+            entryJSON(unadopted.tartVMName, running: true),
+        ]
+        let runner = FakeProcessRunner(script: [
+            "list": .init(stdout: ["[" + inventory.joined(separator: ",") + "]"]),
+            "run": .init(hangs: true), "ip": .init(stdout: ["192.168.64.9"]), "stop": .init(),
+        ])
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        #expect(await lifecycle.environments().count == 2, "the third VM found no free slot")
+        await #expect(throws: GuesthouseError.anotherEnvironmentRunning(unadopted)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+    }
+
+    @Test func statusRefreshesTheGuestAddressOnEveryInspection() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        #expect(try await lifecycle.status(of: environment).guestAddress?.rawValue == "192.168.64.7")
+        // Tart handed the same live VM a different address, as it does after the host sleeps.
+        await runner.set("ip", .init(stdout: ["192.168.64.31"]))
+        #expect(try await lifecycle.status(of: environment).guestAddress?.rawValue == "192.168.64.31")
+        await runner.finishHanging()
+    }
+
+    @Test func aVMThatExitsWhileItsAddressIsLookedUpDoesNotCompleteTheStart() async throws {
+        let runner = tartLikeRunner()
+        // Slow enough that the VM process can end while the lookup is still in flight.
+        await runner.set("ip", .init(stdout: ["192.168.64.7"], delay: .milliseconds(600)))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let operation = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(5))) { event in events.add(event) }
+        for _ in 0..<400 where events.events.count < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(events.events.last == .progress(operation, ProgressPhase(kind: .waitingForNetwork)))
+        await runner.finishHanging(command: "run")
+        let seen = await collect(events)
+        #expect(seen.last == .failed(operation, .guestNotReachable(environment)), "an address for a VM that is gone is not a completed start")
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func aStopWhoseDeadlineExpiresAfterTheGuestStoppedIsNotATimeout() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("stop", .init(hangs: true))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .milliseconds(700))) { event in events.add(event) }
+        for _ in 0..<400 where events.events.isEmpty { try await Task.sleep(for: .milliseconds(5)) }
+        // The guest completes its shutdown while `tart stop` is still being waited on.
+        await runner.finishHanging(command: "run")
+        let seen = await collect(events)
+        #expect(seen.last == .completed(stop), "the deadline expired after the shutdown finished, so nothing timed out")
+        #expect(try await store.replay().inFlight.isEmpty)
+        await runner.finishHanging()
+    }
+
+    @Test func theWaitForTartToExitEndsAtTheStopDeadline() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        // `tart stop` answers, but the process hosting the VM keeps running past the deadline.
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .milliseconds(300))) { event in events.add(event) }
+        let seen = await collect(events)
+        #expect(seen.last == .failed(stop, .operationOutcomeUnknown(stop)), "the wait ends at the deadline with the outcome unestablished")
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(stop)))
+        await runner.finishHanging()
+    }
+
+    @Test func anInterruptedStopStaysUnresolvedWhileTheVMIsStillRunning() async throws {
+        let survivor = try await ProcessRunner().run(ProcessInvocation(executable: try TestHelper.executable(), arguments: ["run", environment.tartVMName, "--no-graphics"], timeout: .seconds(60)))
+        defer { survivor.terminate(gracePeriod: .milliseconds(100)) }
+        let live = try #require(LiveProcessEnumerator().live(pid: survivor.processIdentifier))
+        let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        let (storage, store) = try makeStorage()
+        let lifecycle = try await makeLifecycle(runner: tartLikeRunner(running: true), storage: storage, store: store, recordedIdentities: [identity])
+        let interrupted = try await store.begin(.stopEnvironment, for: environment)
+        try await lifecycle.prepare()
+        #expect(try await store.replay().inFlight[interrupted] != nil, "a running VM does not prove the shutdown finished")
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(interrupted)))
+        await #expect(throws: GuesthouseError.operationOutcomeUnknown(interrupted)) {
+            _ = try await lifecycle.stop(environment, mode: .force) { _ in }
+        }
+    }
+
+    @Test func aProcessRecordThatCannotBeRemovedLeavesTheEnvironmentUncertain() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, storage) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        _ = await collect(events)
+        // The state folder stops accepting new files, so `processes.json` cannot be rewritten
+        // while the journal, whose file already exists, still can be.
+        let state = storage.url(for: .state)
+        try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: state.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: state.path) }
+        await runner.finishHanging()
+        try await waitUntilNotRunning(lifecycle)
+        let status = try await lifecycle.status(of: environment)
+        guard case .uncertain = status.vm else { Issue.record("expected uncertain, got \(status.vm)"); return }
+        #expect(status.readiness == .needsAttention(.vmOwnershipUncertain(environment)))
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+    }
+
+    @Test func anUnreadableInventoryIsAStateFailureNotAnUnreachableGuest() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        await runner.set("list", .init(stderr: ["tart: the virtual machine directory could not be read"], exit: ProcessExit(reason: .status(1))))
+        do {
+            _ = try await lifecycle.status(of: environment)
+            Issue.record("expected the inventory failure to be reported")
+        } catch let error as GuesthouseError {
+            #expect(error.caseName == "runtimeStateUnavailable", "no guest network was probed, so this is not a reachability failure")
+            #expect(error.recoveryActions.contains(.inspectState))
+        }
+    }
+
+    @Test func aCaptureCutOffByTheRecordLimitIsRefused() async throws {
+        let (storage, store) = try makeStorage()
+        // A parseable prefix followed by more records than the cap allows: without the limit
+        // being reported, the parser's answer would be trusted although it never saw the rest.
+        let padded = [listJSON(running: false)] + Array(repeating: "", count: TartBackend.maximumCapturedRecords)
+        let runner = FakeProcessRunner(script: ["list": .init(stdout: padded)])
+        _ = try await makeLifecycle(runner: runner, storage: storage, store: store)
+        let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
+        let backend = TartBackend(bundle: bundle, storage: storage, runner: runner)
+        await #expect(throws: TartInvocationError.unparseableOutput) { _ = try await backend.list() }
     }
 
     @Test func unknownEnvironmentIsRefused() async throws {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -18,11 +18,12 @@ import Testing
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let store = try StateStore(rootURL: storage.url(for: .state))
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
-        // The fixture's executable is a link to `yes`: it accepts any arguments and runs until
-        // ended, so `run` looks like a live VM process with the recorded identity. (A copied
-        // system binary would be killed at launch: platform binaries only run in place.)
+        // The fixture's executable is a link to the test helper: it accepts any arguments,
+        // leaves them untouched, and runs until ended, so `run` looks like a live VM process
+        // whose recorded identity keeps verifying. (A copied system binary would be killed at
+        // launch: platform binaries only run in place.)
         try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: URL(fileURLWithPath: "/usr/bin/yes"))
+        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: try TestHelper.executable())
         let identities = try ProcessIdentityStore(directory: storage.url(for: .state))
         for identity in recordedIdentities { try await identities.record(identity) }
         let supervisor = OperationSupervisor(store: identities)
@@ -56,7 +57,7 @@ import Testing
         let interrupted = try await store.begin(.startEnvironment, for: environment)
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         try FileManager.default.createDirectory(at: bundle.executable.deletingLastPathComponent(), withIntermediateDirectories: true)
-        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: URL(fileURLWithPath: "/usr/bin/yes"))
+        try FileManager.default.createSymbolicLink(at: bundle.executable, withDestinationURL: try TestHelper.executable())
         let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: storage.url(for: .state)))
         let lifecycle = EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
         try await lifecycle.prepare()
@@ -259,6 +260,102 @@ import Testing
         }
     }
 
+    @Test func stoppingAVMThatIsAlreadyStoppedCompletes() async throws {
+        let runner = tartLikeRunner(running: false)
+        await runner.set("stop", .init(stderr: ["vm \"\(environment.tartVMName)\" is not running"], exit: ProcessExit(reason: .status(1))))
+        let (lifecycle, store, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(5))) { event in events.add(event) }
+        let seen = await collect(events)
+        #expect(seen.last == .completed(stop), "the requested state was already reached")
+        #expect(try await lifecycle.status(of: environment).vm == .stopped)
+        #expect(try await store.replay().inFlight.isEmpty)
+    }
+
+    @Test func cancelDuringAProtectedPhaseIsDeferredNotApplied() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("stop", .init(hangs: true))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(20))) { event in stopEvents.add(event) }
+        for _ in 0..<200 where stopEvents.events.isEmpty { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(stopEvents.events.first == .progress(stop, ProgressPhase(kind: .stoppingVM, cancelable: false)))
+        await lifecycle.cancel(stop)
+        try await Task.sleep(for: .milliseconds(150))
+        #expect(stopEvents.events.count == 1, "a protected phase keeps running after a cancel request")
+        await runner.finishHanging()
+        let seen = await collect(stopEvents)
+        #expect(!seen.contains(.failed(stop, .canceled)), "the stop reports its real outcome, never a cancellation")
+    }
+
+    @Test func anUncertainVerdictIsReconciledAgainWhenStatusIsInspected() async throws {
+        let runner = tartLikeRunner()
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        await runner.set("list", .init(stderr: ["cannot read inventory"], exit: ProcessExit(reason: .status(1))))
+        await lifecycle.reconcile()
+        await #expect(throws: GuesthouseError.vmOwnershipUncertain(environment)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        await runner.set("list", .init(stdout: [listJSON(running: false)]))
+        let status = try await lifecycle.status(of: environment)
+        #expect(status.vm == .stopped, "a readable inventory clears the uncertainty without a restart")
+        #expect(status.readiness == .ready)
+    }
+
+    @Test func aForceStopOfAnAdoptedSurvivorSignalsTheVerifiedProcess() async throws {
+        let survivor = try await ProcessRunner().run(ProcessInvocation(executable: try TestHelper.executable(), arguments: ["run", environment.tartVMName, "--no-graphics"], timeout: .seconds(60)))
+        let enumerator = LiveProcessEnumerator()
+        let live = try #require(enumerator.live(pid: survivor.processIdentifier))
+        let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        let runner = tartLikeRunner(running: true)
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner, recordedIdentities: [identity])
+        try await lifecycle.prepare()
+        let adopted = try await lifecycle.status(of: environment)
+        #expect(adopted.vm == .running)
+        #expect(adopted.guestAddress != nil, "an adopted survivor's address is looked up")
+        let events = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .force) { event in events.add(event) }
+        let seen = await collect(events)
+        #expect(seen.last == .completed(stop))
+        #expect(enumerator.live(pid: survivor.processIdentifier) == nil, "the adopted process was ended")
+        #expect(!(await runner.invocations.map(\.arguments).contains { $0.first == "stop" }), "no graceful tart stop stands in for a force-stop")
+    }
+
+    @Test func aFailureTheJournalCannotRecordStaysUnresolved() async throws {
+        let runner = tartLikeRunner()
+        // The address lookup hangs; once the start is waiting for it the journal is made
+        // unwritable and the operation is canceled, so its terminal record cannot be written.
+        await runner.set("ip", .init(hangs: true))
+        let (lifecycle, store, storage) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let state = storage.url(for: .state)
+        let start = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        for _ in 0..<400 where events.events.count < 2 { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(events.events.last == .progress(start, ProgressPhase(kind: .waitingForNetwork)))
+        // The journal file is replaced by a symbolic link, which the store refuses to open.
+        let journal = state.appending(path: "journal.ndjson")
+        let original = try Data(contentsOf: journal)
+        try FileManager.default.removeItem(at: journal)
+        try FileManager.default.createSymbolicLink(at: journal, withDestinationURL: URL(fileURLWithPath: "/dev/null"))
+        defer { try? FileManager.default.removeItem(at: journal); try? original.write(to: journal) }
+        await lifecycle.cancel(start)
+        let seen = await collect(events)
+        await runner.finishHanging()
+        #expect(seen.last == .failed(start, .operationOutcomeUnknown(start)), "an unrecorded failure is reported as unknown, never as a plain failure")
+        #expect(try await lifecycle.status(of: environment).readiness == .needsAttention(.operationOutcomeUnknown(start)))
+        await #expect(throws: GuesthouseError.operationOutcomeUnknown(start)) {
+            _ = try await lifecycle.start(environment, options: StartOptions()) { _ in }
+        }
+        _ = store
+    }
+
     @Test func unknownEnvironmentIsRefused() async throws {
         let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner())
         try await lifecycle.prepare()
@@ -273,4 +370,22 @@ final class EventCollector: Sendable {
     private let storage = Mutex<[RuntimeEvent]>([])
     var events: [RuntimeEvent] { storage.withLock { $0 } }
     func add(_ event: RuntimeEvent) { storage.withLock { $0.append(event) } }
+}
+
+/// The fixture executable built alongside the tests (`GuesthouseKitTestHelper`): SwiftPM and
+/// Xcode both place package executables next to the test bundle.
+enum TestHelper {
+    static func executable() throws -> URL {
+        let bundle = Bundle(for: EventCollector.self).bundleURL
+        let candidates = [
+            bundle.deletingLastPathComponent().appending(path: "GuesthouseKitTestHelper"),
+            bundle.deletingLastPathComponent().deletingLastPathComponent().appending(path: "GuesthouseKitTestHelper"),
+        ]
+        guard let found = candidates.first(where: { FileManager.default.isExecutableFile(atPath: $0.path) }) else {
+            throw TestHelperError.notBuilt(candidates.map(\.path))
+        }
+        return found
+    }
+
+    enum TestHelperError: Error { case notBuilt([String]) }
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
@@ -2,28 +2,58 @@ import Foundation
 import GuesthouseCore
 @testable import GuesthouseRuntimeKit
 
-/// A `ProcessRunning` that never launches anything: it records invocations and replays
-/// scripted output and an exit.
+/// A `ProcessRunning` that never launches anything: it records invocations and answers each
+/// from a script keyed by the first argument, or from fixed output.
 actor FakeProcessRunner: ProcessRunning {
+    struct Reply: Sendable {
+        var stdout: [String] = []
+        var stderr: [String] = []
+        var exit: ProcessExit = ProcessExit(reason: .status(0))
+        /// The run stays alive until `finishHanging` or termination.
+        var hangs = false
+    }
+
     private(set) var invocations: [ProcessInvocation] = []
-    private let stdout: [String]
-    private let stderr: [String]
-    private let exit: ProcessExit
+    private var fixed: Reply
+    private var script: [String: Reply] = [:]
+    private var hanging: [ProcessRun] = []
 
     init(stdout: [String] = [], stderr: [String] = [], exit: ProcessExit) {
-        self.stdout = stdout
-        self.stderr = stderr
-        self.exit = exit
+        fixed = Reply(stdout: stdout, stderr: stderr, exit: exit)
+    }
+
+    init(script: [String: Reply]) {
+        fixed = Reply()
+        self.script = script
+    }
+
+    func set(_ command: String, _ reply: Reply) { script[command] = reply }
+
+    /// Ends every hanging run. Hanging runs are real `sleep` processes (so they have a pid and
+    /// a start time the supervisor can record); ending them terminates the process, and the
+    /// run reports a `terminated` exit with SIGTERM.
+    func finishHanging(with exit: ProcessExit = ProcessExit(reason: .status(0))) async {
+        for run in hanging {
+            run.terminate(gracePeriod: .milliseconds(200))
+            _ = await run.exit()
+        }
+        hanging.removeAll()
     }
 
     func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
         invocations.append(invocation)
+        let reply = invocation.arguments.first.flatMap { script[$0] } ?? fixed
+        if reply.hangs {
+            let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["600"], timeout: .seconds(600)))
+            hanging.append(run)
+            return run
+        }
         let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self, bufferingPolicy: .unbounded)
         let run = ProcessRun(process: Process(), output: stream, continuation: continuation)
         let redactor = Redactor()
-        for line in stdout { continuation.yield(.stdout(redactor.redact(lines: [line])[0])) }
-        for line in stderr { continuation.yield(.stderr(redactor.redact(lines: [line])[0])) }
-        run.finish(with: exit.reason)
+        for line in reply.stdout { continuation.yield(.stdout(redactor.redact(lines: [line])[0])) }
+        for line in reply.stderr { continuation.yield(.stderr(redactor.redact(lines: [line])[0])) }
+        run.finish(with: reply.exit.reason)
         return run
     }
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
@@ -14,6 +14,9 @@ actor FakeProcessRunner: ProcessRunning {
         /// How long the command takes before it answers, so a test can act while it is in
         /// flight without having to end it.
         var delay: Duration = .zero
+        /// The program itself cannot be started, as when the runtime bundle has been removed.
+        /// Nothing runs, so the command has no exit status of its own.
+        var failsToLaunch = false
     }
 
     private(set) var invocations: [ProcessInvocation] = []
@@ -57,8 +60,14 @@ actor FakeProcessRunner: ProcessRunning {
     func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
         invocations.append(invocation)
         let command = invocation.arguments.first ?? ""
+        let delay = (script[command] ?? fixed).delay
+        if delay > .zero { try? await Task.sleep(for: delay) }
+        // Read after the delay, so a test can change what a command answers while that command
+        // is already in flight.
         let reply = script[command] ?? fixed
-        if reply.delay > .zero { try? await Task.sleep(for: reply.delay) }
+        if reply.failsToLaunch {
+            throw ProcessLaunchError.executableNotFound(invocation.executable.lastPathComponent)
+        }
         if reply.hangs {
             // A real process, so the supervisor can record a pid and a start time. When the
             // invocation's executable exists (a fixture bundle whose binary is a copy of

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
@@ -44,7 +44,12 @@ actor FakeProcessRunner: ProcessRunning {
         invocations.append(invocation)
         let reply = invocation.arguments.first.flatMap { script[$0] } ?? fixed
         if reply.hangs {
-            let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["600"], timeout: .seconds(600)))
+            // A real process, so the supervisor can record a pid and a start time. When the
+            // invocation's executable exists (a fixture bundle whose binary is a copy of
+            // `yes`), it runs with the invocation's own arguments so identity checks hold.
+            let executable = FileManager.default.isExecutableFile(atPath: invocation.executable.path) ? invocation.executable : URL(fileURLWithPath: "/bin/sleep")
+            let arguments = executable == invocation.executable ? invocation.arguments : ["600"]
+            let run = try await ProcessRunner().run(ProcessInvocation(executable: executable, arguments: arguments, timeout: min(invocation.timeout, .seconds(600)), terminationGracePeriod: .milliseconds(500), maximumOutputBytes: 64 << 10))
             hanging.append(run)
             return run
         }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
@@ -11,12 +11,15 @@ actor FakeProcessRunner: ProcessRunning {
         var exit: ProcessExit = ProcessExit(reason: .status(0))
         /// The run stays alive until `finishHanging` or termination.
         var hangs = false
+        /// How long the command takes before it answers, so a test can act while it is in
+        /// flight without having to end it.
+        var delay: Duration = .zero
     }
 
     private(set) var invocations: [ProcessInvocation] = []
     private var fixed: Reply
     private var script: [String: Reply] = [:]
-    private var hanging: [ProcessRun] = []
+    private var hanging: [(command: String, run: ProcessRun)] = []
 
     init(stdout: [String] = [], stderr: [String] = [], exit: ProcessExit) {
         fixed = Reply(stdout: stdout, stderr: stderr, exit: exit)
@@ -33,16 +36,29 @@ actor FakeProcessRunner: ProcessRunning {
     /// a start time the supervisor can record); ending them terminates the process, and the
     /// run reports a `terminated` exit with SIGTERM.
     func finishHanging(with exit: ProcessExit = ProcessExit(reason: .status(0))) async {
-        for run in hanging {
-            run.terminate(gracePeriod: .milliseconds(200))
-            _ = await run.exit()
+        await finishHanging { _ in true }
+    }
+
+    /// Ends only the hanging runs of one command, so a test can end the VM's own process while
+    /// another query is still in flight.
+    func finishHanging(command: String) async {
+        await finishHanging { $0 == command }
+    }
+
+    private func finishHanging(_ matches: (String) -> Bool) async {
+        let ending = hanging.filter { matches($0.command) }
+        hanging.removeAll { matches($0.command) }
+        for entry in ending {
+            entry.run.terminate(gracePeriod: .milliseconds(200))
+            _ = await entry.run.exit()
         }
-        hanging.removeAll()
     }
 
     func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
         invocations.append(invocation)
-        let reply = invocation.arguments.first.flatMap { script[$0] } ?? fixed
+        let command = invocation.arguments.first ?? ""
+        let reply = script[command] ?? fixed
+        if reply.delay > .zero { try? await Task.sleep(for: reply.delay) }
         if reply.hangs {
             // A real process, so the supervisor can record a pid and a start time. When the
             // invocation's executable exists (a fixture bundle whose binary is a copy of
@@ -50,7 +66,7 @@ actor FakeProcessRunner: ProcessRunning {
             let executable = FileManager.default.isExecutableFile(atPath: invocation.executable.path) ? invocation.executable : URL(fileURLWithPath: "/bin/sleep")
             let arguments = executable == invocation.executable ? invocation.arguments : ["600"]
             let run = try await ProcessRunner().run(ProcessInvocation(executable: executable, arguments: arguments, timeout: min(invocation.timeout, .seconds(600)), terminationGracePeriod: .milliseconds(500), maximumOutputBytes: 64 << 10))
-            hanging.append(run)
+            hanging.append((command: command, run: run))
             return run
         }
         let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self, bufferingPolicy: .unbounded)

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -62,7 +62,8 @@ import Testing
     }
 
     @Test func anUnreadableProcessIsNeverReportedAsExited() async throws {
-        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: root))
+        let store = try ProcessIdentityStore(directory: root)
+        let supervisor = OperationSupervisor(store: store)
         let environment = EnvironmentID()
         let arguments = ["-e", "sleep 47", "run", environment.tartVMName]
         let fixture = URL(fileURLWithPath: "/usr/bin/perl")
@@ -71,15 +72,19 @@ import Testing
         let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
         #expect(supervisor.observe(identity) == .present(live))
 
-        // PID 1 is launchd: it exists, and this process cannot read its arguments, so the
-        // process table declines to describe it. Supervision must not read that as an exit.
-        guard case .unavailable = LiveProcessEnumerator().observe(pid: 1) else {
-            Issue.record("launchd is readable here, so it no longer stands in for an unobservable process")
+        // A process this user owns whose arguments the kernel declines to describe: the one
+        // shape that is genuinely unobservable. PID 1 is not it — launchd belongs to root, so
+        // the recorded process it once was is certainly gone.
+        let blind = LiveProcessEnumerator(kernel: .init(pids: { LiveProcessEnumerator.listAllPIDs() }, arguments: { _ in nil }))
+        guard case .unavailable = blind.observe(pid: run.processIdentifier) else {
+            Issue.record("an owned process with unreadable arguments must be unobservable")
             return
         }
-        let unreadable = ProcessIdentity(pid: 1, startTime: identity.startTime, executablePath: "/sbin/launchd", argumentsDigest: identity.argumentsDigest, vmName: identity.vmName, environmentID: environment, recordedAt: Date())
-        #expect(supervisor.observe(unreadable) == .unavailable)
-        #expect(supervisor.verify(unreadable) == nil, "unreadable is still not verified")
+        #expect(LiveProcessEnumerator().observe(pid: 1) == .absent, "another account's process is not the one we recorded")
+        let unreadable = ProcessIdentity(pid: run.processIdentifier, startTime: identity.startTime, executablePath: live.executablePath, argumentsDigest: identity.argumentsDigest, vmName: identity.vmName, environmentID: environment, recordedAt: Date())
+        let blindSupervisor = OperationSupervisor(store: store, enumerator: blind)
+        #expect(blindSupervisor.observe(unreadable) == .unavailable)
+        #expect(blindSupervisor.verify(unreadable) == nil, "unreadable is still not verified")
 
         run.terminate(gracePeriod: .milliseconds(100))
         _ = await run.exit()
@@ -154,8 +159,8 @@ import Testing
         let enumerator = LiveProcessEnumerator()
         #expect(enumerator.observe(pid: 2_000_000_000) == .absent)
         #expect(enumerator.observe(pid: 0) == .absent)
-        // launchd exists but its arguments are not readable by an ordinary user.
-        guard case .unavailable = enumerator.observe(pid: 1) else { Issue.record("expected launchd to be unobservable"); return }
+        // launchd exists, but it belongs to root: whatever was recorded under that PID is gone.
+        #expect(enumerator.observe(pid: 1) == .absent)
         let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["39"], timeout: .seconds(20)))
         defer { run.terminate(gracePeriod: .milliseconds(100)) }
         guard case .present(let live) = enumerator.observe(pid: run.processIdentifier) else { Issue.record("expected the spawned process"); return }
@@ -165,8 +170,13 @@ import Testing
     @Test func anUnobservableRecordedProcessIsUncertainNotExited() async throws {
         let store = try ProcessIdentityStore(directory: root)
         let environment = EnvironmentID()
-        try await store.record(ProcessIdentity(pid: 1, startTime: Date(timeIntervalSince1970: 0), executablePath: "/sbin/launchd", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date()))
-        let verdicts = await OperationSupervisor(store: store).reconcile(environments: []) { _ in .absent }
+        // A live process of this user's whose arguments the kernel will not describe: the
+        // reconciler must not read that refusal as an exit.
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["37"], timeout: .seconds(20)))
+        defer { run.terminate(gracePeriod: .milliseconds(100)) }
+        let blind = LiveProcessEnumerator(kernel: .init(pids: { LiveProcessEnumerator.listAllPIDs() }, arguments: { _ in nil }))
+        try await store.record(ProcessIdentity(pid: run.processIdentifier, startTime: Date(timeIntervalSince1970: 0), executablePath: "/bin/sleep", argumentsDigest: "sha256:0", vmName: environment.tartVMName, environmentID: environment, recordedAt: Date()))
+        let verdicts = await OperationSupervisor(store: store, enumerator: blind).reconcile(environments: []) { _ in .absent }
         #expect(verdicts[environment] == .uncertain(.processUnobservable))
     }
 

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SupervisionTests.swift
@@ -61,6 +61,33 @@ import Testing
         #expect(await store.all.isEmpty)
     }
 
+    @Test func anUnreadableProcessIsNeverReportedAsExited() async throws {
+        let supervisor = OperationSupervisor(store: try ProcessIdentityStore(directory: root))
+        let environment = EnvironmentID()
+        let arguments = ["-e", "sleep 47", "run", environment.tartVMName]
+        let fixture = URL(fileURLWithPath: "/usr/bin/perl")
+        let run = try await ProcessRunner().run(ProcessInvocation(executable: fixture, arguments: arguments, timeout: .seconds(20)))
+        let live = try #require(LiveProcessEnumerator().live(pid: run.processIdentifier))
+        let identity = ProcessIdentity(pid: live.pid, startTime: live.startTime, executablePath: live.executablePath, argumentsDigest: live.argumentsDigest, vmName: environment.tartVMName, environmentID: environment, recordedAt: Date())
+        #expect(supervisor.observe(identity) == .present(live))
+
+        // PID 1 is launchd: it exists, and this process cannot read its arguments, so the
+        // process table declines to describe it. Supervision must not read that as an exit.
+        guard case .unavailable = LiveProcessEnumerator().observe(pid: 1) else {
+            Issue.record("launchd is readable here, so it no longer stands in for an unobservable process")
+            return
+        }
+        let unreadable = ProcessIdentity(pid: 1, startTime: identity.startTime, executablePath: "/sbin/launchd", argumentsDigest: identity.argumentsDigest, vmName: identity.vmName, environmentID: environment, recordedAt: Date())
+        #expect(supervisor.observe(unreadable) == .unavailable)
+        #expect(supervisor.verify(unreadable) == nil, "unreadable is still not verified")
+
+        run.terminate(gracePeriod: .milliseconds(100))
+        _ = await run.exit()
+        #expect(supervisor.observe(identity) == .absent, "a process that ended is definitely gone")
+        let neverExisted = ProcessIdentity(pid: 2_000_000_000, startTime: identity.startTime, executablePath: identity.executablePath, argumentsDigest: identity.argumentsDigest, vmName: identity.vmName, environmentID: environment, recordedAt: Date())
+        #expect(supervisor.observe(neverExisted) == .absent)
+    }
+
     @Test func aReusedPIDIsNeverMistakenForTheRecordedProcess() async throws {
         let store = try ProcessIdentityStore(directory: root)
         let supervisor = OperationSupervisor(store: store)


### PR DESCRIPTION
## Summary

Implements #25 (`MVP-PLAN.md` §3 `TartBackend` start/stop/inventory/IP discovery; §10 Phase 1 "one environment and one in-flight lifecycle operation"; §2 Quit waits for the guest and Tart, force-stop is separate; §4 never run two Tart instances against one disk, refuse when ownership is uncertain). Stacked on #72.

- `TartBackend`: `list` (`tart list --format json`), `ip` (`tart ip <vm> --wait N`), `run` (`tart run <vm>`, `--no-graphics` unless the native console is requested; the service chooses every flag), `stop` (`tart stop <vm> --timeout N`). All with the `TART_HOME`-only environment.
- `EnvironmentLifecycle` (actor, in the kit so it is unit-tested): `prepare()` loads the snapshot, adopts any `guesthouse-<uuid>` VM found in the store into a free slot (how a hand-created phase-0 VM becomes an environment; nothing is created), and reconciles recorded processes. `start` refuses on unknown environment, in-flight operation, uncertain ownership, or an already running VM; journals `started` before returning the operation id; then streams `startingVM`, launches, records the process identity and holds a VM transaction, journals the checkpoint, waits for the address (`waitingForNetwork`), journals `completed`, and pushes `status` then `completed`. An unreachable guest fails the operation but keeps the VM supervised. `stop` is graceful through Tart with the requested deadline, waiting for the supervised process to exit, or `force` terminates the process; the slot state is released only after the process is gone. `cancel` cancels the in-flight task. `status` combines inventory, supervision, verdicts, and the in-flight operation; an uncertain verdict surfaces as `vm: .uncertain` with `needsAttention(operationOutcomeUnknown)`.
- Service: lifecycle requests are answered asynchronously through `XPCReceivedMessage.reply` and events are pushed with `session.send`; the lifecycle comes up after Tart discovery succeeds and requests before that fail with `runtimeMissing` or `runtimeIncompatible`.
- Contract additions carried here: `listEnvironments` → `environments([DevelopmentEnvironment])` (the GUI cannot read the runtime's storage), `EnvironmentStatus.guestAddress`, and errors `environmentNotFound`, `environmentAlreadyRunning`, `operationInFlight`. `RuntimeClient` and the fake backend handle the new event.
- VM creation from a restore image remains Phase 2; the manual run against a real VM is gate #35.

Tests (9 lifecycle tests with a Tart-like scripted runner whose long-running `run` is a real `sleep` so the supervisor can record it): adoption into free slots only, start journals before reporting then supervises and resolves the address (with argument and environment assertions), native console flag, second operation refused while one is in flight, unreachable guest fails but stays supervised, graceful stop waits for the process, force stop terminates it, uncertain ownership blocks start, unknown environment refused. Core and app tests pass.

Closes #25

## Checklist

- [x] Tests cover the new logic; kit, core, and app test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] Processes are launched only through `ProcessRunning` in the kit
- [x] Diff is larger than 500 lines because the lifecycle actor and its tests are one unit; split further would leave untestable halves

🤖 Generated with [Claude Code](https://claude.com/claude-code)