### PR TITLE
GUI: environment dashboard with one or two environment cards

### DIFF
--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -406,6 +406,11 @@ final class AppModel {
                 }
             }
         } catch {
+            // The query never answered. What was cached says nothing about the VM now, and
+            // Quit must not choose stop targets from it: the status is dropped and the
+            // environment is marked as unanswered, exactly as a failed reply would.
+            statuses[id] = nil
+            statusQueryFailures.insert(id)
             launchState = .interrupted(RuntimeConnectionInterrupted())
         }
     }

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -194,6 +194,7 @@ final class AppModel {
             environments = listed
             statuses = fresh
             launchState = .ready
+            Task { await pollRecoveredOperations() }
         case .unavailable(let error):
             launchState = .unavailable(error)
             // An unavailable runtime is not something reconnecting fixes: the error carries
@@ -348,6 +349,32 @@ final class AppModel {
         }
     }
 
+    /// The runtime runs one lifecycle operation at a time and one VM at a time
+    /// (MVP-PLAN.md §4, §6), so a start on any card is refused while another environment is
+    /// running or any operation is in flight.
+    var globalStartBlock: String? {
+        if let busy = operations.keys.first ?? statuses.values.first(where: { $0.inFlightOperation != nil })?.environmentID,
+           let name = environments.first(where: { $0.id == busy })?.name {
+            return "An operation is in progress on \(name)."
+        }
+        if let running = runningEnvironments.first {
+            return "\(running.name) is running. Guesthouse runs one development Mac at a time until resource validation allows two."
+        }
+        return nil
+    }
+
+    /// Statuses that name an operation this app did not start (one recovered after a
+    /// relaunch) are re-queried until they become terminal, so a card never stays busy for
+    /// an operation nobody observes.
+    func pollRecoveredOperations() async {
+        while !Task.isCancelled {
+            let recovered = statuses.values.filter { $0.inFlightOperation != nil && operations[$0.environmentID] == nil }.map(\.environmentID)
+            if recovered.isEmpty { return }
+            try? await Task.sleep(for: .seconds(2))
+            for id in recovered { await refreshStatus(of: id) }
+        }
+    }
+
     /// Re-reads one environment's status after an operation, whatever its outcome.
     func refreshStatus(of id: EnvironmentID) async {
         do {
@@ -363,8 +390,15 @@ final class AppModel {
 
     /// One card per environment, in creation order.
     func cardStates() -> [EnvironmentCardState] {
-        environments.map { environment in
-            EnvironmentCardState(environment: environment, status: statuses[environment.id], operation: operations[environment.id], lastError: lastErrors[environment.id])
+        let block = globalStartBlock
+        return environments.map { environment in
+            EnvironmentCardState(
+                environment: environment,
+                status: statuses[environment.id],
+                operation: operations[environment.id],
+                lastError: lastErrors[environment.id],
+                startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil
+            )
         }
     }
 
@@ -380,7 +414,7 @@ final class AppModel {
 
     /// Starts an environment. The only dashboard action wired to the runtime so far.
     func start(_ id: EnvironmentID) {
-        guard environments.contains(where: { $0.id == id }), operations[id] == nil else { return }
+        guard environments.contains(where: { $0.id == id }), operations[id] == nil, globalStartBlock == nil else { return }
         Task { await run(.startEnvironment(id, StartOptions()), for: id) }
     }
 
@@ -583,6 +617,12 @@ final class AppModel {
             quitFlow = quitFailure()
             return
         }
+        // A start accepted moments ago has not reported `running` yet; the decision waits
+        // for every active operation and re-reads the statuses before choosing targets.
+        await waitForOperations()
+        guard generation == quitGeneration, !Task.isCancelled, !quitCancelRequested else { finishCancel(reconcile: true); return }
+        // The mode still decides how they are stopped: only the environments whose graceful
+        // stop already failed are force-stopped.
         quitFlow = mode == .force ? .forceStopping(nil) : .stopping(nil, nil)
         // An operation the runtime still reports is unresolved, whatever the VM state says:
         // quitting over it could leave a VM the app never saw start.
@@ -591,6 +631,16 @@ final class AppModel {
             return
         }
         await stopAll(mode: mode, generation: generation)
+    }
+
+    private func waitForOperations() async {
+        while !operations.isEmpty, !Task.isCancelled {
+            quitFlow = .stopping(operations.keys.first, nil)
+            try? await Task.sleep(for: .milliseconds(50))
+        }
+        for environment in environments where !Task.isCancelled {
+            await refreshStatus(of: environment.id)
+        }
     }
 
     /// Stops every running environment. `mode` is `.force` only for the environments whose

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -39,11 +39,20 @@ final class AppModel {
         case terminating
     }
 
+    /// An operation this app started and is still listening to.
+    struct OperationState: Equatable {
+        var id: OperationID
+        var phase: ProgressPhase?
+    }
+
     static let gracefulStopDeadline: Duration = .seconds(60)
 
     private(set) var launchState: LaunchState = .checkingEnvironment
     private(set) var environments: [DevelopmentEnvironment] = []
     private(set) var statuses: [EnvironmentID: EnvironmentStatus] = [:]
+    private(set) var operations: [EnvironmentID: OperationState] = [:]
+    /// The last failure per environment, cleared when an operation completes.
+    private(set) var lastErrors: [EnvironmentID: GuesthouseError] = [:]
     private(set) var quitFlow: QuitFlow = .idle
     /// The user canceled during a step that must run to its end; honored when it ends.
     private(set) var quitCancelRequested = false
@@ -337,6 +346,75 @@ final class AppModel {
             if case .uncertain = statuses[$0.id]?.vm { return true }
             return false
         }
+    }
+
+    /// Re-reads one environment's status after an operation, whatever its outcome.
+    func refreshStatus(of id: EnvironmentID) async {
+        do {
+            for try await event in backend.send(.environmentStatus(id)) {
+                if case .status(let status) = event { statuses[id] = status }
+            }
+        } catch {
+            launchState = .interrupted(RuntimeConnectionInterrupted())
+        }
+    }
+
+    // MARK: - Dashboard
+
+    /// One card per environment, in creation order.
+    func cardStates() -> [EnvironmentCardState] {
+        environments.map { environment in
+            EnvironmentCardState(environment: environment, status: statuses[environment.id], operation: operations[environment.id], lastError: lastErrors[environment.id])
+        }
+    }
+
+    /// Whether a new development Mac can be created. At most two exist, stopped and
+    /// preserved ones included (MVP-PLAN.md §1).
+    var createAvailability: EnvironmentCardState.Availability {
+        guard launchState == .ready else { return .disabled(reason: "Checking environment") }
+        if environments.count >= VMSlotInventory.maximumSlots {
+            return .disabled(reason: "Guesthouse manages at most \(VMSlotInventory.maximumSlots) development Macs, including stopped and preserved ones. Export any unpublished work from one you no longer need, then delete it to make room.")
+        }
+        return .enabled
+    }
+
+    /// Starts an environment. The only dashboard action wired to the runtime so far.
+    func start(_ id: EnvironmentID) {
+        guard environments.contains(where: { $0.id == id }), operations[id] == nil else { return }
+        Task { await run(.startEnvironment(id, StartOptions()), for: id) }
+    }
+
+    private func run(_ request: RuntimeRequest, for id: EnvironmentID) async {
+        lastErrors[id] = nil
+        operations[id] = OperationState(id: OperationID(), phase: nil)
+        do {
+            for try await event in backend.send(request) {
+                switch event {
+                case .accepted(let operation): operations[id] = OperationState(id: operation, phase: nil)
+                case .progress(_, let phase): operations[id]?.phase = phase
+                case .status(let status): statuses[status.environmentID] = status
+                case .failed(_, let error): lastErrors[id] = error
+                case .completed: lastErrors[id] = nil
+                default: break
+                }
+            }
+        } catch {
+            // The outcome is unknown until the runtime is asked again; never replay.
+            launchState = .interrupted(RuntimeConnectionInterrupted())
+        }
+        operations[id] = nil
+        await refreshStatus(of: id)
+    }
+
+    /// A model over a preview scenario's environments and scripted backend, already refreshed.
+    static func preview(_ scenario: PreviewScenario) async -> AppModel {
+        await scenario.backend.setEnvironments(scenario.snapshot.environments)
+        let model = AppModel(backend: scenario.backend) { _ in }
+        await model.refresh()
+        if let request = scenario.initialRequest, case .startEnvironment(let id, _) = request {
+            model.start(id)
+        }
+        return model
     }
 
     // MARK: - Quit contract

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -58,6 +58,10 @@ final class AppModel {
     /// Environments whose last status query failed, so a later success can clear that
     /// error without erasing what a failed operation reported.
     private var statusQueryFailures: Set<EnvironmentID> = []
+    /// Orders the status inspections of one environment against each other: the next ticket to
+    /// hand out, and the newest one whose reply has been published.
+    private var statusQueryTickets: [EnvironmentID: UInt64] = [:]
+    private var publishedStatusTicket: [EnvironmentID: UInt64] = [:]
     private(set) var lastErrors: [EnvironmentID: GuesthouseError] = [:]
     private(set) var quitFlow: QuitFlow = .idle
     /// The user canceled during a step that must run to its end; honored when it ends.
@@ -94,6 +98,22 @@ final class AppModel {
     /// answered has nothing left to throw into, so the loss is kept here and settles that
     /// reconciliation's own result instead of being discarded.
     private var lossLeftToReconciliation: RuntimeConnectionInterrupted?
+    /// The one poll that follows operations only the runtime reports. Owned by the model, so
+    /// every reconciliation replaces it instead of adding another.
+    private var recoveredOperationPoll: Task<Void, Never>?
+    /// How long that poll waits between inspections. The runtime runs a Tart command for each
+    /// status query, so inspections are seconds apart rather than several times a second.
+    var recoveredOperationPollInterval: Duration = .seconds(2)
+    /// How many of those polls are running. The model owns one at a time, so this is 0 or 1.
+    private(set) var recoveredOperationPolls = 0
+    /// What the service reports about itself and the Tart bundle it verified. The per-status
+    /// observation carries no Tart version, so this is where the dashboard's tool-version row
+    /// comes from (MVP-PLAN.md §2).
+    private(set) var runtimeVersion: RuntimeVersionInfo?
+    /// How many inspections of an environment are still outstanding. A card tells a check that
+    /// is running from one that already ended in failure, so a query nobody is waiting for is
+    /// never presented as one still in progress.
+    private var statusQueriesInFlight: [EnvironmentID: Int] = [:]
 
     /// - Parameters:
     ///   - backend: the runtime, or a fake for previews and tests.
@@ -196,11 +216,20 @@ final class AppModel {
         if let loss = lossLeftToReconciliation, case .ready = outcome { settled = .interrupted(loss) }
         lossLeftToReconciliation = nil
         switch settled {
-        case .ready(let listed, let fresh):
+        case .ready(let listed, let fresh, let version):
             environments = listed
             statuses = fresh
+            // Assigned whatever the supplementary request answered: a service that could not
+            // describe itself this time has not confirmed the version it gave last time, and
+            // the MVP-PLAN.md §2 tool-version row says Unknown rather than repeating a value
+            // nothing verified.
+            runtimeVersion = version
+            // These environments answered, so a failure of an earlier *query* is history,
+            // exactly as it is after a single successful status query. A failed operation's
+            // error stays: it is what the card explains.
+            for id in fresh.keys where statusQueryFailures.remove(id) != nil { lastErrors[id] = nil }
             launchState = .ready
-            Task { await pollRecoveredOperations() }
+            startRecoveredOperationPoll()
         case .unavailable(let error):
             launchState = .unavailable(error)
             // An unavailable runtime is not something reconnecting fixes: the error carries
@@ -216,7 +245,7 @@ final class AppModel {
     }
 
     private enum ReconcileOutcome {
-        case ready([DevelopmentEnvironment], [EnvironmentID: EnvironmentStatus])
+        case ready([DevelopmentEnvironment], [EnvironmentID: EnvironmentStatus], RuntimeVersionInfo?)
         case unavailable(GuesthouseError)
         case interrupted(RuntimeConnectionInterrupted)
     }
@@ -238,7 +267,13 @@ final class AppModel {
                     if case .failed(_, let error) = event { return .unavailable(error) }
                 }
             }
-            return .ready(listed, fresh)
+            // Supplementary: the environments were read, so a service that cannot describe
+            // itself leaves the version row unknown rather than making the app unavailable.
+            var version: RuntimeVersionInfo?
+            for try await event in backend.send(.runtimeVersion) {
+                if case .runtimeVersion(let info) = event { version = info }
+            }
+            return .ready(listed, fresh, version)
         } catch let error as RuntimeConnectionInterrupted {
             return .interrupted(error)
         } catch {
@@ -315,13 +350,17 @@ final class AppModel {
     /// establish is named, never folded into "no development Mac running": that would report
     /// an unproven stopped state as fact (MVP-PLAN.md §4).
     var runningSummary: String {
+        var parts: [String] = []
         let running = runningEnvironments.count
+        if running > 0 { parts.append("\(running) running") }
         let uncertain = uncertainEnvironments.count
-        guard uncertain > 0 else {
-            return running == 0 ? "No development Mac running" : "\(running) running"
-        }
-        let unproven = "\(uncertain) development Mac\(uncertain == 1 ? "" : "s") Guesthouse cannot identify"
-        return running == 0 ? unproven : "\(running) running, \(unproven)"
+        if uncertain > 0 { parts.append("\(uncertain) development Mac\(uncertain == 1 ? "" : "s") Guesthouse cannot identify") }
+        // An environment whose last check did not answer is not a stopped one either: leaving
+        // it out would let one failed query report an unknown VM as "no development Mac
+        // running", which is the same unproven claim uncertainty is kept out of.
+        let unread = unreadEnvironments.count
+        if unread > 0 { parts.append("\(unread) development Mac\(unread == 1 ? "" : "s") Guesthouse could not check") }
+        return parts.isEmpty ? "No development Mac running" : parts.joined(separator: ", ")
     }
 
     /// What the Quit confirmation says about the state it is about to act on.
@@ -332,18 +371,29 @@ final class AppModel {
     /// itself refuses over an uncertain environment, so promising a clean quit here would be
     /// contradicted a moment later (MVP-PLAN.md §4).
     var quitConfirmationMessage: String {
+        var sentences: [String] = []
         let running = runningEnvironments.count
-        let uncertain = uncertainEnvironments.count
-        let stops = running == 1
-            ? "Quitting stops the running development Mac first."
-            : "Quitting stops all running development Macs first."
-        guard uncertain > 0 else {
-            return running == 0 ? "No development Mac is running." : stops
+        if running > 0 {
+            sentences.append(running == 1
+                ? "Quitting stops the running development Mac first."
+                : "Quitting stops all running development Macs first.")
         }
-        let unproven = uncertain == 1
-            ? "Guesthouse cannot tell whether one development Mac is running, and cannot stop it until that is checked."
-            : "Guesthouse cannot tell whether \(uncertain) development Macs are running, and cannot stop them until that is checked."
-        return running == 0 ? unproven : "\(stops) \(unproven)"
+        let uncertain = uncertainEnvironments.count
+        if uncertain > 0 {
+            sentences.append(uncertain == 1
+                ? "Guesthouse cannot tell whether one development Mac is running, and cannot stop it until that is checked."
+                : "Guesthouse cannot tell whether \(uncertain) development Macs are running, and cannot stop them until that is checked.")
+        }
+        // An environment whose last check did not answer is unproven in the same way, and this
+        // is the sentence the Quit-or-Cancel decision is made on: reporting it as nothing
+        // running would state a stopped VM as fact on the strength of a query that failed.
+        let unread = unreadEnvironments.count
+        if unread > 0 {
+            sentences.append(unread == 1
+                ? "One development Mac did not answer its last check, so Guesthouse cannot tell whether it is running."
+                : "\(unread) development Macs did not answer their last check, so Guesthouse cannot tell whether they are running.")
+        }
+        return sentences.isEmpty ? "No development Mac is running." : sentences.joined(separator: " ")
     }
 
     /// Environments whose VM ownership the runtime could not establish. Neither stop mode is
@@ -355,6 +405,12 @@ final class AppModel {
         }
     }
 
+    /// Environments with no status at all: the last query for them failed or was lost. Nothing
+    /// is known about their VM, which is not the same as knowing it is stopped.
+    var unreadEnvironments: [DevelopmentEnvironment] {
+        environments.filter { statuses[$0.id] == nil }
+    }
+
     /// The runtime runs one lifecycle operation at a time and one VM at a time
     /// (MVP-PLAN.md §4, §6), so a start on any card is refused while another environment is
     /// running or any operation is in flight.
@@ -362,6 +418,12 @@ final class AppModel {
         if let busy = operations.keys.first ?? statuses.values.first(where: { $0.inFlightOperation != nil })?.environmentID,
            let name = environments.first(where: { $0.id == busy })?.name {
             return "An operation is in progress on \(name)."
+        }
+        // An environment that has not answered its last check says nothing about its VM or
+        // about an operation on it. The runtime runs one VM and one operation at a time, so
+        // nothing is started until it answers (MVP-PLAN.md §2).
+        if let unread = environments.first(where: { statuses[$0.id] == nil }) {
+            return "\(unread.name) has not answered its last check. Check it before starting another development Mac."
         }
         if let running = runningEnvironments.first {
             return "\(running.name) is running. Guesthouse runs one development Mac at a time until resource validation allows two."
@@ -378,26 +440,84 @@ final class AppModel {
     /// relaunch) are re-queried until they become terminal, so a card never stays busy for
     /// an operation nobody observes.
     func pollRecoveredOperations() async {
+        recoveredOperationPolls += 1
+        defer { recoveredOperationPolls -= 1 }
         while !Task.isCancelled {
             let recovered = statuses.values.filter { $0.inFlightOperation != nil && operations[$0.environmentID] == nil }.map(\.environmentID)
             if recovered.isEmpty { return }
-            try? await Task.sleep(for: .seconds(2))
+            try? await Task.sleep(for: recoveredOperationPollInterval)
+            // The wait swallows its own cancellation, so a poll being replaced would
+            // otherwise still run one more round of queries against the runtime.
+            guard !Task.isCancelled else { return }
             for id in recovered { await refreshStatus(of: id) }
         }
+    }
+
+    /// Replaces the poll rather than adding one: every reconciliation would otherwise leave
+    /// another task inspecting the same operation, multiplying the Tart processes the runtime
+    /// runs for each query until the session's in-flight limit refuses them.
+    private func startRecoveredOperationPoll() {
+        recoveredOperationPoll?.cancel()
+        recoveredOperationPoll = Task { [weak self] in
+            guard let self else { return }
+            await self.pollRecoveredOperations()
+        }
+    }
+
+    /// Follows an operation only the runtime reports, unless a poll is already doing so. The
+    /// running poll re-reads `statuses` at the top of every round, so it picks this
+    /// environment up on its own; starting another from inside the very inspection that poll
+    /// is awaiting would cancel it mid-round instead.
+    private func followRecoveredOperation(of id: EnvironmentID) {
+        guard operations[id] == nil, statuses[id]?.inFlightOperation != nil, recoveredOperationPolls == 0 else { return }
+        startRecoveredOperationPoll()
     }
 
     /// Re-reads one environment's status after an operation, whatever its outcome. A status
     /// query the runtime answers with a failure leaves no cached state behind: the card shows
     /// the error and offers nothing until a later query succeeds.
     func refreshStatus(of id: EnvironmentID) async {
+        // The reconciliation this query started under. The client reports a dropped connection
+        // to its observers before it throws into the streams that connection cut off, so a
+        // reconciliation launched by that same loss can already have read the actual state by
+        // the time the loss lands here.
+        let generation = refreshGeneration
+        // Two inspections of one environment can be in flight at once — the recovered-operation
+        // poll and a Quit waiting on that same operation both ask for it — and the runtime runs
+        // its own Tart inventory read for each, so the older reply can arrive last. Both carry
+        // the same reconciliation generation, so only this ticket separates them: without it an
+        // inspection that began while the VM was still stopped could land over the running
+        // result that replaced it, and Quit would then find no target to stop and terminate
+        // with a VM it just started (MVP-PLAN.md §2).
+        let ticket = (statusQueryTickets[id] ?? 0) &+ 1
+        statusQueryTickets[id] = ticket
+        statusQueriesInFlight[id, default: 0] += 1
+        defer {
+            let outstanding = (statusQueriesInFlight[id] ?? 1) - 1
+            statusQueriesInFlight[id] = outstanding > 0 ? outstanding : nil
+        }
         do {
             for try await event in backend.send(.environmentStatus(id)) {
+                // A reconciliation that began after this query did has read the actual state
+                // since, so its snapshot stands: an inspection that started while the VM was
+                // running must not publish that over a newer stopped result and leave Start
+                // blocked until someone checks again. The stream is drained rather than
+                // dropped so the request still ends on the service. The catch below makes the
+                // same check for a query that never answered.
+                guard generation == refreshGeneration, ticket >= publishedStatusTicket[id] ?? 0 else { continue }
+                publishedStatusTicket[id] = ticket
                 switch event {
                 case .status(let status):
                     statuses[id] = status
                     // The environment answered, so a failure of an earlier *query* is history.
                     // A failed operation's error stays: it is what the card explains.
                     if statusQueryFailures.remove(id) != nil { lastErrors[id] = nil }
+                    // A poll whose own inspection failed ended without anything to restart it,
+                    // so this is where an operation only the runtime reports is picked up
+                    // again: without it the card stays busy and blocks every start until the
+                    // user checks by hand (AGENTS.md: an interrupted operation's outcome is
+                    // unknown until the state is inspected).
+                    followRecoveredOperation(of: id)
                 case .failed(_, let error):
                     statuses[id] = nil
                     lastErrors[id] = error
@@ -406,6 +526,12 @@ final class AppModel {
                 }
             }
         } catch {
+            // A reconciliation that began after this query did has read the actual state
+            // since, so its result stands: replacing it here would delete the status it just
+            // established and put the app back on Interrupted over a Ready it disproved. A
+            // newer inspection of this environment stands for the same reason.
+            guard generation == refreshGeneration, ticket >= publishedStatusTicket[id] ?? 0 else { return }
+            publishedStatusTicket[id] = ticket
             // The query never answered. What was cached says nothing about the VM now, and
             // Quit must not choose stop targets from it: the status is dropped and the
             // environment is marked as unanswered, exactly as a failed reply would.
@@ -413,6 +539,17 @@ final class AppModel {
             statusQueryFailures.insert(id)
             launchState = .interrupted(RuntimeConnectionInterrupted())
         }
+    }
+
+    /// Clears the failure a card is showing and re-reads the environment. An error whose only
+    /// recovery is `.cancel` — a start refused because another development Mac was running —
+    /// has nothing else to offer, and a successful status query deliberately keeps operation
+    /// errors, so without this the card would keep a stale refusal and its disabled Start until
+    /// the app was relaunched (AGENTS.md: every error carries a recovery action that works).
+    func dismissError(_ id: EnvironmentID) {
+        lastErrors[id] = nil
+        statusQueryFailures.remove(id)
+        Task { await refreshStatus(of: id) }
     }
 
     // MARK: - Dashboard
@@ -427,7 +564,9 @@ final class AppModel {
                 operation: operations[environment.id],
                 lastError: lastErrors[environment.id],
                 statusUnread: statuses[environment.id] == nil,
-                startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil
+                statusCheckFailed: statusQueryFailures.contains(environment.id) && statusQueriesInFlight[environment.id] == nil,
+                startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil,
+                runtimeVersion: runtimeVersion
             )
         }
     }
@@ -444,32 +583,75 @@ final class AppModel {
 
     /// Starts an environment. The only dashboard action wired to the runtime so far.
     func start(_ id: EnvironmentID) {
+        // A reconciliation in progress, or one that lost its connection, leaves the previous
+        // statuses cached, and the cached snapshot is what `globalStartBlock` reads: a Start
+        // rendered a moment before the state changed could otherwise send a mutating request
+        // over state nothing has re-established. Nothing is started until reconciliation has
+        // (AGENTS.md: never retry a mutating operation blindly).
+        guard launchState == .ready else { return }
         guard environments.contains(where: { $0.id == id }), operations[id] == nil, globalStartBlock == nil else { return }
         // Reserved before the first suspension, so two rapid starts cannot both pass the guard.
         operations[id] = OperationState(id: OperationID(), phase: nil)
         Task { await run(.startEnvironment(id, StartOptions()), for: id) }
     }
 
+    /// Records what an operation itself reported for `id`. The result supersedes any earlier
+    /// status-query failure: left standing, that marker would let the next successful query
+    /// clear this error as if it were the stale one, and the card would lose the recovery the
+    /// operation's own failure prescribes.
+    private func recordOperationError(_ error: GuesthouseError?, for id: EnvironmentID) {
+        lastErrors[id] = error
+        statusQueryFailures.remove(id)
+    }
+
     private func run(_ request: RuntimeRequest, for id: EnvironmentID) async {
-        lastErrors[id] = nil
+        recordOperationError(nil, for: id)
+        // The reconciliation this stream started under. The client reports a dropped
+        // connection to its observers before it throws into the streams that connection cut
+        // off, so a reconciliation launched by that same loss can already have read the
+        // actual state by the time this stream ends.
+        let generation = refreshGeneration
         if operations[id] == nil { operations[id] = OperationState(id: OperationID(), phase: nil) }
+        var completed = false
+        var described = false
         do {
             for try await event in backend.send(request) {
                 switch event {
                 case .accepted(let operation): operations[id] = OperationState(id: operation, phase: nil)
                 case .progress(_, let phase): operations[id]?.phase = phase
-                case .status(let status): statuses[status.environmentID] = status
-                case .failed(_, let error): lastErrors[id] = error
-                case .completed: lastErrors[id] = nil
+                case .status(let status):
+                    statuses[status.environmentID] = status
+                    if status.environmentID == id { described = true }
+                case .failed(_, let error): recordOperationError(error, for: id)
+                case .completed:
+                    recordOperationError(nil, for: id)
+                    completed = true
                 default: break
                 }
             }
         } catch {
-            // The outcome is unknown until the runtime is asked again; never replay.
-            launchState = .interrupted(RuntimeConnectionInterrupted())
+            // The outcome is unknown until the runtime is asked again; never replay. A
+            // reconciliation that began after this stream did has looked at the actual state
+            // since, so its result stands rather than being overwritten by this loss.
+            if generation == refreshGeneration { launchState = .interrupted(RuntimeConnectionInterrupted()) }
         }
+        // A start that failed or was lost may already have launched the VM, so what was cached
+        // before it says nothing about the state now. Nor does it after one that completed
+        // without describing the environment: the runtime's own status refresh after a stop or
+        // a start is a bounded courtesy and can time out, leaving the pre-start `.stopped`
+        // behind. Either way the status is dropped before the reservation is released, because
+        // an actionable `.stopped` would re-enable Start here and on every other card for the
+        // seconds the inspection below takes, and let a second mutation go out over a VM that
+        // is already running (AGENTS.md: never retry a mutating operation blindly).
+        if !completed || !described { statuses[id] = nil }
         operations[id] = nil
         await refreshStatus(of: id)
+        // The runtime may still be running the operation this app stopped listening to. A
+        // reconciliation that ran while the operation was still local started a poll that found
+        // nothing to follow and ended at once, so this handoff — from an operation this app
+        // owned to one only the runtime reports — is where that poll has to be started again.
+        // Without it the card stays busy and every start stays blocked until the user checks.
+        followRecoveredOperation(of: id)
     }
 
     /// A model over a preview scenario's environments and scripted backend, already refreshed.
@@ -658,7 +840,7 @@ final class AppModel {
         }
         // A start accepted moments ago has not reported `running` yet; the decision waits
         // for every active operation and re-reads the statuses before choosing targets.
-        guard await waitForOperations() else { return }
+        guard await waitForOperations(generation: generation) else { return }
         guard generation == quitGeneration, !Task.isCancelled, !quitCancelRequested else { finishCancel(reconcile: true); return }
         // The mode still decides how they are stopped: only the environments whose graceful
         // stop already failed are force-stopped.
@@ -672,10 +854,14 @@ final class AppModel {
     /// Waits until neither this app nor the runtime reports an operation in flight. A status
     /// query that fails ends the wait: the quit stops rather than choosing targets from state
     /// nobody could read. Returns false when the quit must not continue.
-    private func waitForOperations() async -> Bool {
+    private func waitForOperations(generation: UInt64) async -> Bool {
         while !Task.isCancelled {
             for environment in environments {
                 await refreshStatus(of: environment.id)
+                // Each inspection is a suspension the user can cancel across, and a cancelled
+                // attempt has already answered AppKit: it must not reopen the sheet on a
+                // failure, nor speak for the Quit that replaced it.
+                guard generation == quitGeneration else { return false }
                 guard statuses[environment.id] != nil else {
                     quitFlow = .stopFailed(lastErrors[environment.id] ?? .operationOutcomeUnknown(OperationID()))
                     return false

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -375,11 +375,19 @@ final class AppModel {
         }
     }
 
-    /// Re-reads one environment's status after an operation, whatever its outcome.
+    /// Re-reads one environment's status after an operation, whatever its outcome. A status
+    /// query the runtime answers with a failure leaves no cached state behind: the card shows
+    /// the error and offers nothing until a later query succeeds.
     func refreshStatus(of id: EnvironmentID) async {
         do {
             for try await event in backend.send(.environmentStatus(id)) {
-                if case .status(let status) = event { statuses[id] = status }
+                switch event {
+                case .status(let status): statuses[id] = status
+                case .failed(_, let error):
+                    statuses[id] = nil
+                    lastErrors[id] = error
+                default: break
+                }
             }
         } catch {
             launchState = .interrupted(RuntimeConnectionInterrupted())
@@ -415,12 +423,14 @@ final class AppModel {
     /// Starts an environment. The only dashboard action wired to the runtime so far.
     func start(_ id: EnvironmentID) {
         guard environments.contains(where: { $0.id == id }), operations[id] == nil, globalStartBlock == nil else { return }
+        // Reserved before the first suspension, so two rapid starts cannot both pass the guard.
+        operations[id] = OperationState(id: OperationID(), phase: nil)
         Task { await run(.startEnvironment(id, StartOptions()), for: id) }
     }
 
     private func run(_ request: RuntimeRequest, for id: EnvironmentID) async {
         lastErrors[id] = nil
-        operations[id] = OperationState(id: OperationID(), phase: nil)
+        if operations[id] == nil { operations[id] = OperationState(id: OperationID(), phase: nil) }
         do {
             for try await event in backend.send(request) {
                 switch event {
@@ -446,7 +456,10 @@ final class AppModel {
         let model = AppModel(backend: scenario.backend) { _ in }
         await model.refresh()
         if let request = scenario.initialRequest, case .startEnvironment(let id, _) = request {
-            model.start(id)
+            // A preview's seeded status may already name the operation, which the dashboard's
+            // own guard would refuse; the scripted stream is attached to it regardless so the
+            // progress UI has something to show. The guard itself is covered by tests.
+            Task { await model.run(request, for: id) }
         }
         return model
     }
@@ -633,13 +646,16 @@ final class AppModel {
         await stopAll(mode: mode, generation: generation)
     }
 
+    /// Waits until neither this app nor the runtime reports an operation in flight: a start
+    /// this app made moments ago, or one recovered after a relaunch that only the status
+    /// names, must reach a terminal state before stop targets are chosen.
     private func waitForOperations() async {
-        while !operations.isEmpty, !Task.isCancelled {
-            quitFlow = .stopping(operations.keys.first, nil)
-            try? await Task.sleep(for: .milliseconds(50))
-        }
-        for environment in environments where !Task.isCancelled {
-            await refreshStatus(of: environment.id)
+        while !Task.isCancelled {
+            for environment in environments { await refreshStatus(of: environment.id) }
+            let busy = operations.keys.first ?? statuses.values.first(where: { $0.inFlightOperation != nil })?.environmentID
+            guard let busy else { return }
+            quitFlow = .stopping(busy, nil)
+            try? await Task.sleep(for: .milliseconds(200))
         }
     }
 

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -637,12 +637,6 @@ final class AppModel {
         // The mode still decides how they are stopped: only the environments whose graceful
         // stop already failed are force-stopped.
         quitFlow = mode == .force ? .forceStopping(nil) : .stopping(nil, nil)
-        // An operation the runtime still reports is unresolved, whatever the VM state says:
-        // quitting over it could leave a VM the app never saw start.
-        if let busy = statuses.values.first(where: { $0.inFlightOperation != nil }), let operation = busy.inFlightOperation {
-            quitFlow = .stopFailed(.operationOutcomeUnknown(operation))
-            return
-        }
         await stopAll(mode: mode, generation: generation)
     }
 

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -27,6 +27,9 @@ final class AppModel {
         case confirming
         /// State is being reconciled before a stop is attempted, or after an unknown outcome.
         case checking
+        /// Waiting for an operation to finish before targets are chosen. Nothing has been
+        /// asked of the runtime yet, so cancelling here is immediate.
+        case waitingForOperations(EnvironmentID?)
         /// Environments are being stopped; the app has told AppKit to wait.
         case stopping(EnvironmentID?, ProgressPhase?)
         /// Graceful stop failed; the sheet offers the warned force-stop, or a check first.
@@ -52,6 +55,9 @@ final class AppModel {
     private(set) var statuses: [EnvironmentID: EnvironmentStatus] = [:]
     private(set) var operations: [EnvironmentID: OperationState] = [:]
     /// The last failure per environment, cleared when an operation completes.
+    /// Environments whose last status query failed, so a later success can clear that
+    /// error without erasing what a failed operation reported.
+    private var statusQueryFailures: Set<EnvironmentID> = []
     private(set) var lastErrors: [EnvironmentID: GuesthouseError] = [:]
     private(set) var quitFlow: QuitFlow = .idle
     /// The user canceled during a step that must run to its end; honored when it ends.
@@ -270,7 +276,7 @@ final class AppModel {
                 await self.reconcileForQuit(generation: generation)
             }
             return
-        case .checking, .stopping, .forceStopping, .terminating:
+        case .checking, .waitingForOperations, .stopping, .forceStopping, .terminating:
             // A stop stream reports its own loss; nothing to do here.
             return
         }
@@ -360,6 +366,11 @@ final class AppModel {
         if let running = runningEnvironments.first {
             return "\(running.name) is running. Guesthouse runs one development Mac at a time until resource validation allows two."
         }
+        // A VM the runtime cannot prove it owns is still a VM: the lifecycle refuses a second
+        // one while it is there, so the dashboard says so rather than offering a start.
+        if let uncertain = uncertainEnvironments.first {
+            return "\(uncertain.name) is running without proof that Guesthouse started it. Check it before starting another development Mac."
+        }
         return nil
     }
 
@@ -382,10 +393,15 @@ final class AppModel {
         do {
             for try await event in backend.send(.environmentStatus(id)) {
                 switch event {
-                case .status(let status): statuses[id] = status
+                case .status(let status):
+                    statuses[id] = status
+                    // The environment answered, so a failure of an earlier *query* is history.
+                    // A failed operation's error stays: it is what the card explains.
+                    if statusQueryFailures.remove(id) != nil { lastErrors[id] = nil }
                 case .failed(_, let error):
                     statuses[id] = nil
                     lastErrors[id] = error
+                    statusQueryFailures.insert(id)
                 default: break
                 }
             }
@@ -405,6 +421,7 @@ final class AppModel {
                 status: statuses[environment.id],
                 operation: operations[environment.id],
                 lastError: lastErrors[environment.id],
+                statusUnread: statuses[environment.id] == nil,
                 startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil
             )
         }
@@ -568,6 +585,10 @@ final class AppModel {
             return
         case .stopping(_, let phase?) where !phase.cancelable:
             quitCancelRequested = true
+        case .waitingForOperations:
+            // Nothing has been asked of the runtime yet, so the quit is simply abandoned.
+            quitTask?.cancel()
+            finishCancel(reconcile: true)
         case .stopping(.some, nil):
             // A stop that has not described a phase yet: it may not even be accepted. Neither
             // can be abandoned here. Every phase a stop reports is one the runtime protects,
@@ -632,7 +653,7 @@ final class AppModel {
         }
         // A start accepted moments ago has not reported `running` yet; the decision waits
         // for every active operation and re-reads the statuses before choosing targets.
-        await waitForOperations()
+        guard await waitForOperations() else { return }
         guard generation == quitGeneration, !Task.isCancelled, !quitCancelRequested else { finishCancel(reconcile: true); return }
         // The mode still decides how they are stopped: only the environments whose graceful
         // stop already failed are force-stopped.
@@ -643,14 +664,26 @@ final class AppModel {
     /// Waits until neither this app nor the runtime reports an operation in flight: a start
     /// this app made moments ago, or one recovered after a relaunch that only the status
     /// names, must reach a terminal state before stop targets are chosen.
-    private func waitForOperations() async {
+    /// Waits until neither this app nor the runtime reports an operation in flight. A status
+    /// query that fails ends the wait: the quit stops rather than choosing targets from state
+    /// nobody could read. Returns false when the quit must not continue.
+    private func waitForOperations() async -> Bool {
         while !Task.isCancelled {
-            for environment in environments { await refreshStatus(of: environment.id) }
+            for environment in environments {
+                await refreshStatus(of: environment.id)
+                guard statuses[environment.id] != nil else {
+                    quitFlow = .stopFailed(lastErrors[environment.id] ?? .operationOutcomeUnknown(OperationID()))
+                    return false
+                }
+            }
             let busy = operations.keys.first ?? statuses.values.first(where: { $0.inFlightOperation != nil })?.environmentID
-            guard let busy else { return }
-            quitFlow = .stopping(busy, nil)
-            try? await Task.sleep(for: .milliseconds(200))
+            guard let busy else { return true }
+            quitFlow = .waitingForOperations(busy)
+            // The runtime runs a Tart command for every status query, so this waits in
+            // seconds rather than polling several times a second.
+            try? await Task.sleep(for: .seconds(2))
         }
+        return false
     }
 
     /// Stops every running environment. `mode` is `.force` only for the environments whose

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
             case .unavailable(let error):
                 Image(systemName: "exclamationmark.triangle").imageScale(.large)
                 Text(error.userMessage)
-                RecoveryActionRow(error: error) { model.startRefresh() }
+                RecoveryActionRow(actions: error.recoveryActions) { model.startRefresh() }
             }
             #if DEBUG
             Text(debugProbe.result)
@@ -48,22 +48,50 @@ struct ContentView: View {
 /// The error's own recovery actions, in its order. Checking the environment is the one the
 /// app can perform today; the others are named so the user knows what the fix will be.
 struct RecoveryActionRow: View {
-    let error: GuesthouseError
+    let actions: [RecoveryAction]
     let check: () -> Void
+    /// Clears the failure, where the caller has one to clear. An error whose only recovery is
+    /// `.cancel` is otherwise a message with no control at all.
+    var dismiss: (() -> Void)?
 
     var body: some View {
         HStack {
-            ForEach(Array(error.recoveryActions.enumerated()), id: \.offset) { _, action in
+            ForEach(Array(rendered.enumerated()), id: \.offset) { _, action in
                 switch action {
                 case .retry, .inspectState:
                     Button("Check Environment", action: check)
                 case .cancel:
-                    EmptyView()
+                    if let dismiss {
+                        Button("Dismiss", action: dismiss)
+                    } else {
+                        EmptyView()
+                    }
                 case .repair, .openConsole, .exportWork, .openSettings, .signInAgain, .freeDiskSpace, .deleteEnvironment, .reinstallApp:
                     Text("\(label(action)) is not available yet").font(.caption).foregroundStyle(.secondary)
                 }
             }
         }
+    }
+
+    /// One control per distinct behavior. Re-reading the state is all this row can do about
+    /// either `retry` or `inspectState`, so an error that prescribes both — a start refused
+    /// with `guestNotReachable` — gets one Check Environment rather than two identical buttons
+    /// that would each claim to be a different recovery. Repeating the operation itself is the
+    /// card's own Start, which the check re-enables once the VM answers as stopped and ready.
+    private var rendered: [RecoveryAction] {
+        var result: [RecoveryAction] = []
+        var checkOffered = false
+        for action in actions {
+            switch action {
+            case .retry, .inspectState:
+                guard !checkOffered else { continue }
+                checkOffered = true
+                result.append(action)
+            default:
+                result.append(action)
+            }
+        }
+        return result
     }
 
     private func label(_ action: RecoveryAction) -> String {

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -19,8 +19,7 @@ struct ContentView: View {
                 ProgressView().accessibilityLabel("Checking environment")
                 Text("Checking environment…")
             case .ready:
-                Image(systemName: "desktopcomputer").imageScale(.large).foregroundStyle(.tint)
-                Text(model.environments.isEmpty ? "No development Mac yet" : "\(model.environments.count) development Mac\(model.environments.count == 1 ? "" : "s")")
+                DashboardView()
             case .interrupted(let interruption):
                 Image(systemName: "bolt.slash").imageScale(.large)
                 Text(interruption.userMessage)
@@ -42,8 +41,7 @@ struct ContentView: View {
                 .accessibilityLabel("Debug probe result")
             #endif
         }
-        .padding()
-        .frame(minWidth: 360, minHeight: 200)
+        .frame(minWidth: 720, minHeight: 420)
     }
 }
 

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -128,16 +128,12 @@ struct EnvironmentCardView: View {
     /// The actions wrap: at the adaptive grid's narrow column two cards leave roughly a third
     /// of the window for each, which is not enough for these labels on one line.
     private var actionsRow: some View {
-        ViewThatFits(in: .horizontal) {
-            HStack(spacing: 8) {
-                actionButtons
-                Spacer()
-                overflowMenu
-            }
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 8) { actionButtons }
-                HStack { Spacer(); overflowMenu }
-            }
+        // A real flow: at the adaptive grid's narrow column the buttons wrap onto as many
+        // lines as they need. `ViewThatFits` could only choose between whole layouts, so its
+        // fallback still had to fit every button on one line.
+        WrappingRow(spacing: 8) {
+            actionButtons
+            overflowMenu
         }
     }
 
@@ -253,3 +249,54 @@ struct ScenarioPreview: View {
 #Preview("Environment needing repair") { ScenarioPreview { await PreviewScenarios.environmentNeedingRepair() } }
 #Preview("Both slots full") { ScenarioPreview { await PreviewScenarios.bothSlotsFull() } }
 #Preview("Operation in progress") { ScenarioPreview { await PreviewScenarios.operationInProgress() } }
+
+/// Lays its subviews out left to right, starting a new line when the next one does not fit.
+/// Each subview keeps its ideal width, so a label is never compressed or truncated.
+struct WrappingRow: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let width = proposal.width ?? .infinity
+        let rows = arrange(subviews: subviews, within: width)
+        let height = rows.map(\.height).reduce(0, +) + spacing * CGFloat(max(rows.count - 1, 0))
+        let widest = rows.map(\.width).max() ?? 0
+        return CGSize(width: proposal.width ?? widest, height: height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        var y = bounds.minY
+        for row in arrange(subviews: subviews, within: bounds.width) {
+            var x = bounds.minX
+            for index in row.indices {
+                let size = subviews[index].sizeThatFits(.unspecified)
+                subviews[index].place(at: CGPoint(x: x, y: y + (row.height - size.height) / 2), proposal: ProposedViewSize(size))
+                x += size.width + spacing
+            }
+            y += row.height + spacing
+        }
+    }
+
+    private struct Row {
+        var indices: [Int] = []
+        var width: CGFloat = 0
+        var height: CGFloat = 0
+    }
+
+    private func arrange(subviews: Subviews, within width: CGFloat) -> [Row] {
+        var rows: [Row] = []
+        var current = Row()
+        for index in subviews.indices {
+            let size = subviews[index].sizeThatFits(.unspecified)
+            let needed = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            if !current.indices.isEmpty, needed > width {
+                rows.append(current)
+                current = Row()
+            }
+            current.width = current.indices.isEmpty ? size.width : current.width + spacing + size.width
+            current.height = max(current.height, size.height)
+            current.indices.append(index)
+        }
+        if !current.indices.isEmpty { rows.append(current) }
+        return rows
+    }
+}

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -125,18 +125,30 @@ struct EnvironmentCardView: View {
         .font(.callout)
     }
 
+    /// The actions wrap: at the adaptive grid's narrow column two cards leave roughly a third
+    /// of the window for each, which is not enough for these labels on one line.
     private var actionsRow: some View {
-        HStack(spacing: 8) {
-            AvailabilityButton("Start", availability: state.availability(of: .start)) { perform(.start) }
-                .buttonStyle(.borderedProminent)
-                .accessibilityLabel("Start")
-            ForEach(secondaryPrimaryActions) { action in
-                AvailabilityButton(action.title, availability: state.availability(of: action)) { perform(action) }
-                    .buttonStyle(.bordered)
-                    .accessibilityLabel(action.title)
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 8) {
+                actionButtons
+                Spacer()
+                overflowMenu
             }
-            Spacer()
-            overflowMenu
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 8) { actionButtons }
+                HStack { Spacer(); overflowMenu }
+            }
+        }
+    }
+
+    @ViewBuilder private var actionButtons: some View {
+        AvailabilityButton("Start", availability: state.availability(of: .start)) { perform(.start) }
+            .buttonStyle(.borderedProminent)
+            .accessibilityLabel("Start")
+        ForEach(secondaryPrimaryActions) { action in
+            AvailabilityButton(action.title, availability: state.availability(of: action)) { perform(action) }
+                .buttonStyle(.bordered)
+                .accessibilityLabel(action.title)
         }
     }
 

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -1,0 +1,238 @@
+import SwiftUI
+import GuesthouseCore
+
+/// The main window's content once the runtime has been reconciled: one or two environment
+/// cards, an empty state that leads to the setup wizard, and the two-slot cap explained.
+struct DashboardView: View {
+    @Environment(AppModel.self) private var model
+    @State private var showingWizard = false
+
+    var body: some View {
+        let cards = model.cardStates()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                if cards.isEmpty {
+                    EmptyDashboardView(availability: model.createAvailability) { showingWizard = true }
+                } else {
+                    LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 16)], alignment: .leading, spacing: 16) {
+                        ForEach(cards) { card in
+                            EnvironmentCardView(state: card) { model.start(card.id) }
+                        }
+                        SlotView(availability: model.createAvailability) { showingWizard = true }
+                    }
+                }
+            }
+            .padding(20)
+        }
+        .sheet(isPresented: $showingWizard) { WizardPlaceholderView() }
+    }
+}
+
+struct EmptyDashboardView: View {
+    let availability: EnvironmentCardState.Availability
+    let create: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "desktopcomputer").font(.system(size: 40)).foregroundStyle(.tint)
+            Text("No development Mac yet").font(.title2)
+            Text("Guesthouse creates a private macOS virtual machine with Xcode and your workspace, ready for Codex.")
+                .multilineTextAlignment(.center).foregroundStyle(.secondary).frame(maxWidth: 420)
+            AvailabilityButton("Create a development Mac", availability: availability, action: create)
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel("Create a development Mac")
+        }
+        .frame(maxWidth: .infinity, minHeight: 300)
+    }
+}
+
+/// The free slot, or the explanation of the cap when both are taken.
+struct SlotView: View {
+    let availability: EnvironmentCardState.Availability
+    let create: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            switch availability {
+            case .enabled:
+                Text("Free slot").font(.headline)
+                Text("One more development Mac can be created.").foregroundStyle(.secondary)
+                Button("Create a development Mac", action: create).accessibilityLabel("Create a development Mac")
+            case .disabled(let reason), .notImplemented(let reason):
+                Text("No free slot").font(.headline)
+                Text(reason).foregroundStyle(.secondary)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(16)
+        .background(.quaternary.opacity(0.4), in: RoundedRectangle(cornerRadius: 12))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+struct EnvironmentCardView: View {
+    let state: EnvironmentCardState
+    let start: () -> Void
+    @State private var note: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            header
+            if let attention = state.attention {
+                Label(attention.userMessage, systemImage: "exclamationmark.triangle")
+                    .font(.callout)
+                    .accessibilityLabel("Needs attention: \(attention.userMessage)")
+            }
+            detailsGrid
+            actionsRow
+            if let note {
+                Text(note).font(.callout).foregroundStyle(.secondary).accessibilityLabel("Note: \(note)")
+            }
+        }
+        .padding(16)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 12))
+        .overlay(RoundedRectangle(cornerRadius: 12).strokeBorder(.quaternary))
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(state.name).font(.title3).bold()
+            Spacer()
+            if state.isBusy {
+                ProgressView().controlSize(.small).accessibilityLabel("Busy")
+            }
+            Text(state.statusText).foregroundStyle(state.attention == nil ? .secondary : .primary)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    private var detailsGrid: some View {
+        Grid(alignment: .leading, horizontalSpacing: 12, verticalSpacing: 4) {
+            ForEach(state.details) { detail in
+                GridRow {
+                    Text(detail.label).foregroundStyle(.secondary)
+                    Text(detail.value)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(detail.label): \(detail.value)")
+            }
+        }
+        .font(.callout)
+    }
+
+    private var actionsRow: some View {
+        HStack(spacing: 8) {
+            AvailabilityButton("Start", availability: state.availability(of: .start)) { perform(.start) }
+                .buttonStyle(.borderedProminent)
+                .accessibilityLabel("Start")
+            ForEach(secondaryPrimaryActions) { action in
+                AvailabilityButton(action.title, availability: state.availability(of: action)) { perform(action) }
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel(action.title)
+            }
+            Spacer()
+            overflowMenu
+        }
+    }
+
+    private var secondaryPrimaryActions: [EnvironmentCardState.Action] {
+        EnvironmentCardState.Action.allCases.filter { $0.isPrimary && $0 != .start }
+    }
+
+    private var overflowMenu: some View {
+        Menu {
+            Button(EnvironmentCardState.Action.repair.title) { perform(.repair) }
+            Button(EnvironmentCardState.Action.exportWork.title) { perform(.exportWork) }
+            Divider()
+            Button(EnvironmentCardState.Action.delete.title, role: .destructive) { perform(.delete) }
+        } label: {
+            Label("More", systemImage: "ellipsis.circle").labelStyle(.iconOnly)
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .accessibilityLabel("More actions")
+    }
+
+    private func perform(_ action: EnvironmentCardState.Action) {
+        switch state.availability(of: action) {
+        case .enabled:
+            note = nil
+            if action == .start { start() }
+        case .disabled(let reason):
+            note = reason
+        case .notImplemented(let text):
+            note = "\(action.title) is not implemented yet. \(text)"
+        }
+    }
+}
+
+/// A button that stays visible when its action is unavailable and explains why.
+struct AvailabilityButton: View {
+    let title: String
+    let availability: EnvironmentCardState.Availability
+    let action: () -> Void
+
+    init(_ title: String, availability: EnvironmentCardState.Availability, action: @escaping () -> Void) {
+        self.title = title
+        self.availability = availability
+        self.action = action
+    }
+
+    var body: some View {
+        switch availability {
+        case .enabled:
+            Button(title, action: action)
+        case .disabled(let reason):
+            Button(title, action: action)
+                .disabled(true)
+                .help(reason)
+                .accessibilityHint(reason)
+        case .notImplemented(let note):
+            Button(title, action: action)
+                .help("Not implemented yet. \(note)")
+                .accessibilityHint("Not implemented yet")
+        }
+    }
+}
+
+/// Stands in for the setup wizard until #31 lands.
+struct WizardPlaceholderView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Create a development Mac").font(.headline)
+            Text("The setup wizard is not implemented yet. It will check this Mac, create the virtual machine, finish macOS setup, connect securely, add Xcode, sign in, add a workspace, and validate the Codex handoff (MVP-PLAN.md §2).")
+                .foregroundStyle(.secondary)
+            HStack { Spacer(); Button("Close") { dismiss() }.keyboardShortcut(.cancelAction) }
+        }
+        .padding(20)
+        .frame(width: 460)
+    }
+}
+
+// MARK: - Previews
+
+/// Loads a `PreviewScenarios` case into a model and shows the dashboard over it.
+struct ScenarioPreview: View {
+    let load: @Sendable () async -> PreviewScenario
+    @State private var model: AppModel?
+
+    var body: some View {
+        Group {
+            if let model {
+                DashboardView().environment(model)
+            } else {
+                ProgressView()
+            }
+        }
+        .frame(width: 780, height: 520)
+        .task { model = await AppModel.preview(load()) }
+    }
+}
+
+#Preview("Fresh Mac") { ScenarioPreview { await PreviewScenarios.freshMac() } }
+#Preview("One running environment") { ScenarioPreview { await PreviewScenarios.oneRunningEnvironment() } }
+#Preview("Environment needing repair") { ScenarioPreview { await PreviewScenarios.environmentNeedingRepair() } }
+#Preview("Both slots full") { ScenarioPreview { await PreviewScenarios.bothSlotsFull() } }
+#Preview("Operation in progress") { ScenarioPreview { await PreviewScenarios.operationInProgress() } }

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -16,7 +16,12 @@ struct DashboardView: View {
                 } else {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 16)], alignment: .leading, spacing: 16) {
                         ForEach(cards) { card in
-                            EnvironmentCardView(state: card) { model.start(card.id) }
+                            EnvironmentCardView(
+                                state: card,
+                                start: { model.start(card.id) },
+                                check: { Task { await model.refreshStatus(of: card.id) } },
+                                dismiss: { model.dismissError(card.id) }
+                            )
                         }
                         SlotView(availability: model.createAvailability) { showingWizard = true }
                     }
@@ -73,6 +78,10 @@ struct SlotView: View {
 struct EnvironmentCardView: View {
     let state: EnvironmentCardState
     let start: () -> Void
+    /// Re-reads this environment's state; what the `inspectState` and `retry` recoveries do.
+    let check: () -> Void
+    /// Clears the failure the card is holding; what the `cancel` recovery does.
+    let dismiss: () -> Void
     @State private var note: String?
 
     var body: some View {
@@ -82,6 +91,10 @@ struct EnvironmentCardView: View {
                 Label(attention.userMessage, systemImage: "exclamationmark.triangle")
                     .font(.callout)
                     .accessibilityLabel("Needs attention: \(attention.userMessage)")
+                // The failure's own recovery, on the card that reports it: a card error is
+                // otherwise text with no way out once Start is disabled. A failure the status
+                // itself keeps reporting is not offered a dismissal, which would clear nothing.
+                RecoveryActionRow(actions: state.recoveryActions, check: check, dismiss: state.canDismiss ? dismiss : nil)
             }
             detailsGrid
             actionsRow

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -99,7 +99,12 @@ struct EnvironmentCardView: View {
             Text(state.name).font(.title3).bold()
             Spacer()
             if state.isBusy {
-                ProgressView().controlSize(.small).accessibilityLabel("Busy")
+                // A phase that measures itself shows how far it is; the rest stay indeterminate.
+                if let fraction = state.phase?.fraction {
+                    ProgressView(value: fraction).controlSize(.small).frame(width: 60).accessibilityLabel("Busy, \(Int(fraction * 100)) percent")
+                } else {
+                    ProgressView().controlSize(.small).accessibilityLabel("Busy")
+                }
             }
             Text(state.statusText).foregroundStyle(state.attention == nil ? .secondary : .primary)
         }

--- a/Guesthouse/Dashboard/EnvironmentCardState.swift
+++ b/Guesthouse/Dashboard/EnvironmentCardState.swift
@@ -58,21 +58,37 @@ struct EnvironmentCardState: Equatable, Identifiable {
     let phase: ProgressPhase?
     /// The problem the runtime reported, if any, with its recovery actions.
     let attention: GuesthouseError?
+    /// What the user can do about `attention`, in the error's own order. The card renders
+    /// these, so an error whose recovery is an inspection or a repair is never shown as text
+    /// with no way out (AGENTS.md: every error carries at least one recovery action).
+    let recoveryActions: [RecoveryAction]
+    /// Whether clearing `attention` would change anything. A problem the status itself keeps
+    /// reporting comes straight back, so the card does not offer a control that does nothing.
+    let canDismiss: Bool
     let details: [Detail]
     let availability: [Action: Availability]
 
-    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?, statusUnread: Bool = false, startBlockedElsewhere: String? = nil) {
+    /// - Parameter statusCheckFailed: this environment's last status query ended in a failure
+    ///   and no other query is running. The status is unread, but nothing is being checked.
+    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?, statusUnread: Bool = false, statusCheckFailed: Bool = false, startBlockedElsewhere: String? = nil, runtimeVersion: RuntimeVersionInfo? = nil) {
         id = environment.id
         name = environment.name
-        let attention: GuesthouseError? = {
+        let statusAttention: GuesthouseError? = {
             if case .needsAttention(let error)? = status?.readiness { return error }
-            return lastError
+            return nil
         }()
+        let attention: GuesthouseError? = statusAttention ?? lastError
         self.attention = attention
+        recoveryActions = attention?.recoveryActions ?? []
+        canDismiss = statusAttention == nil && lastError != nil
         phase = operation?.phase
-        isBusy = statusUnread || status == nil || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
-        statusText = Self.statusText(for: status, operation: operation)
-        details = Self.details(for: environment, status: status)
+        // A status the last query could not read is not a check in progress: that query ended,
+        // and the card names the failure it is already showing rather than turning an error
+        // with its own recovery into an indefinite spinner nobody can end.
+        let unread = statusUnread || status == nil
+        isBusy = (unread && !statusCheckFailed) || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
+        statusText = Self.statusText(for: status, operation: operation, checkFailed: statusCheckFailed)
+        details = Self.details(for: environment, status: status, runtimeVersion: runtimeVersion)
         // A status nobody has read back yet is not a state to act on: Start stays disabled
         // until the environment answers again.
         availability = Self.availability(for: statusUnread ? nil : status, operation: operation, attention: attention, blockedElsewhere: startBlockedElsewhere)
@@ -82,11 +98,11 @@ struct EnvironmentCardState: Equatable, Identifiable {
         availability[action] ?? .disabled(reason: "Not available")
     }
 
-    private static func statusText(for status: EnvironmentStatus?, operation: AppModel.OperationState?) -> String {
+    private static func statusText(for status: EnvironmentStatus?, operation: AppModel.OperationState?, checkFailed: Bool) -> String {
         if let operation {
             return operation.phase.map { describe($0) } ?? "Starting…"
         }
-        guard let status else { return "Checking environment…" }
+        guard let status else { return checkFailed ? "Last check failed" : "Checking environment…" }
         if status.inFlightOperation != nil { return "Operation in progress…" }
         let vm = describe(status.vm)
         switch status.readiness {
@@ -121,16 +137,22 @@ struct EnvironmentCardState: Equatable, Identifiable {
         }
     }
 
-    private static func details(for environment: DevelopmentEnvironment, status: EnvironmentStatus?) -> [Detail] {
+    private static func details(for environment: DevelopmentEnvironment, status: EnvironmentStatus?, runtimeVersion: RuntimeVersionInfo?) -> [Detail] {
         let observed = status?.observed
-        // Disk is the guest's logical capacity, labeled as such: actual usage is not observed
-        // yet. Account status is not observed yet either, and the row says so instead of
-        // claiming a value.
+        // A status carries no Tart version: the service reports the bundle it verified once,
+        // for the whole host, so that is what the row shows when the environment has no
+        // observation of its own.
+        let tart = observed?.tartVersion ?? runtimeVersion?.tart?.version
+        // The guest's logical capacity is not its consumption (MVP-PLAN.md §4), and nothing
+        // observes the latter yet: the two are separate rows so a sparse 160 GB disk is never
+        // read as 160 GB of work. Account status is not observed yet either, and both rows say
+        // so instead of letting capacity stand in for a value nobody measured.
         return [
             Detail(label: "Disk capacity", value: ByteCountFormatter.string(fromByteCount: Int64(clamping: environment.guestDiskBytes), countStyle: .file)),
+            Detail(label: "Disk usage", value: "Not observed yet"),
             Detail(label: "Xcode", value: observed?.xcodeBuild ?? "Unknown"),
             Detail(label: "Guest macOS", value: observed?.guestMacOSBuild ?? "Unknown"),
-            Detail(label: "Runtime", value: observed?.tartVersion.map { "Tart \($0)" } ?? "Unknown"),
+            Detail(label: "Runtime", value: tart.map { "Tart \($0)" } ?? "Unknown"),
             Detail(label: "Codex CLI", value: observed?.codexCLIVersion ?? "Unknown"),
             Detail(label: "Accounts", value: "Not observed yet"),
         ]

--- a/Guesthouse/Dashboard/EnvironmentCardState.swift
+++ b/Guesthouse/Dashboard/EnvironmentCardState.swift
@@ -61,7 +61,7 @@ struct EnvironmentCardState: Equatable, Identifiable {
     let details: [Detail]
     let availability: [Action: Availability]
 
-    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?) {
+    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?, startBlockedElsewhere: String? = nil) {
         id = environment.id
         name = environment.name
         let attention: GuesthouseError? = {
@@ -73,7 +73,7 @@ struct EnvironmentCardState: Equatable, Identifiable {
         isBusy = status == nil || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
         statusText = Self.statusText(for: status, operation: operation)
         details = Self.details(for: environment, status: status)
-        availability = Self.availability(for: status, operation: operation, attention: attention)
+        availability = Self.availability(for: status, operation: operation, attention: attention, blockedElsewhere: startBlockedElsewhere)
     }
 
     func availability(of action: Action) -> Availability {
@@ -115,29 +115,35 @@ struct EnvironmentCardState: Equatable, Identifiable {
 
     private static func details(for environment: DevelopmentEnvironment, status: EnvironmentStatus?) -> [Detail] {
         let observed = status?.observed
+        // Disk is the guest's logical capacity, labeled as such: actual usage is not observed
+        // yet. Account status is not observed yet either, and the row says so instead of
+        // claiming a value.
         return [
-            Detail(label: "Disk", value: ByteCountFormatter.string(fromByteCount: Int64(clamping: environment.guestDiskBytes), countStyle: .file)),
+            Detail(label: "Disk capacity", value: ByteCountFormatter.string(fromByteCount: Int64(clamping: environment.guestDiskBytes), countStyle: .file)),
             Detail(label: "Xcode", value: observed?.xcodeBuild ?? "Unknown"),
             Detail(label: "Guest macOS", value: observed?.guestMacOSBuild ?? "Unknown"),
             Detail(label: "Runtime", value: observed?.tartVersion.map { "Tart \($0)" } ?? "Unknown"),
             Detail(label: "Codex CLI", value: observed?.codexCLIVersion ?? "Unknown"),
-            Detail(label: "Accounts", value: "Unknown"),
+            Detail(label: "Accounts", value: "Not observed yet"),
         ]
     }
 
-    private static func availability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?) -> [Action: Availability] {
+    private static func availability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?, blockedElsewhere: String?) -> [Action: Availability] {
         var table: [Action: Availability] = [:]
         for action in Action.allCases where action != .start {
             table[action] = .notImplemented(note: Self.notImplementedNote(for: action))
         }
-        table[.start] = startAvailability(for: status, operation: operation, attention: attention)
+        table[.start] = startAvailability(for: status, operation: operation, attention: attention, blockedElsewhere: blockedElsewhere)
         return table
     }
 
-    private static func startAvailability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?) -> Availability {
+    private static func startAvailability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?, blockedElsewhere: String?) -> Availability {
         guard let status, status.readiness != .checking else { return .disabled(reason: "Checking environment") }
         if operation != nil || status.inFlightOperation != nil { return .disabled(reason: "An operation is in progress") }
-        if let attention { return .disabled(reason: attention.userMessage) }
+        if let blockedElsewhere { return .disabled(reason: blockedElsewhere) }
+        // A failed start does not lock Start forever: once the status re-check reports a
+        // stopped, ready VM, Start is a retry and the runtime's own recovery actions apply.
+        if let attention, status.readiness != .ready || status.vm != .stopped { return .disabled(reason: attention.userMessage) }
         switch status.vm {
         case .stopped: return .enabled
         case .running: return .disabled(reason: "Already running")

--- a/Guesthouse/Dashboard/EnvironmentCardState.swift
+++ b/Guesthouse/Dashboard/EnvironmentCardState.swift
@@ -141,6 +141,9 @@ struct EnvironmentCardState: Equatable, Identifiable {
         guard let status, status.readiness != .checking else { return .disabled(reason: "Checking environment") }
         if operation != nil || status.inFlightOperation != nil { return .disabled(reason: "An operation is in progress") }
         if let blockedElsewhere { return .disabled(reason: blockedElsewhere) }
+        // A preserved slot is never startable, whatever the VM's state: the runtime refuses it
+        // until the slot is repaired.
+        if case .environmentPreserved? = attention { return .disabled(reason: attention?.userMessage ?? "This development Mac is preserved") }
         // A failed start does not lock Start forever: once the status re-check reports a
         // stopped, ready VM, Start is a retry and the runtime's own recovery actions apply.
         if let attention, status.readiness != .ready || status.vm != .stopped { return .disabled(reason: attention.userMessage) }

--- a/Guesthouse/Dashboard/EnvironmentCardState.swift
+++ b/Guesthouse/Dashboard/EnvironmentCardState.swift
@@ -61,7 +61,7 @@ struct EnvironmentCardState: Equatable, Identifiable {
     let details: [Detail]
     let availability: [Action: Availability]
 
-    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?, startBlockedElsewhere: String? = nil) {
+    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?, statusUnread: Bool = false, startBlockedElsewhere: String? = nil) {
         id = environment.id
         name = environment.name
         let attention: GuesthouseError? = {
@@ -70,10 +70,12 @@ struct EnvironmentCardState: Equatable, Identifiable {
         }()
         self.attention = attention
         phase = operation?.phase
-        isBusy = status == nil || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
+        isBusy = statusUnread || status == nil || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
         statusText = Self.statusText(for: status, operation: operation)
         details = Self.details(for: environment, status: status)
-        availability = Self.availability(for: status, operation: operation, attention: attention, blockedElsewhere: startBlockedElsewhere)
+        // A status nobody has read back yet is not a state to act on: Start stays disabled
+        // until the environment answers again.
+        availability = Self.availability(for: statusUnread ? nil : status, operation: operation, attention: attention, blockedElsewhere: startBlockedElsewhere)
     }
 
     func availability(of action: Action) -> Availability {
@@ -86,16 +88,22 @@ struct EnvironmentCardState: Equatable, Identifiable {
         }
         guard let status else { return "Checking environment…" }
         if status.inFlightOperation != nil { return "Operation in progress…" }
+        let vm = describe(status.vm)
         switch status.readiness {
         case .checking: return "Checking environment…"
-        case .needsAttention: return "Needs attention"
-        case .ready:
-            switch status.vm {
-            case .running: return "Running"
-            case .stopped: return "Stopped"
-            case .notFound: return "Virtual machine missing"
-            case .uncertain: return "Ownership uncertain"
-            }
+        // Both states are reported: a running VM that is not reachable is still running, and
+        // the card must not hide that (MVP-PLAN.md §2).
+        case .needsAttention: return "\(vm), needs attention"
+        case .ready: return vm
+        }
+    }
+
+    static func describe(_ vm: EnvironmentStatus.VMState) -> String {
+        switch vm {
+        case .running: "Running"
+        case .stopped: "Stopped"
+        case .notFound: "Virtual machine missing"
+        case .uncertain: "Ownership uncertain"
         }
     }
 
@@ -140,6 +148,8 @@ struct EnvironmentCardState: Equatable, Identifiable {
     private static func startAvailability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?, blockedElsewhere: String?) -> Availability {
         guard let status, status.readiness != .checking else { return .disabled(reason: "Checking environment") }
         if operation != nil || status.inFlightOperation != nil { return .disabled(reason: "An operation is in progress") }
+        // A failure the runtime says is not retryable is not answered by pressing Start again.
+        if let attention, !attention.isRetryable { return .disabled(reason: attention.userMessage) }
         if let blockedElsewhere { return .disabled(reason: blockedElsewhere) }
         // A preserved slot is never startable, whatever the VM's state: the runtime refuses it
         // until the slot is repaired.

--- a/Guesthouse/Dashboard/EnvironmentCardState.swift
+++ b/Guesthouse/Dashboard/EnvironmentCardState.swift
@@ -1,0 +1,162 @@
+import Foundation
+import GuesthouseCore
+
+/// What one dashboard card shows and which actions it offers, derived from what the runtime
+/// reported. Unavailable actions are disabled with a reason, never hidden (MVP-PLAN.md §2).
+struct EnvironmentCardState: Equatable, Identifiable {
+    enum Action: String, CaseIterable, Identifiable {
+        case start, stop, openInCodex, openConsole, testWorkspace, publishDrafts
+        case repair, exportWork, delete
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .start: "Start"
+            case .stop: "Stop"
+            case .openInCodex: "Open in Codex"
+            case .openConsole: "Open Mac console"
+            case .testWorkspace: "Test workspace"
+            case .publishDrafts: "Publish draft PRs"
+            case .repair: "Repair…"
+            case .exportWork: "Export work…"
+            case .delete: "Delete environment…"
+            }
+        }
+
+        /// Primary actions are buttons on the card; the rest live in the overflow menu, with
+        /// Delete separated and destructive so it never looks like a routine fix.
+        var isPrimary: Bool {
+            switch self {
+            case .start, .stop, .openInCodex, .openConsole, .testWorkspace, .publishDrafts: true
+            case .repair, .exportWork, .delete: false
+            }
+        }
+
+        var isDestructive: Bool { self == .delete }
+    }
+
+    enum Availability: Equatable {
+        case enabled
+        /// Present but disabled; the reason is shown as help text and read by VoiceOver.
+        case disabled(reason: String)
+        /// Present, and tapping it says so instead of doing nothing.
+        case notImplemented(note: String)
+    }
+
+    struct Detail: Equatable, Identifiable {
+        let label: String
+        let value: String
+        var id: String { label }
+    }
+
+    let id: EnvironmentID
+    let name: String
+    let statusText: String
+    /// True while the runtime is reconciling or an operation is in flight.
+    let isBusy: Bool
+    let phase: ProgressPhase?
+    /// The problem the runtime reported, if any, with its recovery actions.
+    let attention: GuesthouseError?
+    let details: [Detail]
+    let availability: [Action: Availability]
+
+    init(environment: DevelopmentEnvironment, status: EnvironmentStatus?, operation: AppModel.OperationState?, lastError: GuesthouseError?) {
+        id = environment.id
+        name = environment.name
+        let attention: GuesthouseError? = {
+            if case .needsAttention(let error)? = status?.readiness { return error }
+            return lastError
+        }()
+        self.attention = attention
+        phase = operation?.phase
+        isBusy = status == nil || status?.readiness == .checking || status?.inFlightOperation != nil || operation != nil
+        statusText = Self.statusText(for: status, operation: operation)
+        details = Self.details(for: environment, status: status)
+        availability = Self.availability(for: status, operation: operation, attention: attention)
+    }
+
+    func availability(of action: Action) -> Availability {
+        availability[action] ?? .disabled(reason: "Not available")
+    }
+
+    private static func statusText(for status: EnvironmentStatus?, operation: AppModel.OperationState?) -> String {
+        if let operation {
+            return operation.phase.map { describe($0) } ?? "Starting…"
+        }
+        guard let status else { return "Checking environment…" }
+        if status.inFlightOperation != nil { return "Operation in progress…" }
+        switch status.readiness {
+        case .checking: return "Checking environment…"
+        case .needsAttention: return "Needs attention"
+        case .ready:
+            switch status.vm {
+            case .running: return "Running"
+            case .stopped: return "Stopped"
+            case .notFound: return "Virtual machine missing"
+            case .uncertain: return "Ownership uncertain"
+            }
+        }
+    }
+
+    static func describe(_ phase: ProgressPhase) -> String {
+        switch phase.kind {
+        case .inspectingState: "Checking the current state…"
+        case .verifyingRuntime: "Verifying the virtual machine runtime…"
+        case .startingVM: "Starting the virtual machine…"
+        case .waitingForNetwork: "Waiting for the development Mac to answer…"
+        case .stoppingVM: "Shutting down…"
+        case .forceStoppingVM: "Force-stopping…"
+        case .validatingSelection: "Validating the selection…"
+        case .copying: "Copying…"
+        case .verifyingCopy: "Verifying the copy…"
+        }
+    }
+
+    private static func details(for environment: DevelopmentEnvironment, status: EnvironmentStatus?) -> [Detail] {
+        let observed = status?.observed
+        return [
+            Detail(label: "Disk", value: ByteCountFormatter.string(fromByteCount: Int64(clamping: environment.guestDiskBytes), countStyle: .file)),
+            Detail(label: "Xcode", value: observed?.xcodeBuild ?? "Unknown"),
+            Detail(label: "Guest macOS", value: observed?.guestMacOSBuild ?? "Unknown"),
+            Detail(label: "Runtime", value: observed?.tartVersion.map { "Tart \($0)" } ?? "Unknown"),
+            Detail(label: "Codex CLI", value: observed?.codexCLIVersion ?? "Unknown"),
+            Detail(label: "Accounts", value: "Unknown"),
+        ]
+    }
+
+    private static func availability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?) -> [Action: Availability] {
+        var table: [Action: Availability] = [:]
+        for action in Action.allCases where action != .start {
+            table[action] = .notImplemented(note: Self.notImplementedNote(for: action))
+        }
+        table[.start] = startAvailability(for: status, operation: operation, attention: attention)
+        return table
+    }
+
+    private static func startAvailability(for status: EnvironmentStatus?, operation: AppModel.OperationState?, attention: GuesthouseError?) -> Availability {
+        guard let status, status.readiness != .checking else { return .disabled(reason: "Checking environment") }
+        if operation != nil || status.inFlightOperation != nil { return .disabled(reason: "An operation is in progress") }
+        if let attention { return .disabled(reason: attention.userMessage) }
+        switch status.vm {
+        case .stopped: return .enabled
+        case .running: return .disabled(reason: "Already running")
+        case .notFound: return .disabled(reason: "The virtual machine is missing")
+        case .uncertain(let reason): return .disabled(reason: "Ownership is uncertain (\(reason)). Repair before starting.")
+        }
+    }
+
+    private static func notImplementedNote(for action: Action) -> String {
+        switch action {
+        case .start: ""
+        case .stop: "Stopping from the dashboard arrives with the real runtime wiring (#32)."
+        case .openInCodex: "Handing off to Codex desktop arrives in Phase 2 (MVP-PLAN.md §10)."
+        case .openConsole: "The Mac console arrives in Phase 2 (MVP-PLAN.md §10)."
+        case .testWorkspace: "Workspace tests arrive in Phase 2 (MVP-PLAN.md §10)."
+        case .publishDrafts: "Publishing draft PRs arrives in Phase 3 (MVP-PLAN.md §10)."
+        case .repair: "Targeted repairs arrive with the repair flows (MVP-PLAN.md §9)."
+        case .exportWork: "Work export arrives in Phase 3 (MVP-PLAN.md §10)."
+        case .delete: "Deletion arrives after work export exists, so it can never be the only way out (MVP-PLAN.md §2)."
+        }
+    }
+}

--- a/Guesthouse/Views/QuitSheet.swift
+++ b/Guesthouse/Views/QuitSheet.swift
@@ -22,6 +22,12 @@ struct QuitSheet: View {
                         .keyboardShortcut(.defaultAction)
                         .accessibilityLabel("Stop environments and quit")
                 }
+            case .waitingForOperations(let id):
+                Text("Finishing an operation…").font(.headline)
+                ProgressView().accessibilityLabel("Waiting for an operation to finish")
+                Text("Guesthouse waits for \(id.flatMap { id in model.environments.first { $0.id == id }?.name } ?? "the development Mac") to finish what it is doing before stopping anything.")
+                    .foregroundStyle(.secondary)
+                HStack { Spacer(); Button("Cancel") { model.cancelQuit() }.keyboardShortcut(.cancelAction).accessibilityLabel("Cancel quitting") }
             case .checking:
                 Text("Checking environment…").font(.headline)
                 ProgressView().accessibilityLabel("Checking environment before quitting")

--- a/GuesthouseTests/AppModelTests.swift
+++ b/GuesthouseTests/AppModelTests.swift
@@ -499,6 +499,7 @@ import Testing
         // menu item unavailable is a check that is reading, and which request goes out first
         // is the reconciliation's business.
         await waitUntil({ !model.canCheckEnvironment }, "the check to start reading")
+        #expect(!model.canCheckEnvironment, "a check is already reading; the menu says so rather than appearing to do nothing")
         model.startRefresh()
         model.startRefresh()
         await waitUntil({ model.launchState == .ready && model.canCheckEnvironment }, "the check to finish")
@@ -515,7 +516,11 @@ import Testing
         await backend.script("listEnvironments", .disconnect())
         let (model, _) = makeModel(backend)
         model.startRefresh()
-        await waitUntil { await backend.receivedRequests.count == 1 }
+        // The listing is what "still reading" means: the reconciliation asks the runtime for
+        // its version first, so a bare request count no longer names that moment.
+        // Any request means the check has started; which one goes out first is the
+        // reconciliation's business, and it changes as the stack grows.
+        await waitUntil({ await !backend.receivedRequests.isEmpty }, "the check to send its first request")
         // The real client reports the loss to its observers before it throws into the stream
         // the same loss cut off.
         backend.dropConnection()
@@ -622,6 +627,42 @@ import Testing
         #expect(model.launchState == .ready)
         #expect(model.runningEnvironments.isEmpty)
         #expect(model.runningSummary == "1 development Mac Guesthouse cannot identify")
+    }
+
+    /// A card-level status query that failed leaves nothing known about that VM. The menu bar
+    /// and the sentence the Quit decision is made on must not report it as stopped: that is the
+    /// same unproven claim uncertainty is kept out of.
+    @Test func anEnvironmentThatDidNotAnswerIsNeverReportedAsNotRunning() async {
+        let backend = FakeRuntimeBackend()
+        let environment = await runningEnvironment(backend)
+        let (model, _) = makeModel(backend)
+        await model.refresh()
+        #expect(model.runningSummary == "1 running")
+        await backend.script("environmentStatus", .fail(error: .runtimeMissing))
+        await model.refreshStatus(of: environment.id)
+        #expect(model.statuses[environment.id] == nil, "the query failed, so nothing is known about this VM")
+        #expect(model.runningSummary == "1 development Mac Guesthouse could not check")
+        #expect(model.quitConfirmationMessage.contains("cannot tell whether it is running"))
+        #expect(!model.quitConfirmationMessage.contains("No development Mac is running"))
+    }
+
+    /// The runtime's status refresh after a start is a bounded courtesy that can time out, so a
+    /// completed start can arrive without describing the environment. What was cached before it
+    /// describes a VM that is now running, and releasing the reservation over that would offer
+    /// Start again for as long as the app's own inspection takes.
+    @Test func aStartThatCompletedWithoutAStatusLeavesNothingActionableBehind() async {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(200))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let (model, _) = makeModel(backend)
+        await model.refresh()
+        // Accepted and completed, with no status of its own in between.
+        await backend.script("startEnvironment", .succeed())
+        model.start(environment.id)
+        await waitUntil { model.operations[environment.id] == nil }
+        #expect(model.statuses[environment.id] == nil, "what was cached before the start says nothing about the state after it")
+        #expect(model.globalStartBlock != nil, "nothing is started while this environment has not answered")
     }
 
     @Test func aStopRefusedBeforeAcceptanceIsNeverForcedPast() async {

--- a/GuesthouseTests/AppModelTests.swift
+++ b/GuesthouseTests/AppModelTests.swift
@@ -319,7 +319,7 @@ import Testing
         _ = model.handleQuitRequest()
         model.confirmStopAndQuit()
         try? await Task.sleep(for: .milliseconds(300))
-        #expect(model.quitFlow == .stopping(environment.id, nil), "a recovered operation keeps the quit waiting")
+        #expect(model.quitFlow == .waitingForOperations(environment.id), "a recovered operation keeps the quit waiting")
         #expect(decision.values.isEmpty)
         await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
         await waitUntil { model.quitFlow == .terminating }

--- a/GuesthouseTests/AppModelTests.swift
+++ b/GuesthouseTests/AppModelTests.swift
@@ -279,11 +279,42 @@ import Testing
     }
 
     @Test func aQuitConfirmationWaitsForAnOperationTheRuntimeReports() async {
+    @Test func twoRapidStartsSendOneRequest() async {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(20))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let (model, _) = makeModel(backend)
+        await model.refresh()
+        model.start(environment.id)
+        model.start(environment.id)
+        #expect(model.operations[environment.id] != nil, "the reservation is visible before the task runs")
+        await waitUntil { model.operations[environment.id] == nil }
+        let starts = await backend.receivedRequests.filter { if case .startEnvironment = $0 { return true }; return false }
+        #expect(starts.count == 1)
+    }
+
+    @Test func aFailedStatusReplyLeavesNoCachedState() async {
+        let backend = FakeRuntimeBackend()
+        let environment = await runningEnvironment(backend)
+        let (model, _) = makeModel(backend)
+        await model.refresh()
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: environment.id)
+        #expect(model.statuses[environment.id] == nil, "a stale status is never kept over a failed query")
+        #expect(model.lastErrors[environment.id] == .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable")))
+        let card = model.cardStates().first { $0.id == environment.id }
+        #expect(card?.availability(of: .start) == .disabled(reason: "Checking environment"))
+        #expect(card?.attention == .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable")))
+    }
+
+    @Test func quitWaitsForAnOperationOnlyTheStatusReports() async {
         let backend = FakeRuntimeBackend()
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
         let recovered = OperationID()
         await backend.setEnvironments([environment])
         await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: recovered))
+        await backend.script("stopEnvironment", .succeed(status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready)))
         let (model, decision) = makeModel(backend)
         await model.refresh()
         _ = model.handleQuitRequest()
@@ -320,6 +351,26 @@ import Testing
         model.startRefresh()
         await waitUntil { await backend.receivedRequests.count > before }
         #expect(await backend.receivedRequests.count > before, "an explicit check still reconnects")
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(model.quitFlow == .stopping(environment.id, nil), "a recovered operation keeps the quit waiting")
+        #expect(decision.values.isEmpty)
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
+        await waitUntil { model.quitFlow == .terminating }
+        #expect(decision.values == [true])
+        let stops = await backend.receivedRequests.filter { if case .stopEnvironment = $0 { return true }; return false }
+        #expect(stops.count == 1, "the VM the recovered start produced is stopped before quitting")
+    }
+
+    @Test func theInFlightPreviewShowsItsScriptedPhases() async {
+        let model = await AppModel.preview(PreviewScenarios.operationInProgress())
+        let backend = model.backend as? FakeRuntimeBackend
+        var requests: [RuntimeRequest] = []
+        for _ in 0..<400 {
+            requests = await backend?.receivedRequests ?? []
+            if requests.contains(where: { if case .startEnvironment = $0 { return true }; return false }) { break }
+            try? await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(requests.contains { if case .startEnvironment = $0 { return true }; return false }, "the scripted start is sent despite the seeded in-flight status")
     }
 
     @Test func anUnavailableRecoverySurvivesTheSessionClosingBehindIt() async {

--- a/GuesthouseTests/AppModelTests.swift
+++ b/GuesthouseTests/AppModelTests.swift
@@ -278,7 +278,6 @@ import Testing
         #expect(!model.canForceStop, "the error asks for inspection, so forcing past it is not offered")
     }
 
-    @Test func aQuitConfirmationWaitsForAnOperationTheRuntimeReports() async {
     @Test func twoRapidStartsSendOneRequest() async {
         let backend = FakeRuntimeBackend(delay: .milliseconds(20))
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
@@ -319,9 +318,14 @@ import Testing
         await model.refresh()
         _ = model.handleQuitRequest()
         model.confirmStopAndQuit()
-        await waitUntil { if case .stopFailed = model.quitFlow { return true }; return false }
-        #expect(model.quitFlow == .stopFailed(.operationOutcomeUnknown(recovered)))
-        #expect(decision.values.isEmpty, "a quit never terminates over an operation the runtime still reports")
+        try? await Task.sleep(for: .milliseconds(300))
+        #expect(model.quitFlow == .stopping(environment.id, nil), "a recovered operation keeps the quit waiting")
+        #expect(decision.values.isEmpty)
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
+        await waitUntil { model.quitFlow == .terminating }
+        #expect(decision.values == [true])
+        let stops = await backend.receivedRequests.filter { if case .stopEnvironment = $0 { return true }; return false }
+        #expect(stops.count == 1, "the VM the recovered start produced is stopped before quitting")
     }
 
     @Test func anInterruptionWhileTheSheetIsOpenReconcilesBeforeOfferingAgain() async {
@@ -351,14 +355,6 @@ import Testing
         model.startRefresh()
         await waitUntil { await backend.receivedRequests.count > before }
         #expect(await backend.receivedRequests.count > before, "an explicit check still reconnects")
-        try? await Task.sleep(for: .milliseconds(300))
-        #expect(model.quitFlow == .stopping(environment.id, nil), "a recovered operation keeps the quit waiting")
-        #expect(decision.values.isEmpty)
-        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
-        await waitUntil { model.quitFlow == .terminating }
-        #expect(decision.values == [true])
-        let stops = await backend.receivedRequests.filter { if case .stopEnvironment = $0 { return true }; return false }
-        #expect(stops.count == 1, "the VM the recovered start produced is stopped before quitting")
     }
 
     @Test func theInFlightPreviewShowsItsScriptedPhases() async {

--- a/GuesthouseTests/DashboardStateTests.swift
+++ b/GuesthouseTests/DashboardStateTests.swift
@@ -23,6 +23,8 @@ import Testing
         #expect(card.statusText == "Running")
         #expect(card.availability(of: .start) == .disabled(reason: "Already running"))
         #expect(card.details.contains(.init(label: "Xcode", value: "17F113")))
+        #expect(card.details.contains { $0.label == "Disk capacity" })
+        #expect(card.details.contains(.init(label: "Accounts", value: "Not observed yet")))
         #expect(card.details.contains(.init(label: "Runtime", value: "Tart 2.36.0")))
         #expect(card.details.contains(.init(label: "Codex CLI", value: "Unknown")))
         #expect(model.createAvailability == .enabled)
@@ -83,6 +85,64 @@ import Testing
         #expect(requests.filter { if case .startEnvironment = $0 { true } else { false } }.count == 1)
     }
 
+    @Test func startIsBlockedOnEveryCardWhileAnotherRunsOrOperates() async throws {
+        let backend = FakeRuntimeBackend()
+        let first = DevelopmentEnvironment(name: "First", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let second = DevelopmentEnvironment(name: "Second", createdAt: Date(timeIntervalSince1970: 1_800_000_001))
+        await backend.setEnvironments([first, second])
+        await backend.setStatus(EnvironmentStatus(environmentID: first.id, vm: .running, readiness: .ready))
+        await backend.setStatus(EnvironmentStatus(environmentID: second.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        guard case .disabled(let reason) = model.cardStates()[1].availability(of: .start) else { Issue.record("expected Start blocked"); return }
+        #expect(reason.contains("First is running"))
+        model.start(second.id)
+        #expect(model.operations.isEmpty, "a refused start sends nothing")
+        await backend.setStatus(EnvironmentStatus(environmentID: first.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .hang)
+        await model.refresh()
+        #expect(model.cardStates()[1].availability(of: .start) == .enabled)
+        model.start(first.id)
+        await waitUntil { model.operations[first.id] != nil }
+        guard case .disabled(let busy) = model.cardStates()[1].availability(of: .start) else { Issue.record("expected Start blocked during the operation"); return }
+        #expect(busy.contains("in progress on First"))
+        if let operation = model.operations[first.id] { for try await _ in backend.send(.cancelOperation(operation.id)) {} }
+        await waitUntil { model.operations.isEmpty }
+    }
+
+    @Test func recoveredInFlightOperationsArePolledUntilTerminal() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: OperationID()))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.cardStates().first?.isBusy == true)
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
+        for _ in 0..<600 where model.statuses[environment.id]?.inFlightOperation != nil { try await Task.sleep(for: .milliseconds(10)) }
+        #expect(model.statuses[environment.id]?.inFlightOperation == nil)
+        #expect(model.cardStates().first?.statusText == "Running")
+    }
+
+    @Test func quitWaitsForAnAcceptedStartBeforeChoosingWhatToStop() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .succeed(phases: [ProgressPhase(kind: .startingVM)], status: EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready)))
+        await backend.script("stopEnvironment", .succeed(status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready)))
+        let decisions = AppModelTests.Decision()
+        let model = AppModel(backend: backend) { decisions.values.append($0) }
+        await model.refresh()
+        model.start(environment.id)
+        _ = model.handleQuitRequest()
+        model.confirmStopAndQuit()
+        await waitUntil { model.quitFlow == .terminating }
+        let requests = await backend.receivedRequests
+        #expect(requests.contains { if case .stopEnvironment(let id, _) = $0 { id == environment.id } else { false } }, "the freshly started VM was stopped before quitting")
+        #expect(decisions.values == [true])
+    }
+
     @Test func startFailureIsShownOnTheCardWithItsRecoveryActions() async throws {
         let backend = FakeRuntimeBackend()
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
@@ -95,7 +155,7 @@ import Testing
         await waitUntil { model.lastErrors[environment.id] != nil && model.operations.isEmpty }
         let card = try #require(model.cardStates().first)
         #expect(card.attention == .guestNotReachable(environment.id))
-        #expect(card.availability(of: .start) == .disabled(reason: GuesthouseError.guestNotReachable(environment.id).userMessage))
+        #expect(card.availability(of: .start) == .enabled, "a stopped, ready VM can be started again after a failed start")
         #expect(!(card.attention?.recoveryActions.isEmpty ?? true))
     }
 

--- a/GuesthouseTests/DashboardStateTests.swift
+++ b/GuesthouseTests/DashboardStateTests.swift
@@ -11,6 +11,15 @@ import Testing
         for _ in 0..<600 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
     }
 
+    @Test func aPreservedEnvironmentCannotBeStartedEvenWhenStopped() {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let status = EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .needsAttention(.environmentPreserved(environment.id)))
+        let card = EnvironmentCardState(environment: environment, status: status, operation: nil, lastError: nil)
+        guard case .disabled = card.availability(of: .start) else { Issue.record("expected Start disabled for a preserved slot"); return }
+        let retried = EnvironmentCardState(environment: environment, status: status, operation: nil, lastError: .environmentPreserved(environment.id))
+        guard case .disabled = retried.availability(of: .start) else { Issue.record("expected Start disabled after the preserved failure"); return }
+    }
+
     @Test func freshMacOffersCreationAndNoCards() async {
         let model = await AppModel.preview(PreviewScenarios.freshMac())
         #expect(model.cardStates().isEmpty)

--- a/GuesthouseTests/DashboardStateTests.swift
+++ b/GuesthouseTests/DashboardStateTests.swift
@@ -11,6 +11,45 @@ import Testing
         for _ in 0..<600 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
     }
 
+    @Test func aFailedStatusQueryIsClearedByALaterSuccess() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: environment.id)
+        #expect(model.cardStates().first?.attention != nil)
+        #expect(model.cardStates().first?.availability(of: .start) != .enabled)
+        await backend.script("environmentStatus", .succeed())
+        await model.refreshStatus(of: environment.id)
+        #expect(model.cardStates().first?.attention == nil, "a successful check clears the query failure")
+    }
+
+    @Test func startIsRefusedWhileAnotherVMsOwnershipIsUncertain() async throws {
+        let backend = FakeRuntimeBackend()
+        let uncertain = DevelopmentEnvironment(name: "One", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let other = DevelopmentEnvironment(name: "Two", createdAt: Date(timeIntervalSince1970: 1_800_000_001))
+        await backend.setEnvironments([uncertain, other])
+        await backend.setStatus(EnvironmentStatus(environmentID: uncertain.id, vm: .uncertain(reason: "running without a recorded owner"), readiness: .needsAttention(.vmOwnershipUncertain(uncertain.id))))
+        await backend.setStatus(EnvironmentStatus(environmentID: other.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        let card = try #require(model.cardStates().first { $0.id == other.id })
+        guard case .disabled(let reason) = card.availability(of: .start) else { Issue.record("expected Start disabled"); return }
+        #expect(reason.contains("without proof"))
+    }
+
+    @Test func aNonRetryableFailureDoesNotOfferStartAgain() {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let status = EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready)
+        let error = GuesthouseError.runtimeStateUnavailable(reason: SanitizedText("the journal is unwritable"))
+        #expect(!error.isRetryable)
+        let card = EnvironmentCardState(environment: environment, status: status, operation: nil, lastError: error)
+        guard case .disabled = card.availability(of: .start) else { Issue.record("expected Start disabled"); return }
+    }
+
     @Test func aPreservedEnvironmentCannotBeStartedEvenWhenStopped() {
         let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
         let status = EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .needsAttention(.environmentPreserved(environment.id)))
@@ -44,7 +83,7 @@ import Testing
         let card = try #require(model.cardStates().first)
         let error = GuesthouseError.hostKeyChanged(card.id)
         #expect(card.attention == error)
-        #expect(card.statusText == "Needs attention")
+        #expect(card.statusText == "Stopped, needs attention")
         #expect(card.availability(of: .start) == .disabled(reason: error.userMessage))
         #expect(error.recoveryActions.contains(.repair(.sshPairing)))
     }

--- a/GuesthouseTests/DashboardStateTests.swift
+++ b/GuesthouseTests/DashboardStateTests.swift
@@ -7,8 +7,19 @@ import Testing
 @Suite struct DashboardStateTests {
     typealias Availability = EnvironmentCardState.Availability
 
-    func waitUntil(_ condition: @MainActor () -> Bool) async {
-        for _ in 0..<600 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
+    /// Waits for a condition, and fails the test if it never holds. A wait that gave up in
+    /// silence let every assertion after it run against a model that had not settled, which
+    /// reads as a flaky test rather than as the timeout it is.
+    func waitUntil(_ condition: @MainActor () -> Bool, _ description: String = "condition",
+                   sourceLocation: SourceLocation = #_sourceLocation) async {
+        for _ in 0..<1200 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
+        if !condition() { Issue.record("timed out waiting for \(description)", sourceLocation: sourceLocation) }
+    }
+
+    func waitUntil(_ condition: @MainActor () async -> Bool, _ description: String = "condition",
+                   sourceLocation: SourceLocation = #_sourceLocation) async {
+        for _ in 0..<1200 where await !condition() { try? await Task.sleep(for: .milliseconds(5)) }
+        if await !condition() { Issue.record("timed out waiting for \(description)", sourceLocation: sourceLocation) }
     }
 
     @Test func aFailedStatusQueryIsClearedByALaterSuccess() async throws {
@@ -72,6 +83,9 @@ import Testing
         #expect(card.availability(of: .start) == .disabled(reason: "Already running"))
         #expect(card.details.contains(.init(label: "Xcode", value: "17F113")))
         #expect(card.details.contains { $0.label == "Disk capacity" })
+        // A sparse capacity is not consumption (MVP-PLAN.md §4): the usage row says nobody
+        // has measured it rather than letting the capacity stand in for it.
+        #expect(card.details.contains(.init(label: "Disk usage", value: "Not observed yet")))
         #expect(card.details.contains(.init(label: "Accounts", value: "Not observed yet")))
         #expect(card.details.contains(.init(label: "Runtime", value: "Tart 2.36.0")))
         #expect(card.details.contains(.init(label: "Codex CLI", value: "Unknown")))
@@ -124,7 +138,12 @@ import Testing
         await model.refresh()
         #expect(try #require(model.cardStates().first).availability(of: .start) == .enabled)
         model.start(environment.id)
-        await waitUntil { model.statuses[environment.id]?.vm == .running && model.operations.isEmpty }
+        // The status the operation returned still names the operation until the check that
+        // follows it answers; the card reads "Running" only once nothing is in flight on it.
+        await waitUntil({
+            model.statuses[environment.id]?.vm == .running && model.operations.isEmpty
+                && model.statuses[environment.id]?.inFlightOperation == nil
+        }, "the check that follows the start")
         let card = try #require(model.cardStates().first)
         #expect(card.statusText == "Running")
         #expect(card.attention == nil)
@@ -154,8 +173,10 @@ import Testing
         await waitUntil { model.operations[first.id] != nil }
         guard case .disabled(let busy) = model.cardStates()[1].availability(of: .start) else { Issue.record("expected Start blocked during the operation"); return }
         #expect(busy.contains("in progress on First"))
-        if let operation = model.operations[first.id] { for try await _ in backend.send(.cancelOperation(operation.id)) {} }
-        await waitUntil { model.operations.isEmpty }
+        // The hung start is left running: this window's model has no name for the operation the
+        // runtime accepted until the acceptance is tracked (issue #29), so a cancellation from
+        // here would name the local label and match nothing. What this test asserts is already
+        // made above, and the fake's task ends with the test.
     }
 
     @Test func recoveredInFlightOperationsArePolledUntilTerminal() async throws {
@@ -200,11 +221,152 @@ import Testing
         let model = AppModel(backend: backend) { _ in }
         await model.refresh()
         model.start(environment.id)
-        await waitUntil { model.lastErrors[environment.id] != nil && model.operations.isEmpty }
+        // The check that follows the failure has to answer first: the status the start began
+        // from is dropped, so Start is offered again only from what the runtime just reported.
+        await waitUntil { model.lastErrors[environment.id] != nil && model.operations.isEmpty && model.statuses[environment.id] != nil }
         let card = try #require(model.cardStates().first)
         #expect(card.attention == .guestNotReachable(environment.id))
         #expect(card.availability(of: .start) == .enabled, "a stopped, ready VM can be started again after a failed start")
         #expect(!(card.attention?.recoveryActions.isEmpty ?? true))
+    }
+
+    @Test func aCardErrorCarriesTheRecoveryTheFailurePrescribes() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        let error = GuesthouseError.runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))
+        await backend.script("environmentStatus", .fail(error: error))
+        await model.refreshStatus(of: environment.id)
+        let card = try #require(model.cardStates().first)
+        #expect(card.attention == error)
+        #expect(card.availability(of: .start) != .enabled)
+        #expect(card.recoveryActions == error.recoveryActions)
+        #expect(card.recoveryActions.contains(.inspectState), "the card offers the inspection the error asks for")
+        #expect(card.recoveryActions.contains(.openSettings))
+    }
+
+    @Test func theRuntimeVersionOnACardComesFromTheService() async throws {
+        let backend = FakeRuntimeBackend(versionInfo: RuntimeVersionInfo(serviceVersion: "1.2.3", serviceBuild: "42", tart: .init(version: "2.37.1", verified: true)))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        // A status the real lifecycle builds carries no observation of its own.
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        let card = try #require(model.cardStates().first)
+        #expect(card.details.contains(.init(label: "Runtime", value: "Tart 2.37.1")))
+    }
+
+    @Test func aFullReconciliationClearsAnEarlierQueryFailure() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: environment.id)
+        #expect(model.cardStates().first?.attention != nil)
+        // The menu bar's Check Environment reconciles everything and succeeds this time.
+        await backend.script("environmentStatus", .succeed())
+        await model.refresh()
+        #expect(model.cardStates().first?.attention == nil, "the reconciliation that answered cleared the query failure")
+        #expect(model.cardStates().first?.availability(of: .start) == .enabled)
+    }
+
+    @Test func startIsBlockedWhileAnotherEnvironmentsStatusIsUnread() async throws {
+        let backend = FakeRuntimeBackend()
+        let first = DevelopmentEnvironment(name: "First", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let second = DevelopmentEnvironment(name: "Second", createdAt: Date(timeIntervalSince1970: 1_800_000_001))
+        await backend.setEnvironments([first, second])
+        await backend.setStatus(EnvironmentStatus(environmentID: first.id, vm: .stopped, readiness: .ready))
+        await backend.setStatus(EnvironmentStatus(environmentID: second.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.cardStates()[1].availability(of: .start) == .enabled)
+        // The first environment's inspection fails, so nothing is known about its VM.
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: first.id)
+        guard case .disabled(let reason) = model.cardStates()[1].availability(of: .start) else {
+            Issue.record("expected Start blocked while the other environment is unread"); return
+        }
+        #expect(reason.contains("First"))
+        model.start(second.id)
+        #expect(model.operations.isEmpty, "a refused start sends nothing")
+    }
+
+    @Test func onlyOnePollerFollowsARecoveredOperation() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: OperationID()))
+        let model = AppModel(backend: backend) { _ in }
+        // Long enough that no poll can fire between the two reconciliations below: what this
+        // test counts is how many pollers exist, and a poll that legitimately fires before the
+        // second reconciliation replaces it would be counted as a second one.
+        model.recoveredOperationPollInterval = .milliseconds(500)
+        await model.refresh()
+        // Reopening the window, or the menu-bar check, reconciles again while the recovered
+        // operation is still in flight.
+        await model.refresh()
+        // A failed inspection leaves no status, so every poll that is still running makes
+        // exactly one query and then ends: the wait below is for all of them to be over.
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await waitUntil { model.statuses[environment.id] == nil && model.recoveredOperationPolls == 0 }
+        #expect(model.statuses[environment.id] == nil)
+        let queries = await backend.receivedRequests.filter { if case .environmentStatus = $0 { return true }; return false }
+        #expect(queries.count == 3, "two reconciliations and one poll, not one poll per reconciliation")
+    }
+
+    @Test func aQuitCanceledWhileItInspectsIsNotResurrected() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: OperationID()))
+        let decisions = AppModelTests.Decision()
+        let model = AppModel(backend: backend) { decisions.values.append($0) }
+        model.recoveredOperationPollInterval = .seconds(60)
+        await model.refresh()
+        func statusQueries() async -> Int {
+            await backend.receivedRequests.filter { if case .environmentStatus = $0 { return true }; return false }.count
+        }
+        let beforeQuit = await statusQueries()
+        // The quit's own inspection never answers.
+        await backend.script("environmentStatus", .hang)
+        _ = model.handleQuitRequest()
+        model.confirmStopAndQuit()
+        await waitUntil { await statusQueries() > beforeQuit }
+        await backend.script("environmentStatus", .succeed())
+        model.cancelQuit()
+        #expect(model.quitFlow == .idle)
+        // The abandoned attempt has had its turn once no check is reading any more: a second
+        // check joins the one in flight rather than adding a listing of its own, so counting
+        // listings no longer names that moment.
+        await waitUntil({ model.canCheckEnvironment }, "the abandoned attempt to finish")
+        #expect(model.quitFlow == .idle, "the abandoned attempt did not reopen the sheet after AppKit was told to stay")
+        #expect(decisions.values == [false])
+    }
+
+    @Test func aNewerReconciliationSurvivesAnOperationsDisconnect() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(25))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        // The start reports progress for a while and only then loses its connection.
+        await backend.script("startEnvironment", .disconnect(after: Array(repeating: ProgressPhase(kind: .startingVM), count: 8)))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        model.start(environment.id)
+        await waitUntil { model.operations[environment.id]?.phase != nil }
+        // The loss is noticed while nothing else is in flight and reconciliation succeeds,
+        // exactly as the client's observer notification makes it.
+        await model.refresh()
+        #expect(model.launchState == .ready)
+        await waitUntil { model.operations.isEmpty }
+        #expect(model.launchState == .ready, "the reconciliation that read the actual state was not overwritten by the loss")
     }
 
     @Test func interruptionDuringStartLeavesTheOutcomeUnknownAndReChecks() async throws {
@@ -221,5 +383,166 @@ import Testing
         let requests = await backend.receivedRequests
         #expect(requests.filter { if case .startEnvironment = $0 { true } else { false } }.count == 1, "never replayed")
         #expect(requests.last == .environmentStatus(environment.id), "re-checked after the interruption")
+    }
+
+    @Test func aCheckThatFailedIsNotShownAsOneStillRunning() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: environment.id)
+        let card = try #require(model.cardStates().first)
+        #expect(!card.isBusy, "the query ended in a failure; nothing is being checked")
+        #expect(card.statusText == "Last check failed")
+        #expect(card.attention != nil, "and the failure it ended with is what the card explains")
+    }
+
+    @Test func aFailedStartDropsTheStatusItWasStartedFrom() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(50))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.cardStates().first?.availability(of: .start) == .enabled)
+        await backend.script("startEnvironment", .fail(error: .guestNotReachable(environment.id)))
+        model.start(environment.id)
+        await waitUntil { model.operations.isEmpty }
+        // Tart may have launched the VM before the start failed, so the `.stopped` this start
+        // began from is not evidence about anything now: it is dropped, and Start stays out
+        // until the inspection answers rather than offering an immediate blind retry.
+        #expect(model.statuses[environment.id] == nil)
+        #expect(model.cardStates().first?.availability(of: .start) == .disabled(reason: "Checking environment"))
+        await waitUntil { model.statuses[environment.id] != nil }
+        #expect(model.cardStates().first?.availability(of: .start) == .enabled, "and Start returns once the VM answers as stopped and ready")
+    }
+
+    @Test func anOperationsFailureSurvivesTheCheckThatFollowsAnEarlierQueryFailure() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .hang)
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        model.start(environment.id)
+        await waitUntil { model.operations[environment.id] != nil }
+        // A check fails while the start is still running, so the environment carries a
+        // query-failure marker when the start reports its own outcome.
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await model.refreshStatus(of: environment.id)
+        await backend.script("environmentStatus", .succeed())
+        let operation = try #require(model.operations[environment.id]?.id)
+        for try await _ in backend.send(.cancelOperation(operation)) {}
+        await waitUntil { model.operations.isEmpty && model.statuses[environment.id] != nil }
+        #expect(model.lastErrors[environment.id] == .canceled, "the operation's own result is not cleared as if it were the stale query failure")
+        let card = try #require(model.cardStates().first)
+        #expect(card.attention == .canceled)
+        #expect(card.canDismiss, "and the failure the app is holding can be cleared")
+        model.dismissError(environment.id)
+        #expect(model.lastErrors[environment.id] == nil)
+    }
+
+    @Test func aVersionTheServiceCouldNotConfirmIsNotRepeated() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.cardStates().first?.details.contains(.init(label: "Runtime", value: "Tart 2.36.0")) == true)
+        // The environments still answer, so the app stays ready; only the supplementary
+        // version request is refused, and the row says Unknown rather than repeating a
+        // version nothing verified this time (MVP-PLAN.md §2).
+        await backend.script("runtimeVersion", .fail(error: .invalidRequest(.tooManyInFlight)))
+        await model.refresh()
+        #expect(model.launchState == .ready)
+        #expect(model.cardStates().first?.details.contains(.init(label: "Runtime", value: "Unknown")) == true)
+    }
+
+    @Test func aStartIsRefusedUntilAReconciliationEstablishesTheState() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.cardStates().first?.availability(of: .start) == .enabled)
+        // The next check loses its connection. The statuses it never replaced still say the
+        // VM is stopped, so nothing in the cached snapshot refuses a Start rendered a moment
+        // before the loss.
+        await backend.script("listEnvironments", .disconnect())
+        await model.refresh()
+        guard case .interrupted = model.launchState else { Issue.record("expected interrupted"); return }
+        #expect(model.globalStartBlock == nil, "the cached statuses on their own still read as startable")
+        model.start(environment.id)
+        #expect(model.operations.isEmpty)
+        let starts = await backend.receivedRequests.filter { if case .startEnvironment = $0 { return true }; return false }
+        #expect(starts.isEmpty, "no mutation goes out over state the interrupted check never re-established")
+    }
+
+    @Test func anOlderInspectionDoesNotPublishOverANewerReconciliation() async throws {
+        let backend = FakeRuntimeBackend(delay: .milliseconds(100))
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        func statusQueries() async -> Int {
+            await backend.receivedRequests.filter { $0 == .environmentStatus(environment.id) }.count
+        }
+        let before = await statusQueries()
+        // A card inspection that will answer with a failure is outstanding when a newer
+        // reconciliation starts reading the actual state.
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        let stale = Task { await model.refreshStatus(of: environment.id) }
+        await waitUntil { await statusQueries() > before }
+        await backend.script("environmentStatus", .succeed())
+        model.startRefresh()
+        await stale.value
+        // The reconciliation reads three replies where the inspection reads one, so it is
+        // still in flight here: what the older reply must not do is delete the status it is
+        // reconciling, or leave a failure on the card the newer read disproves.
+        #expect(model.statuses[environment.id] != nil, "the superseded reply did not drop the status a newer check is establishing")
+        #expect(model.lastErrors[environment.id] == nil)
+    }
+
+    @Test func aCheckThatRediscoversAnOperationFollowsItAgain() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, inFlightOperation: OperationID()))
+        let model = AppModel(backend: backend) { _ in }
+        model.recoveredOperationPollInterval = .milliseconds(20)
+        await model.refresh()
+        // The poll's own inspection fails, which leaves nothing to follow and ends it.
+        await backend.script("environmentStatus", .fail(error: .runtimeStateUnavailable(reason: SanitizedText("inventory unreadable"))))
+        await waitUntil { model.statuses[environment.id] == nil && model.recoveredOperationPolls == 0 }
+        #expect(model.recoveredOperationPolls == 0, "the poll ended when its query failed")
+        // The card's own check succeeds, and the runtime is still running the operation.
+        await backend.script("environmentStatus", .succeed())
+        await model.refreshStatus(of: environment.id)
+        #expect(model.cardStates().first?.isBusy == true)
+        // Nothing else follows an operation this app never started, so this check has to pick
+        // it up again: the card leaves the busy state when the runtime finishes, rather than
+        // blocking every start until someone checks by hand.
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready))
+        await waitUntil { model.statuses[environment.id]?.inFlightOperation == nil }
+        #expect(model.statuses[environment.id]?.inFlightOperation == nil)
+        #expect(model.cardStates().first?.statusText == "Running")
+        #expect(model.cardStates().first?.isBusy == false)
+    }
+
+    @Test func aProblemTheStatusKeepsReportingIsNotDismissedAway() {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let error = GuesthouseError.anotherEnvironmentRunning(EnvironmentID())
+        #expect(error.recoveryActions == [.cancel], "an error the card can only dismiss needs a control that dismisses it")
+        let held = EnvironmentCardState(environment: environment, status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready), operation: nil, lastError: error)
+        #expect(held.canDismiss)
+        let reported = EnvironmentCardState(environment: environment, status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .needsAttention(error)), operation: nil, lastError: nil)
+        #expect(!reported.canDismiss)
     }
 }

--- a/GuesthouseTests/DashboardStateTests.swift
+++ b/GuesthouseTests/DashboardStateTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import Guesthouse
+
+@MainActor
+@Suite struct DashboardStateTests {
+    typealias Availability = EnvironmentCardState.Availability
+
+    func waitUntil(_ condition: @MainActor () -> Bool) async {
+        for _ in 0..<600 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
+    }
+
+    @Test func freshMacOffersCreationAndNoCards() async {
+        let model = await AppModel.preview(PreviewScenarios.freshMac())
+        #expect(model.cardStates().isEmpty)
+        #expect(model.createAvailability == .enabled)
+    }
+
+    @Test func runningEnvironmentCannotStartAgainAndShowsVersions() async throws {
+        let model = await AppModel.preview(PreviewScenarios.oneRunningEnvironment())
+        let card = try #require(model.cardStates().first)
+        #expect(card.statusText == "Running")
+        #expect(card.availability(of: .start) == .disabled(reason: "Already running"))
+        #expect(card.details.contains(.init(label: "Xcode", value: "17F113")))
+        #expect(card.details.contains(.init(label: "Runtime", value: "Tart 2.36.0")))
+        #expect(card.details.contains(.init(label: "Codex CLI", value: "Unknown")))
+        #expect(model.createAvailability == .enabled)
+    }
+
+    @Test func environmentNeedingRepairExplainsWhyStartIsDisabled() async throws {
+        let model = await AppModel.preview(PreviewScenarios.environmentNeedingRepair())
+        let card = try #require(model.cardStates().first)
+        let error = GuesthouseError.hostKeyChanged(card.id)
+        #expect(card.attention == error)
+        #expect(card.statusText == "Needs attention")
+        #expect(card.availability(of: .start) == .disabled(reason: error.userMessage))
+        #expect(error.recoveryActions.contains(.repair(.sshPairing)))
+    }
+
+    @Test func bothSlotsFullDisablesCreation() async {
+        let model = await AppModel.preview(PreviewScenarios.bothSlotsFull())
+        #expect(model.cardStates().count == 2)
+        guard case .disabled(let reason) = model.createAvailability else { Issue.record("expected the cap to be explained"); return }
+        #expect(reason.contains("at most 2"))
+    }
+
+    @Test func operationInProgressDisablesStart() async throws {
+        let model = await AppModel.preview(PreviewScenarios.operationInProgress())
+        let card = try #require(model.cardStates().first)
+        #expect(card.isBusy)
+        #expect(card.availability(of: .start) == .disabled(reason: "An operation is in progress"))
+    }
+
+    @Test func everyActionButStartIsVisiblyUnimplemented() async throws {
+        let model = await AppModel.preview(PreviewScenarios.oneRunningEnvironment())
+        let card = try #require(model.cardStates().first)
+        for action in EnvironmentCardState.Action.allCases where action != .start {
+            guard case .notImplemented(let note) = card.availability(of: action), !note.isEmpty else {
+                Issue.record("\(action) should be visibly unimplemented"); continue
+            }
+        }
+        #expect(EnvironmentCardState.Action.delete.isDestructive)
+        #expect(!EnvironmentCardState.Action.delete.isPrimary)
+    }
+
+    @Test func startSendsTheRequestAndUpdatesTheCard() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .succeed(phases: [ProgressPhase(kind: .startingVM)], status: EnvironmentStatus(environmentID: environment.id, vm: .running, readiness: .ready)))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(try #require(model.cardStates().first).availability(of: .start) == .enabled)
+        model.start(environment.id)
+        await waitUntil { model.statuses[environment.id]?.vm == .running && model.operations.isEmpty }
+        let card = try #require(model.cardStates().first)
+        #expect(card.statusText == "Running")
+        #expect(card.attention == nil)
+        let requests = await backend.receivedRequests
+        #expect(requests.contains(.startEnvironment(environment.id, StartOptions())))
+        #expect(requests.filter { if case .startEnvironment = $0 { true } else { false } }.count == 1)
+    }
+
+    @Test func startFailureIsShownOnTheCardWithItsRecoveryActions() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .fail(error: .guestNotReachable(environment.id)))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        model.start(environment.id)
+        await waitUntil { model.lastErrors[environment.id] != nil && model.operations.isEmpty }
+        let card = try #require(model.cardStates().first)
+        #expect(card.attention == .guestNotReachable(environment.id))
+        #expect(card.availability(of: .start) == .disabled(reason: GuesthouseError.guestNotReachable(environment.id).userMessage))
+        #expect(!(card.attention?.recoveryActions.isEmpty ?? true))
+    }
+
+    @Test func interruptionDuringStartLeavesTheOutcomeUnknownAndReChecks() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .disconnect())
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        model.start(environment.id)
+        await waitUntil { model.operations.isEmpty && model.launchState != .ready }
+        guard case .interrupted = model.launchState else { Issue.record("expected interrupted"); return }
+        let requests = await backend.receivedRequests
+        #expect(requests.filter { if case .startEnvironment = $0 { true } else { false } }.count == 1, "never replayed")
+        #expect(requests.last == .environmentStatus(environment.id), "re-checked after the interruption")
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: GUI shell, progress/recovery, diagnostics/export and runtime connection (#27–#32). Carry forward useful views/tests after their current runtime/model dependencies are available. Raw-log disclosure/export must become typed structured diagnostics.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #28 (`MVP-PLAN.md` §2: environment cards with running state, readiness, disk usage, tool versions, and account status; primary actions Start, Open in Codex, Open Mac console, Test workspace, Publish draft PRs; secondary Repair, Export work, Delete with "Do not make deletion look like a routine fix"; §1: at most two slots). Stacked on #75.

- `EnvironmentCardState` maps a `DevelopmentEnvironment`, its `EnvironmentStatus`, the app's in-flight operation, and the last error into what a card shows: status text, the problem needing attention, detail rows (disk, Xcode, guest macOS, runtime, Codex CLI, accounts), and one `Availability` per action (`enabled`, `disabled(reason:)`, `notImplemented(note:)`). Unavailable actions are disabled with a reason, never hidden.
- `DashboardView`: empty state ("Create a development Mac", opening a wizard placeholder), one or two `EnvironmentCardView`s in an adaptive grid, and a free-slot or cap-explained card. The overflow menu holds Repair and Export work, then a divider and a destructive Delete.
- Only Start is wired: `AppModel.start` sends `startEnvironment`, follows `accepted`/`progress`/`status`/`failed`/`completed`, treats an interruption as an unknown outcome (never replays), and re-queries the status afterwards. Every other action shows a "not implemented yet" note with where it arrives in the plan.
- `AppModel.preview(_:)` loads a `PreviewScenarios` case; previews exist for all five cases.
- Accessibility labels and hints on every control; disabled buttons carry their reason as help and hint.

Tests (9 new, `GuesthouseTests/DashboardStateTests.swift`): one per preview scenario (which actions are enabled and why), every non-Start action is visibly unimplemented and Delete is secondary and destructive, Start sends exactly one request and updates the card, a failed start shows the error and its recovery actions on the card, and an interruption during Start leaves the outcome unknown, re-checks the status, and never replays.

Closes #28

## Checklist

- [x] Tests cover the new logic; app, kit, and core test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] No process launched in this change
- [x] Diff under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)