### PR TITLE
GUI: diagnostics sheet with sanitized log disclosure and export

### DIFF
--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -504,7 +504,7 @@
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -550,7 +550,7 @@
 				ENABLE_APP_SANDBOX = YES;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				ENABLE_USER_SELECTED_FILES = readonly;
+				ENABLE_USER_SELECTED_FILES = readwrite;
 				GENERATE_INFOPLIST_FILE = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -787,9 +787,18 @@ final class AppModel {
     /// describing rather than picking one at random.
     func observations(of environment: EnvironmentID) -> ObservedTuple { statuses[environment]?.observed ?? ObservedTuple() }
 
+    /// Everything the app still holds for one environment: what an earlier operation left
+    /// behind, then what the operation in flight has said. A retry must not hide the failure
+    /// output that explains why it is retrying, so these are joined rather than chosen between.
+    func logs(of environment: EnvironmentID) -> [RedactedLine] {
+        let retained = lastLogs[environment] ?? []
+        let live = operations[environment]?.logs ?? []
+        return Array((retained + live).suffix(OperationState.maximumLogLines))
+    }
+
     var diagnosticsLines: [RedactedLine] {
         environments.flatMap { environment -> [RedactedLine] in
-            let lines = operations[environment.id]?.logs ?? lastLogs[environment.id] ?? []
+            let lines = logs(of: environment.id)
             // Prefixing goes back through the redactor: `RedactedLine` is only ever made there.
             return redactor.redact(lines: lines.map { "\(environment.id.uuid.uuidString) \($0.text)" })
         }
@@ -808,7 +817,10 @@ final class AppModel {
             runtime: runtimeInfo,
             compatibility: compatibility,
             environments: subject.map { [$0] } ?? [],
-            logs: diagnosticsLines
+            logs: diagnosticsLines,
+            // On a launch failure there is nothing else in the bundle: no environments, no
+            // operation output. The error the user is looking at is the report.
+            launchError: unavailableLaunchError
         )
     }
 
@@ -828,7 +840,7 @@ final class AppModel {
                 unknownOutcome: unknownOutcomes[environment.id],
                 statusQueryFailure: statusQueryFailures[environment.id],
                 reconciling: reconciling.contains(environment.id),
-                logs: operations[environment.id]?.logs ?? lastLogs[environment.id] ?? [],
+                logs: logs(of: environment.id),
                 retryAvailable: lastRequests[environment.id] != nil && !reconciling.contains(environment.id),
                 retryBlockedReason: startRetryBlock(for: environment.id, block: block),
                 startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil,
@@ -1221,6 +1233,17 @@ final class AppModel {
         case .interrupted(let interruption): .checkFailed(interruption)
         case .checkingEnvironment, .ready: .checkFailed(RuntimeConnectionInterrupted())
         }
+    }
+
+    /// The launch failure the user is looking at, if that is what they are looking at.
+    private var unavailableLaunchError: GuesthouseError? {
+        if case .unavailable(let error) = launchState { return error }
+        return nil
+    }
+
+    private func launchStateError() -> GuesthouseError {
+        if case .unavailable(let error) = launchState { return error }
+        return .operationOutcomeUnknown(OperationID())
     }
 
     /// Stop targets come from reconciled state, never from what was cached before the sheet:

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -309,7 +309,8 @@ final class AppModel {
             // outcome over an inspection that has already happened.
             reconciledGeneration = generation
             startRecoveredOperationPoll()
-        case .unavailable(let error):
+        case .unavailable(let error, let version):
+            if let version { runtimeInfo = version }
             launchState = .unavailable(error)
             // An unavailable runtime is not something reconnecting fixes: the error carries
             // its own recovery, and the app stays on it until the user asks again.
@@ -333,17 +334,27 @@ final class AppModel {
 
     private enum ReconcileOutcome {
         case ready([DevelopmentEnvironment], [EnvironmentID: ReadStatus], RuntimeVersionInfo?)
-        case unavailable(GuesthouseError)
+        /// The runtime answered its version and then could not be used. The version is
+        /// carried anyway: diagnostics must describe the runtime as it is now, not as the
+        /// last successful check left it.
+        case unavailable(GuesthouseError, RuntimeVersionInfo?)
         case interrupted(RuntimeConnectionInterrupted)
     }
 
     private func reconcile() async -> ReconcileOutcome {
         do {
+            // Asked first, so a listing that fails afterwards still names the runtime the
+            // diagnostics bundle reports. Supplementary: a service that cannot describe
+            // itself leaves the version row unknown rather than making the app unavailable.
+            var version: RuntimeVersionInfo?
+            for try await event in backend.send(.runtimeVersion) {
+                if case .runtimeVersion(let info) = event { version = info }
+            }
             var listed: [DevelopmentEnvironment] = []
             for try await event in backend.send(.listEnvironments) {
                 switch event {
                 case .environments(let environments): listed = environments
-                case .failed(_, let error): return .unavailable(error)
+                case .failed(_, let error): return .unavailable(error, version)
                 default: break
                 }
             }
@@ -354,14 +365,8 @@ final class AppModel {
                     if case .status(let status) = event {
                         fresh[environment.id] = ReadStatus(status: status, generation: generation)
                     }
-                    if case .failed(_, let error) = event { return .unavailable(error) }
+                    if case .failed(_, let error) = event { return .unavailable(error, version) }
                 }
-            }
-            // Supplementary: the environments were read, so a service that cannot describe
-            // itself leaves the version row unknown rather than making the app unavailable.
-            var version: RuntimeVersionInfo?
-            for try await event in backend.send(.runtimeVersion) {
-                if case .runtimeVersion(let info) = event { version = info }
             }
             return .ready(listed, fresh, version)
         } catch let error as RuntimeConnectionInterrupted {
@@ -798,9 +803,12 @@ final class AppModel {
 
     var diagnosticsLines: [RedactedLine] {
         environments.flatMap { environment -> [RedactedLine] in
-            let lines = logs(of: environment.id)
+            // Scrubbed as a stream *before* the prefix goes on. A credential printed over two
+            // lines is recognized by the line that ends in its label, and a UUID in front of
+            // that label would hide it from the whole-line match.
+            let scrubbed = DiagnosticsExportBuilder.scrubbedStream(logs(of: environment.id))
             // Prefixing goes back through the redactor: `RedactedLine` is only ever made there.
-            return redactor.redact(lines: lines.map { "\(environment.id.uuid.uuidString) \($0.text)" })
+            return redactor.redact(lines: scrubbed.map { "\(environment.id.uuid.uuidString) \($0)" })
         }
     }
 

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -82,6 +82,8 @@ final class AppModel {
     private(set) var reconciling: Set<EnvironmentID> = []
     /// The log of the last finished operation, for the disclosure after it ends.
     private(set) var lastLogs: [EnvironmentID: [RedactedLine]] = [:]
+    /// What the runtime reported about itself at the last refresh.
+    private(set) var runtimeInfo: RuntimeVersionInfo?
     private(set) var quitFlow: QuitFlow = .idle
     /// The user canceled during a step that must run to its end; honored when it ends.
     private(set) var quitCancelRequested = false
@@ -333,6 +335,9 @@ final class AppModel {
 
     private func reconcile() async -> ReconcileOutcome {
         do {
+            for try await event in backend.send(.runtimeVersion) {
+                if case .runtimeVersion(let info) = event { runtimeInfo = info }
+            }
             var listed: [DevelopmentEnvironment] = []
             for try await event in backend.send(.listEnvironments) {
                 switch event {
@@ -771,6 +776,30 @@ final class AppModel {
         guard let failure = cancellationFailures[id], status.inFlightOperation != failure.operation else { return }
         cancellationFailures[id] = nil
         if lastErrors[id] == failure.error { lastErrors[id] = nil }
+    }
+
+    // MARK: - Diagnostics
+
+    /// Every redacted line the app holds, oldest first, prefixed with the environment it
+    /// belongs to (by UUID, never by address).
+    var diagnosticsLines: [RedactedLine] {
+        environments.flatMap { environment -> [RedactedLine] in
+            operations[environment.id]?.logs ?? lastLogs[environment.id] ?? []
+        }
+    }
+
+    /// The bundle "Export diagnostics" writes.
+    func diagnosticsExport() -> DiagnosticsExport {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let compatibility = statuses.values.first?.observed ?? ObservedTuple()
+        return DiagnosticsExportBuilder.build(
+            appVersion: info["CFBundleShortVersionString"] as? String ?? "0",
+            appBuild: info["CFBundleVersion"] as? String ?? "0",
+            runtime: runtimeInfo,
+            compatibility: compatibility,
+            environments: environments,
+            logs: diagnosticsLines
+        )
     }
 
     // MARK: - Dashboard

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -82,7 +82,9 @@ final class AppModel {
     private(set) var reconciling: Set<EnvironmentID> = []
     /// The log of the last finished operation, for the disclosure after it ends.
     private(set) var lastLogs: [EnvironmentID: [RedactedLine]] = [:]
-    /// What the runtime reported about itself at the last refresh.
+    /// What the service reports about itself and the Tart bundle it verified. The per-status
+    /// observation carries no Tart version, so this is where the dashboard's tool-version row
+    /// and the diagnostics bundle's metadata come from (MVP-PLAN.md §2).
     private(set) var runtimeInfo: RuntimeVersionInfo?
     private let redactor = Redactor()
     private(set) var quitFlow: QuitFlow = .idle
@@ -134,7 +136,7 @@ final class AppModel {
     /// What the service reports about itself and the Tart bundle it verified. The per-status
     /// observation carries no Tart version, so this is where the dashboard's tool-version row
     /// comes from (MVP-PLAN.md §2).
-    private(set) var runtimeVersion: RuntimeVersionInfo?
+    private(set) var runtimeInfo: RuntimeVersionInfo?
     /// How many inspections of an environment are still outstanding. A card tells a check that
     /// is running from one that already ended in failure, so a query nobody is waiting for is
     /// never presented as one still in progress.
@@ -286,11 +288,12 @@ final class AppModel {
                 _ = claimStatusGeneration(of: id)
             }
             statuses = published
-            // Assigned whatever the supplementary request answered: a service that could not
-            // describe itself this time has not confirmed the version it gave last time, and
-            // the MVP-PLAN.md §2 tool-version row says Unknown rather than repeating a value
-            // nothing verified.
-            runtimeVersion = version
+            // Assigned whatever the supplementary request answered, and only now, with the
+            // rest of this refresh's result: a service that could not describe itself this
+            // time has not confirmed the version it gave last time, so the tool-version row
+            // says Unknown rather than repeating a value nothing verified, and an overtaken
+            // reconciliation cannot change the metadata diagnostics report.
+            runtimeInfo = version
             // These environments answered, so a failure of an earlier *query* is history,
             // exactly as it is after a single successful status query. A failed operation's
             // error stays: it is what the card explains.
@@ -336,13 +339,6 @@ final class AppModel {
 
     private func reconcile() async -> ReconcileOutcome {
         do {
-            for try await event in backend.send(.runtimeVersion) {
-                switch event {
-                case .runtimeVersion(let info): runtimeInfo = info
-                case .failed(_, let error): return .unavailable(error)
-                default: break
-                }
-            }
             var listed: [DevelopmentEnvironment] = []
             for try await event in backend.send(.listEnvironments) {
                 switch event {
@@ -787,6 +783,10 @@ final class AppModel {
 
     /// Every redacted line the app holds, oldest first, each prefixed with the environment it
     /// belongs to (by UUID, never by address), so two development Macs' lines stay apart.
+    /// The observations for one environment, so an export says which development Mac it is
+    /// describing rather than picking one at random.
+    func observations(of environment: EnvironmentID) -> ObservedTuple { statuses[environment]?.observed ?? ObservedTuple() }
+
     var diagnosticsLines: [RedactedLine] {
         environments.flatMap { environment -> [RedactedLine] in
             let lines = operations[environment.id]?.logs ?? lastLogs[environment.id] ?? []
@@ -798,13 +798,16 @@ final class AppModel {
     /// The bundle "Export diagnostics" writes.
     func diagnosticsExport() -> DiagnosticsExport {
         let info = Bundle.main.infoDictionary ?? [:]
-        let compatibility = statuses.values.first?.observed ?? ObservedTuple()
+        // The manifest describes one environment: the first in creation order, named in the
+        // export, rather than whichever status happened to be first in a dictionary.
+        let subject = environments.first
+        let compatibility = subject.map { observations(of: $0.id) } ?? ObservedTuple()
         return DiagnosticsExportBuilder.build(
             appVersion: info["CFBundleShortVersionString"] as? String ?? "0",
             appBuild: info["CFBundleVersion"] as? String ?? "0",
             runtime: runtimeInfo,
             compatibility: compatibility,
-            environments: environments,
+            environments: subject.map { [$0] } ?? [],
             logs: diagnosticsLines
         )
     }
@@ -829,7 +832,7 @@ final class AppModel {
                 retryAvailable: lastRequests[environment.id] != nil && !reconciling.contains(environment.id),
                 retryBlockedReason: startRetryBlock(for: environment.id, block: block),
                 startBlockedElsewhere: (operations[environment.id] == nil && statuses[environment.id]?.vm != .running) ? block : nil,
-                runtimeVersion: runtimeVersion
+                runtimeVersion: runtimeInfo
             )
         }
     }
@@ -1324,6 +1327,13 @@ final class AppModel {
                         if case .stopping = quitFlow { quitFlow = .stopping(environment.id, phase) }
                     case .status(let status):
                         statuses[status.environmentID] = status
+                    case .log(_, let line):
+                        // Shutdown output belongs in diagnostics: it is what explains a stop
+                        // that failed, and the quit sheet does not show it.
+                        var logs = lastLogs[environment.id] ?? []
+                        logs.append(line)
+                        if logs.count > OperationState.maximumLogLines { logs.removeFirst(logs.count - OperationState.maximumLogLines) }
+                        lastLogs[environment.id] = logs
                     case .failed(_, let error):
                         if accepted { gracefulFailures.insert(environment.id) }
                         // A cancellation deferred by a protected phase is honored here too:

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -68,6 +68,12 @@ final class AppModel {
     /// check's own failure from a problem the environment reported.
     private var statusQueryFailures: [EnvironmentID: GuesthouseError] = [:]
     private(set) var lastErrors: [EnvironmentID: GuesthouseError] = [:]
+    /// How the last operation this app sent for an environment failed, kept apart from the
+    /// error a status query leaves on the card. The check that must follow a failed operation
+    /// is allowed to fail too, and its error replaces the operation's in `lastErrors`; without
+    /// this the bundle would name that check rather than the start or stop the user is
+    /// reporting, and would carry the check's recovery actions instead of the operation's.
+    private var operationFailures: [EnvironmentID: GuesthouseError] = [:]
     /// Operations whose connection dropped before a result arrived. Cleared only by a
     /// successful status query; Retry is never offered while an entry exists (MVP-PLAN.md §3).
     private(set) var unknownOutcomes: [EnvironmentID: OperationID] = [:]
@@ -133,10 +139,6 @@ final class AppModel {
     var quitWaitPollInterval: Duration = .seconds(2)
     /// How many of those polls are running. The model owns one at a time, so this is 0 or 1.
     private(set) var recoveredOperationPolls = 0
-    /// What the service reports about itself and the Tart bundle it verified. The per-status
-    /// observation carries no Tart version, so this is where the dashboard's tool-version row
-    /// comes from (MVP-PLAN.md §2).
-    private(set) var runtimeInfo: RuntimeVersionInfo?
     /// How many inspections of an environment are still outstanding. A card tells a check that
     /// is running from one that already ended in failure, so a query nobody is waiting for is
     /// never presented as one still in progress.
@@ -259,7 +261,11 @@ final class AppModel {
         // gone, and publishing it as Ready would leave that state on screen until the user
         // happened to ask again, so the loss settles the refresh instead (MVP-PLAN.md §2).
         var settled = outcome
-        if let loss = lossLeftToReconciliation, case .ready = outcome { settled = .interrupted(loss) }
+        if let loss = lossLeftToReconciliation, case .ready(_, _, let version) = outcome {
+            // The version this reconciliation did read is still what diagnostics should report:
+            // the loss is about the session, not about what the runtime said of itself.
+            settled = .interrupted(loss, version)
+        }
         lossLeftToReconciliation = nil
         switch settled {
         case .ready(let listed, let read, let version):
@@ -310,12 +316,20 @@ final class AppModel {
             reconciledGeneration = generation
             startRecoveredOperationPoll()
         case .unavailable(let error, let version):
-            if let version { runtimeInfo = version }
+            // Assigned whole, including a nil: a request rejected before it returned metadata
+            // has no current version to publish, and keeping the last verified one would have
+            // diagnostics report a runtime that is not the one that just failed.
+            runtimeInfo = version
             launchState = .unavailable(error)
             // An unavailable runtime is not something reconnecting fixes: the error carries
             // its own recovery, and the app stays on it until the user asks again.
             automaticReconciliationSuspended = true
-        case .interrupted(let interruption):
+        case .interrupted(let interruption, let version):
+            // Assigned whole, including a nil, for the same reason as above: the session that
+            // answered the last version is the one that just dropped, so keeping its answer
+            // would have diagnostics describe a runtime beside a connection failure this
+            // refresh never got past. What this refresh did read before the loss stands.
+            runtimeInfo = version
             launchState = .interrupted(interruption)
             // A reconciliation that was itself cut off would otherwise be restarted by the
             // loss it just suffered, relaunching a service that keeps crashing forever. The
@@ -338,17 +352,32 @@ final class AppModel {
         /// carried anyway: diagnostics must describe the runtime as it is now, not as the
         /// last successful check left it.
         case unavailable(GuesthouseError, RuntimeVersionInfo?)
-        case interrupted(RuntimeConnectionInterrupted)
+        /// The connection dropped mid-reconciliation. The version is carried for the same
+        /// reason: whatever this refresh read before the loss is the current metadata, and
+        /// what it never read is not.
+        case interrupted(RuntimeConnectionInterrupted, RuntimeVersionInfo?)
     }
 
     private func reconcile() async -> ReconcileOutcome {
+        // Declared outside the attempt so an interrupted reconciliation reports what it did
+        // read: the alternative is publishing the previous session's version beside the
+        // failure of this one.
+        var version: RuntimeVersionInfo?
         do {
             // Asked first, so a listing that fails afterwards still names the runtime the
-            // diagnostics bundle reports. Supplementary: a service that cannot describe
-            // itself leaves the version row unknown rather than making the app unavailable.
-            var version: RuntimeVersionInfo?
+            // diagnostics bundle reports. This request is supplementary: a service that cannot
+            // describe itself still works, and the tool-version row says Unknown rather than
+            // taking the whole app down. A protocol mismatch is the exception, because it is a
+            // fact about the session rather than about this request — nothing else this app
+            // sends will be understood — so it reports the runtime as unavailable with the
+            // recovery that error carries.
             for try await event in backend.send(.runtimeVersion) {
-                if case .runtimeVersion(let info) = event { version = info }
+                switch event {
+                case .runtimeVersion(let info): version = info
+                case .failed(_, let error):
+                    if case .protocolMismatch = error { return .unavailable(error, version) }
+                default: break
+                }
             }
             var listed: [DevelopmentEnvironment] = []
             for try await event in backend.send(.listEnvironments) {
@@ -370,9 +399,9 @@ final class AppModel {
             }
             return .ready(listed, fresh, version)
         } catch let error as RuntimeConnectionInterrupted {
-            return .interrupted(error)
+            return .interrupted(error, version)
         } catch {
-            return .interrupted(RuntimeConnectionInterrupted())
+            return .interrupted(RuntimeConnectionInterrupted(), version)
         }
     }
 
@@ -746,6 +775,7 @@ final class AppModel {
     /// the app was relaunched (AGENTS.md: every error carries a recovery action that works).
     func dismissError(_ id: EnvironmentID) {
         lastErrors[id] = nil
+        operationFailures[id] = nil
         statusQueryFailures[id] = nil
         Task { await refreshStatus(of: id) }
     }
@@ -801,8 +831,23 @@ final class AppModel {
         return Array((retained + live).suffix(OperationState.maximumLogLines))
     }
 
-    var diagnosticsLines: [RedactedLine] {
-        environments.flatMap { environment -> [RedactedLine] in
+    var diagnosticsLines: [RedactedLine] { diagnosticsLines(of: environments) }
+
+    /// The lines the diagnostics sheet shows: one environment's when it was opened from that
+    /// environment's card, every environment's when it was opened from the toolbar or from a
+    /// dashboard that has no cards.
+    func diagnosticsLines(subject: EnvironmentID?) -> [RedactedLine] { diagnosticsLines(of: subjects(subject)) }
+
+    /// The environments an export or the sheet describes. A subject that is no longer on the
+    /// dashboard names nothing, so the bundle falls back to what it can still describe rather
+    /// than to an empty report.
+    private func subjects(_ subject: EnvironmentID?) -> [DevelopmentEnvironment] {
+        guard let subject, let named = environments.first(where: { $0.id == subject }) else { return environments }
+        return [named]
+    }
+
+    private func diagnosticsLines(of subjects: [DevelopmentEnvironment]) -> [RedactedLine] {
+        subjects.flatMap { environment -> [RedactedLine] in
             // Scrubbed as a stream *before* the prefix goes on. A credential printed over two
             // lines is recognized by the line that ends in its label, and a UUID in front of
             // that label would hide it from the whole-line match.
@@ -812,12 +857,15 @@ final class AppModel {
         }
     }
 
-    /// The bundle "Export diagnostics" writes.
-    func diagnosticsExport() -> DiagnosticsExport {
+    /// The bundle "Export diagnostics" writes, describing the environment whose card opened
+    /// the sheet.
+    func diagnosticsExport(subject requested: EnvironmentID? = nil) -> DiagnosticsExport {
         let info = Bundle.main.infoDictionary ?? [:]
-        // The manifest describes one environment: the first in creation order, named in the
-        // export, rather than whichever status happened to be first in a dictionary.
-        let subject = environments.first
+        // The manifest describes one environment: the one the user opened Diagnostics from,
+        // and otherwise the first in creation order rather than whichever status happened to
+        // be first in a dictionary. Exporting the first environment for a second one's card
+        // would answer a report about the failing Mac with the healthy Mac's evidence.
+        let subject = subjects(requested).first
         let compatibility = subject.map { observations(of: $0.id) } ?? ObservedTuple()
         return DiagnosticsExportBuilder.build(
             appVersion: info["CFBundleShortVersionString"] as? String ?? "0",
@@ -825,10 +873,19 @@ final class AppModel {
             runtime: runtimeInfo,
             compatibility: compatibility,
             environments: subject.map { [$0] } ?? [],
-            logs: diagnosticsLines,
+            // Only the named environment's log. The manifest declares one environment ID and
+            // one compatibility tuple, so lines prefixed with a second, undeclared UUID would
+            // describe a development Mac the bundle says nothing else about.
+            logs: diagnosticsLines(of: subject.map { [$0] } ?? []),
             // On a launch failure there is nothing else in the bundle: no environments, no
             // operation output. The error the user is looking at is the report.
-            launchError: unavailableLaunchError
+            launchFailure: launchFailure,
+            // An operation that failed before it wrote anything leaves no log either, so the
+            // failure is carried in its own right. The operation's own failure comes first:
+            // the mandatory check after it may fail as well, and that error takes the card
+            // while the state stays unread, but it is not how the operation ended. A card with
+            // no failed operation behind it still reports what it is showing.
+            operationFailure: subject.flatMap { operationFailures[$0.id] ?? lastErrors[$0.id] }.map { .init($0) }
         )
     }
 
@@ -935,6 +992,9 @@ final class AppModel {
             // with nothing to press. The presentation disables the option for the same reason.
             guard let shown = lastErrors[id], shown != statusQueryFailures[id] else { return }
             lastErrors[id] = nil
+            // A dismissed failure is not what the bundle reports either: the user said they
+            // are done with it, and the next export describes what the card shows now.
+            operationFailures[id] = nil
         default:
             break
         }
@@ -971,6 +1031,7 @@ final class AppModel {
     /// operation's own failure prescribes.
     private func recordOperationError(_ error: GuesthouseError?, for id: EnvironmentID) {
         lastErrors[id] = error
+        operationFailures[id] = error
         statusQueryFailures[id] = nil
     }
 
@@ -1243,10 +1304,22 @@ final class AppModel {
         }
     }
 
-    /// The launch failure the user is looking at, if that is what they are looking at.
-    private var unavailableLaunchError: GuesthouseError? {
-        if case .unavailable(let error) = launchState { return error }
-        return nil
+    /// The launch failure the user is looking at, if that is what they are looking at. A lost
+    /// connection counts: the interrupted screen offers Diagnostics too, and on a fresh launch
+    /// the bundle it produces has no environments and no logs to explain itself with.
+    private var launchFailure: DiagnosticsExport.Manifest.ReportedFailure? {
+        switch launchState {
+        case .unavailable(let error):
+            return .init(error)
+        case .interrupted(let interruption):
+            return .init(
+                message: interruption.userMessage,
+                recovery: interruption.recoveryMessage,
+                recoveryActions: interruption.recoveryActions.map { String(describing: $0) }
+            )
+        case .checkingEnvironment, .ready:
+            return nil
+        }
     }
 
     private func launchStateError() -> GuesthouseError {

--- a/Guesthouse/App/AppModel.swift
+++ b/Guesthouse/App/AppModel.swift
@@ -84,6 +84,7 @@ final class AppModel {
     private(set) var lastLogs: [EnvironmentID: [RedactedLine]] = [:]
     /// What the runtime reported about itself at the last refresh.
     private(set) var runtimeInfo: RuntimeVersionInfo?
+    private let redactor = Redactor()
     private(set) var quitFlow: QuitFlow = .idle
     /// The user canceled during a step that must run to its end; honored when it ends.
     private(set) var quitCancelRequested = false
@@ -336,7 +337,11 @@ final class AppModel {
     private func reconcile() async -> ReconcileOutcome {
         do {
             for try await event in backend.send(.runtimeVersion) {
-                if case .runtimeVersion(let info) = event { runtimeInfo = info }
+                switch event {
+                case .runtimeVersion(let info): runtimeInfo = info
+                case .failed(_, let error): return .unavailable(error)
+                default: break
+                }
             }
             var listed: [DevelopmentEnvironment] = []
             for try await event in backend.send(.listEnvironments) {
@@ -780,11 +785,13 @@ final class AppModel {
 
     // MARK: - Diagnostics
 
-    /// Every redacted line the app holds, oldest first, prefixed with the environment it
-    /// belongs to (by UUID, never by address).
+    /// Every redacted line the app holds, oldest first, each prefixed with the environment it
+    /// belongs to (by UUID, never by address), so two development Macs' lines stay apart.
     var diagnosticsLines: [RedactedLine] {
         environments.flatMap { environment -> [RedactedLine] in
-            operations[environment.id]?.logs ?? lastLogs[environment.id] ?? []
+            let lines = operations[environment.id]?.logs ?? lastLogs[environment.id] ?? []
+            // Prefixing goes back through the redactor: `RedactedLine` is only ever made there.
+            return redactor.redact(lines: lines.map { "\(environment.id.uuid.uuidString) \($0.text)" })
         }
     }
 

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -11,6 +11,7 @@ import GuesthouseCore
 struct ContentView: View {
     @Environment(AppModel.self) private var model
     @Environment(DebugRuntimeProbe.self) private var debugProbe
+    @State private var showingDiagnostics = false
 
     var body: some View {
         VStack(spacing: 12) {
@@ -27,11 +28,17 @@ struct ContentView: View {
                 // repeated clicks replace the check in flight instead of piling concurrent
                 // request streams onto one session until the service refuses them, and a check
                 // the Quit sheet owns is not overtaken by one started here.
-                Button("Check Environment") { model.startRefresh() }
+                HStack {
+                    Button("Check Environment") { model.startRefresh() }
+                    Button("Diagnostics…") { showingDiagnostics = true }.accessibilityLabel("Open diagnostics")
+                }
             case .unavailable(let error):
                 Image(systemName: "exclamationmark.triangle").imageScale(.large)
                 Text(error.userMessage)
                 RecoveryActionRow(actions: error.recoveryActions) { model.startRefresh() }
+                // Diagnostics stay reachable exactly when the dashboard, and with it the
+                // card's own menu item, cannot be shown.
+                Button("Diagnostics…") { showingDiagnostics = true }.accessibilityLabel("Open diagnostics")
             }
             #if DEBUG
             Text(debugProbe.result)
@@ -42,6 +49,7 @@ struct ContentView: View {
             #endif
         }
         .frame(minWidth: 720, minHeight: 420)
+        .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model) }
     }
 }
 

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -7,13 +7,16 @@ struct DashboardView: View {
     @Environment(AppModel.self) private var model
     @State private var showingWizard = false
     @State private var showingDiagnostics = false
+    /// Which environment the sheet is about, so Export writes the failing development Mac's
+    /// evidence rather than whichever environment was created first.
+    @State private var diagnosticsSubject: EnvironmentID?
 
     var body: some View {
         let cards = model.cardStates()
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 if cards.isEmpty {
-                    EmptyDashboardView(availability: model.createAvailability, openDiagnostics: { showingDiagnostics = true }) { showingWizard = true }
+                    EmptyDashboardView(availability: model.createAvailability, openDiagnostics: { diagnosticsSubject = nil; showingDiagnostics = true }) { showingWizard = true }
                 } else {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 16)], alignment: .leading, spacing: 16) {
                         ForEach(cards) { card in
@@ -22,7 +25,7 @@ struct DashboardView: View {
                                 start: { model.start(card.id) },
                                 cancel: { model.cancel(card.id) },
                                 recover: { model.perform($0, for: card.id) },
-                                openDiagnostics: { showingDiagnostics = true }
+                                openDiagnostics: { diagnosticsSubject = card.id; showingDiagnostics = true }
                             )
                         }
                         SlotView(availability: model.createAvailability) { showingWizard = true }
@@ -32,7 +35,7 @@ struct DashboardView: View {
             .padding(20)
         }
         .sheet(isPresented: $showingWizard) { WizardPlaceholderView() }
-        .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model) }
+        .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model, subject: diagnosticsSubject) }
     }
 }
 

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -6,6 +6,7 @@ import GuesthouseCore
 struct DashboardView: View {
     @Environment(AppModel.self) private var model
     @State private var showingWizard = false
+    @State private var showingDiagnostics = false
 
     var body: some View {
         let cards = model.cardStates()
@@ -20,7 +21,8 @@ struct DashboardView: View {
                                 state: card,
                                 start: { model.start(card.id) },
                                 cancel: { model.cancel(card.id) },
-                                recover: { model.perform($0, for: card.id) }
+                                recover: { model.perform($0, for: card.id) },
+                                openDiagnostics: { showingDiagnostics = true }
                             )
                         }
                         SlotView(availability: model.createAvailability) { showingWizard = true }
@@ -30,6 +32,7 @@ struct DashboardView: View {
             .padding(20)
         }
         .sheet(isPresented: $showingWizard) { WizardPlaceholderView() }
+        .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model) }
     }
 }
 
@@ -80,6 +83,7 @@ struct EnvironmentCardView: View {
     let start: () -> Void
     let cancel: () -> Void
     let recover: (RecoveryAction) -> Void
+    let openDiagnostics: () -> Void
     @State private var note: String?
 
     var body: some View {
@@ -165,6 +169,7 @@ struct EnvironmentCardView: View {
         Menu {
             Button(EnvironmentCardState.Action.repair.title) { perform(.repair) }
             Button(EnvironmentCardState.Action.exportWork.title) { perform(.exportWork) }
+            Button("Diagnostics…") { openDiagnostics() }
             Divider()
             Button(EnvironmentCardState.Action.delete.title, role: .destructive) { perform(.delete) }
         } label: {

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -13,7 +13,7 @@ struct DashboardView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 if cards.isEmpty {
-                    EmptyDashboardView(availability: model.createAvailability) { showingWizard = true }
+                    EmptyDashboardView(availability: model.createAvailability, openDiagnostics: { showingDiagnostics = true }) { showingWizard = true }
                 } else {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 16)], alignment: .leading, spacing: 16) {
                         ForEach(cards) { card in
@@ -38,6 +38,7 @@ struct DashboardView: View {
 
 struct EmptyDashboardView: View {
     let availability: EnvironmentCardState.Availability
+    let openDiagnostics: () -> Void
     let create: () -> Void
 
     var body: some View {
@@ -49,6 +50,9 @@ struct EmptyDashboardView: View {
             AvailabilityButton("Create a development Mac", availability: availability, action: create)
                 .buttonStyle(.borderedProminent)
                 .accessibilityLabel("Create a development Mac")
+            // Diagnostics are reachable with no environment too: a fresh install that cannot
+            // get further still needs the screen that says what Guesthouse saw.
+            Button("Diagnostics…", action: openDiagnostics).accessibilityLabel("Open diagnostics")
         }
         .frame(maxWidth: .infinity, minHeight: 300)
     }

--- a/Guesthouse/Dashboard/DiagnosticsView.swift
+++ b/Guesthouse/Dashboard/DiagnosticsView.swift
@@ -62,7 +62,9 @@ struct DiagnosticsView: View {
     private func copyVisible() {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
-        pasteboard.setString(visibleLines.map(\.text).joined(separator: "\n"), forType: .string)
+        // The pasteboard is shared with every other application: what leaves the sheet is
+        // scrubbed exactly like the written bundle.
+        pasteboard.setString(visibleLines.map { DiagnosticsExportBuilder.scrub($0.text) }.joined(separator: "\n"), forType: .string)
         exportNote = "\(visibleLines.count) lines copied."
     }
 
@@ -75,7 +77,7 @@ struct DiagnosticsView: View {
         panel.showsTagField = false
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
-            try DiagnosticsExportBuilder.write(model.diagnosticsExport(), to: url)
+            try DiagnosticsExportWriter.write(model.diagnosticsExport(), to: url)
             exportNote = "Exported to \(url.lastPathComponent): manifest.json, log.txt, and excluded.txt."
         } catch {
             exportNote = "The export could not be written (\(GuesthouseError.sanitize(error.localizedDescription, limit: 120))). Choose another location or free disk space."

--- a/Guesthouse/Dashboard/DiagnosticsView.swift
+++ b/Guesthouse/Dashboard/DiagnosticsView.swift
@@ -7,19 +7,28 @@ import GuesthouseCore
 /// "Local storage": nothing sensitive leaves the Mac, and environments are named by UUID).
 struct DiagnosticsView: View {
     @Bindable var model: AppModel
+    /// The environment whose card opened the sheet, or nil when it was opened from the
+    /// toolbar. It decides which environment the log and the exported bundle describe.
+    var subject: EnvironmentID?
     @Environment(\.dismiss) private var dismiss
     @State private var filter = ""
     @State private var exportNote: String?
 
-    /// What the sheet shows is what an export would contain: addresses and account names are
-    /// scrubbed before anything is rendered, filtered, or copied.
+    /// What the sheet shows is what an export would contain: the model has already scrubbed
+    /// addresses and account names out of these lines, so only the filter is applied here.
+    /// Scrubbing again would run every address and identity pattern over the whole log a
+    /// second time, on the UI actor, for no change in what is rendered.
     private var visibleLines: [String] {
-        let lines = model.diagnosticsLines.map { DiagnosticsExportBuilder.scrub($0.text) }
+        let lines = model.diagnosticsLines(subject: subject).map(\.text)
         guard !filter.isEmpty else { return lines }
         return lines.filter { $0.localizedCaseInsensitiveContains(filter) }
     }
 
     var body: some View {
+        // Read once. The empty check, the rows, the accessibility count, and the Copy button
+        // all need the same list, and each read of the property rebuilds and rescrubs the
+        // whole retained log — up to 500 records of up to 64 KiB each, synchronously.
+        let lines = visibleLines
         VStack(alignment: .leading, spacing: 12) {
             Text("Diagnostics").font(.headline)
             Text("Redacted output from the runtime and the development Mac. Private keys, tokens, device codes, authorization headers, and network addresses are never shown or exported.")
@@ -29,10 +38,10 @@ struct DiagnosticsView: View {
                 .accessibilityLabel("Filter log lines")
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 2) {
-                    if visibleLines.isEmpty {
+                    if lines.isEmpty {
                         Text(filter.isEmpty ? "No log lines yet." : "No lines match the filter.").foregroundStyle(.secondary)
                     }
-                    ForEach(Array(visibleLines.enumerated()), id: \.offset) { entry in
+                    ForEach(Array(lines.enumerated()), id: \.offset) { entry in
                         Text(entry.element)
                             .font(.system(.caption, design: .monospaced))
                             .textSelection(.enabled)
@@ -43,13 +52,13 @@ struct DiagnosticsView: View {
             }
             .frame(minHeight: 220)
             .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
-            .accessibilityLabel("Log, \(visibleLines.count) lines")
+            .accessibilityLabel("Log, \(lines.count) lines")
             if let exportNote {
                 Text(exportNote).font(.callout).foregroundStyle(.secondary).accessibilityLabel("Export result: \(exportNote)")
             }
             HStack {
-                Button("Copy") { copyVisible() }
-                    .disabled(visibleLines.isEmpty)
+                Button("Copy") { copyVisible(lines) }
+                    .disabled(lines.isEmpty)
                     .accessibilityLabel("Copy visible lines")
                 Button("Export diagnostics…") { export() }
                     .accessibilityLabel("Export diagnostics")
@@ -61,13 +70,13 @@ struct DiagnosticsView: View {
         .frame(minWidth: 560, minHeight: 420)
     }
 
-    private func copyVisible() {
+    private func copyVisible(_ lines: [String]) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         // The pasteboard is shared with every other application: what leaves the sheet is
         // scrubbed exactly like the written bundle.
-        pasteboard.setString(visibleLines.joined(separator: "\n"), forType: .string)
-        exportNote = "\(visibleLines.count) lines copied."
+        pasteboard.setString(lines.joined(separator: "\n"), forType: .string)
+        exportNote = "\(lines.count) lines copied."
     }
 
     /// Writes the bundle as a folder the user names, through the sandbox-friendly save panel.
@@ -79,7 +88,7 @@ struct DiagnosticsView: View {
         panel.showsTagField = false
         guard panel.runModal() == .OK, let url = panel.url else { return }
         do {
-            try DiagnosticsExportWriter.write(model.diagnosticsExport(), to: url)
+            try DiagnosticsExportWriter.write(model.diagnosticsExport(subject: subject), to: url)
             exportNote = "Exported to \(url.lastPathComponent): manifest.json, log.txt, and excluded.txt."
         } catch {
             exportNote = "The export could not be written (\(GuesthouseError.sanitize(error.localizedDescription, limit: 120))). Choose another location or free disk space."

--- a/Guesthouse/Dashboard/DiagnosticsView.swift
+++ b/Guesthouse/Dashboard/DiagnosticsView.swift
@@ -1,0 +1,92 @@
+import AppKit
+import SwiftUI
+import GuesthouseCore
+
+/// The diagnostics and repair sheet: a filterable, read-only, copyable view of the redacted
+/// log and an export to a folder the user chooses (MVP-PLAN.md §2 "Essential screens"; §3
+/// "Local storage": nothing sensitive leaves the Mac, and environments are named by UUID).
+struct DiagnosticsView: View {
+    @Bindable var model: AppModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var filter = ""
+    @State private var exportNote: String?
+
+    private var visibleLines: [RedactedLine] {
+        let lines = model.diagnosticsLines
+        guard !filter.isEmpty else { return lines }
+        return lines.filter { $0.text.localizedCaseInsensitiveContains(filter) }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Diagnostics").font(.headline)
+            Text("Redacted output from the runtime and the development Mac. Private keys, tokens, device codes, authorization headers, and network addresses are never shown or exported.")
+                .font(.callout).foregroundStyle(.secondary)
+            TextField("Filter", text: $filter)
+                .textFieldStyle(.roundedBorder)
+                .accessibilityLabel("Filter log lines")
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    if visibleLines.isEmpty {
+                        Text(filter.isEmpty ? "No log lines yet." : "No lines match the filter.").foregroundStyle(.secondary)
+                    }
+                    ForEach(Array(visibleLines.enumerated()), id: \.offset) { entry in
+                        Text(entry.element.text)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding(8)
+            }
+            .frame(minHeight: 220)
+            .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 8))
+            .accessibilityLabel("Log, \(visibleLines.count) lines")
+            if let exportNote {
+                Text(exportNote).font(.callout).foregroundStyle(.secondary).accessibilityLabel("Export result: \(exportNote)")
+            }
+            HStack {
+                Button("Copy") { copyVisible() }
+                    .disabled(visibleLines.isEmpty)
+                    .accessibilityLabel("Copy visible lines")
+                Button("Export diagnostics…") { export() }
+                    .accessibilityLabel("Export diagnostics")
+                Spacer()
+                Button("Close") { dismiss() }.keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 560, minHeight: 420)
+    }
+
+    private func copyVisible() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(visibleLines.map(\.text).joined(separator: "\n"), forType: .string)
+        exportNote = "\(visibleLines.count) lines copied."
+    }
+
+    /// Writes the bundle as a folder the user names, through the sandbox-friendly save panel.
+    private func export() {
+        let panel = NSSavePanel()
+        panel.title = "Export Diagnostics"
+        panel.nameFieldStringValue = "Guesthouse Diagnostics \(Self.stamp(Date()))"
+        panel.canCreateDirectories = true
+        panel.showsTagField = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try DiagnosticsExportBuilder.write(model.diagnosticsExport(), to: url)
+            exportNote = "Exported to \(url.lastPathComponent): manifest.json, log.txt, and excluded.txt."
+        } catch {
+            exportNote = "The export could not be written (\(GuesthouseError.sanitize(error.localizedDescription, limit: 120))). Choose another location or free disk space."
+        }
+    }
+
+    static func stamp(_ date: Date) -> String {
+        date.formatted(Date.ISO8601FormatStyle(dateSeparator: .dash, timeSeparator: .omitted)).replacingOccurrences(of: ":", with: "")
+    }
+}
+
+#Preview("Diagnostics") {
+    ScenarioPreview { await PreviewScenarios.oneRunningEnvironment() }
+}

--- a/Guesthouse/Dashboard/DiagnosticsView.swift
+++ b/Guesthouse/Dashboard/DiagnosticsView.swift
@@ -11,10 +11,12 @@ struct DiagnosticsView: View {
     @State private var filter = ""
     @State private var exportNote: String?
 
-    private var visibleLines: [RedactedLine] {
-        let lines = model.diagnosticsLines
+    /// What the sheet shows is what an export would contain: addresses and account names are
+    /// scrubbed before anything is rendered, filtered, or copied.
+    private var visibleLines: [String] {
+        let lines = model.diagnosticsLines.map { DiagnosticsExportBuilder.scrub($0.text) }
         guard !filter.isEmpty else { return lines }
-        return lines.filter { $0.text.localizedCaseInsensitiveContains(filter) }
+        return lines.filter { $0.localizedCaseInsensitiveContains(filter) }
     }
 
     var body: some View {
@@ -31,7 +33,7 @@ struct DiagnosticsView: View {
                         Text(filter.isEmpty ? "No log lines yet." : "No lines match the filter.").foregroundStyle(.secondary)
                     }
                     ForEach(Array(visibleLines.enumerated()), id: \.offset) { entry in
-                        Text(entry.element.text)
+                        Text(entry.element)
                             .font(.system(.caption, design: .monospaced))
                             .textSelection(.enabled)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -64,7 +66,7 @@ struct DiagnosticsView: View {
         pasteboard.clearContents()
         // The pasteboard is shared with every other application: what leaves the sheet is
         // scrubbed exactly like the written bundle.
-        pasteboard.setString(visibleLines.map { DiagnosticsExportBuilder.scrub($0.text) }.joined(separator: "\n"), forType: .string)
+        pasteboard.setString(visibleLines.joined(separator: "\n"), forType: .string)
         exportNote = "\(visibleLines.count) lines copied."
     }
 

--- a/Guesthouse/Diagnostics/DiagnosticsExportWriter.swift
+++ b/Guesthouse/Diagnostics/DiagnosticsExportWriter.swift
@@ -1,0 +1,14 @@
+import Foundation
+import GuesthouseCore
+
+/// Writes a diagnostics bundle where the user chose to put it. The bundle itself is built in
+/// GuesthouseCore; the host write happens here, in the app, under the save panel's grant.
+enum DiagnosticsExportWriter {
+    /// Writes the bundle as a folder. Existing files of the same names are replaced.
+    static func write(_ export: DiagnosticsExport, to directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        for file in export.files {
+            try file.contents.write(to: directory.appending(path: file.name), options: .atomic)
+        }
+    }
+}

--- a/Guesthouse/Diagnostics/DiagnosticsExportWriter.swift
+++ b/Guesthouse/Diagnostics/DiagnosticsExportWriter.swift
@@ -4,11 +4,56 @@ import GuesthouseCore
 /// Writes a diagnostics bundle where the user chose to put it. The bundle itself is built in
 /// GuesthouseCore; the host write happens here, in the app, under the save panel's grant.
 enum DiagnosticsExportWriter {
-    /// Writes the bundle as a folder. Existing files of the same names are replaced.
-    static func write(_ export: DiagnosticsExport, to directory: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
-        for file in export.files {
-            try file.contents.write(to: directory.appending(path: file.name), options: .atomic)
+    /// Writes the bundle as a folder of its own.
+    ///
+    /// A destination that already holds something is refused rather than written into.
+    /// `createDirectory` does not apply its attributes to a directory that exists, so a
+    /// repeated export would leave the folder world-traversable; and the user shares whatever
+    /// the folder contains, so unrelated files sitting beside the three would travel with the
+    /// bundle the UI presented as a diagnostics export (MVP-PLAN.md §3 "Local storage").
+    /// Nothing of the user's is deleted or moved on their behalf: they choose another location.
+    ///
+    /// A write that fails part way takes its own files back out again. Otherwise the folder
+    /// holds a manifest with no log — which still reads as an export — and the emptiness guard
+    /// above then refuses the retry to the same folder the save panel just offered.
+    ///
+    /// `writeFile` exists so that partial failure can be tested: the three names are fixed and
+    /// the destination is checked empty first, so there is no way to make the second write fail
+    /// from outside.
+    static func write(
+        _ export: DiagnosticsExport,
+        to directory: URL,
+        writeFile: (Data, URL) throws -> Void = { try $0.write(to: $1, options: .atomic) }
+    ) throws {
+        let directoryWasCreated: Bool
+        if FileManager.default.fileExists(atPath: directory.path) {
+            let existing = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            guard existing.isEmpty else {
+                throw GuesthouseError.runtimeStorageUnavailable(
+                    reason: SanitizedText("the chosen folder is not empty"),
+                    problem: .unsafeLocation
+                )
+            }
+            // The folder was made by someone else, with whatever mode they chose.
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: directory.path)
+            directoryWasCreated = false
+        } else {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+            directoryWasCreated = true
+        }
+        var written: [URL] = []
+        do {
+            for file in export.files {
+                let destination = directory.appending(path: file.name)
+                try writeFile(file.contents, destination)
+                written.append(destination)
+            }
+        } catch {
+            for file in written { try? FileManager.default.removeItem(at: file) }
+            // A folder the user already had stays, emptied of this attempt; one this attempt
+            // made goes with it, so a failed export leaves the destination as it found it.
+            if directoryWasCreated { try? FileManager.default.removeItem(at: directory) }
+            throw error
         }
     }
 }

--- a/GuesthouseTests/AppModelTests.swift
+++ b/GuesthouseTests/AppModelTests.swift
@@ -551,6 +551,7 @@ import Testing
         let statusQueries = await backend.receivedRequests.filter { if case .environmentStatus = $0 { return true }; return false }
         #expect(statusQueries.count == 1)
         #expect(model.canCheckEnvironment, "the check finished, so another one may be asked for")
+        #expect(model.launchState == .ready)
     }
 
     @Test func aLossDuringReconciliationLetsThatReconciliationSettle() async {
@@ -559,8 +560,6 @@ import Testing
         await backend.script("listEnvironments", .disconnect())
         let (model, _) = makeModel(backend)
         model.startRefresh()
-        // The listing is what "still reading" means: the reconciliation asks the runtime for
-        // its version first, so a bare request count no longer names that moment.
         // Any request means the check has started; which one goes out first is the
         // reconciliation's business, and it changes as the stack grows.
         await waitUntil({ await !backend.receivedRequests.isEmpty }, "the check to send its first request")

--- a/GuesthouseTests/DiagnosticsTests.swift
+++ b/GuesthouseTests/DiagnosticsTests.swift
@@ -17,7 +17,12 @@ import Testing
         await model.refresh()
         #expect(model.runtimeInfo?.serviceVersion == "9.9")
         model.start(environment.id)
-        for _ in 0..<400 where model.lastLogs[environment.id] == nil { try await Task.sleep(for: .milliseconds(5)) }
+        // The start drops the status it began from — it completed without describing the
+        // environment — so the export is taken once the check that follows has answered and
+        // the observation the manifest reports is back.
+        for _ in 0..<1200 where model.lastLogs[environment.id] == nil || model.statuses[environment.id] == nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
         #expect(model.diagnosticsLines.count == 2)
         let export = model.diagnosticsExport()
         #expect(!export.logText.contains("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"))
@@ -42,5 +47,175 @@ import Testing
         #expect(names == [DiagnosticsExport.excludedFileName, DiagnosticsExport.logFileName, DiagnosticsExport.manifestFileName])
         let attributes = try FileManager.default.attributesOfItem(atPath: directory.path)
         #expect(attributes[.posixPermissions] as? Int == 0o700)
+    }
+
+    @Test func theWriterRefusesADestinationThatHoldsAnythingElse() throws {
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(), environments: [], logs: [])
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let bystander = directory.appending(path: "id_ed25519")
+        try Data("not part of the bundle".utf8).write(to: bystander)
+        #expect(throws: GuesthouseError.self) { try DiagnosticsExportWriter.write(export, to: directory) }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["id_ed25519"], "nothing was written beside it and nothing was removed")
+    }
+
+    @Test func aFailedWriteLeavesNoHalfBundleBehind() throws {
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(), environments: [], logs: [])
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        struct DiskFull: Error {}
+        var written = 0
+        #expect(throws: DiskFull.self) {
+            try DiagnosticsExportWriter.write(export, to: directory) { contents, url in
+                written += 1
+                guard written < 2 else { throw DiskFull() }
+                try contents.write(to: url, options: .atomic)
+            }
+        }
+        #expect(!FileManager.default.fileExists(atPath: directory.path), "a folder this attempt made goes with the files it wrote")
+        // The retry the user makes next has to be allowed to land in the folder the save
+        // panel offers again, which the emptiness guard would refuse over a leftover manifest.
+        try DiagnosticsExportWriter.write(export, to: directory)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted() == [DiagnosticsExport.excludedFileName, DiagnosticsExport.logFileName, DiagnosticsExport.manifestFileName])
+    }
+
+    @Test func aFailedWriteIntoAFolderTheUserChoseEmptiesItAgain() throws {
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(), environments: [], logs: [])
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        struct DiskFull: Error {}
+        var written = 0
+        #expect(throws: DiskFull.self) {
+            try DiagnosticsExportWriter.write(export, to: directory) { contents, url in
+                written += 1
+                guard written < 3 else { throw DiskFull() }
+                try contents.write(to: url, options: .atomic)
+            }
+        }
+        #expect(FileManager.default.fileExists(atPath: directory.path), "the folder was the user's, so it stays")
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty, "but the two files this attempt wrote do not")
+    }
+
+    @Test func theWriterTightensAnExistingEmptyDestination() throws {
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(), environments: [], logs: [])
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o755])
+        try DiagnosticsExportWriter.write(export, to: directory)
+        let attributes = try FileManager.default.attributesOfItem(atPath: directory.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o700, "a folder the panel already made is protected like a new one")
+    }
+
+    @Test func theExportedLogCoversOnlyTheEnvironmentTheManifestNames() async throws {
+        let first = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let second = DevelopmentEnvironment(name: "Spare Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_100))
+        let operation = OperationID()
+        var events: [RuntimeEvent] = [.accepted(operation)]
+        events += Redactor().redact(lines: ["Booting virtual machine"]).map { RuntimeEvent.log(operation, $0) }
+        events.append(.completed(operation))
+        let backend = ScriptedBackend(events: events, environments: [first, second], status: EnvironmentStatus(environmentID: first.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        for environment in [first, second] {
+            model.start(environment.id)
+            // The check that follows an operation blocks every start while it runs, so the
+            // second environment is started only once the first one has settled.
+            for _ in 0..<400 where model.lastLogs[environment.id] == nil
+                || !model.operations.isEmpty || !model.reconciling.isEmpty {
+                try await Task.sleep(for: .milliseconds(5))
+            }
+        }
+        #expect(model.diagnosticsLines.count == 2, "the sheet still shows both")
+        let export = model.diagnosticsExport()
+        #expect(export.manifest.environmentIDs == [first.id])
+        #expect(export.logText.contains(first.id.uuid.uuidString))
+        #expect(!export.logText.contains(second.id.uuid.uuidString), "an undeclared environment is not described by the bundle")
+        // Diagnostics opened from the second card is a report about the second development
+        // Mac, so that is the one the bundle and the sheet describe.
+        #expect(model.diagnosticsLines(subject: second.id).count == 1)
+        let spare = model.diagnosticsExport(subject: second.id)
+        #expect(spare.manifest.environmentIDs == [second.id])
+        #expect(spare.logText.contains(second.id.uuid.uuidString))
+        #expect(!spare.logText.contains(first.id.uuid.uuidString))
+    }
+
+    @Test func aLostConnectionIsTheLaunchFailureTheExportReports() async throws {
+        let backend = FakeRuntimeBackend()
+        await backend.script("listEnvironments", .disconnect())
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        guard case .interrupted(let interruption) = model.launchState else { Issue.record("expected interrupted, got \(model.launchState)"); return }
+        let failure = try #require(model.diagnosticsExport().manifest.launchFailure)
+        #expect(failure.message == interruption.userMessage)
+        #expect(failure.recovery == interruption.recoveryMessage)
+        #expect(!failure.recoveryActions.isEmpty)
+    }
+
+    @Test func theFailureTheCardIsShowingIsInTheExport() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        await backend.script("startEnvironment", .fail(error: .guestNotReachable(environment.id)))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        model.start(environment.id)
+        for _ in 0..<400 where model.lastErrors[environment.id] == nil { try await Task.sleep(for: .milliseconds(5)) }
+        let failure = try #require(model.diagnosticsExport().manifest.operationFailure)
+        #expect(failure.message == GuesthouseError.guestNotReachable(environment.id).userMessage)
+        #expect(!failure.recoveryActions.isEmpty, "the bundle names what the user was offered")
+    }
+
+    @Test func theOperationsOwnFailureIsExportedEvenWhenItsCheckFailedToo() async throws {
+        let backend = FakeRuntimeBackend()
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        await backend.setEnvironments([environment])
+        await backend.setStatus(EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        await backend.script("startEnvironment", .fail(error: .guestNotReachable(environment.id)))
+        // The check that follows a failed start is where the state is read back, and it is
+        // allowed to fail: what the card then shows is the check's failure, not the start's.
+        await backend.script("environmentStatus", .fail(error: .runtimeStarting))
+        model.start(environment.id)
+        for _ in 0..<400 where model.lastErrors[environment.id] != .runtimeStarting { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(model.lastErrors[environment.id] == .runtimeStarting, "the card is showing the failed check")
+        let failure = try #require(model.diagnosticsExport().manifest.operationFailure)
+        #expect(failure.message == GuesthouseError.guestNotReachable(environment.id).userMessage, "the bundle names the start the user is reporting")
+        #expect(!failure.recoveryActions.isEmpty, "with the start's own recovery actions")
+    }
+
+    @Test func aVersionLookupThatFailsClearsTheMetadataTheExportWouldReport() async throws {
+        let backend = FakeRuntimeBackend()
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.runtimeInfo != nil, "the first check published the runtime it found")
+        await backend.script("runtimeVersion", .fail(error: .protocolMismatch(client: 2, service: 1)))
+        await model.refresh()
+        #expect(model.launchState == .unavailable(.protocolMismatch(client: 2, service: 1)))
+        #expect(model.runtimeInfo == nil, "no current metadata means none is exported")
+        #expect(model.diagnosticsExport().manifest.runtime == nil)
+    }
+
+    @Test func aLostReconciliationReportsWhatItReadRatherThanTheLastSession() async throws {
+        let backend = FakeRuntimeBackend()
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.runtimeInfo != nil, "the first check published the runtime it found")
+        // The connection drops before the runtime describes itself. The version the previous
+        // session gave is not evidence about this one, and the export must not put it beside
+        // the connection failure.
+        await backend.script("runtimeVersion", .disconnect())
+        await model.refresh()
+        guard case .interrupted = model.launchState else { Issue.record("expected interrupted, got \(model.launchState)"); return }
+        #expect(model.runtimeInfo == nil, "nothing verified a runtime this time")
+        #expect(model.diagnosticsExport().manifest.runtime == nil)
+        // A refresh that did read the version before losing the listing reports that reading:
+        // it is the current one, and discarding it would keep the export empty for no reason.
+        await backend.script("runtimeVersion", .succeed())
+        await backend.setVersionInfo(RuntimeVersionInfo(serviceVersion: "9.9", serviceBuild: "fake", tart: .init(version: "2.37.1", verified: true)))
+        await backend.script("listEnvironments", .disconnect())
+        await model.refresh()
+        guard case .interrupted = model.launchState else { Issue.record("expected interrupted, got \(model.launchState)"); return }
+        #expect(model.runtimeInfo?.serviceVersion == "9.9")
+        #expect(model.diagnosticsExport().manifest.runtime?.tart?.version == "2.37.1")
     }
 }

--- a/GuesthouseTests/DiagnosticsTests.swift
+++ b/GuesthouseTests/DiagnosticsTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import Guesthouse
+
+@MainActor
+@Suite struct DiagnosticsTests {
+    @Test func exportCarriesRedactedLinesEnvironmentIDsAndRuntimeInfoButNoAddresses() async throws {
+        let environment = DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))
+        let operation = OperationID()
+        let raw = ["remote: token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab used", "guest 192.168.64.7 answered"]
+        var events: [RuntimeEvent] = [.accepted(operation)]
+        events += Redactor().redact(lines: raw).map { RuntimeEvent.log(operation, $0) }
+        events.append(.completed(operation))
+        let backend = ScriptedBackend(events: events, environments: [environment], status: EnvironmentStatus(environmentID: environment.id, vm: .stopped, readiness: .ready, observed: ObservedTuple(tartVersion: "2.36.0")))
+        let model = AppModel(backend: backend) { _ in }
+        await model.refresh()
+        #expect(model.runtimeInfo?.serviceVersion == "9.9")
+        model.start(environment.id)
+        for _ in 0..<400 where model.lastLogs[environment.id] == nil { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(model.diagnosticsLines.count == 2)
+        let export = model.diagnosticsExport()
+        #expect(!export.logText.contains("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"))
+        #expect(!export.logText.contains("192.168.64.7"))
+        #expect(export.logText.contains("[redacted:github-token]"))
+        #expect(export.manifest.environmentIDs == [environment.id])
+        #expect(export.manifest.runtime?.serviceVersion == "9.9")
+        #expect(export.manifest.compatibility.tartVersion == "2.36.0")
+        let manifest = String(decoding: export.files[0].contents, as: UTF8.self)
+        #expect(!manifest.contains("192.168"))
+    }
+
+    @Test func fileStampsHaveNoColons() {
+        #expect(!DiagnosticsView.stamp(Date(timeIntervalSince1970: 1_800_000_000)).contains(":"))
+    }
+}

--- a/GuesthouseTests/DiagnosticsTests.swift
+++ b/GuesthouseTests/DiagnosticsTests.swift
@@ -33,4 +33,14 @@ import Testing
     @Test func fileStampsHaveNoColons() {
         #expect(!DiagnosticsView.stamp(Date(timeIntervalSince1970: 1_800_000_000)).contains(":"))
     }
+
+    @Test func theWriterCreatesAFolderWithThreeFiles() throws {
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(), environments: [], logs: [])
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        try DiagnosticsExportWriter.write(export, to: directory)
+        let names = try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
+        #expect(names == [DiagnosticsExport.excludedFileName, DiagnosticsExport.logFileName, DiagnosticsExport.manifestFileName])
+        let attributes = try FileManager.default.attributesOfItem(atPath: directory.path)
+        #expect(attributes[.posixPermissions] as? Int == 0o700)
+    }
 }

--- a/GuesthouseTests/OperationPresentationTests.swift
+++ b/GuesthouseTests/OperationPresentationTests.swift
@@ -10,9 +10,24 @@ final class ScriptedBackend: RuntimeBackend, Sendable {
     let events: [String: [RuntimeEvent]]
     init(_ events: [String: [RuntimeEvent]]) { self.events = events }
 
+    /// The queries answered from fixed data, one event list replayed for every operation: the
+    /// shape a diagnostics fixture needs, expressed in the same script.
+    init(events: [RuntimeEvent], environments: [DevelopmentEnvironment] = [], status: EnvironmentStatus? = nil) {
+        var script: [String: [RuntimeEvent]] = [:]
+        script["runtimeVersion"] = [.runtimeVersion(RuntimeVersionInfo(serviceVersion: "9.9", serviceBuild: "1"))]
+        script["listEnvironments"] = [.environments(environments)]
+        if let status { script["environmentStatus"] = [.status(status)] }
+        for name in ["startEnvironment", "stopEnvironment", "cancelOperation", "importXcode"] { script[name] = events }
+        self.events = script
+    }
+
     nonisolated func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
         AsyncThrowingStream { continuation in
-            for event in events[request.caseName] ?? [] { continuation.yield(event) }
+            if let scripted = events[request.caseName] {
+                for event in scripted { continuation.yield(event) }
+            } else if case .environmentStatus(let id) = request {
+                continuation.yield(.status(EnvironmentStatus(environmentID: id, vm: .stopped, readiness: .ready)))
+            }
             continuation.finish()
         }
     }

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -337,6 +337,46 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
         #expect(events.count <= 2 * RuntimeClient.consumerBufferLimit + 2)
     }
 
+    @Test func aConsumerThatKeepsUpIsNeverCutOff() async throws {
+        actor Sink {
+            private(set) var logs = 0
+            private(set) var operation: OperationID?
+            func tick() { logs += 1 }
+            func accept(_ id: OperationID) { operation = id }
+        }
+        let transport = FakeTransport(.acceptThenStream([]))
+        let client = RuntimeClient(transport: transport)
+        let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        let sink = Sink()
+        let consumer = Task {
+            for try await event in stream {
+                switch event {
+                case .accepted(let id): await sink.accept(id)
+                case .log: await sink.tick()
+                default: break
+                }
+            }
+        }
+        var accepted: OperationID?
+        for _ in 0..<100 where accepted == nil {
+            accepted = await sink.operation
+            if accepted == nil { try await Task.sleep(for: .milliseconds(5)) }
+        }
+        guard let id = accepted else { Issue.record("the operation was never accepted"); return }
+        let incoming = transport.lock.withLock { transport.incoming }
+        let total = RuntimeClient.consumerBufferLimit * 2
+        // Paced like a real operation: the reader is given time to take what was sent, so the
+        // stream's queue never fills. A cap on lifetime traffic would silence the second half.
+        for index in 0..<total {
+            incoming?(.log(id, Redactor().redact(lines: ["line \(index)"])[0]))
+            if index % 32 == 31 { try await Task.sleep(for: .milliseconds(1)) }
+        }
+        incoming?(.completed(id))
+        try await consumer.value
+        let delivered = await sink.logs
+        #expect(delivered > RuntimeClient.consumerBufferLimit, "a consumer that keeps reading is never cut off (\(delivered) of \(total))")
+    }
+
     @Test func aFailedSendDoesNotLeaveAnAbandonedMarker() async throws {
         let transport = FakeTransport(.throwOnSend)
         let client = RuntimeClient(transport: transport)

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -22,6 +22,11 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
         }
         reply?(.success(.accepted(preparedID)))
     }
+    /// Set once an `.acceptThenStream` script has pushed everything it holds. A test that
+    /// measures what a full stream drops waits for this instead of sleeping: on a loaded
+    /// machine a fixed sleep ends mid-flood, and the consumer then reads a different log.
+    private var streamed = false
+    var hasStreamedEverything: Bool { lock.withLock { streamed } }
     let lock = NSLock()
     var behavior: Behavior
     var incoming: (@Sendable (RuntimeEvent) -> Void)?
@@ -77,6 +82,7 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
                 default: incoming?(event)
                 }
             }
+            lock.withLock { streamed = true }
         case .acceptThenDrop:
             reply(.success(.accepted(OperationID())))
             lock.withLock { self.interrupted }?()
@@ -153,6 +159,11 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
         let transport = FakeTransport(.acceptThenStream(flood))
         let client = RuntimeClient(transport: transport)
         let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<2000 where !transport.hasStreamedEverything { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(transport.hasStreamedEverything, "the flood finished before the consumer began reading")
+        // Then long enough for the client to work through what it was handed: the bound is
+        // applied as the events are taken in, so a consumer that starts reading mid-flood
+        // measures the wrong thing.
         try await Task.sleep(for: .milliseconds(200))
         let events = try await collect(stream)
         #expect(events.first?.caseName == "accepted", "the operation id is learned before any traffic")
@@ -180,6 +191,11 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
         let transport = FakeTransport(.acceptThenStream(flood))
         let client = RuntimeClient(transport: transport)
         let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<2000 where !transport.hasStreamedEverything { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(transport.hasStreamedEverything, "the flood finished before the consumer began reading")
+        // Then long enough for the client to work through what it was handed: the bound is
+        // applied as the events are taken in, so a consumer that starts reading mid-flood
+        // measures the wrong thing.
         try await Task.sleep(for: .milliseconds(200))
         let events = try await collect(stream)
         let numbers = events.compactMap { event -> Int? in
@@ -330,6 +346,11 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
         let transport = FakeTransport(.acceptThenStream(flood))
         let client = RuntimeClient(transport: transport)
         let stream = client.send(.startEnvironment(EnvironmentID(), StartOptions()))
+        for _ in 0..<2000 where !transport.hasStreamedEverything { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(transport.hasStreamedEverything, "the flood finished before the consumer began reading")
+        // Then long enough for the client to work through what it was handed: the bound is
+        // applied as the events are taken in, so a consumer that starts reading mid-flood
+        // measures the wrong thing.
         try await Task.sleep(for: .milliseconds(200))
         let events = try await collect(stream)
         #expect(events.contains { if case .accepted = $0 { true } else { false } })

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// A diagnostics bundle the user can share: a manifest of what is known, the redacted log,
+/// and a list of what was deliberately left out (MVP-PLAN.md §2 "Essential screens", §3
+/// "Local storage": private keys, tokens, device codes, authorization headers, and raw
+/// authentication logs never leave the Mac; environments are named by UUID, never by address).
+public struct DiagnosticsExport: Hashable, Sendable {
+    public struct Manifest: Codable, Hashable, Sendable {
+        public var exportedAt: Date
+        public var appVersion: String
+        public var appBuild: String
+        public var runtime: RuntimeVersionInfo?
+        /// The compatibility fields that are known; unknown ones stay `nil`.
+        public var compatibility: ObservedTuple
+        public var environmentIDs: [EnvironmentID]
+        public var logLineCount: Int
+        public var excludedCategories: [String]
+    }
+
+    public static let manifestFileName = "manifest.json"
+    public static let logFileName = "log.txt"
+    public static let excludedFileName = "excluded.txt"
+
+    public let manifest: Manifest
+    public let logText: String
+    public let excludedText: String
+
+    /// The files of the bundle, in a fixed order.
+    public var files: [(name: String, contents: Data)] {
+        [
+            (Self.manifestFileName, DiagnosticsExportBuilder.encode(manifest)),
+            (Self.logFileName, Data(logText.utf8)),
+            (Self.excludedFileName, Data(excludedText.utf8)),
+        ]
+    }
+}
+
+public enum DiagnosticsExportBuilder {
+    /// What an export never contains, listed in `excluded.txt` so the reader knows why a
+    /// value is missing rather than guessing.
+    public static let excludedCategories = [
+        "Private keys and certificates",
+        "Tokens, API keys, and passwords",
+        "Device and one-time codes",
+        "Authorization headers and raw authentication output",
+        "Network addresses (development Macs are identified by UUID instead)",
+        "User account names and e-mail addresses",
+    ]
+
+    /// Builds the export from already-redacted lines and known facts. Addresses are scrubbed
+    /// from the log as well, since a redacted line may still name one.
+    public static func build(
+        appVersion: String,
+        appBuild: String,
+        runtime: RuntimeVersionInfo?,
+        compatibility: ObservedTuple,
+        environments: [DevelopmentEnvironment],
+        logs: [RedactedLine],
+        exportedAt: Date = Date()
+    ) -> DiagnosticsExport {
+        let lines = logs.map { scrubAddresses($0.text) }
+        let manifest = DiagnosticsExport.Manifest(
+            exportedAt: exportedAt,
+            appVersion: GuesthouseError.sanitize(appVersion),
+            appBuild: GuesthouseError.sanitize(appBuild),
+            runtime: runtime,
+            compatibility: compatibility,
+            environmentIDs: environments.map(\.id),
+            logLineCount: lines.count,
+            excludedCategories: excludedCategories
+        )
+        let excluded = "This export deliberately omits:\n" + excludedCategories.map { "- \($0)" }.joined(separator: "\n") + "\n"
+        return DiagnosticsExport(manifest: manifest, logText: lines.joined(separator: "\n") + (lines.isEmpty ? "" : "\n"), excludedText: excluded)
+    }
+
+    /// Writes the bundle as a folder. Existing files of the same names are replaced.
+    public static func write(_ export: DiagnosticsExport, to directory: URL) throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        for file in export.files {
+            try file.contents.write(to: directory.appending(path: file.name), options: .atomic)
+        }
+    }
+
+    static func encode(_ manifest: DiagnosticsExport.Manifest) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return (try? encoder.encode(manifest)) ?? Data()
+    }
+
+    /// IPv4 and IPv6 literals become `[redacted:address]`.
+    static func scrubAddresses(_ text: String) -> String {
+        text.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#, with: "[redacted:address]")
+            .replacing(#/\b(?:[0-9A-Fa-f]{1,4}:){2,7}[0-9A-Fa-f]{1,4}\b/#, with: "[redacted:address]")
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// A diagnostics bundle the user can share: a manifest of what is known, the redacted log,
@@ -47,8 +48,8 @@ public enum DiagnosticsExportBuilder {
         "User account names and e-mail addresses",
     ]
 
-    /// Builds the export from already-redacted lines and known facts. Addresses are scrubbed
-    /// from the log as well, since a redacted line may still name one.
+    /// Builds the export from already-redacted lines and known facts. Addresses and account
+    /// identifiers are scrubbed from the log as well, since a redacted line may still name one.
     public static func build(
         appVersion: String,
         appBuild: String,
@@ -58,7 +59,7 @@ public enum DiagnosticsExportBuilder {
         logs: [RedactedLine],
         exportedAt: Date = Date()
     ) -> DiagnosticsExport {
-        let lines = logs.map { scrubAddresses($0.text) }
+        let lines = logs.map { scrub($0.text) }
         let manifest = DiagnosticsExport.Manifest(
             exportedAt: exportedAt,
             appVersion: GuesthouseError.sanitize(appVersion),
@@ -73,14 +74,6 @@ public enum DiagnosticsExportBuilder {
         return DiagnosticsExport(manifest: manifest, logText: lines.joined(separator: "\n") + (lines.isEmpty ? "" : "\n"), excludedText: excluded)
     }
 
-    /// Writes the bundle as a folder. Existing files of the same names are replaced.
-    public static func write(_ export: DiagnosticsExport, to directory: URL) throws {
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
-        for file in export.files {
-            try file.contents.write(to: directory.appending(path: file.name), options: .atomic)
-        }
-    }
-
     static func encode(_ manifest: DiagnosticsExport.Manifest) -> Data {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys, .prettyPrinted, .withoutEscapingSlashes]
@@ -88,9 +81,37 @@ public enum DiagnosticsExportBuilder {
         return (try? encoder.encode(manifest)) ?? Data()
     }
 
-    /// IPv4 and IPv6 literals become `[redacted:address]`.
+    /// Everything the export removes from a line that redaction left in: network addresses
+    /// and account identifiers. Applied to anything shown or copied as diagnostics, not only
+    /// to the written bundle.
+    public static func scrub(_ text: String) -> String {
+        scrubIdentities(scrubAddresses(text))
+    }
+
+    /// IPv4 and IPv6 literals become `[redacted:address]`. IPv6 candidates are validated with
+    /// `inet_pton`, so compressed (`::1`, `2001:db8::1`) and IPv4-mapped forms are caught and
+    /// clock times are not.
     static func scrubAddresses(_ text: String) -> String {
-        text.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#, with: "[redacted:address]")
-            .replacing(#/\b(?:[0-9A-Fa-f]{1,4}:){2,7}[0-9A-Fa-f]{1,4}\b/#, with: "[redacted:address]")
+        // IPv6 first, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole.
+        let withoutIPv6 = text.replacing(#/[0-9A-Fa-f:.]{2,45}/#) { match in
+            let token = String(text[match.range])
+            guard token.contains(":"), isIPv6(token) else { return token }
+            return "[redacted:address]"
+        }
+        return withoutIPv6.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#, with: "[redacted:address]")
+    }
+
+    static func isIPv6(_ token: String) -> Bool {
+        var buffer = in6_addr()
+        return token.withCString { inet_pton(AF_INET6, $0, &buffer) } == 1
+    }
+
+    /// E-mail addresses and the identifier after "signed in as", "logged in as", "user",
+    /// or "account" become `[redacted:account]`.
+    static func scrubIdentities(_ text: String) -> String {
+        text.replacing(#/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#, with: "[redacted:account]")
+            .replacing(#/(?i)\b((?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?)\s+(?!\[redacted)(\S+)/#) { match in
+                "\(match.output.1) [redacted:account]"
+            }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -76,7 +76,7 @@ public enum DiagnosticsExportBuilder {
             exportedAt: exportedAt,
             appVersion: GuesthouseError.sanitize(appVersion),
             appBuild: GuesthouseError.sanitize(appBuild),
-            runtime: runtime,
+            runtime: scrubbed(runtime),
             compatibility: scrubbed(compatibility),
             environmentIDs: environments.map(\.id),
             logLineCount: lines.count,
@@ -171,7 +171,7 @@ public enum DiagnosticsExportBuilder {
     /// Scrubs a stream of lines. A credential is often printed over two lines (`password:`
     /// on one, the value on the next), so a line that ends in a credential label redacts the
     /// value that follows it.
-    static func scrubbedStream(_ logs: [RedactedLine]) -> [String] {
+    public static func scrubbedStream(_ logs: [RedactedLine]) -> [String] {
         var result: [String] = []
         var expectingValue = false
         for line in logs {
@@ -186,6 +186,16 @@ public enum DiagnosticsExportBuilder {
             result.append(scrubbed)
         }
         return result
+    }
+
+    /// The runtime's own report can name a path: a storage failure quotes where it tried to
+    /// write, which is often under the user's home directory. Its problem is replaced with a
+    /// scrubbed description so the manifest keeps the failure without the account name.
+    static func scrubbed(_ runtime: RuntimeVersionInfo?) -> RuntimeVersionInfo? {
+        guard var info = runtime, var tart = info.tart, let problem = tart.problem else { return runtime }
+        tart.problem = .runtimeStateUnavailable(reason: SanitizedText(scrub(problem.userMessage), limit: 300))
+        info.tart = tart
+        return info
     }
 
     /// The observations that may appear in the manifest: paths carry the account name of

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -59,13 +59,13 @@ public enum DiagnosticsExportBuilder {
         logs: [RedactedLine],
         exportedAt: Date = Date()
     ) -> DiagnosticsExport {
-        let lines = logs.map { scrub($0.text) }
+        let lines = scrubbedStream(logs)
         let manifest = DiagnosticsExport.Manifest(
             exportedAt: exportedAt,
             appVersion: GuesthouseError.sanitize(appVersion),
             appBuild: GuesthouseError.sanitize(appBuild),
             runtime: runtime,
-            compatibility: compatibility,
+            compatibility: scrubbed(compatibility),
             environmentIDs: environments.map(\.id),
             logLineCount: lines.count,
             excludedCategories: excludedCategories
@@ -92,13 +92,35 @@ public enum DiagnosticsExportBuilder {
     /// `inet_pton`, so compressed (`::1`, `2001:db8::1`) and IPv4-mapped forms are caught and
     /// clock times are not.
     static func scrubAddresses(_ text: String) -> String {
-        // IPv6 first, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole.
+        // IPv6 first, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole. Trailing
+        // punctuation is trimmed before validation: a sentence's period is not part of the
+        // address, and leaving it in would let the address through.
         let withoutIPv6 = text.replacing(#/[0-9A-Fa-f:.]{2,45}/#) { match in
             let token = String(text[match.range])
-            guard token.contains(":"), isIPv6(token) else { return token }
-            return "[redacted:address]"
+            guard token.contains(":") else { return token }
+            // Only trailing punctuation is trimmed: a leading colon is part of a compressed
+            // address (`::1`), while a sentence's period at the end is not.
+            let trimmed = Self.trimmingTrailingPunctuation(token)
+            guard !trimmed.isEmpty, isIPv6(trimmed) else { return token }
+            return "[redacted:address]" + token.dropFirst(trimmed.count)
         }
-        return withoutIPv6.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#, with: "[redacted:address]")
+        // Only a real IPv4 literal is an address: a four-part version such as `1.2.3.456` is
+        // exactly the information diagnostics exist to keep.
+        return withoutIPv6.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#) { match in
+            let token = String(withoutIPv6[match.range])
+            return isIPv4(token) ? "[redacted:address]" : token
+        }
+    }
+
+    static func trimmingTrailingPunctuation(_ token: String) -> String {
+        var trimmed = Substring(token)
+        while let last = trimmed.last, ".,;)]}".contains(last) { trimmed = trimmed.dropLast() }
+        return String(trimmed)
+    }
+
+    static func isIPv4(_ token: String) -> Bool {
+        var buffer = in_addr()
+        return token.withCString { inet_pton(AF_INET, $0, &buffer) } == 1
     }
 
     static func isIPv6(_ token: String) -> Bool {
@@ -113,5 +135,39 @@ public enum DiagnosticsExportBuilder {
             .replacing(#/(?i)\b((?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?)\s+(?!\[redacted)(\S+)/#) { match in
                 "\(match.output.1) [redacted:account]"
             }
+            // A home directory names its owner: `/Users/alice/…` is an account name in a path.
+            .replacing(#/(/Users/)(?!\[redacted)[^/\s]+/#) { match in
+                "\(match.output.1)[redacted:account]"
+            }
+    }
+
+    /// Scrubs a stream of lines. A credential is often printed over two lines (`password:`
+    /// on one, the value on the next), so a line that ends in a credential label redacts the
+    /// value that follows it.
+    static func scrubbedStream(_ logs: [RedactedLine]) -> [String] {
+        var result: [String] = []
+        var expectingValue = false
+        for line in logs {
+            let scrubbed = scrub(line.text)
+            let trimmed = scrubbed.trimmingCharacters(in: .whitespaces)
+            if expectingValue, !trimmed.isEmpty {
+                result.append(scrubbed.replacingOccurrences(of: trimmed, with: Redactor.marker("credential")))
+                expectingValue = trimmed.isEmpty
+                continue
+            }
+            expectingValue = trimmed.wholeMatch(of: #/(?i)(password|passphrase|secret|token|api[ _-]?key|credential)s?\s*[:=]/#) != nil
+            result.append(scrubbed)
+        }
+        return result
+    }
+
+    /// The observations that may appear in the manifest: paths carry the account name of
+    /// whoever owns them, so they are scrubbed like any other exported value.
+    static func scrubbed(_ tuple: ObservedTuple) -> ObservedTuple {
+        var copy = tuple
+        copy.codexDesktopPath = tuple.codexDesktopPath.map { scrub($0) }
+        copy.codexCLIPath = tuple.codexCLIPath.map { scrub($0) }
+        copy.codexCLICapabilities = tuple.codexCLICapabilities.map { $0.map { scrub($0) } }
+        return copy
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -15,7 +15,18 @@ public struct DiagnosticsExport: Hashable, Sendable {
         public var compatibility: ObservedTuple
         public var environmentIDs: [EnvironmentID]
         public var logLineCount: Int
+        /// The failure the user is reporting when the app could not reach its runtime. On a
+        /// fresh launch there are no environments and no operation logs, so without this the
+        /// bundle would describe nothing at all.
+        public var launchFailure: LaunchFailure?
         public var excludedCategories: [String]
+
+        /// A launch failure as the export records it: what the user was told, in their words.
+        public struct LaunchFailure: Codable, Hashable, Sendable {
+            public var message: String
+            public var recovery: String?
+            public var recoveryActions: [String]
+        }
     }
 
     public static let manifestFileName = "manifest.json"
@@ -57,6 +68,7 @@ public enum DiagnosticsExportBuilder {
         compatibility: ObservedTuple,
         environments: [DevelopmentEnvironment],
         logs: [RedactedLine],
+        launchError: GuesthouseError? = nil,
         exportedAt: Date = Date()
     ) -> DiagnosticsExport {
         let lines = scrubbedStream(logs)
@@ -68,6 +80,13 @@ public enum DiagnosticsExportBuilder {
             compatibility: scrubbed(compatibility),
             environmentIDs: environments.map(\.id),
             logLineCount: lines.count,
+            launchFailure: launchError.map { error in
+                DiagnosticsExport.Manifest.LaunchFailure(
+                    message: scrub(error.userMessage),
+                    recovery: error.recoverySuggestion.map { scrub($0) },
+                    recoveryActions: error.recoveryActions.map { String(describing: $0) }
+                )
+            },
             excludedCategories: excludedCategories
         )
         let excluded = "This export deliberately omits:\n" + excludedCategories.map { "- \($0)" }.joined(separator: "\n") + "\n"
@@ -95,14 +114,17 @@ public enum DiagnosticsExportBuilder {
         // IPv6 first, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole. Trailing
         // punctuation is trimmed before validation: a sentence's period is not part of the
         // address, and leaving it in would let the address through.
-        let withoutIPv6 = text.replacing(#/[0-9A-Fa-f:.]{2,45}/#) { match in
-            let token = String(text[match.range])
-            guard token.contains(":") else { return token }
+        // The candidate must stand on its own: without these boundaries `foo::bar` offers
+        // `::ba`, which is a valid compressed address, and the identifier would be eaten.
+        let withoutIPv6 = text.replacing(#/(^|[^0-9A-Za-z_])([0-9A-Fa-f:.]{2,45})(?![0-9A-Za-z_])/#) { match in
+            let before = String(match.output.1)
+            let token = String(match.output.2)
+            guard token.contains(":") else { return before + token }
             // Only trailing punctuation is trimmed: a leading colon is part of a compressed
             // address (`::1`), while a sentence's period at the end is not.
             let trimmed = Self.trimmingTrailingPunctuation(token)
-            guard !trimmed.isEmpty, isIPv6(trimmed) else { return token }
-            return "[redacted:address]" + token.dropFirst(trimmed.count)
+            guard !trimmed.isEmpty, isIPv6(trimmed) else { return before + token }
+            return before + "[redacted:address]" + token.dropFirst(trimmed.count)
         }
         // Only a real IPv4 literal is an address: a four-part version such as `1.2.3.456` is
         // exactly the information diagnostics exist to keep.
@@ -132,8 +154,13 @@ public enum DiagnosticsExportBuilder {
     /// or "account" become `[redacted:account]`.
     static func scrubIdentities(_ text: String) -> String {
         text.replacing(#/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#, with: "[redacted:account]")
-            .replacing(#/(?i)\b((?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?)\s+(?!\[redacted)(\S+)/#) { match in
+            .replacing(#/(?i)\b((?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?)\s+(?!\[redacted)(?![=:])(\S+)/#) { match in
                 "\(match.output.1) [redacted:account]"
+            }
+            // Structured output writes the same fact without a space: `user=octocat`,
+            // `"account":"alice"`. The label keeps its quoting so the line still parses.
+            .replacing(#/(?i)(["']?\b(?:account|owner|user(?:name)?)["']?\s*[:=]\s*)(["']?)(?!\[redacted)[A-Za-z0-9._%+@-]+(["']?)/#) { match in
+                "\(match.output.1)\(match.output.2)[redacted:account]\(match.output.3)"
             }
             // A home directory names its owner: `/Users/alice/…` is an account name in a path.
             .replacing(#/(/Users/)(?!\[redacted)[^/\s]+/#) { match in

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticsExportBuilder.swift
@@ -18,14 +18,34 @@ public struct DiagnosticsExport: Hashable, Sendable {
         /// The failure the user is reporting when the app could not reach its runtime. On a
         /// fresh launch there are no environments and no operation logs, so without this the
         /// bundle would describe nothing at all.
-        public var launchFailure: LaunchFailure?
+        public var launchFailure: ReportedFailure?
+        /// What the exported environment's last operation failed with. An operation that fails
+        /// before it produces output leaves nothing in the log, so the failure the user opened
+        /// Diagnostics about would otherwise be absent from the bundle.
+        public var operationFailure: ReportedFailure?
         public var excludedCategories: [String]
 
-        /// A launch failure as the export records it: what the user was told, in their words.
-        public struct LaunchFailure: Codable, Hashable, Sendable {
+        /// A failure as the export records it: what the user was told, in their words.
+        public struct ReportedFailure: Codable, Hashable, Sendable {
             public var message: String
             public var recovery: String?
             public var recoveryActions: [String]
+
+            /// Scrubbed on the way in, because a message quotes what failed: a path under the
+            /// user's home directory, or the address a guest did not answer on.
+            public init(message: String, recovery: String?, recoveryActions: [String]) {
+                self.message = DiagnosticsExportBuilder.scrub(message)
+                self.recovery = recovery.map { DiagnosticsExportBuilder.scrub($0) }
+                self.recoveryActions = recoveryActions
+            }
+
+            public init(_ error: GuesthouseError) {
+                self.init(
+                    message: error.userMessage,
+                    recovery: error.recoverySuggestion,
+                    recoveryActions: error.recoveryActions.map { String(describing: $0) }
+                )
+            }
         }
     }
 
@@ -68,7 +88,8 @@ public enum DiagnosticsExportBuilder {
         compatibility: ObservedTuple,
         environments: [DevelopmentEnvironment],
         logs: [RedactedLine],
-        launchError: GuesthouseError? = nil,
+        launchFailure: DiagnosticsExport.Manifest.ReportedFailure? = nil,
+        operationFailure: DiagnosticsExport.Manifest.ReportedFailure? = nil,
         exportedAt: Date = Date()
     ) -> DiagnosticsExport {
         let lines = scrubbedStream(logs)
@@ -80,13 +101,8 @@ public enum DiagnosticsExportBuilder {
             compatibility: scrubbed(compatibility),
             environmentIDs: environments.map(\.id),
             logLineCount: lines.count,
-            launchFailure: launchError.map { error in
-                DiagnosticsExport.Manifest.LaunchFailure(
-                    message: scrub(error.userMessage),
-                    recovery: error.recoverySuggestion.map { scrub($0) },
-                    recoveryActions: error.recoveryActions.map { String(describing: $0) }
-                )
-            },
+            launchFailure: launchFailure,
+            operationFailure: operationFailure,
             excludedCategories: excludedCategories
         )
         let excluded = "This export deliberately omits:\n" + excludedCategories.map { "- \($0)" }.joined(separator: "\n") + "\n"
@@ -107,37 +123,58 @@ public enum DiagnosticsExportBuilder {
         scrubIdentities(scrubAddresses(text))
     }
 
-    /// IPv4 and IPv6 literals become `[redacted:address]`. IPv6 candidates are validated with
-    /// `inet_pton`, so compressed (`::1`, `2001:db8::1`) and IPv4-mapped forms are caught and
-    /// clock times are not.
+    /// IPv4, IPv6, and MAC literals become `[redacted:address]`. IPv6 candidates are validated
+    /// with `inet_pton`, so compressed (`::1`, `2001:db8::1`) and IPv4-mapped forms are caught
+    /// and clock times are not.
     static func scrubAddresses(_ text: String) -> String {
-        // IPv6 first, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole. Trailing
+        // A MAC address is six hex pairs, which `inet_pton` rejects as an IPv6 candidate and
+        // the IPv4 pass never sees; it identifies the machine just as well as an IP does, so
+        // it is taken first, before the IPv6 pass can consume part of it. The boundaries are
+        // identifier-aware like the IPv4 and IPv6 ones: guest output writes the address inside
+        // a generated name (`nic_52:54:00:12:34:56_state`), and an underscore boundary let that
+        // form through both this pass and the IPv6 one. A colon is still not a boundary, so a
+        // longer colon run cannot be cut into six pairs.
+        let withoutMAC = text.replacing(#/(^|[^0-9A-Za-z:])([0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5})(?![0-9A-Za-z:])/#) { match in
+            String(match.output.1) + "[redacted:address]"
+        }
+        // IPv6 next, so an IPv4-mapped address (`::ffff:192.0.2.1`) is taken whole. Trailing
         // punctuation is trimmed before validation: a sentence's period is not part of the
         // address, and leaving it in would let the address through.
-        // The candidate must stand on its own: without these boundaries `foo::bar` offers
-        // `::ba`, which is a valid compressed address, and the identifier would be eaten.
-        let withoutIPv6 = text.replacing(#/(^|[^0-9A-Za-z_])([0-9A-Fa-f:.]{2,45})(?![0-9A-Za-z_])/#) { match in
+        // The candidate must not start or end inside a word: without a boundary `foo::bar`
+        // offers `::ba`, which is a valid compressed address, and the identifier would be
+        // eaten. An underscore is a boundary all the same, because machine-generated output
+        // writes an address inside an identifier (`peer_2001:db8::1_status`) the way it does
+        // with IPv4 — and `foo_::bar` still offers only `::ba` in front of a letter.
+        let withoutIPv6 = withoutMAC.replacing(#/(^|[^0-9A-Za-z])([0-9A-Fa-f:.]{2,45})(?![0-9A-Za-z])/#) { match in
             let before = String(match.output.1)
             let token = String(match.output.2)
             guard token.contains(":") else { return before + token }
-            // Only trailing punctuation is trimmed: a leading colon is part of a compressed
-            // address (`::1`), while a sentence's period at the end is not.
-            let trimmed = Self.trimmingTrailingPunctuation(token)
-            guard !trimmed.isEmpty, isIPv6(trimmed) else { return before + token }
-            return before + "[redacted:address]" + token.dropFirst(trimmed.count)
+            guard let address = Self.longestAddressPrefix(of: token) else { return before + token }
+            return before + "[redacted:address]" + token.dropFirst(address.count)
         }
         // Only a real IPv4 literal is an address: a four-part version such as `1.2.3.456` is
-        // exactly the information diagnostics exist to keep.
-        return withoutIPv6.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#) { match in
-            let token = String(withoutIPv6[match.range])
-            return isIPv4(token) ? "[redacted:address]" : token
+        // exactly the information diagnostics exist to keep. The boundaries are digit-aware
+        // rather than word-aware, because machine-generated output writes an address inside an
+        // identifier (`peer_192.168.64.7`, `192.168.64.7_status`) where `\b` does not fall.
+        return withoutIPv6.replacing(#/(^|[^0-9.])((?:\d{1,3}\.){3}\d{1,3})(?![0-9])(?!\.[0-9])/#) { match in
+            let before = String(match.output.1)
+            let token = String(match.output.2)
+            return isIPv4(token) ? before + "[redacted:address]" : before + token
         }
     }
 
-    static func trimmingTrailingPunctuation(_ token: String) -> String {
-        var trimmed = Substring(token)
-        while let last = trimmed.last, ".,;)]}".contains(last) { trimmed = trimmed.dropLast() }
-        return String(trimmed)
+    /// The longest leading part of `token` that is a valid IPv6 address, or nil. A delimiter
+    /// that follows an address is not part of it — `2001:db8::1: connection failed` ends the
+    /// address at the label's colon — while `2001:db8::` is itself a whole address, so the
+    /// candidate is tried at full length first and shortened one character at a time.
+    static func longestAddressPrefix(of token: String) -> String? {
+        var candidate = Substring(token)
+        while !candidate.isEmpty {
+            if isIPv6(String(candidate)) { return String(candidate) }
+            guard let last = candidate.last, ".,;)]}:".contains(last) else { return nil }
+            candidate = candidate.dropLast()
+        }
+        return nil
     }
 
     static func isIPv4(_ token: String) -> Bool {
@@ -153,14 +190,29 @@ public enum DiagnosticsExportBuilder {
     /// E-mail addresses and the identifier after "signed in as", "logged in as", "user",
     /// or "account" become `[redacted:account]`.
     static func scrubIdentities(_ text: String) -> String {
-        text.replacing(#/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#, with: "[redacted:account]")
-            .replacing(#/(?i)\b((?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?)\s+(?!\[redacted)(?![=:])(\S+)/#) { match in
+        // A local login is `user@host` with no dotted suffix (`alice@guesthouse`), and the
+        // host half of `alice@192.168.64.7` is already `[redacted:address]` by the time this
+        // runs. Both name the account `excluded.txt` promises the export omits. SSH syntax
+        // brackets an IPv6 host, and the address pass keeps those brackets around its marker,
+        // so `alice@[2001:db8::1]` reaches this as a doubled-bracket form; without it the
+        // account in front of an IPv6 host would stay in the export.
+        text.replacing(#/[A-Za-z0-9._%+-]+@(?:\[\[redacted:address\]\]|\[redacted:address\]|[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?)/#, with: "[redacted:account]")
+            // A display name has spaces in it: `Signed in as Alice Smith` left `Smith` behind
+            // when the value was a single token. A quoted value is taken whole; an unquoted one
+            // continues through further capitalized words, which is what the rest of a name
+            // looks like, and stops at anything else so `user: octocat (admin)` keeps its
+            // qualifier and a sentence after the name is not swallowed. The label group carries
+            // its own case-insensitivity, because the continuation must stay case-sensitive.
+            .replacing(#/\b((?i:(?:signed|logged) in (?:to \S+ )?as|account:?|user(?:name)?:?))\s+(?!\[redacted)(?![=:])("[^"]*"|'[^']*'|\S+(?: [A-Z][^\s]*){0,3})/#) { match in
                 "\(match.output.1) [redacted:account]"
             }
             // Structured output writes the same fact without a space: `user=octocat`,
-            // `"account":"alice"`. The label keeps its quoting so the line still parses.
-            .replacing(#/(?i)(["']?\b(?:account|owner|user(?:name)?)["']?\s*[:=]\s*)(["']?)(?!\[redacted)[A-Za-z0-9._%+@-]+(["']?)/#) { match in
-                "\(match.output.1)\(match.output.2)[redacted:account]\(match.output.3)"
+            // `"account":"alice"`. A quoted value runs to its closing quote, so a name with a
+            // space in it (`"user":"Alice Smith"`) goes whole rather than leaving its surname.
+            // The label keeps its quoting so the line still parses.
+            .replacing(#/(?i)(["']?\b(?:account|owner|user(?:name)?)["']?\s*[:=]\s*)(?:(")(?!\[redacted)[^"]*"|(')(?!\[redacted)[^']*'|(?!\[redacted)[A-Za-z0-9._%+@-]+)/#) { match in
+                let quote = match.output.2.map(String.init) ?? match.output.3.map(String.init) ?? ""
+                return "\(match.output.1)\(quote)[redacted:account]\(quote)"
             }
             // A home directory names its owner: `/Users/alice/…` is an account name in a path.
             .replacing(#/(/Users/)(?!\[redacted)[^/\s]+/#) { match in
@@ -189,22 +241,60 @@ public enum DiagnosticsExportBuilder {
     }
 
     /// The runtime's own report can name a path: a storage failure quotes where it tried to
-    /// write, which is often under the user's home directory. Its problem is replaced with a
-    /// scrubbed description so the manifest keeps the failure without the account name.
+    /// write, which is often under the user's home directory. Only the free text is replaced.
     static func scrubbed(_ runtime: RuntimeVersionInfo?) -> RuntimeVersionInfo? {
         guard var info = runtime, var tart = info.tart, let problem = tart.problem else { return runtime }
-        tart.problem = .runtimeStateUnavailable(reason: SanitizedText(scrub(problem.userMessage), limit: 300))
+        tart.problem = scrubbed(problem)
         info.tart = tart
         return info
     }
 
-    /// The observations that may appear in the manifest: paths carry the account name of
-    /// whoever owns them, so they are scrubbed like any other exported value.
+    /// Replaces an error's free text and keeps its case. The manifest's category, message,
+    /// and recovery actions are all derived from the case, so rewriting a missing runtime or
+    /// a failed verification as a saved-state failure would make the export say the wrong
+    /// thing about what went wrong and what to do about it.
+    static func scrubbed(_ error: GuesthouseError) -> GuesthouseError {
+        switch error {
+        case .runtimeStateUnavailable(let reason):
+            .runtimeStateUnavailable(reason: scrubbed(reason))
+        case .runtimeStorageUnavailable(let reason, let problem):
+            .runtimeStorageUnavailable(reason: scrubbed(reason), problem: problem)
+        case .runtimeIncompatible(let found, let required):
+            .runtimeIncompatible(found: found.map { scrubbed($0) }, required: required)
+        case .insufficientDisk(let required, let available, let volumePath):
+            .insufficientDisk(requiredBytes: required, availableBytes: available, volumePath: scrubbed(volumePath))
+        case .downloadVerificationFailed(let artifact, let check):
+            .downloadVerificationFailed(artifact: scrubbed(artifact), check: check)
+        case .toolMismatch(let tool, let found, let expected):
+            .toolMismatch(tool: scrubbed(tool), found: found.map { scrubbed($0) }, expected: expected)
+        default:
+            // Every remaining case carries identifiers, sizes, and enumerated reasons, never
+            // text that could name an address or an account.
+            error
+        }
+    }
+
+    static func scrubbed(_ text: SanitizedText) -> SanitizedText {
+        SanitizedText(scrub(text.value), limit: SanitizedText.maximumLimit)
+    }
+
+    /// The observations that may appear in the manifest. Wire sanitization removes credentials
+    /// but not identities, and a guest is free to answer any of these with an address or an
+    /// account name, so every string the tuple carries is scrubbed rather than only the paths.
     static func scrubbed(_ tuple: ObservedTuple) -> ObservedTuple {
         var copy = tuple
+        copy.hostMacOSBuild = tuple.hostMacOSBuild.map { scrub($0) }
+        copy.codexDesktopVersion = tuple.codexDesktopVersion.map { scrub($0) }
+        copy.codexDesktopBuild = tuple.codexDesktopBuild.map { scrub($0) }
         copy.codexDesktopPath = tuple.codexDesktopPath.map { scrub($0) }
+        copy.tartVersion = tuple.tartVersion.map { scrub($0) }
+        copy.guestMacOSBuild = tuple.guestMacOSBuild.map { scrub($0) }
+        copy.xcodeBuild = tuple.xcodeBuild.map { scrub($0) }
+        copy.codexCLIVersion = tuple.codexCLIVersion.map { scrub($0) }
         copy.codexCLIPath = tuple.codexCLIPath.map { scrub($0) }
         copy.codexCLICapabilities = tuple.codexCLICapabilities.map { $0.map { scrub($0) } }
+        copy.githubCLIVersion = tuple.githubCLIVersion.map { scrub($0) }
+        copy.provisioningScriptVersion = tuple.provisioningScriptVersion.map { scrub($0) }
         return copy
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
@@ -56,7 +56,9 @@ import Testing
         let redactor = Redactor()
         let lines = redactor.redact(lines: ["password:", "  hunter2", "next line"])
         let scrubbed = DiagnosticsExportBuilder.scrubbedStream(lines)
-        #expect(scrubbed[1].contains("[redacted:credential]"))
+        // The redactor's own streaming state now catches this first, so the marker may be its
+        // `secret` rather than the export's `credential`. What matters is that the value is gone.
+        #expect(scrubbed[1].contains("[redacted:"))
         #expect(!scrubbed[1].contains("hunter2"))
         #expect(scrubbed[2] == "next line")
     }
@@ -75,5 +77,30 @@ import Testing
         #expect(DiagnosticsExportBuilder.scrub("user: octocat (admin)") == "user: [redacted:account] (admin)")
         #expect(DiagnosticsExportBuilder.scrub("Contact ops@example.org for help") == "Contact [redacted:account] for help")
         #expect(DiagnosticsExportBuilder.scrub("Xcode 26.6 selected") == "Xcode 26.6 selected")
+    }
+    @Test func qualifiedNamesAreNotMistakenForAddresses() {
+        #expect(DiagnosticsExportBuilder.scrub("foo::bar failed to build") == "foo::bar failed to build")
+        #expect(DiagnosticsExportBuilder.scrub("std::vector<int>::size") == "std::vector<int>::size")
+        #expect(DiagnosticsExportBuilder.scrub("guest at 2001:db8::1 answered") == "guest at [redacted:address] answered")
+    }
+
+    @Test func equalsDelimitedAndQuotedAccountFieldsAreScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("user=octocat") == "user=[redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("account = alice") == "account = [redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("{\"user\":\"alice\"}") == "{\"user\":\"[redacted:account]\"}")
+        #expect(DiagnosticsExportBuilder.scrub("owner=alice@example.com") == "owner=[redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("timeout=30") == "timeout=30", "only account labels are scrubbed")
+    }
+
+    @Test func theLaunchFailureTheUserIsReportingIsInTheManifest() {
+        let error = GuesthouseError.runtimeMissing
+        let export = DiagnosticsExportBuilder.build(
+            appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(),
+            environments: [], logs: [], launchError: error
+        )
+        let failure = export.manifest.launchFailure
+        #expect(failure?.message == error.userMessage)
+        #expect(failure?.recoveryActions.isEmpty == false, "the export names what the user was offered")
+        #expect(String(decoding: DiagnosticsExportBuilder.encode(export.manifest), as: UTF8.self).contains("launchFailure"))
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
@@ -45,6 +45,30 @@ import Testing
         #expect(DiagnosticsExportBuilder.scrubAddresses("ratio 1:2") == "ratio 1:2")
     }
 
+    @Test func punctuationVersionsAndHomePathsAreHandled() {
+        #expect(DiagnosticsExportBuilder.scrub("guest at 2001:db8::1.") == "guest at [redacted:address].")
+        #expect(DiagnosticsExportBuilder.scrub("tool 1.2.3.456 built") == "tool 1.2.3.456 built", "a version is not an address")
+        #expect(DiagnosticsExportBuilder.scrub("guest at 192.168.64.7 answered") == "guest at [redacted:address] answered")
+        #expect(DiagnosticsExportBuilder.scrub("/Users/alice/Library/Logs") == "/Users/[redacted:account]/Library/Logs")
+    }
+
+    @Test func aCredentialContinuedOnTheNextLineIsRedacted() {
+        let redactor = Redactor()
+        let lines = redactor.redact(lines: ["password:", "  hunter2", "next line"])
+        let scrubbed = DiagnosticsExportBuilder.scrubbedStream(lines)
+        #expect(scrubbed[1].contains("[redacted:credential]"))
+        #expect(!scrubbed[1].contains("hunter2"))
+        #expect(scrubbed[2] == "next line")
+    }
+
+    @Test func compatibilityPathsAreScrubbedInTheManifest() {
+        let observed = ObservedTuple(codexDesktopPath: "/Users/alice/Applications/Codex.app", codexCLIPath: "/Users/alice/.codex/bin/codex")
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: observed, environments: [], logs: [])
+        let manifest = String(decoding: DiagnosticsExportBuilder.encode(export.manifest), as: UTF8.self)
+        #expect(!manifest.contains("alice"))
+        #expect(manifest.contains("[redacted:account]"))
+    }
+
     @Test func accountIdentifiersAreScrubbed() {
         #expect(DiagnosticsExportBuilder.scrub("Signed in as alice@example.com") == "Signed in as [redacted:account]")
         #expect(DiagnosticsExportBuilder.scrub("Logged in to github.com as octocat") == "Logged in to github.com as [redacted:account]")

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct DiagnosticsExportBuilderTests {
+    let token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"
+
+    func export(lines: [String]) -> DiagnosticsExport {
+        DiagnosticsExportBuilder.build(
+            appVersion: "0.1", appBuild: "7",
+            runtime: RuntimeVersionInfo(serviceVersion: "0.1", serviceBuild: "7", tart: .init(version: "2.36.0", verified: true)),
+            compatibility: ObservedTuple(hostMacOSVersion: SemanticVersion("26.5.2"), tartVersion: "2.36.0"),
+            environments: [DevelopmentEnvironment(name: "Dev Mac", createdAt: Date(timeIntervalSince1970: 1_800_000_000))],
+            logs: Redactor().redact(lines: lines),
+            exportedAt: Date(timeIntervalSince1970: 1_800_000_000)
+        )
+    }
+
+    @Test func secretsAndAddressesNeverReachTheExport() throws {
+        let export = export(lines: ["remote: token \(token) used", "guest at 192.168.64.7 answered", "ssh fe80::1c2a:3b4c:5d6e:7f80 pinged", "password: hunter2"])
+        #expect(!export.logText.contains(token))
+        #expect(export.logText.contains("[redacted:github-token]"))
+        #expect(!export.logText.contains("192.168.64.7"))
+        #expect(!export.logText.contains("fe80::1c2a"))
+        #expect(!export.logText.contains("hunter2"))
+        let manifest = String(decoding: try #require(export.files.first { $0.name == "manifest.json" }?.contents), as: UTF8.self)
+        #expect(!manifest.contains(#/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/#))
+        #expect(manifest.contains("\"hostMacOSVersion\" : \"26.5.2\""))
+        #expect(manifest.contains("\"logLineCount\" : 4"))
+        #expect(export.manifest.environmentIDs.count == 1)
+        #expect(export.excludedText.contains("Network addresses"))
+    }
+
+    @Test func versionsAreAlsoScrubbedByTheAddressRule() {
+        #expect(DiagnosticsExportBuilder.scrubAddresses("Tart 2.36.0 on macOS 26.5.2") == "Tart 2.36.0 on macOS 26.5.2", "three-component versions are not addresses")
+        #expect(DiagnosticsExportBuilder.scrubAddresses("host 10.0.0.1:22") == "host [redacted:address]:22")
+    }
+
+    @Test func writesAFolderWithThreeFiles() throws {
+        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
+        try DiagnosticsExportBuilder.write(export(lines: ["one"]), to: directory)
+        let names = try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
+        #expect(names == ["excluded.txt", "log.txt", "manifest.json"])
+        #expect(try String(contentsOf: directory.appending(path: "log.txt"), encoding: .utf8) == "one\n")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let manifest = try decoder.decode(DiagnosticsExport.Manifest.self, from: try Data(contentsOf: directory.appending(path: "manifest.json")))
+        #expect(manifest.appVersion == "0.1")
+        #expect(manifest.excludedCategories == DiagnosticsExportBuilder.excludedCategories)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
@@ -36,16 +36,20 @@ import Testing
         #expect(DiagnosticsExportBuilder.scrubAddresses("host 10.0.0.1:22") == "host [redacted:address]:22")
     }
 
-    @Test func writesAFolderWithThreeFiles() throws {
-        let directory = FileManager.default.temporaryDirectory.appending(path: "Diagnostics-\(UUID().uuidString)")
-        try DiagnosticsExportBuilder.write(export(lines: ["one"]), to: directory)
-        let names = try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
-        #expect(names == ["excluded.txt", "log.txt", "manifest.json"])
-        #expect(try String(contentsOf: directory.appending(path: "log.txt"), encoding: .utf8) == "one\n")
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let manifest = try decoder.decode(DiagnosticsExport.Manifest.self, from: try Data(contentsOf: directory.appending(path: "manifest.json")))
-        #expect(manifest.appVersion == "0.1")
-        #expect(manifest.excludedCategories == DiagnosticsExportBuilder.excludedCategories)
+    @Test func compressedAndMappedIPv6AddressesAreScrubbedButTimesAreNot() {
+        for address in ["::1", "2001:db8::1", "fe80::1c2a:3b4c:5d6e:7f80", "::ffff:192.0.2.1", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"] {
+            let scrubbed = DiagnosticsExportBuilder.scrubAddresses("guest at \(address) answered")
+            #expect(scrubbed == "guest at [redacted:address] answered", "\(address)")
+        }
+        #expect(DiagnosticsExportBuilder.scrubAddresses("12:30:45.123 started") == "12:30:45.123 started")
+        #expect(DiagnosticsExportBuilder.scrubAddresses("ratio 1:2") == "ratio 1:2")
+    }
+
+    @Test func accountIdentifiersAreScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("Signed in as alice@example.com") == "Signed in as [redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("Logged in to github.com as octocat") == "Logged in to github.com as [redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("user: octocat (admin)") == "user: [redacted:account] (admin)")
+        #expect(DiagnosticsExportBuilder.scrub("Contact ops@example.org for help") == "Contact [redacted:account] for help")
+        #expect(DiagnosticsExportBuilder.scrub("Xcode 26.6 selected") == "Xcode 26.6 selected")
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticsExportBuilderTests.swift
@@ -96,11 +96,115 @@ import Testing
         let error = GuesthouseError.runtimeMissing
         let export = DiagnosticsExportBuilder.build(
             appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(),
-            environments: [], logs: [], launchError: error
+            environments: [], logs: [], launchFailure: .init(error)
         )
         let failure = export.manifest.launchFailure
         #expect(failure?.message == error.userMessage)
         #expect(failure?.recoveryActions.isEmpty == false, "the export names what the user was offered")
         #expect(String(decoding: DiagnosticsExportBuilder.encode(export.manifest), as: UTF8.self).contains("launchFailure"))
+    }
+
+    @Test func theOperationFailureIsInTheManifestBesideTheLaunchFailure() {
+        let error = GuesthouseError.guestNotReachable(EnvironmentID())
+        let export = DiagnosticsExportBuilder.build(
+            appVersion: "1", appBuild: "1", runtime: nil, compatibility: ObservedTuple(),
+            environments: [], logs: [], operationFailure: .init(error)
+        )
+        #expect(export.manifest.operationFailure?.message == error.userMessage)
+        #expect(export.manifest.operationFailure?.recoveryActions.isEmpty == false)
+        #expect(export.manifest.launchFailure == nil)
+    }
+
+    @Test func macAddressesAreScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("guest nic 52:54:00:12:34:56 up") == "guest nic [redacted:address] up")
+        #expect(DiagnosticsExportBuilder.scrub("started at 12:30:45 sharp") == "started at 12:30:45 sharp", "a clock time is not an address")
+    }
+
+    @Test func aMACAddressInsideAMachineGeneratedIdentifierIsScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("nic_52:54:00:12:34:56_state up") == "nic_[redacted:address]_state up")
+        #expect(DiagnosticsExportBuilder.scrub("52:54:00:12:34:56_link=down") == "[redacted:address]_link=down")
+        #expect(
+            DiagnosticsExportBuilder.scrub("prefix 2001:0db8:0000:0000:0000:ff00:0042:8329 up") == "prefix [redacted:address] up",
+            "a longer colon run is still taken whole rather than cut into six pairs"
+        )
+    }
+
+    @Test func multiWordAccountNamesAreScrubbedWhole() {
+        #expect(DiagnosticsExportBuilder.scrub("Signed in as Alice Smith") == "Signed in as [redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("{\"user\":\"Alice Smith\"}") == "{\"user\":\"[redacted:account]\"}")
+        // A label followed by a space is prose, so the marker replaces the quotes with it;
+        // the quoting is only kept where a parser depends on it, in the structured form above.
+        #expect(DiagnosticsExportBuilder.scrub("account: 'Alice Smith'") == "account: [redacted:account]")
+        #expect(DiagnosticsExportBuilder.scrub("Signed in as \"Alice Smith\"") == "Signed in as [redacted:account]")
+        // The value still ends where it stops looking like a name, so the qualifier a CLI
+        // prints after the account survives for the reader of the bundle.
+        #expect(DiagnosticsExportBuilder.scrub("user: octocat (admin)") == "user: [redacted:account] (admin)")
+        #expect(DiagnosticsExportBuilder.scrub("Logged in to github.com as octocat with a keyring token") == "Logged in to github.com as [redacted:account] with a keyring token")
+    }
+
+    @Test func anIPv6AddressFollowedByALabelDelimiterIsScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("peer 2001:db8::1: connection failed") == "peer [redacted:address]: connection failed")
+        #expect(DiagnosticsExportBuilder.scrub("prefix 2001:db8:: assigned") == "prefix [redacted:address] assigned", "a prefix is itself an address")
+    }
+
+    @Test func addressesInsideMachineGeneratedIdentifiersAreScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("peer_192.168.64.7 timed out") == "peer_[redacted:address] timed out")
+        #expect(DiagnosticsExportBuilder.scrub("192.168.64.7_status=down") == "[redacted:address]_status=down")
+        #expect(DiagnosticsExportBuilder.scrub("build 1.2.3.4.5 shipped") == "build 1.2.3.4.5 shipped", "a five-part version is not an address")
+    }
+
+    @Test func localUserAtHostIdentifiersAreScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("ssh alice@guesthouse failed") == "ssh [redacted:account] failed")
+        #expect(DiagnosticsExportBuilder.scrub("ssh alice@192.168.64.7 failed") == "ssh [redacted:account] failed")
+    }
+
+    @Test func theAccountInFrontOfABracketedIPv6HostIsScrubbed() {
+        // SSH brackets an IPv6 host, and the address pass keeps those brackets around its
+        // marker, so the account is met as `alice@[[redacted:address]]`.
+        #expect(DiagnosticsExportBuilder.scrub("ssh alice@[2001:db8::1] failed") == "ssh [redacted:account] failed")
+        #expect(DiagnosticsExportBuilder.scrub("ssh alice@[192.168.64.7] failed") == "ssh [redacted:account] failed")
+    }
+
+    @Test func anIPv6AddressInsideAMachineGeneratedIdentifierIsScrubbed() {
+        #expect(DiagnosticsExportBuilder.scrub("peer_2001:db8::1_status down") == "peer_[redacted:address]_status down")
+        #expect(DiagnosticsExportBuilder.scrub("fe80::1_state=up") == "[redacted:address]_state=up")
+        #expect(DiagnosticsExportBuilder.scrub("foo_::bar failed to build") == "foo_::bar failed to build", "an underscore does not make a qualified name an address")
+    }
+
+    @Test func theRuntimeProblemKeepsItsOwnCase() throws {
+        let info = RuntimeVersionInfo(
+            serviceVersion: "1", serviceBuild: "1",
+            tart: .init(version: nil, verified: false, problem: .runtimeVerificationFailed(check: .signature))
+        )
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: info, compatibility: ObservedTuple(), environments: [], logs: [])
+        #expect(export.manifest.runtime?.tart?.problem == .runtimeVerificationFailed(check: .signature))
+    }
+
+    @Test func theRuntimeProblemsFreeTextIsScrubbedInPlace() throws {
+        let info = RuntimeVersionInfo(
+            serviceVersion: "1", serviceBuild: "1",
+            tart: .init(version: nil, verified: false, problem: .runtimeStorageUnavailable(reason: SanitizedText("/Users/alice/Library/Application Support is full"), problem: .unwritable))
+        )
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: info, compatibility: ObservedTuple(), environments: [], logs: [])
+        let problem = try #require(export.manifest.runtime?.tart?.problem)
+        guard case .runtimeStorageUnavailable(let reason, let kind) = problem else {
+            Issue.record("the storage problem lost its case")
+            return
+        }
+        #expect(!reason.value.contains("alice"))
+        #expect(kind == .unwritable)
+    }
+
+    @Test func everyCompatibilityStringIsScrubbed() {
+        let observed = ObservedTuple(
+            xcodeBuild: "reported by 192.168.64.7",
+            githubCLIVersion: "2.62.0 as alice@example.com",
+            provisioningScriptVersion: "run from /Users/alice/scripts"
+        )
+        let export = DiagnosticsExportBuilder.build(appVersion: "1", appBuild: "1", runtime: nil, compatibility: observed, environments: [], logs: [])
+        let manifest = String(decoding: DiagnosticsExportBuilder.encode(export.manifest), as: UTF8.self)
+        #expect(!manifest.contains("192.168.64.7"))
+        #expect(!manifest.contains("alice"))
+        #expect(export.manifest.compatibility.xcodeBuild == "reported by [redacted:address]")
     }
 }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -59,6 +59,11 @@ public actor EnvironmentLifecycle {
     /// client believing the work is still in flight (MVP-PLAN.md §2).
     static let statusRefreshBudget = Duration.seconds(2)
 
+    /// Where a VM process's output goes while an operation on its environment is in flight:
+    /// the operation's own event stream, as `log` events. Between operations nobody listens
+    /// and the lines are dropped, never buffered.
+    private var outputSinks: [EnvironmentID: (operation: OperationID, events: EventSink)] = [:]
+
     public init(dependencies: Dependencies) {
         deps = dependencies
     }
@@ -469,9 +474,11 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, inventory: [TartVMInfo], token: OperationSupervisor.Token, events: EventSink) async {
+    private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, inventory: [TartVMInfo], token: OperationSupervisor.Token, events: @escaping EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
+        outputSinks[id] = (operation, events)
+        defer { token.end(); inFlight = nil; outputSinks[id] = nil }
         let arguments = TartBackend.runArguments(vmName: environment.tartVMName, console: options.console)
         do {
             report(operation, ProgressPhase(kind: .startingVM, cancelable: false), events)
@@ -483,7 +490,7 @@ public actor EnvironmentLifecycle {
             // list` would let a hanging inventory hold up a launch it cannot inform.
             try await refuseIfAnySlotIsClaimed(startingFor: id, inventory: inventory)
             let run = try await deps.backend.run(vmName: environment.tartVMName, console: options.console)
-            drainOutput(of: run)
+            drainOutput(of: run, environment: id)
             let identity: ProcessIdentity
             do {
                 identity = try await deps.supervisor.recordLaunch(pid: run.processIdentifier, executable: deps.backend.bundle.executable, arguments: arguments, vmName: environment.tartVMName, environment: id)
@@ -598,9 +605,11 @@ public actor EnvironmentLifecycle {
         }
     }
 
-    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: EventSink) async {
+    private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: @escaping EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
+        outputSinks[id] = (operation, events)
+        defer { token.end(); inFlight = nil; outputSinks[id] = nil }
         do {
             // Ownership was proven before the journal write suspended, and that answer only
             // described the instant it was taken: the owned process can have exited since and
@@ -848,11 +857,23 @@ public actor EnvironmentLifecycle {
         if case .uncertain? = verdicts[id] { throw GuesthouseError.vmOwnershipUncertain(id) }
     }
 
-    /// Tart's output over a VM's lifetime is already redacted and is not kept: the stream is
-    /// consumed so the bounded buffer never fills.
-    private func drainOutput(of run: ProcessRun) {
-        Task.detached {
-            for await _ in run.output {}
+    /// Tart's output over a VM's lifetime is already redacted. While an operation on the
+    /// environment is in flight each line is forwarded to it as a `log` event, so the GUI's
+    /// diagnostics see what Tart said; otherwise the stream is consumed so the bounded buffer
+    /// never fills.
+    private func drainOutput(of run: ProcessRun, environment id: EnvironmentID) {
+        Task { [weak self] in
+            for await output in run.output {
+                await self?.forward(output, from: id)
+            }
+        }
+    }
+
+    private func forward(_ output: ProcessOutput, from id: EnvironmentID) {
+        guard let sink = outputSinks[id] else { return }
+        switch output {
+        case .stdout(let line), .stderr(let line):
+            sink.events(.log(sink.operation, line))
         }
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -63,6 +63,11 @@ public actor EnvironmentLifecycle {
     /// the operation's own event stream, as `log` events. Between operations nobody listens
     /// and the lines are dropped, never buffered.
     private var outputSinks: [EnvironmentID: (operation: OperationID, events: EventSink)] = [:]
+    /// The task forwarding each supervised process's output, so a failure can wait for the
+    /// tail of that output before the sink goes away, and the environments whose output has
+    /// not run out yet.
+    private var drains: [EnvironmentID: Task<Void, Never>] = [:]
+    private var draining: Set<EnvironmentID> = []
 
     public init(dependencies: Dependencies) {
         deps = dependencies
@@ -648,6 +653,7 @@ public actor EnvironmentLifecycle {
                     }
                 }
             }
+            await settleOutput(of: id)
             if let failure = await release(id) {
                 throw GuesthouseError.runtimeStateUnavailable(reason: SanitizedText(Self.describe(failure), limit: 200))
             }
@@ -862,10 +868,29 @@ public actor EnvironmentLifecycle {
     /// diagnostics see what Tart said; otherwise the stream is consumed so the bounded buffer
     /// never fills.
     private func drainOutput(of run: ProcessRun, environment id: EnvironmentID) {
-        Task { [weak self] in
+        draining.insert(id)
+        drains[id] = Task { [weak self] in
             for await output in run.output {
                 await self?.forward(output, from: id)
             }
+            await self?.finishedDraining(id)
+        }
+    }
+
+    private func finishedDraining(_ id: EnvironmentID) {
+        draining.remove(id)
+    }
+
+    /// Waits, briefly, for output already read from the process to reach the operation's
+    /// stream. A process that exits after writing its last lines resumes the exit waiters
+    /// before this task has forwarded them, and those lines are exactly the ones that explain
+    /// the failure. The wait is bounded: a pipe an inherited child still holds open must not
+    /// keep the operation from finishing.
+    private func settleOutput(of id: EnvironmentID, within limit: Duration = .milliseconds(500)) async {
+        guard draining.contains(id) else { return }
+        let deadline = ContinuousClock.now.advanced(by: limit)
+        while draining.contains(id), ContinuousClock.now < deadline {
+            try? await Task.sleep(for: .milliseconds(5))
         }
     }
 
@@ -921,6 +946,8 @@ public actor EnvironmentLifecycle {
         if let live = supervised.removeValue(forKey: id) {
             live.token.end()
         }
+        drains.removeValue(forKey: id)
+        draining.remove(id)
         verdicts[id] = failure == nil ? nil : .uncertain(.identityNotForgotten)
         return failure
     }
@@ -928,6 +955,7 @@ public actor EnvironmentLifecycle {
     /// Journals the failure under the operation's own kind (the journal refuses a record whose
     /// kind differs from its `started` record), then reports it.
     private func fail(_ operation: OperationID, kind: JournalOperation, environment: EnvironmentID, with error: GuesthouseError, events: EventSink) async {
+        await settleOutput(of: environment)
         do {
             try await deps.store.append(JournalRecord(id: operation, environmentID: environment, operation: kind, timestamp: Date(), outcome: .failed(error)))
             // A recorded outcome that is itself unknown settles nothing: the environment stays

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lifecycle/EnvironmentLifecycle.swift
@@ -63,11 +63,20 @@ public actor EnvironmentLifecycle {
     /// the operation's own event stream, as `log` events. Between operations nobody listens
     /// and the lines are dropped, never buffered.
     private var outputSinks: [EnvironmentID: (operation: OperationID, events: EventSink)] = [:]
+    /// The instant the operation in flight must answer by, while one has a deadline of its
+    /// own. Waiting for a process's last lines is worth a moment, but not a moment past what
+    /// the caller asked for: Quit budgets the whole graceful stop, drain included.
+    private var outputSettleDeadline: ContinuousClock.Instant?
     /// The task forwarding each supervised process's output, so a failure can wait for the
-    /// tail of that output before the sink goes away, and the environments whose output has
-    /// not run out yet.
+    /// tail of that output before the sink goes away.
     private var drains: [EnvironmentID: Task<Void, Never>] = [:]
-    private var draining: Set<EnvironmentID> = []
+    /// Which drain each environment is still waiting on, and which drain is allowed to speak
+    /// for it. A pipe an inherited child holds open keeps a drain alive after its VM is gone,
+    /// so both are keyed by generation: the stale drain neither ends the wait for the current
+    /// run's output nor forwards the old machine's lines into the next operation (§4).
+    private var draining: [EnvironmentID: UInt64] = [:]
+    private var currentDrain: [EnvironmentID: UInt64] = [:]
+    private var drainSequence: UInt64 = 0
 
     public init(dependencies: Dependencies) {
         deps = dependencies
@@ -482,8 +491,9 @@ public actor EnvironmentLifecycle {
     private func performStart(_ operation: OperationID, environment: DevelopmentEnvironment, options: StartOptions, inventory: [TartVMInfo], token: OperationSupervisor.Token, events: @escaping EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
+        retireReleasedDrain(of: id)
         outputSinks[id] = (operation, events)
-        defer { token.end(); inFlight = nil; outputSinks[id] = nil }
+        defer { token.end(); inFlight = nil; outputSinks[id] = nil; outputSettleDeadline = nil }
         let arguments = TartBackend.runArguments(vmName: environment.tartVMName, console: options.console)
         do {
             report(operation, ProgressPhase(kind: .startingVM, cancelable: false), events)
@@ -613,8 +623,13 @@ public actor EnvironmentLifecycle {
     private func performStop(_ operation: OperationID, environment: DevelopmentEnvironment, mode: StopMode, token: OperationSupervisor.Token, events: @escaping EventSink) async {
         defer { token.end(); inFlight = nil }
         let id = environment.id
+        retireReleasedDrain(of: id)
         outputSinks[id] = (operation, events)
-        defer { token.end(); inFlight = nil; outputSinks[id] = nil }
+        // The deadline belongs to the operation that set it. A graceful stop that exhausted
+        // its own deadline would otherwise leave that past instant behind for the warned
+        // force-stop that follows, and `settleOutput` would clamp to it and return before the
+        // shutdown's last lines were forwarded (MVP-PLAN.md §2, Quit).
+        defer { token.end(); inFlight = nil; outputSinks[id] = nil; outputSettleDeadline = nil }
         do {
             // Ownership was proven before the journal write suspended, and that answer only
             // described the instant it was taken: the owned process can have exited since and
@@ -631,7 +646,8 @@ public actor EnvironmentLifecycle {
                     // the process hosting the VM share it, so a normal Quit never takes close
                     // to twice what the caller asked for (MVP-PLAN.md §2).
                     let end = ContinuousClock.now.advanced(by: deadline)
-                    try await gracefulStop(operation, environment: environment, deadline: deadline)
+                    outputSettleDeadline = end
+                    try await gracefulStop(operation, environment: environment, deadline: deadline, events: events)
                     // Tart's command has returned, but the process hosting the VM may still be
                     // unwinding, and Quit waits for both. The run itself was launched with a
                     // year-long timeout, so an unbounded wait here would never end.
@@ -649,7 +665,7 @@ public actor EnvironmentLifecycle {
                         // An adopted survivor has no run to end; its process is signaled directly.
                         try await terminateAdopted(live, operation: operation)
                     } else {
-                        try await endUnsupervisedVM(environment, operation: operation)
+                        try await endUnsupervisedVM(environment, operation: operation) { events(.log(operation, $0)) }
                     }
                 }
             }
@@ -685,9 +701,12 @@ public actor EnvironmentLifecycle {
     /// the timeout alone: a VM still running is the reported timeout, a VM that is gone is a
     /// stop that completed late, and a state that cannot be read leaves the outcome unknown
     /// rather than unblocking the environment for a retry or a force-stop (MVP-PLAN.md §3).
-    private func gracefulStop(_ operation: OperationID, environment: DevelopmentEnvironment, deadline: Duration) async throws {
+    private func gracefulStop(_ operation: OperationID, environment: DevelopmentEnvironment, deadline: Duration, events: @escaping EventSink) async throws {
         do {
-            try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline)
+            // The stop command's own output is forwarded: when a shutdown fails or times out,
+            // what it wrote is the explanation diagnostics need, and the VM's own stream says
+            // nothing about it (MVP-PLAN.md §2).
+            try await deps.backend.stop(vmName: environment.tartVMName, deadline: deadline) { events(.log(operation, $0)) }
         } catch TartInvocationError.timedOut {
             // The caller's whole budget is spent by definition on this branch, and when the
             // supervised process is already gone `observe` falls through to `tart list`, whose
@@ -737,10 +756,14 @@ public actor EnvironmentLifecycle {
     /// in which case the requested stopped state is already reached and no command is needed:
     /// `tart stop` would answer `notRunning`, and that would be reported as a failure for a
     /// stop that succeeded (MVP-PLAN.md §2, Quit).
-    func endUnsupervisedVM(_ environment: DevelopmentEnvironment, operation: OperationID) async throws {
+    func endUnsupervisedVM(
+        _ environment: DevelopmentEnvironment,
+        operation: OperationID,
+        onOutput: (@Sendable (RedactedLine) -> Void)? = nil
+    ) async throws {
         switch await observe(environment) {
         case .stopped: return
-        case .running: try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10))
+        case .running: try await deps.backend.stop(vmName: environment.tartVMName, deadline: .seconds(10), onOutput: onOutput)
         case .unknown: throw GuesthouseError.operationOutcomeUnknown(operation)
         }
     }
@@ -868,17 +891,47 @@ public actor EnvironmentLifecycle {
     /// diagnostics see what Tart said; otherwise the stream is consumed so the bounded buffer
     /// never fills.
     private func drainOutput(of run: ProcessRun, environment id: EnvironmentID) {
-        draining.insert(id)
+        drainSequence &+= 1
+        let generation = drainSequence
+        // A drain the previous run left behind can no longer reach an operation, so ending it
+        // here keeps one stuck pipe from holding a task for the life of the service.
+        drains[id]?.cancel()
+        draining[id] = generation
+        currentDrain[id] = generation
         drains[id] = Task { [weak self] in
             for await output in run.output {
-                await self?.forward(output, from: id)
+                await self?.forward(output, from: id, generation: generation)
             }
-            await self?.finishedDraining(id)
+            // The runner drops output past its byte and line limits and says so on the exit.
+            // A log that simply stops reads as a complete one, so the omission is stated
+            // rather than left for the reader to infer (MVP-PLAN.md §2). The exit is only
+            // waited for when the stream ended on its own: a canceled drain leaves a process
+            // that may still be running, and `exit()` would never return.
+            if !Task.isCancelled, await run.exit().outputTruncated {
+                await self?.forward(.stderr(Self.truncationMarker), from: id, generation: generation)
+            }
+            await self?.finishedDraining(id, generation: generation)
         }
     }
 
-    private func finishedDraining(_ id: EnvironmentID) {
-        draining.remove(id)
+    private func finishedDraining(_ id: EnvironmentID, generation: UInt64) {
+        guard draining[id] == generation else { return }
+        draining[id] = nil
+    }
+
+    /// Retires the drain of a run that is no longer supervised, before the next operation
+    /// installs its sink.
+    ///
+    /// A released run's pipe can stay open in an inherited child, so its drain outlives the
+    /// machine it read. `drainOutput` advances the generation for the next run, but an
+    /// operation that starts no run — a stop whose preflight already found the VM stopped, or
+    /// a start that fails before it launches — installs a sink with the old generation still
+    /// current, and the dead machine's lines would be attributed to it (MVP-PLAN.md §4).
+    /// Nothing is waited on either: a drain that may no longer speak has no tail to settle.
+    private func retireReleasedDrain(of id: EnvironmentID) {
+        guard supervised[id] == nil else { return }
+        currentDrain[id] = nil
+        draining[id] = nil
     }
 
     /// Waits, briefly, for output already read from the process to reach the operation's
@@ -887,15 +940,21 @@ public actor EnvironmentLifecycle {
     /// the failure. The wait is bounded: a pipe an inherited child still holds open must not
     /// keep the operation from finishing.
     private func settleOutput(of id: EnvironmentID, within limit: Duration = .milliseconds(500)) async {
-        guard draining.contains(id) else { return }
-        let deadline = ContinuousClock.now.advanced(by: limit)
-        while draining.contains(id), ContinuousClock.now < deadline {
+        guard draining[id] != nil else { return }
+        var deadline = ContinuousClock.now.advanced(by: limit)
+        if let bound = outputSettleDeadline, bound < deadline { deadline = bound }
+        while draining[id] != nil, ContinuousClock.now < deadline {
             try? await Task.sleep(for: .milliseconds(5))
         }
     }
 
-    private func forward(_ output: ProcessOutput, from id: EnvironmentID) {
-        guard let sink = outputSinks[id] else { return }
+    /// What the log event says when the runner dropped output it could not hold.
+    static let truncationMarker = RedactedLine.runnerTruncatedOutput
+
+    private func forward(_ output: ProcessOutput, from id: EnvironmentID, generation: UInt64) {
+        // A drain outlives the run it reads when a child inherited the pipe. Its lines belong
+        // to the machine that is gone, never to whatever operation started since.
+        guard currentDrain[id] == generation, let sink = outputSinks[id] else { return }
         switch output {
         case .stdout(let line), .stderr(let line):
             sink.events(.log(sink.operation, line))
@@ -946,8 +1005,10 @@ public actor EnvironmentLifecycle {
         if let live = supervised.removeValue(forKey: id) {
             live.token.end()
         }
-        drains.removeValue(forKey: id)
-        draining.remove(id)
+        // The drain is deliberately left alone. Ending supervision does not forward the lines
+        // already read from the process, and clearing the drain here would let `settleOutput`
+        // return while the tail that explains the failure is still queued. The drain clears
+        // itself when it runs out, and the next run replaces it.
         verdicts[id] = failure == nil ? nil : .uncertain(.identityNotForgotten)
         return failure
     }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessInvocation.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessInvocation.swift
@@ -97,6 +97,14 @@ public struct ProcessExit: Hashable, Sendable {
     }
 }
 
+extension RedactedLine {
+    /// What a log says when the runner dropped output it could not hold. `ProcessExit` records
+    /// the fact, but only for whoever inspects the exit; a log that simply stops reads as a
+    /// complete one to the person reading the bundle, so every path that forwards a run's
+    /// output states it in the log itself (MVP-PLAN.md §2).
+    static let runnerTruncatedOutput = RedactedLine(literal: "[truncated] the runtime dropped output past its limit")
+}
+
 /// Why a program could not be started, with what the user can do about it.
 public enum ProcessLaunchError: Error, Hashable, Sendable, LocalizedError {
     case executableNotFound(String)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Tart/TartBackend.swift
@@ -129,8 +129,12 @@ public struct TartBackend: Sendable {
     /// escalates to a force-stop, so it is set far beyond the deadline; when the deadline
     /// passes, the stop command is ended and `TartInvocationError.timedOut` is thrown with the
     /// guest still running. Force-stopping is a separate, warned path.
-    public func stop(vmName: String, deadline: Duration) async throws {
-        _ = try await capture(["stop", vmName, "--timeout", String(Self.neverForceSeconds)], timeout: deadline)
+    ///
+    /// `onOutput` receives each redacted line the stop command itself writes. A shutdown that
+    /// fails explains itself on that command's stderr, not on the VM's, so diagnostics would
+    /// otherwise be missing exactly the output the user is reporting (MVP-PLAN.md §2).
+    public func stop(vmName: String, deadline: Duration, onOutput: (@Sendable (RedactedLine) -> Void)? = nil) async throws {
+        _ = try await capture(["stop", vmName, "--timeout", String(Self.neverForceSeconds)], timeout: deadline, onOutput: onOutput)
     }
 
     static let neverForceSeconds = 86_400
@@ -148,7 +152,7 @@ public struct TartBackend: Sendable {
         let stderr: String
     }
 
-    private func capture(_ arguments: [String], timeout: Duration, terminationGracePeriod: Duration = .seconds(5)) async throws -> Captured {
+    private func capture(_ arguments: [String], timeout: Duration, terminationGracePeriod: Duration = .seconds(5), onOutput: (@Sendable (RedactedLine) -> Void)? = nil) async throws -> Captured {
         let run = try await launch(ProcessInvocation(
             executable: bundle.executable,
             arguments: arguments,
@@ -163,11 +167,18 @@ public struct TartBackend: Sendable {
             var stderr: [String] = []
             var reachedLimit = false
             for await line in run.output {
+                onOutput?(line.line)
                 // A command whose output is parsed is bounded by record count as well as by
                 // the runner's byte cap: empty records cost no bytes but still cost memory.
                 guard stdout.count + stderr.count < Self.maximumCapturedRecords else {
                     reachedLimit = true
-                    break
+                    // Storage is full, but a caller that is forwarding is reading a log rather
+                    // than parsing an answer, and the lines that explain a failed shutdown are
+                    // the last ones: ending the loop here would drop exactly them (§2). The
+                    // records are no longer kept, so the rest costs nothing to read. With
+                    // nobody forwarding there is nothing left to read for.
+                    if onOutput == nil { break }
+                    continue
                 }
                 switch line {
                 case .stdout(let text): stdout.append(text.text)
@@ -179,6 +190,11 @@ public struct TartBackend: Sendable {
             run.terminate(gracePeriod: .seconds(1))
         }
         if Task.isCancelled { throw CancellationError() }
+        // The runner's byte and record caps cut the output off before the stream ended, and
+        // this is the only place that sees the flag: `stop` discards the capture and a failure
+        // throws below. A forwarding caller is reading a log whose last lines are the ones a
+        // failed shutdown wrote, so the omission is stated rather than left to look complete.
+        if exit.outputTruncated { onOutput?(RedactedLine.runnerTruncatedOutput) }
         if exit.timedOut { throw TartInvocationError.timedOut }
         guard exit.succeeded else {
             throw TartInvocationError.failed(TartErrorClassifier.classify(stderr: stderr.joined(separator: "\n"), exitStatus: Self.exitStatus(exit)))

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -26,7 +26,7 @@ import Testing
 
     /// A lifecycle over storage the test already holds, so a snapshot or a journal record can
     /// be seeded before the service starts.
-    func makeLifecycle(runner: FakeProcessRunner, storage: RuntimeStorage, store: StateStore, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> EnvironmentLifecycle {
+    func makeLifecycle(runner: any ProcessRunning, storage: RuntimeStorage, store: StateStore, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> EnvironmentLifecycle {
         let bundle = TartBundle(url: storage.url(for: .runtime).appending(path: "tart.app"))
         // The fixture's executable is a link to the test helper: it accepts any arguments,
         // leaves them untouched, and runs until ended, so `run` looks like a live VM process
@@ -40,7 +40,7 @@ import Testing
         return EnvironmentLifecycle(dependencies: .init(backend: TartBackend(bundle: bundle, storage: storage, runner: runner), supervisor: supervisor, store: store))
     }
 
-    func makeLifecycle(runner: FakeProcessRunner, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
+    func makeLifecycle(runner: any ProcessRunning, recordedIdentities: [ProcessIdentity] = [], enumerator: LiveProcessEnumerator = LiveProcessEnumerator()) async throws -> (EnvironmentLifecycle, StateStore, RuntimeStorage) {
         let (storage, store) = try makeStorage()
         let lifecycle = try await makeLifecycle(runner: runner, storage: storage, store: store, recordedIdentities: recordedIdentities, enumerator: enumerator)
         return (lifecycle, store, storage)
@@ -1220,12 +1220,122 @@ import Testing
         #expect(logs.contains { $0.1.text == "line 39" }, "the last lines written before the exit are forwarded, not lost with the sink")
     }
 
+    @Test func truncatedProcessOutputIsReportedRatherThanLeftLookingComplete() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("run", .init(stdout: ["Booting virtual machine"], exit: ProcessExit(reason: .status(1), outputTruncated: true)))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        let seen = await collect(events)
+        let logs = seen.compactMap { event -> String? in if case .log(_, let line) = event { line.text } else { nil } }
+        #expect(logs.contains(EnvironmentLifecycle.truncationMarker.text), "a log the runner cut short says so: \(logs)")
+    }
+
+    @Test func theStopCommandsOwnOutputReachesTheOperationsLog() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("stop", .init(stderr: ["the guest refused to shut down"], exit: ProcessExit(reason: .status(2))))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(20))) { event in stopEvents.add(event) }
+        let seen = await collect(stopEvents)
+        let logs = seen.compactMap { event -> (OperationID?, String)? in if case .log(let id, let line) = event { (id, line.text) } else { nil } }
+        #expect(logs.contains { $0 == (stop, "the guest refused to shut down") }, "the failing stop command explains itself: \(logs)")
+        await runner.finishHanging()
+    }
+
+    @Test func aStopWhoseOwnOutputWasCutShortSaysSo() async throws {
+        // The VM's drain reports its own truncation, but the stop command is a separate run
+        // whose output `capture` consumes; without a marker its failure explanation just ends.
+        let runner = tartLikeRunner()
+        await runner.set("stop", .init(stderr: ["the guest refused to shut down"], exit: ProcessExit(reason: .status(2), outputTruncated: true)))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let startEvents = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in startEvents.add(event) }
+        _ = await collect(startEvents)
+        let stopEvents = EventCollector()
+        let stop = try await lifecycle.stop(environment, mode: .graceful(deadline: .seconds(20))) { event in stopEvents.add(event) }
+        let seen = await collect(stopEvents)
+        let logs = seen.compactMap { event -> (OperationID?, String)? in if case .log(let id, let line) = event { (id, line.text) } else { nil } }
+        #expect(logs.contains { $0 == (stop, EnvironmentLifecycle.truncationMarker.text) }, "the stop's log names what it lost: \(logs)")
+        await runner.finishHanging()
+    }
+
+    @Test func outputFromAReleasedRunNeverReachesTheNextOperation() async throws {
+        let ghost = GhostPipeRunner(inner: tartLikeRunner())
+        await ghost.setInner("ip", .init(stdout: ["192.168.64.9"], delay: .milliseconds(200)))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: ghost)
+        try await lifecycle.prepare()
+        let first = EventCollector()
+        _ = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in first.add(event) }
+        _ = await collect(first)
+
+        // The second start installs its own sink; only then can the abandoned pipe be seen
+        // writing into it.
+        let second = EventCollector()
+        let restart = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in second.add(event) }
+        for _ in 0..<400 where second.events.isEmpty { try await Task.sleep(for: .milliseconds(5)) }
+        await ghost.writeToAbandonedPipe("ghost line from the machine that exited")
+        let seen = await collect(second)
+        let logs = seen.compactMap { event -> String? in if case .log(_, let line) = event { line.text } else { nil } }
+        #expect(!logs.contains("ghost line from the machine that exited"), "the released run's pipe cannot speak for \(restart): \(logs)")
+        await ghost.finishAbandonedPipe()
+        await ghost.finishInnerHanging()
+    }
+
     @Test func unknownEnvironmentIsRefused() async throws {
         let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner())
         try await lifecycle.prepare()
         let stranger = EnvironmentID()
         await #expect(throws: GuesthouseError.environmentNotFound(stranger)) { _ = try await lifecycle.status(of: stranger) }
         await #expect(throws: GuesthouseError.environmentNotFound(stranger)) { _ = try await lifecycle.start(stranger, options: StartOptions()) { _ in } }
+    }
+}
+
+/// A runner whose first `run` answers with a process that has already exited while its output
+/// pipe stays open, as it does when a child inherited it. The test writes into that abandoned
+/// pipe afterwards; every other command is answered by the wrapped fake.
+actor GhostPipeRunner: ProcessRunning {
+    private let inner: FakeProcessRunner
+    private var abandoned: AsyncStream<ProcessOutput>.Continuation?
+
+    init(inner: FakeProcessRunner) {
+        self.inner = inner
+    }
+
+    func setInner(_ command: String, _ reply: FakeProcessRunner.Reply) async {
+        await inner.set(command, reply)
+    }
+
+    func writeToAbandonedPipe(_ text: String) {
+        abandoned?.yield(.stdout(Redactor().redact(lines: [text])[0]))
+    }
+
+    func finishAbandonedPipe() {
+        abandoned?.finish()
+        abandoned = nil
+    }
+
+    func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
+        guard invocation.arguments.first == "run", abandoned == nil else { return try await inner.run(invocation) }
+        let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self, bufferingPolicy: .unbounded)
+        abandoned = continuation
+        // The run is given a second, throwaway continuation to close on exit, so recording the
+        // exit does not end the pipe the test still holds: that is what an inherited handle
+        // does to a real one.
+        let (_, closed) = AsyncStream.makeStream(of: ProcessOutput.self)
+        let run = ProcessRun(process: Process(), output: stream, continuation: closed)
+        run.finish(with: .status(1))
+        return run
+    }
+
+    func finishInnerHanging() async {
+        await inner.finishHanging()
     }
 }
 

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -1206,7 +1206,8 @@ import Testing
 
     @Test func tartOutputDuringAnOperationReachesItsEventStream() async throws {
         let runner = tartLikeRunner()
-        await runner.set("run", .init(stdout: ["Booting virtual machine", "token=abcdef0123456789abcdef0123456789"], exit: ProcessExit(reason: .status(1))))
+        let tail = (0..<40).map { "line \($0)" }
+        await runner.set("run", .init(stdout: ["Booting virtual machine", "token=abcdef0123456789abcdef0123456789"] + tail, exit: ProcessExit(reason: .status(1))))
         let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
         try await lifecycle.prepare()
         let events = EventCollector()
@@ -1215,7 +1216,9 @@ import Testing
         let logs = seen.compactMap { event -> (OperationID?, RedactedLine)? in if case .log(let id, let line) = event { return (id, line) } else { return nil } }
         #expect(logs.contains { $0.1.text == "Booting virtual machine" }, "Tart's lines are forwarded as log events")
         #expect(logs.allSatisfy { $0.0 == start })
-        #expect(!logs.contains { $0.1.text.contains("abcdef0123456789") }, "forwarded lines are the redacted ones")    }
+        #expect(!logs.contains { $0.1.text.contains("abcdef0123456789") }, "forwarded lines are the redacted ones")
+        #expect(logs.contains { $0.1.text == "line 39" }, "the last lines written before the exit are forwarded, not lost with the sink")
+    }
 
     @Test func unknownEnvironmentIsRefused() async throws {
         let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner())

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/EnvironmentLifecycleTests.swift
@@ -1204,6 +1204,19 @@ import Testing
         try repairJournal(in: storage, with: original)
     }
 
+    @Test func tartOutputDuringAnOperationReachesItsEventStream() async throws {
+        let runner = tartLikeRunner()
+        await runner.set("run", .init(stdout: ["Booting virtual machine", "token=abcdef0123456789abcdef0123456789"], exit: ProcessExit(reason: .status(1))))
+        let (lifecycle, _, _) = try await makeLifecycle(runner: runner)
+        try await lifecycle.prepare()
+        let events = EventCollector()
+        let start = try await lifecycle.start(environment, options: StartOptions(ipWait: .seconds(1))) { event in events.add(event) }
+        let seen = await collect(events)
+        let logs = seen.compactMap { event -> (OperationID?, RedactedLine)? in if case .log(let id, let line) = event { return (id, line) } else { return nil } }
+        #expect(logs.contains { $0.1.text == "Booting virtual machine" }, "Tart's lines are forwarded as log events")
+        #expect(logs.allSatisfy { $0.0 == start })
+        #expect(!logs.contains { $0.1.text.contains("abcdef0123456789") }, "forwarded lines are the redacted ones")    }
+
     @Test func unknownEnvironmentIsRefused() async throws {
         let (lifecycle, _, _) = try await makeLifecycle(runner: tartLikeRunner())
         try await lifecycle.prepare()

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/FakeProcessRunner.swift
@@ -83,6 +83,9 @@ actor FakeProcessRunner: ProcessRunning {
         let redactor = Redactor()
         for line in reply.stdout { continuation.yield(.stdout(redactor.redact(lines: [line])[0])) }
         for line in reply.stderr { continuation.yield(.stderr(redactor.redact(lines: [line])[0])) }
+        // `finish` builds the exit from the run's own state, so a scripted truncation has to
+        // be recorded on the run rather than carried by the reply's exit value.
+        if reply.exit.outputTruncated { run.markOutputTruncated() }
         run.finish(with: reply.exit.reason)
         return run
     }


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: GUI shell, progress/recovery, diagnostics/export and runtime connection (#27–#32). Carry forward useful views/tests after their current runtime/model dependencies are available. Raw-log disclosure/export must become typed structured diagnostics.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #30 (`MVP-PLAN.md` §2 "Essential screens": a diagnostics and repair sheet with sanitized logs and export controls, read-only log disclosure rather than an embedded terminal; §3 "Local storage": private keys, tokens, device codes, authorization headers, and raw authentication logs never leave the Mac; environment UUIDs over IP addresses). Stacked on #78.

- `DiagnosticsExportBuilder` (`GuesthouseCore/Diagnostics`): builds a `DiagnosticsExport` from already-redacted `RedactedLine`s and known facts, and writes it as a folder of `manifest.json` (app version and build, runtime version info when known, the known compatibility fields, environment IDs, line count, and the excluded categories), `log.txt` (IPv4 and IPv6 literals scrubbed on top of the redaction), and `excluded.txt` (what is deliberately omitted and why).
- `DiagnosticsView`: filterable, read-only, selectable log; Copy puts the visible lines on the pasteboard; "Export diagnostics…" runs `NSSavePanel` and writes the folder there (sandbox-friendly). Reachable from every environment card's overflow menu.
- `AppModel` keeps the runtime's version info from the last refresh and collects the per-environment logs into `diagnosticsLines`; `diagnosticsExport()` assembles the bundle.

Tests (core, 3 new): a synthetic token, a password, and IPv4/IPv6 addresses in the log never reach the export and the manifest contains no address; version strings are not mistaken for addresses; the folder has exactly the three files and the manifest decodes. App (2 new): an end-to-end export through the model carries redacted lines, environment IDs, runtime info, and compatibility fields with no address; export folder names contain no colons.

Closes #30

## Checklist

- [x] Tests cover the new logic; app, kit, and core test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] No process launched in this change
- [x] Diff under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)