### PR TITLE
GUI: setup wizard container and the "Check this Mac" step

### DIFF
--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -12,6 +12,9 @@ struct ContentView: View {
     @Environment(AppModel.self) private var model
     @Environment(DebugRuntimeProbe.self) private var debugProbe
     @State private var showingDiagnostics = false
+    @State private var showingWizard = false
+    /// Owned here so a recomputation while the sheet is open keeps the check in progress.
+    @State private var wizard = SetupWizardModel()
 
     var body: some View {
         VStack(spacing: 12) {
@@ -36,9 +39,14 @@ struct ContentView: View {
                 Image(systemName: "exclamationmark.triangle").imageScale(.large)
                 Text(error.userMessage)
                 RecoveryActionRow(actions: error.recoveryActions) { model.startRefresh() }
-                // Diagnostics stay reachable exactly when the dashboard, and with it the
-                // card's own menu item, cannot be shown.
-                Button("Diagnostics…") { showingDiagnostics = true }.accessibilityLabel("Open diagnostics")
+                HStack {
+                    // On a fresh Mac the runtime is missing, so the dashboard never appears;
+                    // setup has to be reachable from here or first launch has no way in.
+                    Button("Set Up Guesthouse…") { showingWizard = true }.accessibilityLabel("Set up Guesthouse")
+                    // Diagnostics stay reachable exactly when the dashboard, and with it the
+                    // card's own menu item, cannot be shown.
+                    Button("Diagnostics…") { showingDiagnostics = true }.accessibilityLabel("Open diagnostics")
+                }
             }
             #if DEBUG
             Text(debugProbe.result)
@@ -50,6 +58,7 @@ struct ContentView: View {
         }
         .frame(minWidth: 720, minHeight: 420)
         .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model) }
+        .sheet(isPresented: $showingWizard) { SetupWizardView(wizard: wizard) }
     }
 }
 

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -13,8 +13,9 @@ struct ContentView: View {
     @Environment(DebugRuntimeProbe.self) private var debugProbe
     @State private var showingDiagnostics = false
     @State private var showingWizard = false
-    /// Owned here, and handed to the dashboard, so both entry points into setup share one
-    /// stage: a recomputation while the sheet is open keeps the check in progress too.
+    /// The wizard's model and its presentation both live here, above the switch, so that a
+    /// runtime failure that swaps the dashboard for the interrupted screen cannot take the
+    /// open setup sheet with it, and so both entry points into setup share one stage.
     @State private var wizard = SetupWizardModel()
 
     var body: some View {
@@ -24,7 +25,7 @@ struct ContentView: View {
                 ProgressView().accessibilityLabel("Checking environment")
                 Text("Checking environment…")
             case .ready:
-                DashboardView(wizard: wizard)
+                DashboardView(openSetup: { showingWizard = true })
             case .interrupted(let interruption):
                 Image(systemName: "bolt.slash").imageScale(.large)
                 Text(interruption.userMessage)

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -13,7 +13,8 @@ struct ContentView: View {
     @Environment(DebugRuntimeProbe.self) private var debugProbe
     @State private var showingDiagnostics = false
     @State private var showingWizard = false
-    /// Owned here so a recomputation while the sheet is open keeps the check in progress.
+    /// Owned here, and handed to the dashboard, so both entry points into setup share one
+    /// stage: a recomputation while the sheet is open keeps the check in progress too.
     @State private var wizard = SetupWizardModel()
 
     var body: some View {
@@ -23,7 +24,7 @@ struct ContentView: View {
                 ProgressView().accessibilityLabel("Checking environment")
                 Text("Checking environment…")
             case .ready:
-                DashboardView()
+                DashboardView(wizard: wizard)
             case .interrupted(let interruption):
                 Image(systemName: "bolt.slash").imageScale(.large)
                 Text(interruption.userMessage)

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -5,18 +5,18 @@ import GuesthouseCore
 /// cards, an empty state that leads to the setup wizard, and the two-slot cap explained.
 struct DashboardView: View {
     @Environment(AppModel.self) private var model
-    @State private var showingWizard = false
     @State private var showingDiagnostics = false
     /// Which environment the sheet is about, so Export writes the failing development Mac's
     /// evidence rather than whichever environment was created first.
     @State private var diagnosticsSubject: EnvironmentID?
-    /// One wizard for the whole window, owned above the dashboard: this view disappears when
-    /// the runtime becomes unavailable, and a second model of its own would then present a
-    /// stage that the one still alive had already advanced past.
-    let wizard: SetupWizardModel
+    /// Setup is opened, not presented, from here. This view is removed the moment the runtime
+    /// connection drops, and a sheet it owned would go with it: a transient failure would
+    /// close the host check in the middle and leave no way back to it, since the interrupted
+    /// screen has no setup entry point of its own.
+    let openSetup: () -> Void
 
-    init(wizard: SetupWizardModel) {
-        self.wizard = wizard
+    init(openSetup: @escaping () -> Void) {
+        self.openSetup = openSetup
     }
 
     var body: some View {
@@ -24,7 +24,7 @@ struct DashboardView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
                 if cards.isEmpty {
-                    EmptyDashboardView(availability: model.createAvailability, openDiagnostics: { diagnosticsSubject = nil; showingDiagnostics = true }) { showingWizard = true }
+                    EmptyDashboardView(availability: model.createAvailability, openDiagnostics: { diagnosticsSubject = nil; showingDiagnostics = true }, create: openSetup)
                 } else {
                     LazyVGrid(columns: [GridItem(.adaptive(minimum: 340), spacing: 16)], alignment: .leading, spacing: 16) {
                         ForEach(cards) { card in
@@ -36,13 +36,12 @@ struct DashboardView: View {
                                 openDiagnostics: { diagnosticsSubject = card.id; showingDiagnostics = true }
                             )
                         }
-                        SlotView(availability: model.createAvailability) { showingWizard = true }
+                        SlotView(availability: model.createAvailability, create: openSetup)
                     }
                 }
             }
             .padding(20)
         }
-        .sheet(isPresented: $showingWizard) { SetupWizardView(wizard: wizard) }
         .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model, subject: diagnosticsSubject) }
     }
 }
@@ -250,7 +249,7 @@ struct ScenarioPreview: View {
     var body: some View {
         Group {
             if let model {
-                DashboardView(wizard: SetupWizardModel()).environment(model)
+                DashboardView(openSetup: {}).environment(model)
             } else {
                 ProgressView()
             }

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -10,6 +10,9 @@ struct DashboardView: View {
     /// Which environment the sheet is about, so Export writes the failing development Mac's
     /// evidence rather than whichever environment was created first.
     @State private var diagnosticsSubject: EnvironmentID?
+    /// Owned by the dashboard, not by the sheet closure: a recomputation while the wizard is
+    /// open must not hand it a fresh model and lose the check in progress.
+    @State private var wizard = SetupWizardModel()
 
     var body: some View {
         let cards = model.cardStates()
@@ -34,7 +37,7 @@ struct DashboardView: View {
             }
             .padding(20)
         }
-        .sheet(isPresented: $showingWizard) { SetupWizardView(wizard: SetupWizardModel()) }
+        .sheet(isPresented: $showingWizard) { SetupWizardView(wizard: wizard) }
         .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model, subject: diagnosticsSubject) }
     }
 }

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -34,7 +34,7 @@ struct DashboardView: View {
             }
             .padding(20)
         }
-        .sheet(isPresented: $showingWizard) { WizardPlaceholderView() }
+        .sheet(isPresented: $showingWizard) { SetupWizardView(wizard: SetupWizardModel()) }
         .sheet(isPresented: $showingDiagnostics) { DiagnosticsView(model: model, subject: diagnosticsSubject) }
     }
 }
@@ -229,22 +229,6 @@ struct AvailabilityButton: View {
                 .help("Not implemented yet. \(note)")
                 .accessibilityHint("Not implemented yet")
         }
-    }
-}
-
-/// Stands in for the setup wizard until #31 lands.
-struct WizardPlaceholderView: View {
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Create a development Mac").font(.headline)
-            Text("The setup wizard is not implemented yet. It will check this Mac, create the virtual machine, finish macOS setup, connect securely, add Xcode, sign in, add a workspace, and validate the Codex handoff (MVP-PLAN.md §2).")
-                .foregroundStyle(.secondary)
-            HStack { Spacer(); Button("Close") { dismiss() }.keyboardShortcut(.cancelAction) }
-        }
-        .padding(20)
-        .frame(width: 460)
     }
 }
 

--- a/Guesthouse/Dashboard/DashboardView.swift
+++ b/Guesthouse/Dashboard/DashboardView.swift
@@ -10,9 +10,14 @@ struct DashboardView: View {
     /// Which environment the sheet is about, so Export writes the failing development Mac's
     /// evidence rather than whichever environment was created first.
     @State private var diagnosticsSubject: EnvironmentID?
-    /// Owned by the dashboard, not by the sheet closure: a recomputation while the wizard is
-    /// open must not hand it a fresh model and lose the check in progress.
-    @State private var wizard = SetupWizardModel()
+    /// One wizard for the whole window, owned above the dashboard: this view disappears when
+    /// the runtime becomes unavailable, and a second model of its own would then present a
+    /// stage that the one still alive had already advanced past.
+    let wizard: SetupWizardModel
+
+    init(wizard: SetupWizardModel) {
+        self.wizard = wizard
+    }
 
     var body: some View {
         let cards = model.cardStates()
@@ -245,7 +250,7 @@ struct ScenarioPreview: View {
     var body: some View {
         Group {
             if let model {
-                DashboardView().environment(model)
+                DashboardView(wizard: SetupWizardModel()).environment(model)
             } else {
                 ProgressView()
             }

--- a/Guesthouse/Wizard/SetupWizardModel.swift
+++ b/Guesthouse/Wizard/SetupWizardModel.swift
@@ -38,7 +38,7 @@ enum SetupStage: String, CaseIterable, Codable, Identifiable {
 @MainActor
 final class CheckThisMacModel {
     struct Row: Equatable, Identifiable {
-        enum Verdict: Equatable { case pass, warn, fail }
+        enum Verdict: Equatable { case pass, warn, undetermined, fail }
         let kind: PreflightCheckKind
         let title: String
         let verdict: Verdict
@@ -76,7 +76,9 @@ final class CheckThisMacModel {
         }
     }
 
-    var canProceed: Bool { report?.canProceed ?? false }
+    /// A report that is being re-checked no longer vouches for anything: Next waits for the
+    /// fresh result.
+    var canProceed: Bool { !isChecking && (report?.canProceed ?? false) }
 
     var rows: [Row] {
         guard let report else { return [] }
@@ -85,9 +87,11 @@ final class CheckThisMacModel {
             case .pass(let detail):
                 Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .pass, detail: detail, recovery: [])
             case .warn(let detail, let recovery):
-                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .warn, detail: detail, recovery: recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) })
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .warn, detail: detail, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
+            case .undetermined(let detail, let recovery):
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .undetermined, detail: detail, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
             case .fail(let error):
-                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .fail, detail: error.userMessage, recovery: RecoveryPresentation(error: error).options)
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .fail, detail: error.userMessage, recovery: Self.presentable(RecoveryPresentation(error: error).options))
             }
         }
     }
@@ -102,6 +106,17 @@ final class CheckThisMacModel {
             "The development Mac's disk can grow to \(format(storage.guestDiskBytes)); setup needs \(format(storage.firstSetupAllowanceBytes)) free.",
             "Everything lives under \(storage.storageRootPath).",
         ] + (report?.powerSource == .battery ? ["This Mac is on battery power. Setup downloads and installs a lot; plug it in first."] : [])
+    }
+
+    /// "Dismiss" means nothing inside a check row, but the action behind it does: closing
+    /// setup. It is retitled so the button says what it will do, and the view closes the
+    /// sheet when it is chosen. Some checks (an Intel Mac) have no other action.
+    static func presentable(_ options: [RecoveryPresentation.Option]) -> [RecoveryPresentation.Option] {
+        options.map { option in
+            option.action == .cancel
+                ? RecoveryPresentation.Option(action: .cancel, title: "Close setup", availability: .enabled)
+                : option
+        }
     }
 
     static func title(for kind: PreflightCheckKind) -> String {

--- a/Guesthouse/Wizard/SetupWizardModel.swift
+++ b/Guesthouse/Wizard/SetupWizardModel.swift
@@ -53,6 +53,9 @@ final class CheckThisMacModel {
     private let probe: any HostProbe
     private let storageRoot: URL
     private let policy: ResourcePolicy
+    /// Identifies one check. A recovery action can start a second check while the first is
+    /// still running, and only the newest may publish.
+    private var checkGeneration: UInt64 = 0
 
     init(probe: any HostProbe = SystemHostProbe(), storageRoot: URL = CheckThisMacModel.defaultStorageRoot, policy: ResourcePolicy = .standard) {
         self.probe = probe
@@ -60,16 +63,24 @@ final class CheckThisMacModel {
         self.policy = policy
     }
 
-    /// Where the runtime keeps its data. The sandboxed GUI cannot see it; the path is shown
-    /// so the user knows where the VM will live, and its volume is what the disk check reads.
-    static let defaultStorageRoot = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library/Application Support/Guesthouse")
+    /// Where the runtime keeps its data. The sandboxed GUI cannot read inside it; the path is
+    /// shown so the user knows where the VM will live, and its volume is what the disk check
+    /// measures. It is the runtime's canonical root, not this app's container, which is what
+    /// `FileManager`'s own home directory would name here (MVP-PLAN.md §3, "Local storage").
+    static let defaultStorageRoot = RuntimeStorageLocation.defaultRoot()
 
     func check() {
+        checkGeneration &+= 1
+        let generation = checkGeneration
         isChecking = true
         let probe = probe, storageRoot = storageRoot, policy = policy
         Task.detached {
             let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: storageRoot)
             await MainActor.run {
+                // A check that has been superseded publishes nothing: its answer is older than
+                // the one on screen, and clearing `isChecking` would enable Next over a result
+                // the newest check has not confirmed.
+                guard generation == self.checkGeneration else { return }
                 self.report = report
                 self.isChecking = false
             }
@@ -143,7 +154,20 @@ final class SetupWizardModel {
     init(defaults: UserDefaults = .standard, checkThisMac: CheckThisMacModel = CheckThisMacModel()) {
         self.defaults = defaults
         self.checkThisMac = checkThisMac
-        current = defaults.string(forKey: Self.stageKey).flatMap(SetupStage.init(rawValue:)) ?? .checkThisMac
+        current = Self.persistedStage(in: defaults)
+    }
+
+    /// The wizard is being shown. The position is read again, because setup may have advanced
+    /// since this model was made, and the host is checked again, because a report from an
+    /// earlier presentation cannot vouch for conditions that changed while the sheet was
+    /// closed (MVP-PLAN.md §2, "First launch").
+    func presented() {
+        current = Self.persistedStage(in: defaults)
+        checkThisMac.check()
+    }
+
+    private static func persistedStage(in defaults: UserDefaults) -> SetupStage {
+        defaults.string(forKey: stageKey).flatMap(SetupStage.init(rawValue:)) ?? .checkThisMac
     }
 
     var stages: [SetupStage] { SetupStage.allCases }

--- a/Guesthouse/Wizard/SetupWizardModel.swift
+++ b/Guesthouse/Wizard/SetupWizardModel.swift
@@ -51,31 +51,55 @@ final class CheckThisMacModel {
     private(set) var report: PreflightReport?
     private(set) var isChecking = false
     private let probe: any HostProbe
-    private let storageRoot: URL
+    /// How the account's canonical root is resolved. Called once per check, never cached: the
+    /// lookup reads the account record, which can fail transiently, and an answer held for the
+    /// life of the process would leave the disk check undetermined behind a "Try again" that
+    /// could only repeat the failure (AGENTS.md: every error carries a recovery that works).
+    /// It still answers nil when the record cannot be read, which leaves the disk check
+    /// undetermined rather than naming a path the runtime will not use.
+    private let resolveStorageRoot: @Sendable () -> URL?
+    private let volumeProbe: URL
     private let policy: ResourcePolicy
     /// Identifies one check. A recovery action can start a second check while the first is
     /// still running, and only the newest may publish.
     private var checkGeneration: UInt64 = 0
 
-    init(probe: any HostProbe = SystemHostProbe(), storageRoot: URL = CheckThisMacModel.defaultStorageRoot, policy: ResourcePolicy = .standard) {
+    init(
+        probe: any HostProbe = SystemHostProbe(),
+        storageRoot: @escaping @Sendable () -> URL? = CheckThisMacModel.defaultStorageRoot,
+        volumeProbe: URL = CheckThisMacModel.defaultVolumeProbe,
+        policy: ResourcePolicy = .standard
+    ) {
         self.probe = probe
-        self.storageRoot = storageRoot
+        self.resolveStorageRoot = storageRoot
+        self.volumeProbe = volumeProbe
         self.policy = policy
     }
 
-    /// Where the runtime keeps its data. The sandboxed GUI cannot read inside it; the path is
-    /// shown so the user knows where the VM will live, and its volume is what the disk check
-    /// measures. It is the runtime's canonical root, not this app's container, which is what
-    /// `FileManager`'s own home directory would name here (MVP-PLAN.md §3, "Local storage").
-    static let defaultStorageRoot = RuntimeStorageLocation.defaultRoot()
+    /// Where the runtime keeps its data. The path is shown so the user knows where the VM will
+    /// live, and its volume is what the disk check measures. It is the runtime's canonical
+    /// root, not this app's container, which is what `FileManager`'s own home directory would
+    /// name here (MVP-PLAN.md §3, "Local storage"). nil when the account record could not be
+    /// read: the step then says the location is undetermined instead of showing the wrong one.
+    nonisolated static func defaultStorageRoot() -> URL? { RuntimeStorageLocation.defaultRoot() }
+
+    /// Where the disk check actually looks. A signed build is sandboxed, so the runtime's root
+    /// is outside the container and outside what `Guesthouse.entitlements` grants: probing it
+    /// fails the destination's own write check and leaves the disk verdict undetermined, which
+    /// blocks step 1 with a retry that can only be denied again. This process's home is inside
+    /// the container and under the same account home as the runtime's root, so it names the
+    /// same volume, and the volume is what the check is about.
+    static let defaultVolumeProbe = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
 
     func check() {
         checkGeneration &+= 1
         let generation = checkGeneration
         isChecking = true
-        let probe = probe, storageRoot = storageRoot, policy = policy
+        let probe = probe, resolveStorageRoot = resolveStorageRoot, volumeProbe = volumeProbe, policy = policy
         Task.detached {
-            let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: storageRoot)
+            // Resolved inside the check, so a lookup that failed once is retried by the very
+            // action the undetermined disk row offers.
+            let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: resolveStorageRoot(), measuredAt: volumeProbe)
             await MainActor.run {
                 // A check that has been superseded publishes nothing: its answer is older than
                 // the one on screen, and clearing `isChecking` would enable Next over a result
@@ -91,16 +115,24 @@ final class CheckThisMacModel {
     /// fresh result.
     var canProceed: Bool { !isChecking && (report?.canProceed ?? false) }
 
+    /// What the step says while it is working, or nil when it is not. A refresh over an
+    /// existing report says so too: its rows stay on screen as the previous answer, and
+    /// without this the only sign that they no longer stand is Next going dim.
+    var progressMessage: String? {
+        guard isChecking else { return nil }
+        return report == nil ? "Checking this Mac…" : "Checking this Mac again…"
+    }
+
     var rows: [Row] {
         guard let report else { return [] }
         return report.results.map { result in
             switch result.outcome {
             case .pass(let detail):
-                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .pass, detail: detail, recovery: [])
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .pass, detail: detail.value, recovery: [])
             case .warn(let detail, let recovery):
-                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .warn, detail: detail, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .warn, detail: detail.value, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
             case .undetermined(let detail, let recovery):
-                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .undetermined, detail: detail, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .undetermined, detail: detail.value, recovery: Self.presentable(recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) }))
             case .fail(let error):
                 Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .fail, detail: error.userMessage, recovery: Self.presentable(RecoveryPresentation(error: error).options))
             }
@@ -111,11 +143,16 @@ final class CheckThisMacModel {
     var storageSummary: [String] {
         guard let storage = report?.storage else { return [] }
         let format: (UInt64) -> String = { ByteCountFormatter.string(fromByteCount: Int64(clamping: $0), countStyle: .file) }
+        // The location line is omitted when the root is unknown rather than filled in with a
+        // guess: the disk check is already undetermined in that case, and naming this app's
+        // container would tell the user the runtime writes somewhere it never will.
+        let location = storage.storageRootPath.map { "Everything lives under \($0)." }
+            ?? "Guesthouse could not determine where the development Mac would be stored."
         return [
             "The virtual machine runtime download is about \(format(storage.runtimeDownloadEstimateBytes)).",
             "The macOS restore image download is about \(format(storage.restoreImageEstimateBytes)).",
             "The development Mac's disk can grow to \(format(storage.guestDiskBytes)); setup needs \(format(storage.firstSetupAllowanceBytes)) free.",
-            "Everything lives under \(storage.storageRootPath).",
+            location,
         ] + (report?.powerSource == .battery ? ["This Mac is on battery power. Setup downloads and installs a lot; plug it in first."] : [])
     }
 

--- a/Guesthouse/Wizard/SetupWizardModel.swift
+++ b/Guesthouse/Wizard/SetupWizardModel.swift
@@ -1,0 +1,161 @@
+import Foundation
+import GuesthouseCore
+import Observation
+
+/// The ordered stages of first-launch setup (MVP-PLAN.md §2 "First launch"). The current
+/// stage is persisted so the wizard resumes where it stopped.
+enum SetupStage: String, CaseIterable, Codable, Identifiable {
+    case checkThisMac
+    case createDevelopmentMac
+    case finishMacOSSetup
+    case connectSecurely
+    case addXcode
+    case signIn
+    case addWorkspace
+    case validateAndOpen
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .checkThisMac: "Check this Mac"
+        case .createDevelopmentMac: "Create the development Mac"
+        case .finishMacOSSetup: "Finish macOS setup"
+        case .connectSecurely: "Connect securely"
+        case .addXcode: "Add Xcode"
+        case .signIn: "Sign in"
+        case .addWorkspace: "Add a workspace"
+        case .validateAndOpen: "Validate and open in Codex"
+        }
+    }
+
+    /// Only the first stage has content so far; the rest say so.
+    var isImplemented: Bool { self == .checkThisMac }
+}
+
+/// Runs the "Check this Mac" step and decides whether setup may continue.
+@Observable
+@MainActor
+final class CheckThisMacModel {
+    struct Row: Equatable, Identifiable {
+        enum Verdict: Equatable { case pass, warn, fail }
+        let kind: PreflightCheckKind
+        let title: String
+        let verdict: Verdict
+        let detail: String
+        /// Recovery options for a warning or failure; empty for a pass.
+        let recovery: [RecoveryPresentation.Option]
+        var id: PreflightCheckKind { kind }
+    }
+
+    private(set) var report: PreflightReport?
+    private(set) var isChecking = false
+    private let probe: any HostProbe
+    private let storageRoot: URL
+    private let policy: ResourcePolicy
+
+    init(probe: any HostProbe = SystemHostProbe(), storageRoot: URL = CheckThisMacModel.defaultStorageRoot, policy: ResourcePolicy = .standard) {
+        self.probe = probe
+        self.storageRoot = storageRoot
+        self.policy = policy
+    }
+
+    /// Where the runtime keeps its data. The sandboxed GUI cannot see it; the path is shown
+    /// so the user knows where the VM will live, and its volume is what the disk check reads.
+    static let defaultStorageRoot = FileManager.default.homeDirectoryForCurrentUser.appending(path: "Library/Application Support/Guesthouse")
+
+    func check() {
+        isChecking = true
+        let probe = probe, storageRoot = storageRoot, policy = policy
+        Task.detached {
+            let report = PreflightCheck.run(probe: probe, policy: policy, storageRoot: storageRoot)
+            await MainActor.run {
+                self.report = report
+                self.isChecking = false
+            }
+        }
+    }
+
+    var canProceed: Bool { report?.canProceed ?? false }
+
+    var rows: [Row] {
+        guard let report else { return [] }
+        return report.results.map { result in
+            switch result.outcome {
+            case .pass(let detail):
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .pass, detail: detail, recovery: [])
+            case .warn(let detail, let recovery):
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .warn, detail: detail, recovery: recovery.map { RecoveryPresentation.option(for: $0, outcomeUnknown: false) })
+            case .fail(let error):
+                Row(kind: result.kind, title: Self.title(for: result.kind), verdict: .fail, detail: error.userMessage, recovery: RecoveryPresentation(error: error).options)
+            }
+        }
+    }
+
+    /// "What will be downloaded and where the VM will live" (MVP-PLAN.md §2, step 1).
+    var storageSummary: [String] {
+        guard let storage = report?.storage else { return [] }
+        let format: (UInt64) -> String = { ByteCountFormatter.string(fromByteCount: Int64(clamping: $0), countStyle: .file) }
+        return [
+            "The virtual machine runtime download is about \(format(storage.runtimeDownloadEstimateBytes)).",
+            "The macOS restore image download is about \(format(storage.restoreImageEstimateBytes)).",
+            "The development Mac's disk can grow to \(format(storage.guestDiskBytes)); setup needs \(format(storage.firstSetupAllowanceBytes)) free.",
+            "Everything lives under \(storage.storageRootPath).",
+        ] + (report?.powerSource == .battery ? ["This Mac is on battery power. Setup downloads and installs a lot; plug it in first."] : [])
+    }
+
+    static func title(for kind: PreflightCheckKind) -> String {
+        switch kind {
+        case .architecture: "Processor"
+        case .macOSVersion: "macOS version"
+        case .memory: "Memory"
+        case .freeDisk: "Free disk space"
+        case .codexDesktop: "Codex desktop"
+        }
+    }
+}
+
+/// The wizard container: an ordered stage model with a persisted position and back/next rules.
+@Observable
+@MainActor
+final class SetupWizardModel {
+    static let stageKey = "setupWizard.stage"
+
+    private(set) var current: SetupStage
+    let checkThisMac: CheckThisMacModel
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard, checkThisMac: CheckThisMacModel = CheckThisMacModel()) {
+        self.defaults = defaults
+        self.checkThisMac = checkThisMac
+        current = defaults.string(forKey: Self.stageKey).flatMap(SetupStage.init(rawValue:)) ?? .checkThisMac
+    }
+
+    var stages: [SetupStage] { SetupStage.allCases }
+
+    var canGoBack: Bool { current != .checkThisMac }
+
+    /// Next is offered only when the current stage is complete: the checks must all pass, and
+    /// unimplemented stages cannot be completed yet.
+    var canGoNext: Bool {
+        switch current {
+        case .checkThisMac: checkThisMac.canProceed
+        default: false
+        }
+    }
+
+    func next() {
+        guard canGoNext, let index = stages.firstIndex(of: current), index + 1 < stages.count else { return }
+        move(to: stages[index + 1])
+    }
+
+    func back() {
+        guard canGoBack, let index = stages.firstIndex(of: current), index > 0 else { return }
+        move(to: stages[index - 1])
+    }
+
+    private func move(to stage: SetupStage) {
+        current = stage
+        defaults.set(stage.rawValue, forKey: Self.stageKey)
+    }
+}

--- a/Guesthouse/Wizard/SetupWizardView.swift
+++ b/Guesthouse/Wizard/SetupWizardView.swift
@@ -31,6 +31,7 @@ struct SetupWizardView: View {
             .padding(20)
         }
         .frame(minWidth: 780, minHeight: 520)
+        .task { wizard.presented() }
     }
 
     private var stageList: some View {
@@ -92,6 +93,9 @@ struct CheckThisMacView: View {
                     ForEach(model.storageSummary, id: \.self) { line in Text(line).font(.callout) }
                 }
                 .padding(.top, 8)
+                // The storage line names where the VM will live; MVP-PLAN.md §"Essential
+                // screens" asks for selectable paths, so the user can copy it.
+                .textSelection(.enabled)
                 .accessibilityElement(children: .combine)
             }
             if let note {
@@ -102,7 +106,6 @@ struct CheckThisMacView: View {
                 .accessibilityLabel("Check this Mac again")
             Spacer()
         }
-        .task { if model.report == nil { model.check() } }
     }
 
     private func choose(_ option: RecoveryPresentation.Option) {

--- a/Guesthouse/Wizard/SetupWizardView.swift
+++ b/Guesthouse/Wizard/SetupWizardView.swift
@@ -56,6 +56,7 @@ struct SetupWizardView: View {
 /// One row per check with pass, warn, or fail, the download and storage summary, a re-run
 /// button, and recovery actions on failure.
 struct CheckThisMacView: View {
+    @Environment(\.dismiss) private var dismiss
     @Bindable var model: CheckThisMacModel
     @State private var note: String?
 
@@ -108,7 +109,11 @@ struct CheckThisMacView: View {
         switch option.availability {
         case .enabled:
             note = nil
-            if option.action == .retry || option.action == .inspectState { model.check() }
+            switch option.action {
+            case .retry, .inspectState: model.check()
+            case .cancel: dismiss()
+            default: break
+            }
         case .disabled(let reason):
             note = reason
         case .notImplemented(let text):
@@ -120,6 +125,7 @@ struct CheckThisMacView: View {
         switch verdict {
         case .pass: "checkmark.circle.fill"
         case .warn: "exclamationmark.triangle.fill"
+        case .undetermined: "questionmark.circle.fill"
         case .fail: "xmark.octagon.fill"
         }
     }
@@ -128,6 +134,7 @@ struct CheckThisMacView: View {
         switch verdict {
         case .pass: .green
         case .warn: .orange
+        case .undetermined: .orange
         case .fail: .red
         }
     }
@@ -136,6 +143,7 @@ struct CheckThisMacView: View {
         switch verdict {
         case .pass: "passed"
         case .warn: "warning"
+        case .undetermined: "could not be checked"
         case .fail: "failed"
         }
     }

--- a/Guesthouse/Wizard/SetupWizardView.swift
+++ b/Guesthouse/Wizard/SetupWizardView.swift
@@ -12,14 +12,23 @@ struct SetupWizardView: View {
             stageList
             Divider()
             VStack(alignment: .leading, spacing: 16) {
-                Text(wizard.current.title).font(.title2).bold()
-                    .accessibilityAddTraits(.isHeader)
-                if wizard.current == .checkThisMac {
-                    CheckThisMacView(model: wizard.checkThisMac)
-                } else {
-                    Text("This step is not implemented yet. It arrives with a later change; the wizard resumes here when it does.")
-                        .foregroundStyle(.secondary)
-                    Spacer()
+                // The stage's own content scrolls and the footer below does not. Verbose
+                // failure details, a row's recovery buttons and the storage summary together
+                // exceed 520 points on a smaller display or at an accessibility text size, and
+                // a plain stack would clip whatever did not fit — the recovery controls and
+                // the navigation both. Setup has to stay actionable (MVP-PLAN.md §2).
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text(wizard.current.title).font(.title2).bold()
+                            .accessibilityAddTraits(.isHeader)
+                        if wizard.current == .checkThisMac {
+                            CheckThisMacView(model: wizard.checkThisMac)
+                        } else {
+                            Text("This step is not implemented yet. It arrives with a later change; the wizard resumes here when it does.")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 HStack {
                     Button("Close") { dismiss() }.keyboardShortcut(.cancelAction).accessibilityLabel("Close setup")
@@ -34,7 +43,19 @@ struct SetupWizardView: View {
         .task { wizard.presented() }
     }
 
+    /// Scrolls for the same reason the stage content does: eight steps at an accessibility
+    /// text size are taller than the sheet, and a clipped list hides the later steps.
     private var stageList: some View {
+        ScrollView {
+            stageRows
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(width: 240)
+        .background(.quaternary.opacity(0.3))
+    }
+
+    private var stageRows: some View {
         VStack(alignment: .leading, spacing: 6) {
             ForEach(Array(wizard.stages.enumerated()), id: \.element) { index, stage in
                 HStack(spacing: 8) {
@@ -46,11 +67,7 @@ struct SetupWizardView: View {
                 .accessibilityElement(children: .combine)
                 .accessibilityLabel("Step \(index + 1), \(stage.title)\(stage == wizard.current ? ", current" : "")\(stage.isImplemented ? "" : ", not implemented yet")")
             }
-            Spacer()
         }
-        .padding(16)
-        .frame(width: 240)
-        .background(.quaternary.opacity(0.3))
     }
 }
 
@@ -63,15 +80,18 @@ struct CheckThisMacView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            if model.rows.isEmpty, model.isChecking {
-                ProgressView("Checking this Mac…").accessibilityLabel("Checking this Mac")
+            if let progress = model.progressMessage {
+                ProgressView(progress).accessibilityLabel(progress)
             }
             ForEach(model.rows) { row in
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Image(systemName: symbol(for: row.verdict)).foregroundStyle(color(for: row.verdict))
                         Text(row.title).bold()
-                        Text(row.detail).foregroundStyle(.secondary)
+                        // A check's detail names a path: where Codex desktop was found, or the
+                        // folder that could not be written. MVP-PLAN.md §2 "Essential screens"
+                        // asks for paths the user can select and copy.
+                        Text(row.detail).foregroundStyle(.secondary).textSelection(.enabled)
                     }
                     .accessibilityElement(children: .combine)
                     .accessibilityLabel("\(row.title): \(name(for: row.verdict)). \(row.detail)")
@@ -101,10 +121,13 @@ struct CheckThisMacView: View {
             if let note {
                 Text(note).font(.callout).foregroundStyle(.secondary).accessibilityLabel("Note: \(note)")
             }
-            Button("Check again") { model.check() }
+            // The note explains a recovery that was offered by the report on screen. A new
+            // check replaces that report, so the note is cleared here exactly as it is when a
+            // recovery button starts one: otherwise a note about "Open Settings" outlives the
+            // failing row that offered it and sits under a report that now passes.
+            Button("Check again") { note = nil; model.check() }
                 .disabled(model.isChecking)
                 .accessibilityLabel("Check this Mac again")
-            Spacer()
         }
     }
 
@@ -174,5 +197,8 @@ private func previewWizard(_ probe: PreviewHostProbe) -> SetupWizardModel {
 }
 
 #Preview("All pass") { SetupWizardView(wizard: previewWizard(PreviewHostProbe())) }
-#Preview("Warnings") { SetupWizardView(wizard: previewWizard(PreviewHostProbe(physicalMemoryBytes: 16 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))) }
+// Above the floor (the guest's 16 GiB allocation plus 8 GiB of host headroom) and below the
+// recommendation, so this preview shows the warning state it is named for rather than the
+// blocking memory failure 16 GiB produces.
+#Preview("Warnings") { SetupWizardView(wizard: previewWizard(PreviewHostProbe(physicalMemoryBytes: 28 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))) }
 #Preview("Failure") { SetupWizardView(wizard: previewWizard(PreviewHostProbe(cpuArchitecture: .intel, freeBytesValue: 20 * ResourcePreset.gigabyte))) }

--- a/Guesthouse/Wizard/SetupWizardView.swift
+++ b/Guesthouse/Wizard/SetupWizardView.swift
@@ -1,0 +1,167 @@
+import SwiftUI
+import GuesthouseCore
+
+/// The setup wizard: resumable stages, the "Check this Mac" step, and placeholders that say
+/// what is not implemented yet (MVP-PLAN.md §2 "First launch", "Essential screens").
+struct SetupWizardView: View {
+    @Bindable var wizard: SetupWizardModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        HStack(spacing: 0) {
+            stageList
+            Divider()
+            VStack(alignment: .leading, spacing: 16) {
+                Text(wizard.current.title).font(.title2).bold()
+                    .accessibilityAddTraits(.isHeader)
+                if wizard.current == .checkThisMac {
+                    CheckThisMacView(model: wizard.checkThisMac)
+                } else {
+                    Text("This step is not implemented yet. It arrives with a later change; the wizard resumes here when it does.")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+                HStack {
+                    Button("Close") { dismiss() }.keyboardShortcut(.cancelAction).accessibilityLabel("Close setup")
+                    Spacer()
+                    Button("Back") { wizard.back() }.disabled(!wizard.canGoBack).accessibilityLabel("Back")
+                    Button("Next") { wizard.next() }.disabled(!wizard.canGoNext).keyboardShortcut(.defaultAction).accessibilityLabel("Next")
+                }
+            }
+            .padding(20)
+        }
+        .frame(minWidth: 780, minHeight: 520)
+    }
+
+    private var stageList: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(Array(wizard.stages.enumerated()), id: \.element) { index, stage in
+                HStack(spacing: 8) {
+                    Image(systemName: stage == wizard.current ? "circle.fill" : "circle").imageScale(.small)
+                    Text("\(index + 1). \(stage.title)")
+                        .fontWeight(stage == wizard.current ? .semibold : .regular)
+                        .foregroundStyle(stage.isImplemented ? .primary : .secondary)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Step \(index + 1), \(stage.title)\(stage == wizard.current ? ", current" : "")\(stage.isImplemented ? "" : ", not implemented yet")")
+            }
+            Spacer()
+        }
+        .padding(16)
+        .frame(width: 240)
+        .background(.quaternary.opacity(0.3))
+    }
+}
+
+/// One row per check with pass, warn, or fail, the download and storage summary, a re-run
+/// button, and recovery actions on failure.
+struct CheckThisMacView: View {
+    @Bindable var model: CheckThisMacModel
+    @State private var note: String?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if model.rows.isEmpty, model.isChecking {
+                ProgressView("Checking this Mac…").accessibilityLabel("Checking this Mac")
+            }
+            ForEach(model.rows) { row in
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
+                        Image(systemName: symbol(for: row.verdict)).foregroundStyle(color(for: row.verdict))
+                        Text(row.title).bold()
+                        Text(row.detail).foregroundStyle(.secondary)
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(row.title): \(name(for: row.verdict)). \(row.detail)")
+                    if !row.recovery.isEmpty {
+                        HStack(spacing: 8) {
+                            ForEach(row.recovery) { option in
+                                AvailabilityButton(option.title, availability: option.availability) { choose(option) }
+                                    .buttonStyle(.bordered)
+                                    .accessibilityLabel(option.title)
+                            }
+                        }
+                        .padding(.leading, 26)
+                    }
+                }
+            }
+            if !model.storageSummary.isEmpty {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Downloads and storage").font(.headline)
+                    ForEach(model.storageSummary, id: \.self) { line in Text(line).font(.callout) }
+                }
+                .padding(.top, 8)
+                .accessibilityElement(children: .combine)
+            }
+            if let note {
+                Text(note).font(.callout).foregroundStyle(.secondary).accessibilityLabel("Note: \(note)")
+            }
+            Button("Check again") { model.check() }
+                .disabled(model.isChecking)
+                .accessibilityLabel("Check this Mac again")
+            Spacer()
+        }
+        .task { if model.report == nil { model.check() } }
+    }
+
+    private func choose(_ option: RecoveryPresentation.Option) {
+        switch option.availability {
+        case .enabled:
+            note = nil
+            if option.action == .retry || option.action == .inspectState { model.check() }
+        case .disabled(let reason):
+            note = reason
+        case .notImplemented(let text):
+            note = "\(option.title) is not implemented yet. \(text)"
+        }
+    }
+
+    private func symbol(for verdict: CheckThisMacModel.Row.Verdict) -> String {
+        switch verdict {
+        case .pass: "checkmark.circle.fill"
+        case .warn: "exclamationmark.triangle.fill"
+        case .fail: "xmark.octagon.fill"
+        }
+    }
+
+    private func color(for verdict: CheckThisMacModel.Row.Verdict) -> Color {
+        switch verdict {
+        case .pass: .green
+        case .warn: .orange
+        case .fail: .red
+        }
+    }
+
+    private func name(for verdict: CheckThisMacModel.Row.Verdict) -> String {
+        switch verdict {
+        case .pass: "passed"
+        case .warn: "warning"
+        case .fail: "failed"
+        }
+    }
+}
+
+// MARK: - Previews
+
+/// A probe with fixed answers, for previews.
+struct PreviewHostProbe: HostProbe {
+    var cpuArchitecture: CPUArchitecture = .appleSilicon
+    var operatingSystemVersion = SemanticVersion([26, 5, 2])
+    var operatingSystemBuild: String? = "25F84"
+    var physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    var powerSource: PowerSource = .externalPower
+    var freeBytesValue: UInt64 = 500 * ResourcePreset.gigabyte
+    var applications: [String: InstalledApplication] = ["com.openai.chat": InstalledApplication(url: URL(fileURLWithPath: "/Applications/ChatGPT.app"), version: "1.2.3", build: "456")]
+
+    func freeBytes(at url: URL) throws -> UInt64 { freeBytesValue }
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication? { applications[bundleIdentifier] }
+}
+
+private func previewWizard(_ probe: PreviewHostProbe) -> SetupWizardModel {
+    let defaults = UserDefaults(suiteName: "preview-\(UUID().uuidString)")!
+    return SetupWizardModel(defaults: defaults, checkThisMac: CheckThisMacModel(probe: probe))
+}
+
+#Preview("All pass") { SetupWizardView(wizard: previewWizard(PreviewHostProbe())) }
+#Preview("Warnings") { SetupWizardView(wizard: previewWizard(PreviewHostProbe(physicalMemoryBytes: 16 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))) }
+#Preview("Failure") { SetupWizardView(wizard: previewWizard(PreviewHostProbe(cpuArchitecture: .intel, freeBytesValue: 20 * ResourcePreset.gigabyte))) }

--- a/GuesthouseTests/SetupWizardTests.swift
+++ b/GuesthouseTests/SetupWizardTests.swift
@@ -13,14 +13,45 @@ struct StubHostProbe: HostProbe {
     var applications: [String: InstalledApplication] = ["com.openai.chat": InstalledApplication(url: URL(fileURLWithPath: "/Applications/ChatGPT.app"), version: "1.2.3", build: "456")]
 
     var freeThrows = false
+    /// A specific probe failure, so a test can exercise one undetermined outcome.
+    var freeError: HostProbeError?
 
     struct ProbeFailure: Error {}
 
     func freeBytes(at url: URL) throws -> UInt64 {
+        if let freeError { throw freeError }
         if freeThrows { throw ProbeFailure() }
         return free
     }
     func installedApplication(bundleIdentifier: String) -> InstalledApplication? { applications[bundleIdentifier] }
+}
+
+/// A probe that holds its first free-space answer until the test releases it, so two
+/// overlapping checks finish in a known order.
+final class GatedHostProbe: HostProbe, @unchecked Sendable {
+    let cpuArchitecture: CPUArchitecture = .appleSilicon
+    let operatingSystemVersion = SemanticVersion([26, 5, 2])
+    let operatingSystemBuild: String? = "25F84"
+    let physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    let powerSource: PowerSource = .externalPower
+
+    private let lock = NSLock()
+    private var calls = 0
+    private let gate = DispatchSemaphore(value: 0)
+
+    var callCount: Int { lock.withLock { calls } }
+    func releaseFirstAnswer() { gate.signal() }
+
+    /// The first call is held and then answers with plenty of space; every later call answers
+    /// at once with too little.
+    func freeBytes(at url: URL) throws -> UInt64 {
+        let call = lock.withLock { calls += 1; return calls }
+        guard call == 1 else { return 20 * ResourcePreset.gigabyte }
+        gate.wait()
+        return 500 * ResourcePreset.gigabyte
+    }
+
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication? { nil }
 }
 
 @MainActor
@@ -121,5 +152,68 @@ struct StubHostProbe: HostProbe {
         #expect(SetupWizardModel(defaults: store, checkThisMac: model).current == .checkThisMac)
         #expect(SetupStage.allCases.count == 8)
         #expect(SetupStage.allCases.filter(\.isImplemented) == [.checkThisMac])
+    }
+
+    @Test func onlyTheNewestOverlappingCheckPublishesItsResult() async {
+        let probe = GatedHostProbe()
+        let model = CheckThisMacModel(probe: probe, storageRoot: URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse"))
+        // A recovery action starts a check while the first one, held in the probe, still runs.
+        model.check()
+        await waitUntil { probe.callCount >= 1 }
+        model.check()
+        await waitUntil { model.report != nil && !model.isChecking }
+        #expect(model.report?.result(.freeDisk)?.isFailure == true, "the newest check answered")
+        probe.releaseFirstAnswer()
+        try? await Task.sleep(for: .milliseconds(200))
+        #expect(model.report?.result(.freeDisk)?.isFailure == true, "the superseded check never replaced it")
+        #expect(!model.canProceed, "and Next is never enabled from the older answer")
+    }
+
+    @Test func reopeningTheWizardResumesTheStageSetupActuallyReached() async {
+        let store = defaults()
+        let model = await checked(StubHostProbe())
+        let dashboard = SetupWizardModel(defaults: store, checkThisMac: model)
+        let window = SetupWizardModel(defaults: store, checkThisMac: model)
+        dashboard.next()
+        #expect(dashboard.current == .createDevelopmentMac)
+        #expect(window.current == .checkThisMac, "this model was made before the stage advanced")
+        window.presented()
+        #expect(window.current == .createDevelopmentMac, "reopening resumes where setup stopped, not where this model started")
+    }
+
+    @Test func reopeningTheWizardChecksThisMacAgain() async {
+        let model = await checked(StubHostProbe())
+        let wizard = SetupWizardModel(defaults: defaults(), checkThisMac: model)
+        #expect(wizard.canGoNext)
+        wizard.presented()
+        #expect(model.isChecking)
+        #expect(!wizard.canGoNext, "a report made before the sheet was closed no longer enables Next")
+        await waitUntil { !model.isChecking }
+        #expect(wizard.canGoNext)
+    }
+
+    @Test func theStorageSummaryNamesTheRuntimesRoot() async {
+        #expect(CheckThisMacModel.defaultStorageRoot == RuntimeStorageLocation.defaultRoot())
+        #expect(CheckThisMacModel.defaultStorageRoot.path.hasSuffix("/Library/Application Support/Guesthouse"))
+        let model = await checked(StubHostProbe())
+        #expect(model.storageSummary.contains { $0.contains("Everything lives under /Users/dev/Library/Application Support/Guesthouse") })
+    }
+
+    @Test func aCheckThatCouldNotBeMadeStillOffersAnActionTheAppCanPerform() async {
+        for error in [HostProbeError.volumeUnavailable(path: "/Volumes/Gone/Guesthouse"), .notADirectory(path: "/Users/dev/Guesthouse")] {
+            var probe = StubHostProbe()
+            probe.freeError = error
+            let model = await checked(probe)
+            guard let disk = model.rows.first(where: { $0.kind == .freeDisk }) else { Issue.record("no disk row"); return }
+            #expect(disk.verdict == .undetermined)
+            #expect(
+                disk.recovery.contains { $0.availability == .enabled && $0.action != .cancel },
+                "setup offers something other than closing when a check cannot be made"
+            )
+        }
+    }
+
+    func waitUntil(_ condition: @MainActor () -> Bool) async {
+        for _ in 0..<400 where !condition() { try? await Task.sleep(for: .milliseconds(5)) }
     }
 }

--- a/GuesthouseTests/SetupWizardTests.swift
+++ b/GuesthouseTests/SetupWizardTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import Guesthouse
+
+struct StubHostProbe: HostProbe {
+    var cpuArchitecture: CPUArchitecture = .appleSilicon
+    var operatingSystemVersion = SemanticVersion([26, 5, 2])
+    var operatingSystemBuild: String? = "25F84"
+    var physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    var powerSource: PowerSource = .externalPower
+    var free: UInt64 = 500 * ResourcePreset.gigabyte
+    var applications: [String: InstalledApplication] = ["com.openai.chat": InstalledApplication(url: URL(fileURLWithPath: "/Applications/ChatGPT.app"), version: "1.2.3", build: "456")]
+
+    func freeBytes(at url: URL) throws -> UInt64 { free }
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication? { applications[bundleIdentifier] }
+}
+
+@MainActor
+@Suite struct SetupWizardTests {
+    func defaults() -> UserDefaults { UserDefaults(suiteName: "SetupWizardTests-\(UUID().uuidString)")! }
+
+    func checked(_ probe: StubHostProbe) async -> CheckThisMacModel {
+        let model = CheckThisMacModel(probe: probe, storageRoot: URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse"))
+        model.check()
+        for _ in 0..<400 where model.report == nil { try? await Task.sleep(for: .milliseconds(5)) }
+        return model
+    }
+
+    @Test func allPassEnablesNextAndSummarizesStorage() async {
+        let model = await checked(StubHostProbe())
+        #expect(model.canProceed)
+        #expect(model.rows.count == PreflightCheckKind.allCases.count)
+        #expect(model.rows.allSatisfy { $0.verdict == .pass && $0.recovery.isEmpty && !$0.detail.isEmpty })
+        #expect(model.storageSummary.contains { $0.contains("/Users/dev/Library/Application Support/Guesthouse") })
+        #expect(model.storageSummary.contains { $0.contains("restore image") })
+        let wizard = SetupWizardModel(defaults: defaults(), checkThisMac: model)
+        #expect(wizard.current == .checkThisMac)
+        #expect(!wizard.canGoBack)
+        #expect(wizard.canGoNext)
+    }
+
+    @Test func warningsOnlyStillAllowNextAndCarryRecovery() async {
+        let model = await checked(StubHostProbe(physicalMemoryBytes: 16 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))
+        #expect(model.canProceed)
+        let warnings = model.rows.filter { $0.verdict == .warn }
+        #expect(warnings.map(\.kind).contains(.codexDesktop))
+        #expect(warnings.allSatisfy { !$0.detail.isEmpty })
+        #expect(warnings.first { $0.kind == .codexDesktop }?.detail.contains("not installed") == true)
+        #expect(model.storageSummary.contains { $0.contains("battery") })
+        #expect(SetupWizardModel(defaults: defaults(), checkThisMac: model).canGoNext)
+    }
+
+    @Test func aFailureDisablesNextAndOffersRecovery() async {
+        let model = await checked(StubHostProbe(cpuArchitecture: .intel, free: 20 * ResourcePreset.gigabyte))
+        #expect(!model.canProceed)
+        let failures = model.rows.filter { $0.verdict == .fail }
+        #expect(failures.map(\.kind) == [.architecture, .freeDisk])
+        #expect(failures.allSatisfy { !$0.recovery.isEmpty && !$0.detail.isEmpty })
+        let wizard = SetupWizardModel(defaults: defaults(), checkThisMac: model)
+        #expect(!wizard.canGoNext)
+        wizard.next()
+        #expect(wizard.current == .checkThisMac, "Next is refused while a check fails")
+    }
+
+    @Test func theStageIsPersistedAndResumed() async {
+        let store = defaults()
+        let model = await checked(StubHostProbe())
+        let wizard = SetupWizardModel(defaults: store, checkThisMac: model)
+        wizard.next()
+        #expect(wizard.current == .createDevelopmentMac)
+        #expect(!wizard.canGoNext, "an unimplemented stage cannot be completed")
+        #expect(wizard.canGoBack)
+        let resumed = SetupWizardModel(defaults: store, checkThisMac: model)
+        #expect(resumed.current == .createDevelopmentMac)
+        resumed.back()
+        #expect(resumed.current == .checkThisMac)
+        #expect(SetupWizardModel(defaults: store, checkThisMac: model).current == .checkThisMac)
+        #expect(SetupStage.allCases.count == 8)
+        #expect(SetupStage.allCases.filter(\.isImplemented) == [.checkThisMac])
+    }
+}

--- a/GuesthouseTests/SetupWizardTests.swift
+++ b/GuesthouseTests/SetupWizardTests.swift
@@ -54,12 +54,32 @@ final class GatedHostProbe: HostProbe, @unchecked Sendable {
     func installedApplication(bundleIdentifier: String) -> InstalledApplication? { nil }
 }
 
+/// Records which path the disk check was asked about.
+final class PathRecordingProbe: HostProbe, @unchecked Sendable {
+    let cpuArchitecture: CPUArchitecture = .appleSilicon
+    let operatingSystemVersion = SemanticVersion([26, 5, 2])
+    let operatingSystemBuild: String? = "25F84"
+    let physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    let powerSource: PowerSource = .externalPower
+
+    private let lock = NSLock()
+    private var asked: [URL] = []
+    var probedPaths: [URL] { lock.withLock { asked } }
+
+    func freeBytes(at url: URL) throws -> UInt64 {
+        lock.withLock { asked.append(url) }
+        return 500 * ResourcePreset.gigabyte
+    }
+
+    func installedApplication(bundleIdentifier: String) -> InstalledApplication? { nil }
+}
+
 @MainActor
 @Suite struct SetupWizardTests {
     func defaults() -> UserDefaults { UserDefaults(suiteName: "SetupWizardTests-\(UUID().uuidString)")! }
 
     func checked(_ probe: StubHostProbe) async -> CheckThisMacModel {
-        let model = CheckThisMacModel(probe: probe, storageRoot: URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse"))
+        let model = CheckThisMacModel(probe: probe, storageRoot: { URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse") })
         model.check()
         for _ in 0..<400 where model.report == nil { try? await Task.sleep(for: .milliseconds(5)) }
         return model
@@ -156,7 +176,7 @@ final class GatedHostProbe: HostProbe, @unchecked Sendable {
 
     @Test func onlyTheNewestOverlappingCheckPublishesItsResult() async {
         let probe = GatedHostProbe()
-        let model = CheckThisMacModel(probe: probe, storageRoot: URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse"))
+        let model = CheckThisMacModel(probe: probe, storageRoot: { URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse") })
         // A recovery action starts a check while the first one, held in the probe, still runs.
         model.check()
         await waitUntil { probe.callCount >= 1 }
@@ -192,11 +212,46 @@ final class GatedHostProbe: HostProbe, @unchecked Sendable {
         #expect(wizard.canGoNext)
     }
 
-    @Test func theStorageSummaryNamesTheRuntimesRoot() async {
-        #expect(CheckThisMacModel.defaultStorageRoot == RuntimeStorageLocation.defaultRoot())
-        #expect(CheckThisMacModel.defaultStorageRoot.path.hasSuffix("/Library/Application Support/Guesthouse"))
+    @Test func theStorageSummaryNamesTheRuntimesRoot() async throws {
+        #expect(CheckThisMacModel.defaultStorageRoot() == RuntimeStorageLocation.defaultRoot())
+        let root = try #require(CheckThisMacModel.defaultStorageRoot())
+        #expect(root.path.hasSuffix("/Library/Application Support/Guesthouse"))
         let model = await checked(StubHostProbe())
         #expect(model.storageSummary.contains { $0.contains("Everything lives under /Users/dev/Library/Application Support/Guesthouse") })
+    }
+
+    @Test func aRootThatCannotBeResolvedStopsSetupInsteadOfNamingTheWrongPath() async {
+        // The account record is unreadable, so the canonical root is unknown. Naming this
+        // app's container instead would tell the user the runtime writes somewhere it never
+        // will, and would measure the container's volume as though it were the destination's.
+        let model = CheckThisMacModel(probe: StubHostProbe(), storageRoot: { nil })
+        model.check()
+        await waitUntil { model.report != nil && !model.isChecking }
+        #expect(!model.canProceed, "an unknown destination is not a satisfied requirement")
+        guard let disk = model.rows.first(where: { $0.kind == .freeDisk }) else { Issue.record("no disk row"); return }
+        #expect(disk.verdict == .undetermined)
+        #expect(!model.storageSummary.contains { $0.contains("Everything lives under") })
+        #expect(model.storageSummary.contains { $0.contains("could not determine where the development Mac would be stored") })
+    }
+
+    @Test func aRootLookupThatFailedOnceIsResolvedAgainByTheRetry() async {
+        // The account record is unreadable for the first check and readable afterwards. The
+        // lookup is what the undetermined row's "Try again" repeats, so a root cached for the
+        // life of the process would leave setup blocked until the app was relaunched.
+        let root = URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse")
+        let lookups = Counter()
+        let model = CheckThisMacModel(probe: StubHostProbe(), storageRoot: {
+            lookups.increment()
+            return lookups.value > 1 ? root : nil
+        })
+        model.check()
+        await waitUntil { model.report != nil && !model.isChecking }
+        #expect(!model.canProceed)
+        #expect(model.rows.first(where: { $0.kind == .freeDisk })?.verdict == .undetermined)
+        model.check()
+        await waitUntil { model.report != nil && !model.isChecking && model.canProceed }
+        #expect(model.rows.first(where: { $0.kind == .freeDisk })?.verdict == .pass, "the retry resolved the root again")
+        #expect(model.storageSummary.contains { $0.contains(root.path) })
     }
 
     @Test func aCheckThatCouldNotBeMadeStillOffersAnActionTheAppCanPerform() async {
@@ -211,6 +266,29 @@ final class GatedHostProbe: HostProbe, @unchecked Sendable {
                 "setup offers something other than closing when a check cannot be made"
             )
         }
+    }
+
+    @Test func theDiskCheckLooksWhereThisProcessMayActuallyLook() async {
+        let probe = PathRecordingProbe()
+        let root = URL(fileURLWithPath: "/Users/dev/Library/Application Support/Guesthouse")
+        let model = CheckThisMacModel(probe: probe, storageRoot: { root })
+        model.check()
+        await waitUntil { model.report != nil && !model.isChecking }
+        #expect(probe.probedPaths == [CheckThisMacModel.defaultVolumeProbe])
+        #expect(CheckThisMacModel.defaultVolumeProbe != root, "the sandboxed app cannot stat its way to the runtime's root")
+        #expect(FileManager.default.isWritableFile(atPath: CheckThisMacModel.defaultVolumeProbe.path), "and the path it does use passes the probe's own write check")
+        #expect(model.storageSummary.contains { $0.contains(root.path) }, "the summary still names where the development Mac will live")
+        #expect(model.canProceed, "a first launch is not stopped by a folder the app was never allowed to open")
+    }
+
+    @Test func aRefreshOverAnExistingReportStillShowsThatItIsWorking() async {
+        let model = await checked(StubHostProbe())
+        #expect(model.progressMessage == nil)
+        #expect(!model.rows.isEmpty)
+        model.check()
+        #expect(model.progressMessage != nil, "the rows on screen are the previous answer, and only this says they are being replaced")
+        await waitUntil { !model.isChecking }
+        #expect(model.progressMessage == nil)
     }
 
     func waitUntil(_ condition: @MainActor () -> Bool) async {

--- a/GuesthouseTests/SetupWizardTests.swift
+++ b/GuesthouseTests/SetupWizardTests.swift
@@ -12,7 +12,14 @@ struct StubHostProbe: HostProbe {
     var free: UInt64 = 500 * ResourcePreset.gigabyte
     var applications: [String: InstalledApplication] = ["com.openai.chat": InstalledApplication(url: URL(fileURLWithPath: "/Applications/ChatGPT.app"), version: "1.2.3", build: "456")]
 
-    func freeBytes(at url: URL) throws -> UInt64 { free }
+    var freeThrows = false
+
+    struct ProbeFailure: Error {}
+
+    func freeBytes(at url: URL) throws -> UInt64 {
+        if freeThrows { throw ProbeFailure() }
+        return free
+    }
     func installedApplication(bundleIdentifier: String) -> InstalledApplication? { applications[bundleIdentifier] }
 }
 
@@ -25,6 +32,40 @@ struct StubHostProbe: HostProbe {
         model.check()
         for _ in 0..<400 where model.report == nil { try? await Task.sleep(for: .milliseconds(5)) }
         return model
+    }
+
+    @Test func checkingAgainWithdrawsThePassingReportUntilTheNewOneArrives() async {
+        let model = await checked(StubHostProbe())
+        #expect(model.canProceed)
+        model.check()
+        #expect(model.isChecking)
+        #expect(!model.canProceed, "Next waits for the fresh result")
+        for _ in 0..<400 where model.isChecking { try? await Task.sleep(for: .milliseconds(5)) }
+        #expect(model.canProceed)
+    }
+
+    @Test func anUnreadableVolumeStopsSetupInsteadOfWarning() async {
+        var probe = StubHostProbe(); probe.freeThrows = true
+        let model = await checked(probe)
+        #expect(!model.canProceed, "an unanswered question is not a satisfied requirement")
+        guard let disk = model.rows.first(where: { $0.kind == .freeDisk }) else { Issue.record("no disk row"); return }
+        #expect(disk.verdict == .undetermined)
+        #expect(disk.recovery.contains { $0.action == .retry })
+    }
+
+    @Test func dismissBecomesAWorkingCloseSetupInsideACheckRow() {
+        let options = [RecoveryPresentation.option(for: .cancel, outcomeUnknown: false), RecoveryPresentation.option(for: .retry, outcomeUnknown: false)]
+        let presented = CheckThisMacModel.presentable(options)
+        #expect(presented.map(\.action) == [.cancel, .retry])
+        #expect(presented.first?.title == "Close setup")
+        #expect(presented.first?.availability == .enabled)
+    }
+
+    @Test func aCheckWithOnlyACancelActionStillOffersOne() async {
+        let model = await checked(StubHostProbe(cpuArchitecture: .intel))
+        guard let architecture = model.rows.first(where: { $0.kind == .architecture }) else { Issue.record("no architecture row"); return }
+        #expect(architecture.verdict == .fail)
+        #expect(architecture.recovery.map(\.title) == ["Close setup"])
     }
 
     @Test func allPassEnablesNextAndSummarizesStorage() async {
@@ -41,7 +82,9 @@ struct StubHostProbe: HostProbe {
     }
 
     @Test func warningsOnlyStillAllowNextAndCarryRecovery() async {
-        let model = await checked(StubHostProbe(physicalMemoryBytes: 16 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))
+        // Above the floor (the guest's allocation plus the host's headroom) but below what
+        // Guesthouse recommends: a warning, not a refusal.
+        let model = await checked(StubHostProbe(physicalMemoryBytes: 28 * ResourcePreset.gibibyte, powerSource: .battery, applications: [:]))
         #expect(model.canProceed)
         let warnings = model.rows.filter { $0.verdict == .warn }
         #expect(warnings.map(\.kind).contains(.codexDesktop))

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbe.swift
@@ -242,8 +242,11 @@ public enum HostProbeError: Error, Hashable, Sendable, LocalizedError {
     public var recoveryActions: [RecoveryAction] {
         switch self {
         case .volumeUnavailable: [.retry, .openSettings, .cancel]
-        case .notADirectory: [.openSettings, .cancel]
-        case .destinationNotWritable: [.openSettings, .retry, .cancel]
+        // Checking again is what the user does after moving the file out of the way, and it
+        // is the only recovery the app can perform today: without it an undetermined disk
+        // check would block first-launch setup with nothing to do about it.
+        case .notADirectory: [.retry, .openSettings, .cancel]
+        case .destinationNotWritable: [.retry, .openSettings, .cancel]
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -61,13 +61,16 @@ public struct PreflightResult: Codable, Hashable, Sendable {
 
 /// "What will be downloaded and where the VM will live" (MVP-PLAN.md §2, step 1).
 public struct StorageSummary: Codable, Hashable, Sendable {
-    public var storageRootPath: String
+    /// Where the development Mac will live, or `nil` when the account's canonical root could
+    /// not be resolved. A summary that cannot name the root says nothing rather than naming
+    /// a path the runtime will not use (MVP-PLAN.md §3, "Local storage").
+    public var storageRootPath: String?
     public var runtimeDownloadEstimateBytes: UInt64
     public var restoreImageEstimateBytes: UInt64
     public var guestDiskBytes: UInt64
     public var firstSetupAllowanceBytes: UInt64
 
-    public init(storageRootPath: String, runtimeDownloadEstimateBytes: UInt64, restoreImageEstimateBytes: UInt64, guestDiskBytes: UInt64, firstSetupAllowanceBytes: UInt64) {
+    public init(storageRootPath: String?, runtimeDownloadEstimateBytes: UInt64, restoreImageEstimateBytes: UInt64, guestDiskBytes: UInt64, firstSetupAllowanceBytes: UInt64) {
         self.storageRootPath = storageRootPath
         self.runtimeDownloadEstimateBytes = runtimeDownloadEstimateBytes
         self.restoreImageEstimateBytes = restoreImageEstimateBytes
@@ -103,10 +106,22 @@ public struct PreflightReport: Codable, Hashable, Sendable {
 
 /// The "Check this Mac" step. Pure given a probe; every threshold comes from `ResourcePolicy`.
 public enum PreflightCheck: Sendable {
+    /// - Parameters:
+    ///   - storageRoot: where the development Mac will live; the path the report names. `nil`
+    ///     when the account's canonical root could not be resolved at all, which leaves the
+    ///     disk check undetermined: setup does not continue toward a destination Guesthouse
+    ///     cannot name (MVP-PLAN.md §3 "Local storage").
+    ///   - measuredAt: a path on that same volume the caller is allowed to open, for callers
+    ///     that cannot open the storage root itself. A sandboxed GUI cannot stat its way to
+    ///     the runtime's root, and a disk question nobody could answer blocks setup, so the
+    ///     volume is measured through a reachable path on it while the report still names the
+    ///     root (MVP-PLAN.md §3 "Local storage"). The detail then says where it measured,
+    ///     because measuring the volume is not the same as inspecting the destination.
     public static func run(
         probe: any HostProbe,
         policy: ResourcePolicy = .standard,
-        storageRoot: URL,
+        storageRoot: URL?,
+        measuredAt: URL? = nil,
         preset: ResourcePreset = .recommended,
         now: Date = Date()
     ) -> PreflightReport {
@@ -155,19 +170,35 @@ public enum PreflightCheck: Sendable {
         results.append(PreflightResult(kind: .memory, outcome: memoryOutcome))
 
         let diskOutcome: PreflightResult.Outcome
-        do {
-            let free = try probe.freeBytes(at: storageRoot)
-            if free >= policy.firstSetupAllowanceBytes {
-                diskOutcome = .pass(detail: PreflightResult.detail("\(format(free)) free on the volume that will hold the development Mac"))
-            } else {
-                diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
+        if let storageRoot {
+            // Measuring a proxy path answers a question about the volume, not about the
+            // destination, so a pass that came from one says where it looked instead of
+            // implying the runtime's root was inspected.
+            let measured = measuredAt ?? storageRoot
+            do {
+                let free = try probe.freeBytes(at: measured)
+                if free >= policy.firstSetupAllowanceBytes {
+                    let where_ = measured.standardizedFileURL == storageRoot.standardizedFileURL
+                        ? ""
+                        : " Measured at \(GuesthouseError.sanitize(measured.path, limit: 200)); the destination folder itself is checked when the development Mac is created."
+                    diskOutcome = .pass(detail: PreflightResult.detail("\(format(free)) free on the volume that will hold the development Mac.\(where_)"))
+                } else {
+                    diskOutcome = .fail(.insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: free, volumePath: SanitizedText(storageRoot.path)))
+                }
+            } catch let error as HostProbeError {
+                // The destination is unusable or its volume is not there: not a transient lookup
+                // failure, and never a warning, since there is no disk to check.
+                diskOutcome = .undetermined(detail: PreflightResult.detail(error.userMessage), recovery: error.recoveryActions)
+            } catch {
+                diskOutcome = .undetermined(detail: PreflightResult.detail("Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read."), recovery: [.retry, .openSettings])
             }
-        } catch let error as HostProbeError {
-            // The destination is unusable or its volume is not there: not a transient lookup
-            // failure, and never a warning, since there is no disk to check.
-            diskOutcome = .undetermined(detail: PreflightResult.detail(error.userMessage), recovery: error.recoveryActions)
-        } catch {
-            diskOutcome = .undetermined(detail: PreflightResult.detail("Free space on \(GuesthouseError.sanitize(storageRoot.path, limit: 200)) could not be determined, so Guesthouse cannot tell whether the download will fit. Check again, or choose a storage location Guesthouse can read."), recovery: [.retry, .openSettings])
+        } else {
+            // No root means no destination and no volume to measure. An unanswerable question
+            // is not a satisfied requirement, so this blocks rather than guessing a path.
+            diskOutcome = .undetermined(
+                detail: PreflightResult.detail("Guesthouse could not read this account's home directory, so it cannot tell where the development Mac would be stored or which disk to measure. Check again; if this continues, log out and back in."),
+                recovery: [.retry]
+            )
         }
         results.append(PreflightResult(kind: .freeDisk, outcome: diskOutcome))
 
@@ -180,7 +211,7 @@ public enum PreflightCheck: Sendable {
         } ?? .warn(detail: PreflightResult.detail("Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but you will need it to open a workspace in Codex."), recovery: [])))
 
         let storage = StorageSummary(
-            storageRootPath: GuesthouseError.sanitize(storageRoot.path, limit: 400),
+            storageRootPath: storageRoot.map { GuesthouseError.sanitize($0.path, limit: 400) },
             runtimeDownloadEstimateBytes: policy.runtimeDownloadEstimateBytes,
             restoreImageEstimateBytes: policy.restoreImageEstimateBytes,
             guestDiskBytes: preset.diskBytes,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Storage/RuntimeStorageLocation.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Storage/RuntimeStorageLocation.swift
@@ -1,0 +1,28 @@
+import Darwin
+import Foundation
+
+/// Where the runtime keeps everything on this Mac, derived the same way in both processes.
+///
+/// The GUI is sandboxed and the runtime service is not, so `homeDirectoryForCurrentUser` and
+/// `FileManager.url(for: .applicationSupportDirectory …)` do not agree: inside the sandbox
+/// they name the app container, which is not where the runtime stores anything. MVP-PLAN.md
+/// §3 ("Local storage") says not to assume the two processes resolve Application Support
+/// identically, so the canonical root is derived from the account record instead, which the
+/// sandbox does not rewrite.
+public enum RuntimeStorageLocation: Sendable {
+    /// `~/Library/Application Support/Guesthouse` in the account's own home directory.
+    public static func defaultRoot(home: URL = accountHomeDirectory()) -> URL {
+        home.appending(path: "Library/Application Support/Guesthouse")
+    }
+
+    /// The account's home directory, read from the password database so a sandboxed caller
+    /// gets the same answer as an unsandboxed one.
+    public static func accountHomeDirectory() -> URL {
+        guard let record = getpwuid(getuid()), let directory = record.pointee.pw_dir else {
+            return FileManager.default.homeDirectoryForCurrentUser
+        }
+        let path = FileManager.default.string(withFileSystemRepresentation: directory, length: strlen(directory))
+        guard !path.isEmpty else { return FileManager.default.homeDirectoryForCurrentUser }
+        return URL(fileURLWithPath: path, isDirectory: true)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Storage/RuntimeStorageLocation.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Storage/RuntimeStorageLocation.swift
@@ -10,19 +10,53 @@ import Foundation
 /// identically, so the canonical root is derived from the account record instead, which the
 /// sandbox does not rewrite.
 public enum RuntimeStorageLocation: Sendable {
-    /// `~/Library/Application Support/Guesthouse` in the account's own home directory.
-    public static func defaultRoot(home: URL = accountHomeDirectory()) -> URL {
+    /// `~/Library/Application Support/Guesthouse` in the given home directory.
+    public static func defaultRoot(home: URL) -> URL {
         home.appending(path: "Library/Application Support/Guesthouse")
     }
 
+    /// The canonical root for this account, or `nil` when the account record cannot be read.
+    ///
+    /// There is deliberately no fallback. `homeDirectoryForCurrentUser` is the container in
+    /// the sandboxed GUI and the real home in the runtime service, so falling back to it
+    /// restores exactly the disagreement this type exists to prevent — silently, and in only
+    /// one of the two processes. A caller that does not know the root must say so instead of
+    /// naming the wrong one: the wizard would otherwise tell the user "Everything lives under"
+    /// a container path the runtime never writes to, and measure the wrong volume to boot.
+    public static func defaultRoot() -> URL? {
+        accountHomeDirectory().map { defaultRoot(home: $0) }
+    }
+
     /// The account's home directory, read from the password database so a sandboxed caller
-    /// gets the same answer as an unsandboxed one.
-    public static func accountHomeDirectory() -> URL {
-        guard let record = getpwuid(getuid()), let directory = record.pointee.pw_dir else {
-            return FileManager.default.homeDirectoryForCurrentUser
+    /// gets the same answer as an unsandboxed one, or `nil` when that record is unavailable.
+    ///
+    /// This is a nonisolated public function, and the wizard now resolves the root inside a
+    /// detached task on every check, so two lookups can overlap — a Try again racing the
+    /// preflight it is retrying. `getpwuid` hands back a pointer into the library's own static
+    /// record, which the second call is free to overwrite while the first is still reading
+    /// `pw_dir`, so the reentrant form with caller-owned storage is the only safe one here.
+    public static func accountHomeDirectory() -> URL? {
+        // `_SC_GETPW_R_SIZE_MAX` is the suggested size, not a guaranteed one, so ERANGE is
+        // answered by doubling rather than by giving up on the account record.
+        var capacity = sysconf(_SC_GETPW_R_SIZE_MAX)
+        if capacity <= 0 { capacity = 4096 }
+        while capacity <= 1 << 20 {
+            var record = passwd()
+            var found: UnsafeMutablePointer<passwd>?
+            var buffer = [CChar](repeating: 0, count: Int(capacity))
+            let outcome = buffer.withUnsafeMutableBufferPointer { storage -> (status: Int32, home: URL?) in
+                let status = getpwuid_r(getuid(), &record, storage.baseAddress, storage.count, &found)
+                guard status == 0 else { return (status, nil) }
+                // `pw_dir` points into `storage`, so the string is copied out before it ends.
+                guard found != nil, let directory = record.pw_dir else { return (0, nil) }
+                let path = FileManager.default.string(withFileSystemRepresentation: directory, length: strlen(directory))
+                guard !path.isEmpty else { return (0, nil) }
+                return (0, URL(fileURLWithPath: path, isDirectory: true))
+            }
+            guard outcome.status != 0 else { return outcome.home }
+            guard outcome.status == ERANGE else { return nil }
+            capacity *= 2
         }
-        let path = FileManager.default.string(withFileSystemRepresentation: directory, length: strlen(directory))
-        guard !path.isEmpty else { return FileManager.default.homeDirectoryForCurrentUser }
-        return URL(fileURLWithPath: path, isDirectory: true)
+        return nil
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -88,7 +88,7 @@ struct StubProbe: HostProbe {
         let report = PreflightCheck.run(probe: probe, storageRoot: hostile, now: Date(timeIntervalSince1970: 1_800_000_000))
         guard case .undetermined(let detail, _) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
         #expect(!detail.value.contains("\u{202E}"))
-        #expect(!report.storage.storageRootPath.contains("\u{202E}"))
+        #expect(report.storage.storageRootPath?.contains("\u{202E}") == false)
     }
 
     @Test func largeOperationRequirementsThatOverflowAreInsufficient() {
@@ -199,6 +199,50 @@ struct StubProbe: HostProbe {
         #expect(json.contains("[redacted:github-token]"))
         let restored = try JSONDecoder().decode(GuesthouseError.self, from: Data(json.utf8))
         #expect(restored == error)
+    }
+
+    @Test func theVolumeCanBeMeasuredThroughAPathTheCallerCanOpen() {
+        final class Recorder: HostProbe, @unchecked Sendable {
+            let cpuArchitecture: CPUArchitecture = .appleSilicon
+            let operatingSystemVersion = SemanticVersion([26, 5, 2])
+            let operatingSystemBuild: String? = "25F84"
+            let physicalMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+            let powerSource: PowerSource = .externalPower
+            private(set) nonisolated(unsafe) var asked: [URL] = []
+            func freeBytes(at url: URL) throws -> UInt64 {
+                asked.append(url)
+                return 500 * ResourcePreset.gigabyte
+            }
+            func installedApplication(bundleIdentifier: String) -> InstalledApplication? { nil }
+        }
+        let probe = Recorder()
+        let reachable = URL(fileURLWithPath: "/Users/dev/Library/Containers/app/Data", isDirectory: true)
+        let report = PreflightCheck.run(probe: probe, storageRoot: root, measuredAt: reachable, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(probe.asked == [reachable], "the volume is measured where the caller may look")
+        #expect(report.storage.storageRootPath == root.path, "and the report still names where the development Mac will live")
+        #expect(report.canProceed)
+        // Measuring a proxy is not inspecting the destination, and the detail says so rather
+        // than letting a pass read as though the runtime's own root had been checked.
+        guard case .pass(let detail) = report.result(.freeDisk)!.outcome else { Issue.record("expected pass"); return }
+        #expect(detail.value.contains(reachable.path))
+        #expect(detail.value.contains("checked when the development Mac is created"))
+    }
+
+    @Test func aRootThatCannotBeResolvedLeavesTheDiskCheckUndetermined() {
+        // No account record means no destination and no volume: the step blocks instead of
+        // measuring this process's own home and calling it the runtime's.
+        let report = PreflightCheck.run(probe: StubProbe(), storageRoot: nil, now: Date(timeIntervalSince1970: 1_800_000_000))
+        #expect(!report.canProceed)
+        #expect(report.storage.storageRootPath == nil, "a summary that cannot name the root names nothing")
+        guard case .undetermined(let detail, let recovery) = report.result(.freeDisk)!.outcome else { Issue.record("expected undetermined"); return }
+        #expect(detail.value.contains("home directory"))
+        #expect(recovery == [.retry])
+    }
+
+    @Test func aResolvedRootIsMeasuredAtTheDestinationWhenNoProxyIsGiven() {
+        let report = PreflightCheck.run(probe: StubProbe(), storageRoot: root, now: Date(timeIntervalSince1970: 1_800_000_000))
+        guard case .pass(let detail) = report.result(.freeDisk)!.outcome else { Issue.record("expected pass"); return }
+        #expect(!detail.value.contains("Measured at"), "nothing was substituted, so there is nothing to disclose")
     }
 
     @Test func aReportMissingACheckNeverProceeds() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Storage/RuntimeStorageLocationTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Storage/RuntimeStorageLocationTests.swift
@@ -1,0 +1,18 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeStorageLocationTests {
+    @Test func theRootIsApplicationSupportUnderTheGivenHome() {
+        #expect(RuntimeStorageLocation.defaultRoot(home: URL(fileURLWithPath: "/Users/dev")).path == "/Users/dev/Library/Application Support/Guesthouse")
+    }
+
+    @Test func theDefaultRootIsDerivedFromTheAccountHome() {
+        let home = RuntimeStorageLocation.accountHomeDirectory()
+        #expect(!home.path.isEmpty)
+        // The account's home, not the caller's own: a sandboxed process's home is its
+        // container, and the runtime stores nothing there (MVP-PLAN.md §3, "Local storage").
+        #expect(!home.path.contains("/Library/Containers/"))
+        #expect(RuntimeStorageLocation.defaultRoot().path == RuntimeStorageLocation.defaultRoot(home: home).path)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Storage/RuntimeStorageLocationTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Storage/RuntimeStorageLocationTests.swift
@@ -7,12 +7,38 @@ import Testing
         #expect(RuntimeStorageLocation.defaultRoot(home: URL(fileURLWithPath: "/Users/dev")).path == "/Users/dev/Library/Application Support/Guesthouse")
     }
 
-    @Test func theDefaultRootIsDerivedFromTheAccountHome() {
-        let home = RuntimeStorageLocation.accountHomeDirectory()
+    @Test func theDefaultRootIsDerivedFromTheAccountHome() throws {
+        let home = try #require(RuntimeStorageLocation.accountHomeDirectory())
         #expect(!home.path.isEmpty)
         // The account's home, not the caller's own: a sandboxed process's home is its
         // container, and the runtime stores nothing there (MVP-PLAN.md §3, "Local storage").
         #expect(!home.path.contains("/Library/Containers/"))
-        #expect(RuntimeStorageLocation.defaultRoot().path == RuntimeStorageLocation.defaultRoot(home: home).path)
+        #expect(RuntimeStorageLocation.defaultRoot()?.path == RuntimeStorageLocation.defaultRoot(home: home).path)
+    }
+
+    @Test func overlappingLookupsAllReadTheSameHome() async throws {
+        // The wizard resolves the root inside a detached task on every check, so a Try again
+        // can overlap the check it is retrying. With the shared static record this asserts
+        // nothing on a lucky run, but a torn or substituted `pw_dir` shows up as a disagreement.
+        let expected = try #require(RuntimeStorageLocation.accountHomeDirectory()).path
+        let answers = await withTaskGroup(of: String?.self) { group in
+            for _ in 0..<64 {
+                group.addTask { RuntimeStorageLocation.accountHomeDirectory()?.path }
+            }
+            return await group.reduce(into: [String?]()) { $0.append($1) }
+        }
+        #expect(answers.count == 64)
+        #expect(answers.allSatisfy { $0 == expected })
+    }
+
+    @Test func anUnreadableAccountRecordNamesNoRoot() {
+        // There is no fallback by design: `homeDirectoryForCurrentUser` is the container in
+        // the sandboxed GUI and the real home in the runtime, so returning it here would put
+        // the two processes back on different paths — silently, and in only one of them.
+        // The optional is the whole contract, so what is asserted is that callers must handle
+        // nil rather than receive a substitute.
+        #expect(RuntimeStorageLocation.defaultRoot(home: URL(fileURLWithPath: "/Users/dev")).path.hasPrefix("/Users/dev"))
+        let unresolved: URL? = nil
+        #expect(unresolved.map(RuntimeStorageLocation.defaultRoot(home:)) == nil)
     }
 }


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: GUI shell, progress/recovery, diagnostics/export and runtime connection (#27–#32). Carry forward useful views/tests after their current runtime/model dependencies are available. Raw-log disclosure/export must become typed structured diagnostics.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Summary

Implements #31 (`MVP-PLAN.md` §2 "First launch" step 1: check this Mac (architecture, macOS version, free disk, memory, Codex desktop installed) and explain what will be downloaded and where the VM will live; "Essential screens": a wizard with resumable stages and actionable failures). Stacked on #79.

- `SetupStage`: the eight ordered stages (`checkThisMac`, `createDevelopmentMac`, `finishMacOSSetup`, `connectSecurely`, `addXcode`, `signIn`, `addWorkspace`, `validateAndOpen`); only the first has content, the others say so.
- `SetupWizardModel`: current stage persisted in `UserDefaults`, so the wizard resumes; Back is available after the first stage; Next only when the current stage is complete (all checks pass), never on an unimplemented stage.
- `CheckThisMacModel`: runs `PreflightCheck` through a `HostProbe` (`SystemHostProbe` in the app) off the main actor, yields one row per check with pass/warn/fail, its detail, and recovery options (the error's `RecoveryAction`s, with retry and inspect re-running the check), plus the download and storage summary and a battery warning.
- `SetupWizardView` / `CheckThisMacView`: stage list with the current step, rows with icons and full accessibility labels, storage summary, "Check again", Back/Next/Close. The dashboard's "Create a development Mac" opens the wizard (the placeholder is gone).
- Previews for all-pass, warnings, and failure with a fixed probe.

Tests (4 new, `GuesthouseTests/SetupWizardTests.swift`, stub probe): all-pass enables Next and summarizes storage; warnings only (16 GB, battery, no Codex desktop) still allow Next; failures (Intel, low disk) disable Next, refuse `next()`, and carry recovery; the stage is persisted and resumed, Back works, unimplemented stages cannot be completed.

Closes #31

## Checklist

- [x] Tests cover the new logic; app, kit, and core test commands pass locally
- [x] No new warnings
- [x] No new third-party dependencies
- [x] No secrets
- [x] No process launched in this change
- [x] Diff under 500 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)