### PR TITLE
Spike: add a non-VM-mutating Lume capability probe

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBackend.swift
@@ -1,0 +1,199 @@
+import Foundation
+import GuesthouseCore
+
+public struct LumeProbeResult: Hashable, Sendable {
+    public let version: SemanticVersion
+    public let capabilities: RuntimeVersionInfo.LumeCapabilities
+}
+
+public enum LumeInvocationError: Error, Hashable, Sendable {
+    case storageMismatch
+    case bundleChanged
+    case failed(status: Int32)
+    case timedOut
+    case outputTruncated
+    case unparseableOutput
+    case versionMismatch(found: SemanticVersion, required: SemanticVersion)
+
+    public var userMessage: String {
+        switch self {
+        case .storageMismatch:
+            "The verified Lume runtime does not belong to the selected Guesthouse storage."
+        case .bundleChanged:
+            "The installed Lume runtime changed after it was verified."
+        case .failed:
+            "Lume exited before Guesthouse could inspect its capabilities."
+        case .timedOut:
+            "Lume did not answer the capability probe before its safety timeout."
+        case .outputTruncated:
+            "Lume returned more capability output than Guesthouse can safely inspect."
+        case .unparseableOutput:
+            "Lume returned capability information Guesthouse does not understand."
+        case .versionMismatch:
+            "The running Lume version does not match the verified release."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.repair(.runtime), .cancel] }
+
+    public var errorDescription: String? { userMessage }
+}
+
+extension LumeInvocationError: LocalizedError {}
+
+/// Non-VM-mutating interrogation of one verified Lume executable. Lume may still create its
+/// own config, so XDG and temporary state are redirected into private runtime storage. VM
+/// inventory and mutating operations remain out of scope until the hardware gate.
+public struct LumeBackend: Sendable {
+    private let bundle: VerifiedLumeBundle
+    private let storage: RuntimeStorage
+    private let runner: any ProcessRunning
+    private let verifyBeforeLaunch: @Sendable () throws -> URL
+
+    public init(bundle: VerifiedLumeBundle, storage: RuntimeStorage, runner: any ProcessRunning) throws {
+        guard Self.bundlePath(bundle, belongsTo: storage) else {
+            throw LumeInvocationError.storageMismatch
+        }
+        guard let currentIdentity = RuntimeStorage.fileIdentity(of: LumeBundle.expectedLocation(in: storage)),
+              bundle.fileIdentity == currentIdentity
+        else {
+            throw LumeInvocationError.bundleChanged
+        }
+        self.init(bundle: bundle, storage: storage, runner: runner) {
+            try Self.reverify(bundle, in: storage)
+        }
+    }
+
+    init(
+        bundle: VerifiedLumeBundle,
+        storage: RuntimeStorage,
+        runner: any ProcessRunning,
+        verifyBeforeLaunch: @escaping @Sendable () throws -> URL
+    ) {
+        self.bundle = bundle
+        self.storage = storage
+        self.runner = runner
+        self.verifyBeforeLaunch = verifyBeforeLaunch
+    }
+
+    private static func bundlePath(_ bundle: VerifiedLumeBundle, belongsTo storage: RuntimeStorage) -> Bool {
+        let expectedURL = LumeBundle.expectedLocation(in: storage)
+        return bundle.bundle.url.standardizedFileURL.path == expectedURL.standardizedFileURL.path
+    }
+
+    /// Repeats discovery as well as signature verification at the launch boundary. Discovery
+    /// rechecks every app-managed ancestor, so replacing `runtime/` or the release directory with
+    /// a link cannot redirect a still-valid bundle token outside the leased storage tree.
+    private static func reverify(_ bundle: VerifiedLumeBundle, in storage: RuntimeStorage) throws -> URL {
+        try relocateForLaunch(bundle, in: storage).verify().executable
+    }
+
+    /// Separated from signature verification so the managed-path recheck has focused regression
+    /// coverage without weakening or substituting the production signature gate.
+    static func relocateForLaunch(_ bundle: VerifiedLumeBundle, in storage: RuntimeStorage) throws -> LumeBundle {
+        guard let current = LumeBundle.locate(in: storage),
+              RuntimeStorage.fileIdentity(of: current.url) == bundle.fileIdentity
+        else { throw LumeInvocationError.bundleChanged }
+        return current
+    }
+
+    public func probe() async throws -> LumeProbeResult {
+        try await LumeRuntimeCoordinator.shared.withExclusiveAccess(for: storage) {
+            try await probeExclusively()
+        }
+    }
+
+    private func probeExclusively() async throws -> LumeProbeResult {
+        let versionOutput = try await capture(["--version"], timeout: .seconds(5))
+        guard let version = SemanticVersion(versionOutput.trimmingCharacters(in: .whitespacesAndNewlines)) else {
+            throw LumeInvocationError.unparseableOutput
+        }
+        guard version == bundle.version else {
+            throw LumeInvocationError.versionMismatch(found: version, required: bundle.version)
+        }
+        // Bare `run --help` enters AppKit in 0.5.3. `--detach` makes help safe to inspect.
+        // These remain serial within the coordinator's whole-probe lease because Lume can
+        // initialize shared XDG configuration even for introspection.
+        let createHelp = try await capture(["create", "--help"], timeout: .seconds(5))
+        let runHelp = try await capture(["run", "--detach", "--help"], timeout: .seconds(5))
+        let attachHelp = try await capture(["attach", "--help"], timeout: .seconds(5))
+        return LumeProbeResult(
+            version: version,
+            capabilities: Self.capabilities(createHelp: createHelp, runHelp: runHelp, attachHelp: attachHelp)
+        )
+    }
+
+    static func capabilities(createHelp: String, runHelp: String, attachHelp: String) -> RuntimeVersionInfo.LumeCapabilities {
+        RuntimeVersionInfo.LumeCapabilities(
+            unattendedTahoe: hasOption("--unattended", in: createHelp) && hasWord("tahoe", in: createHelp),
+            createRunAttachStorage: hasOption("--storage", in: createHelp) && hasOption("--storage", in: runHelp) && hasOption("--storage", in: attachHelp),
+            detachedRun: hasOption("--detach", in: runHelp),
+            nativeAttach: hasOption("--display", in: attachHelp) && hasWord("native", in: attachHelp),
+            // This adapter accepts exactly 0.5.3. That release cannot disable its always-on
+            // private-API VNC server; keep the security result pinned instead of inferring it
+            // from prose or similarly named help options.
+            vncCanBeDisabled: false
+        )
+    }
+
+    private static func hasOption(_ option: String, in help: String) -> Bool {
+        help.split(whereSeparator: { !$0.isLetter && !$0.isNumber && $0 != "-" }).contains(Substring(option))
+    }
+
+    private static func hasWord(_ word: String, in help: String) -> Bool {
+        help.split(whereSeparator: { !$0.isLetter && !$0.isNumber }).contains { $0.caseInsensitiveCompare(word) == .orderedSame }
+    }
+
+    private func capture(_ arguments: [String], timeout: Duration) async throws -> String {
+        try Task.checkCancellation()
+        // The token proves an earlier check, but the app could have been updated or replaced
+        // since then. Revalidate immediately before every launch and fail closed. Guesthouse's
+        // threat boundary excludes a hostile process already running as the host user; the
+        // eventual installer must use `LumeRuntimeCoordinator.shared.withExclusiveAccess(for:)`
+        // while atomically placing the new bundle in this private directory.
+        let executable: URL
+        do { executable = try verifyBeforeLaunch() }
+        catch { throw LumeInvocationError.bundleChanged }
+        try Task.checkCancellation()
+        let run: ProcessRun
+        do {
+            run = try await runner.run(ProcessInvocation(
+                executable: executable,
+                arguments: arguments,
+                environment: storage.environmentForLume(),
+                currentDirectory: storage.url(for: .staging),
+                timeout: timeout,
+                maximumOutputBytes: 1 << 20
+            ))
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            // A path swap can surface as a launch error in the narrow interval after the first
+            // check. Reverify before preserving the earlier `verified` verdict.
+            do { _ = try verifyBeforeLaunch() }
+            catch { throw LumeInvocationError.bundleChanged }
+            throw error
+        }
+        let (stdout, exit) = await withTaskCancellationHandler {
+            var stdout: [String] = []
+            for await line in run.output {
+                if case .stdout(let text) = line { stdout.append(text.text) }
+            }
+            return (stdout.joined(separator: "\n"), await run.exit())
+        } onCancel: {
+            run.terminate(gracePeriod: .seconds(1))
+        }
+        if Task.isCancelled { throw CancellationError() }
+        if exit.timedOut { throw LumeInvocationError.timedOut }
+        if exit.outputTruncated { throw LumeInvocationError.outputTruncated }
+        guard exit.succeeded else { throw LumeInvocationError.failed(status: Self.exitStatus(exit)) }
+        return stdout
+    }
+
+    private static func exitStatus(_ exit: ProcessExit) -> Int32 {
+        switch exit.reason {
+        case .status(let status): status
+        case .signal(let signal): 128 + signal
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBackend.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBackend.swift
@@ -54,8 +54,8 @@ public struct LumeBackend: Sendable {
         guard Self.bundlePath(bundle, belongsTo: storage) else {
             throw LumeInvocationError.storageMismatch
         }
-        guard let currentIdentity = RuntimeStorage.fileIdentity(of: LumeBundle.expectedLocation(in: storage)),
-              bundle.fileIdentity == currentIdentity
+        guard let current = LumeBundle.locate(in: storage),
+              bundle.matchesVerifiedFiles(in: current)
         else {
             throw LumeInvocationError.bundleChanged
         }
@@ -92,7 +92,7 @@ public struct LumeBackend: Sendable {
     /// coverage without weakening or substituting the production signature gate.
     static func relocateForLaunch(_ bundle: VerifiedLumeBundle, in storage: RuntimeStorage) throws -> LumeBundle {
         guard let current = LumeBundle.locate(in: storage),
-              RuntimeStorage.fileIdentity(of: current.url) == bundle.fileIdentity
+              bundle.matchesVerifiedFiles(in: current)
         else { throw LumeInvocationError.bundleChanged }
         return current
     }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
@@ -1,0 +1,380 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+private actor ScriptedLumeRunner: ProcessRunning {
+    struct Reply: Sendable {
+        var stdout: [String]
+        var stderr: [String] = []
+        var status: Int32 = 0
+        var outputTruncated = false
+    }
+
+    private var replies: [String: Reply]
+    private let delay: Duration
+    private var activeInvocationCount = 0
+    private(set) var maximumConcurrentInvocationCount = 0
+    private(set) var invocations: [ProcessInvocation] = []
+
+    init(_ replies: [String: Reply], delay: Duration = .zero) {
+        self.replies = replies
+        self.delay = delay
+    }
+
+    func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
+        invocations.append(invocation)
+        activeInvocationCount += 1
+        maximumConcurrentInvocationCount = max(maximumConcurrentInvocationCount, activeInvocationCount)
+        defer { activeInvocationCount -= 1 }
+        if delay > .zero { try await Task.sleep(for: delay) }
+        guard let reply = replies[invocation.arguments.joined(separator: " ")] else {
+            throw LumeInvocationError.unparseableOutput
+        }
+        let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self, bufferingPolicy: .unbounded)
+        let run = ProcessRun(process: Process(), output: stream, continuation: continuation)
+        let redactor = Redactor()
+        for line in reply.stdout { continuation.yield(.stdout(redactor.redact(lines: [line])[0])) }
+        for line in reply.stderr { continuation.yield(.stderr(redactor.redact(lines: [line])[0])) }
+        if reply.outputTruncated { run.markOutputTruncated() }
+        run.finish(with: .status(reply.status))
+        return run
+    }
+}
+
+/// Produces a real timed-out `ProcessRun` so the Lume adapter's timeout mapping is covered,
+/// while still never invoking Lume or accepting caller-controlled commands.
+private actor TimedOutLumeRunner: ProcessRunning {
+    func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sleep")
+        process.arguments = ["60"]
+        process.environment = [:]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self, bufferingPolicy: .unbounded)
+        let run = ProcessRun(process: process, output: stream, continuation: continuation)
+        process.terminationHandler = { process in
+            run.finish(with: process.terminationReason == .uncaughtSignal ? .signal(process.terminationStatus) : .status(process.terminationStatus))
+        }
+        run.retainWhileRunning()
+        try process.run()
+        run.timeOut(gracePeriod: .milliseconds(10))
+        return run
+    }
+}
+
+private actor LaunchFailingLumeRunner: ProcessRunning {
+    private(set) var invocations: [ProcessInvocation] = []
+
+    func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
+        invocations.append(invocation)
+        throw LumeInvocationError.unparseableOutput
+    }
+}
+
+@Suite(.serialized) struct LumeBackendTests {
+    let root = FileManager.default.temporaryDirectory.appending(path: "LumeBackendTests-\(UUID().uuidString)")
+
+    private func backend(
+        runner: any ProcessRunning,
+        suffix: String = UUID().uuidString,
+        resolvedExecutable: URL? = nil,
+        verifyBeforeLaunch: @escaping @Sendable () throws -> Void = {}
+    ) throws -> (LumeBackend, RuntimeStorage, VerifiedLumeBundle) {
+        let storage = try RuntimeStorage(root: root.appending(path: suffix))
+        let bundle = LumeBundle(url: storage.url(for: .runtime).appending(path: "fixture/lume.app"))
+        try FileManager.default.createDirectory(at: bundle.url, withIntermediateDirectories: true)
+        let verified = try VerifiedLumeBundle(
+            bundle: bundle,
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        return (
+            LumeBackend(
+                bundle: verified,
+                storage: storage,
+                runner: runner,
+                verifyBeforeLaunch: {
+                    try verifyBeforeLaunch()
+                    return resolvedExecutable ?? bundle.executable
+                }
+            ),
+            storage,
+            verified
+        )
+    }
+
+    private static var successfulReplies: [String: ScriptedLumeRunner.Reply] {
+        [
+            "--version": .init(stdout: ["0.5.3"]),
+            "create --help": .init(stdout: ["--unattended tahoe --storage"]),
+            "run --detach --help": .init(stdout: ["--detach --storage --vnc-port"]),
+            "attach --help": .init(stdout: ["--display native --storage"]),
+        ]
+    }
+
+    @Test func probeUsesOnlyPinnedIntrospectionAndPrivateState() async throws {
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let verificationCount = Mutex(0)
+        let (backend, storage, bundle) = try backend(runner: runner) {
+            verificationCount.withLock { $0 += 1 }
+        }
+
+        let result = try await backend.probe()
+
+        #expect(result.version == LumePin.version)
+        #expect(result.capabilities == .init(
+            unattendedTahoe: true,
+            createRunAttachStorage: true,
+            detachedRun: true,
+            nativeAttach: true,
+            vncCanBeDisabled: false
+        ))
+        let invocations = await runner.invocations
+        #expect(invocations.map(\.executable) == Array(repeating: bundle.executable, count: 4))
+        #expect(invocations.first?.arguments == ["--version"])
+        #expect(invocations.dropFirst().map(\.arguments) == [
+            ["create", "--help"],
+            ["run", "--detach", "--help"],
+            ["attach", "--help"],
+        ])
+        #expect(invocations.allSatisfy { $0.environment == storage.environmentForLume() })
+        #expect(invocations.allSatisfy { $0.currentDirectory == storage.url(for: .staging) && $0.standardInput == .none })
+        #expect(invocations.allSatisfy { $0.maximumOutputBytes == 1 << 20 })
+        #expect(invocations.allSatisfy { $0.timeout == .seconds(5) })
+        #expect(invocations.allSatisfy { !$0.environment.keys.contains("HOME") && !$0.environment.keys.contains("PATH") })
+        #expect(verificationCount.withLock { $0 } == 4, "every launch gets a fresh static verification")
+    }
+
+    @Test func probesShareOneExclusiveRuntimeLease() async throws {
+        let runner = ScriptedLumeRunner(Self.successfulReplies, delay: .milliseconds(10))
+        let suffix = UUID().uuidString
+        let (first, _, _) = try backend(runner: runner, suffix: suffix)
+        let (second, _, _) = try backend(runner: runner, suffix: suffix)
+
+        async let firstResult = first.probe()
+        async let secondResult = second.probe()
+        _ = try await (firstResult, secondResult)
+
+        let argumentGroups = await runner.invocations.map(\.arguments)
+        let expectedGroup = [
+            ["--version"],
+            ["create", "--help"],
+            ["run", "--detach", "--help"],
+            ["attach", "--help"],
+        ]
+        #expect(argumentGroups == expectedGroup + expectedGroup)
+        #expect(await runner.maximumConcurrentInvocationCount == 1)
+    }
+
+    @Test func probeLaunchesOnlyTheFreshlyResolvedExecutable() async throws {
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let resolved = root.appending(path: "freshly-relocated-lume")
+        let (backend, _, _) = try backend(runner: runner, resolvedExecutable: resolved)
+
+        _ = try await backend.probe()
+
+        #expect(await runner.invocations.allSatisfy { $0.executable == resolved })
+    }
+
+    @Test func capabilityParsingRequiresExactOptionsAndWords() {
+        let oldStable = LumeBackend.capabilities(
+            createHelp: "--unattended Tahoe --storage",
+            runHelp: "--detach --storage --vnc-port --vnc-password disabled-ish",
+            attachHelp: "--display native --storage"
+        )
+        #expect(oldStable.unattendedTahoe)
+        #expect(oldStable.createRunAttachStorage)
+        #expect(oldStable.detachedRun)
+        #expect(oldStable.nativeAttach)
+        #expect(!oldStable.vncCanBeDisabled, "--vnc-port and disabled-ish are not --vnc disabled")
+
+        let misleadingSurface = LumeBackend.capabilities(
+            createHelp: "--unattended tahoe --storage",
+            runHelp: "--detach --storage --vnc disabled",
+            attachHelp: "--display native --storage"
+        )
+        #expect(!misleadingSurface.vncCanBeDisabled, "the exact 0.5.3 pin has a fixed security verdict")
+    }
+
+    @Test func publicBackendRejectsABundleFromAnotherStorageRoot() throws {
+        let firstStorage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let secondStorage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: firstStorage)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        let verified = try VerifiedLumeBundle(
+            bundle: LumeBundle(url: bundleURL),
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+
+        #expect(throws: LumeInvocationError.storageMismatch) {
+            _ = try LumeBackend(bundle: verified, storage: secondStorage, runner: ScriptedLumeRunner(Self.successfulReplies))
+        }
+    }
+
+    @Test func publicBackendRejectsAnAliasedBundlePath() throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let expectedURL = LumeBundle.expectedLocation(in: storage)
+        try FileManager.default.createDirectory(at: expectedURL, withIntermediateDirectories: true)
+        let alias = storage.root.appending(path: "runtime-alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: storage.url(for: .runtime))
+        let aliasedURL = alias
+            .appending(path: LumePin.releaseTag)
+            .appending(path: LumePin.bundleName)
+        let verified = try VerifiedLumeBundle(
+            bundle: LumeBundle(url: aliasedURL),
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+
+        #expect(throws: LumeInvocationError.storageMismatch) {
+            _ = try LumeBackend(bundle: verified, storage: storage, runner: ScriptedLumeRunner(Self.successfulReplies))
+        }
+    }
+
+    @Test func publicBackendReportsAChangedBundleAtTheExpectedPath() throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: storage)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        let verified = try VerifiedLumeBundle(
+            bundle: LumeBundle(url: bundleURL),
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        let originalIdentity = verified.fileIdentity
+        try FileManager.default.removeItem(at: bundleURL)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != originalIdentity)
+
+        #expect(throws: LumeInvocationError.bundleChanged) {
+            _ = try LumeBackend(bundle: verified, storage: storage, runner: ScriptedLumeRunner(Self.successfulReplies))
+        }
+    }
+
+    @Test func launchRevalidationRejectsAReplacedManagedAncestor() async throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: storage)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        let verified = try VerifiedLumeBundle(
+            bundle: LumeBundle(url: bundleURL),
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
+
+        #expect(try LumeBackend.relocateForLaunch(verified, in: storage).url == bundleURL)
+
+        let runtime = storage.url(for: .runtime)
+        let movedRuntime = storage.root.appending(path: "runtime-before-link")
+        try FileManager.default.moveItem(at: runtime, to: movedRuntime)
+        try FileManager.default.createSymbolicLink(at: runtime, withDestinationURL: movedRuntime)
+
+        #expect(throws: LumeInvocationError.bundleChanged) {
+            try LumeBackend.relocateForLaunch(verified, in: storage)
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await backend.probe() }
+        #expect(await runner.invocations.isEmpty, "an ancestor swap is rejected before launch")
+    }
+
+    @Test func launchRevalidationRejectsAReplacementAtTheSamePath() async throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: storage)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        let verified = try VerifiedLumeBundle(
+            bundle: LumeBundle(url: bundleURL),
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
+
+        try FileManager.default.removeItem(at: bundleURL)
+        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
+        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != verified.fileIdentity)
+        #expect(throws: LumeInvocationError.bundleChanged) {
+            try LumeBackend.relocateForLaunch(verified, in: storage)
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await backend.probe() }
+        #expect(await runner.invocations.isEmpty, "a replaced bundle is rejected before launch")
+    }
+
+    @Test func invocationErrorsAreActionable() {
+        let failures: [LumeInvocationError] = [
+            .storageMismatch,
+            .bundleChanged,
+            .failed(status: 1),
+            .timedOut,
+            .outputTruncated,
+            .unparseableOutput,
+            .versionMismatch(found: SemanticVersion([0, 5, 4]), required: LumePin.version),
+        ]
+        for failure in failures {
+            #expect(failure.errorDescription == failure.userMessage)
+            #expect(failure.localizedDescription == failure.userMessage)
+            #expect(failure.recoveryActions == [.repair(.runtime), .cancel])
+        }
+    }
+
+    @Test func processFailuresDoNotBecomeProbeResults() async throws {
+        let canceledRunner = ScriptedLumeRunner(Self.successfulReplies)
+        let (canceledBackend, _, _) = try backend(runner: canceledRunner)
+        let canceledTask = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await canceledBackend.probe()
+        }
+        await #expect(throws: CancellationError.self) { try await canceledTask.value }
+        #expect(await canceledRunner.invocations.isEmpty, "a canceled probe launches nothing")
+
+        let changedRunner = ScriptedLumeRunner(Self.successfulReplies)
+        let (changedBackend, _, _) = try backend(runner: changedRunner) {
+            throw LumeVerificationError.executableDigestMismatch
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await changedBackend.probe() }
+        #expect(await changedRunner.invocations.isEmpty, "changed code is rejected before launch")
+
+        let launchFailingRunner = LaunchFailingLumeRunner()
+        let verificationCount = Mutex(0)
+        let (launchFailingBackend, _, _) = try backend(runner: launchFailingRunner) {
+            try verificationCount.withLock {
+                $0 += 1
+                if $0 == 2 { throw LumeVerificationError.executableDigestMismatch }
+            }
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await launchFailingBackend.probe() }
+        #expect(await launchFailingRunner.invocations.count == 1)
+        #expect(verificationCount.withLock { $0 } == 2, "launch errors get a fresh verification")
+
+        let badVersion = ScriptedLumeRunner(["--version": .init(stdout: ["lume 0.5.3"])])
+        let (badVersionBackend, _, _) = try backend(runner: badVersion)
+        await #expect(throws: LumeInvocationError.unparseableOutput) { try await badVersionBackend.probe() }
+
+        let unexpectedVersion = ScriptedLumeRunner(["--version": .init(stdout: ["0.5.4"])])
+        let (unexpectedVersionBackend, _, _) = try backend(runner: unexpectedVersion)
+        await #expect(throws: LumeInvocationError.versionMismatch(found: SemanticVersion([0, 5, 4]), required: LumePin.version)) {
+            try await unexpectedVersionBackend.probe()
+        }
+        #expect(await unexpectedVersion.invocations.count == 1, "a mismatched executable is not interrogated further")
+
+        let nonzero = ScriptedLumeRunner(["--version": .init(stdout: [], stderr: ["opaque failure"], status: 17)])
+        let (nonzeroBackend, _, _) = try backend(runner: nonzero)
+        await #expect(throws: LumeInvocationError.failed(status: 17)) { try await nonzeroBackend.probe() }
+
+        let truncated = ScriptedLumeRunner(["--version": .init(stdout: ["0.5.3"], outputTruncated: true)])
+        let (truncatedBackend, _, _) = try backend(runner: truncated)
+        await #expect(throws: LumeInvocationError.outputTruncated) { try await truncatedBackend.probe() }
+
+        let (timedOutBackend, _, _) = try backend(runner: TimedOutLumeRunner())
+        await #expect(throws: LumeInvocationError.timedOut) { try await timedOutBackend.probe() }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
@@ -241,7 +241,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: storage)
         let verified = try verifiedFixture(at: bundleURL)
-        let originalIdentity = verified.verifiedFileIdentity.bundle
+        let originalIdentity = verified.verifiedFileIdentity.bundle.coordination
         try FileManager.default.removeItem(at: bundleURL)
         try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
         #expect(RuntimeStorage.fileIdentity(of: bundleURL) != originalIdentity)
@@ -293,6 +293,27 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         #expect(await runner.invocations.isEmpty, "an inner executable swap is rejected before launch")
     }
 
+    @Test func launchRevalidationRejectsAnInPlaceExecutableWrite() async throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: storage)
+        let verified = try verifiedFixture(at: bundleURL)
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
+        let executableIdentity = RuntimeStorage.fileIdentity(of: verified.executable)
+
+        let handle = try FileHandle(forWritingTo: verified.executable)
+        try handle.write(contentsOf: Data([0]))
+        try handle.close()
+
+        #expect(RuntimeStorage.fileIdentity(of: verified.executable) == executableIdentity)
+        #expect(!verified.matchesVerifiedFiles(in: LumeBundle(url: bundleURL)))
+        #expect(throws: LumeInvocationError.bundleChanged) {
+            try LumeBackend.relocateForLaunch(verified, in: storage)
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await backend.probe() }
+        #expect(await runner.invocations.isEmpty, "an in-place write is rejected before launch")
+    }
+
     @Test func launchRevalidationRejectsAReplacementAtTheSamePath() async throws {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: storage)
@@ -302,7 +323,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
 
         try FileManager.default.removeItem(at: bundleURL)
         try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != verified.verifiedFileIdentity.bundle)
+        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != verified.verifiedFileIdentity.bundle.coordination)
         #expect(throws: LumeInvocationError.bundleChanged) {
             try LumeBackend.relocateForLaunch(verified, in: storage)
         }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
@@ -152,7 +152,8 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
             ["run", "--detach", "--help"],
             ["attach", "--help"],
         ])
-        #expect(invocations.allSatisfy { $0.environment == storage.environmentForLume() })
+        let expectedEnvironment = try storage.environmentForLume()
+        #expect(invocations.allSatisfy { $0.environment == expectedEnvironment })
         #expect(invocations.allSatisfy { $0.currentDirectory == storage.url(for: .staging) && $0.standardInput == .none })
         #expect(invocations.allSatisfy { $0.maximumOutputBytes == 1 << 20 })
         #expect(invocations.allSatisfy { $0.timeout == .seconds(5) })

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
@@ -78,6 +78,22 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
 @Suite(.serialized) struct LumeBackendTests {
     let root = FileManager.default.temporaryDirectory.appending(path: "LumeBackendTests-\(UUID().uuidString)")
 
+    private func verifiedFixture(at url: URL) throws -> VerifiedLumeBundle {
+        let bundle = LumeBundle(url: url)
+        try FileManager.default.createDirectory(
+            at: bundle.executable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Data("fixture metadata".utf8).write(to: url.appending(path: "Contents/Info.plist"))
+        try Data("fixture executable".utf8).write(to: bundle.executable)
+        return try VerifiedLumeBundle(
+            bundle: bundle,
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+    }
+
     private func backend(
         runner: any ProcessRunning,
         suffix: String = UUID().uuidString,
@@ -85,14 +101,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         verifyBeforeLaunch: @escaping @Sendable () throws -> Void = {}
     ) throws -> (LumeBackend, RuntimeStorage, VerifiedLumeBundle) {
         let storage = try RuntimeStorage(root: root.appending(path: suffix))
-        let bundle = LumeBundle(url: storage.url(for: .runtime).appending(path: "fixture/lume.app"))
-        try FileManager.default.createDirectory(at: bundle.url, withIntermediateDirectories: true)
-        let verified = try VerifiedLumeBundle(
-            bundle: bundle,
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
+        let verified = try verifiedFixture(at: storage.url(for: .runtime).appending(path: "fixture/lume.app"))
         return (
             LumeBackend(
                 bundle: verified,
@@ -100,7 +109,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
                 runner: runner,
                 verifyBeforeLaunch: {
                     try verifyBeforeLaunch()
-                    return resolvedExecutable ?? bundle.executable
+                    return resolvedExecutable ?? verified.executable
                 }
             ),
             storage,
@@ -205,13 +214,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         let firstStorage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let secondStorage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: firstStorage)
-        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        let verified = try VerifiedLumeBundle(
-            bundle: LumeBundle(url: bundleURL),
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
+        let verified = try verifiedFixture(at: bundleURL)
 
         #expect(throws: LumeInvocationError.storageMismatch) {
             _ = try LumeBackend(bundle: verified, storage: secondStorage, runner: ScriptedLumeRunner(Self.successfulReplies))
@@ -227,12 +230,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         let aliasedURL = alias
             .appending(path: LumePin.releaseTag)
             .appending(path: LumePin.bundleName)
-        let verified = try VerifiedLumeBundle(
-            bundle: LumeBundle(url: aliasedURL),
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
+        let verified = try verifiedFixture(at: aliasedURL)
 
         #expect(throws: LumeInvocationError.storageMismatch) {
             _ = try LumeBackend(bundle: verified, storage: storage, runner: ScriptedLumeRunner(Self.successfulReplies))
@@ -242,14 +240,8 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
     @Test func publicBackendReportsAChangedBundleAtTheExpectedPath() throws {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: storage)
-        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        let verified = try VerifiedLumeBundle(
-            bundle: LumeBundle(url: bundleURL),
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
-        let originalIdentity = verified.fileIdentity
+        let verified = try verifiedFixture(at: bundleURL)
+        let originalIdentity = verified.verifiedFileIdentity.bundle
         try FileManager.default.removeItem(at: bundleURL)
         try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
         #expect(RuntimeStorage.fileIdentity(of: bundleURL) != originalIdentity)
@@ -262,13 +254,7 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
     @Test func launchRevalidationRejectsAReplacedManagedAncestor() async throws {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: storage)
-        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        let verified = try VerifiedLumeBundle(
-            bundle: LumeBundle(url: bundleURL),
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
+        let verified = try verifiedFixture(at: bundleURL)
         let runner = ScriptedLumeRunner(Self.successfulReplies)
         let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
 
@@ -286,22 +272,37 @@ private actor LaunchFailingLumeRunner: ProcessRunning {
         #expect(await runner.invocations.isEmpty, "an ancestor swap is rejected before launch")
     }
 
+    @Test func launchRevalidationRejectsAReplacedExecutableInsideTheSameBundle() async throws {
+        let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
+        let bundleURL = LumeBundle.expectedLocation(in: storage)
+        let verified = try verifiedFixture(at: bundleURL)
+        let runner = ScriptedLumeRunner(Self.successfulReplies)
+        let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
+        let outerIdentity = RuntimeStorage.fileIdentity(of: bundleURL)
+
+        let preservedExecutable = storage.url(for: .staging).appending(path: "lume-before-replacement")
+        try FileManager.default.moveItem(at: verified.executable, to: preservedExecutable)
+        try Data("replacement".utf8).write(to: verified.executable)
+
+        #expect(RuntimeStorage.fileIdentity(of: bundleURL) == outerIdentity)
+        #expect(!verified.matchesVerifiedFiles(in: LumeBundle(url: bundleURL)))
+        #expect(throws: LumeInvocationError.bundleChanged) {
+            try LumeBackend.relocateForLaunch(verified, in: storage)
+        }
+        await #expect(throws: LumeInvocationError.bundleChanged) { try await backend.probe() }
+        #expect(await runner.invocations.isEmpty, "an inner executable swap is rejected before launch")
+    }
+
     @Test func launchRevalidationRejectsAReplacementAtTheSamePath() async throws {
         let storage = try RuntimeStorage(root: root.appending(path: UUID().uuidString))
         let bundleURL = LumeBundle.expectedLocation(in: storage)
-        try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        let verified = try VerifiedLumeBundle(
-            bundle: LumeBundle(url: bundleURL),
-            version: LumePin.version,
-            teamIdentifier: LumePin.teamIdentifier,
-            signingIdentifier: LumePin.bundleIdentifier
-        )
+        let verified = try verifiedFixture(at: bundleURL)
         let runner = ScriptedLumeRunner(Self.successfulReplies)
         let backend = try LumeBackend(bundle: verified, storage: storage, runner: runner)
 
         try FileManager.default.removeItem(at: bundleURL)
         try FileManager.default.createDirectory(at: bundleURL, withIntermediateDirectories: true)
-        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != verified.fileIdentity)
+        #expect(RuntimeStorage.fileIdentity(of: bundleURL) != verified.verifiedFileIdentity.bundle)
         #expect(throws: LumeInvocationError.bundleChanged) {
             try LumeBackend.relocateForLaunch(verified, in: storage)
         }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBackendTests.swift
@@ -61,6 +61,7 @@ private actor TimedOutLumeRunner: ProcessRunning {
         }
         run.retainWhileRunning()
         try process.run()
+        run.recordChildIdentity()
         run.timeOut(gracePeriod: .milliseconds(10))
         return run
     }


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Deferred Lume candidate work (#82). Preserve verifier, ownership, storage and probe regressions. Resume only on current shared dependencies; strict artifact verification, real cleanup/restart proof, human preflight and provider selection remain outstanding. No provider or hardware readiness is claimed.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Stack

Stacked on #87 → #86 → #83 → #88 → #70. Review commits `b89c04a` and `6a42f69` and this PR delta. Part of #82.

## What this adds

- A narrow `LumeBackend.probe()` that accepts only a verified Lume type-state token bound to the selected private storage and the complete critical-file identity from #86.
- Four fixed, non-VM-mutating invocations: `--version`, `create --help`, `run --detach --help`, and `attach --help`.
- A fully explicit private environment with telemetry and update checks disabled; no inherited `HOME` or `PATH`.
- Five-second timeouts, bounded/redacted output, cancellation, and the #87 coordinator around the complete probe.
- Fresh managed-path discovery and full static verification immediately before every launch.
- Rejection when only the inner executable is replaced even though the outer app inode is unchanged; the runner is never called in that regression.
- Actionable repair/cancel errors and capability reporting pinned to Lume 0.5.3.

`lume ls` is deliberately absent because pinned source shows that listing can remove stale provisioning markers and VNC-session files. No create, run, attach, inventory, installer, SSH, or generic command surface is exposed.

The final path-based verification-to-spawn interval remains inside the documented same-user-process exclusion. Guesthouse-managed replacement must hold #87; this PR does not claim a held-inode launch primitive that macOS does not provide.

## Known provider-preflight blocker

The official 0.5.3 artifact cannot reach this probe because it fails the strict verifier in #83. The fake-runner suite validates the adapter and failure behavior; this PR does not claim the real binary was successfully probed.

## Validation

The composed stack passes `LumeBackendTests` 12/12, 286 Core tests, 80 RuntimeKit tests, 14 app tests, and the shared macOS Xcode scheme. Xcode Cloud independently validates this exact intermediate head.