### PR TITLE
Spike: harden the pinned Lume verifier

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
@@ -52,14 +52,15 @@ public enum LumeVerificationError: Error, Hashable, Sendable {
 
 extension LumeVerificationError: LocalizedError {}
 
-/// Files whose identity must stay coherent across static verification. The outer app inode alone
-/// is insufficient because a replacement below `Contents` does not change it.
+/// Files whose identity and change state must stay coherent across static verification. The
+/// outer app inode alone is insufficient because replacement or an in-place write below
+/// `Contents` does not change it.
 struct LumeBundleFileIdentity: Hashable, Sendable {
-    let bundle: RuntimeStorage.CoordinationIdentity
-    let contents: RuntimeStorage.CoordinationIdentity
-    let executables: RuntimeStorage.CoordinationIdentity
-    let infoPlist: RuntimeStorage.CoordinationIdentity
-    let executable: RuntimeStorage.CoordinationIdentity
+    let bundle: RuntimeStorage.VerificationIdentity
+    let contents: RuntimeStorage.VerificationIdentity
+    let executables: RuntimeStorage.VerificationIdentity
+    let infoPlist: RuntimeStorage.VerificationIdentity
+    let executable: RuntimeStorage.VerificationIdentity
 }
 
 /// Snapshot returned after pinned static verification. This is deliberately not durable launch
@@ -134,11 +135,11 @@ public struct LumeBundle: Hashable, Sendable {
               Self.isUnlinkedItem(executables, kind: S_IFDIR),
               Self.isUnlinkedItem(infoPlist, kind: S_IFREG),
               Self.isUnlinkedItem(executable, kind: S_IFREG),
-              let bundleIdentity = RuntimeStorage.fileIdentity(of: url),
-              let contentsIdentity = RuntimeStorage.fileIdentity(of: contents),
-              let executablesIdentity = RuntimeStorage.fileIdentity(of: executables),
-              let infoPlistIdentity = RuntimeStorage.fileIdentity(of: infoPlist),
-              let executableIdentity = RuntimeStorage.fileIdentity(of: executable)
+              let bundleIdentity = RuntimeStorage.verificationIdentity(of: url),
+              let contentsIdentity = RuntimeStorage.verificationIdentity(of: contents),
+              let executablesIdentity = RuntimeStorage.verificationIdentity(of: executables),
+              let infoPlistIdentity = RuntimeStorage.verificationIdentity(of: infoPlist),
+              let executableIdentity = RuntimeStorage.verificationIdentity(of: executable)
         else { return nil }
         return LumeBundleFileIdentity(
             bundle: bundleIdentity,

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
@@ -52,16 +52,30 @@ public enum LumeVerificationError: Error, Hashable, Sendable {
 
 extension LumeVerificationError: LocalizedError {}
 
+/// Files whose identity must stay coherent across static verification. The outer app inode alone
+/// is insufficient because a replacement below `Contents` does not change it.
+struct LumeBundleFileIdentity: Hashable, Sendable {
+    let bundle: RuntimeStorage.CoordinationIdentity
+    let contents: RuntimeStorage.CoordinationIdentity
+    let executables: RuntimeStorage.CoordinationIdentity
+    let infoPlist: RuntimeStorage.CoordinationIdentity
+    let executable: RuntimeStorage.CoordinationIdentity
+}
+
 /// Snapshot returned after pinned static verification. This is deliberately not durable launch
 /// authorization: RuntimeKit must coordinate runtime replacement and reverify at the launch
 /// boundary. The executable URL stays internal so clients cannot treat this token as permission
 /// to launch it themselves.
 public struct VerifiedLumeBundle: Hashable, Sendable {
     let bundle: LumeBundle
-    let fileIdentity: RuntimeStorage.CoordinationIdentity
+    let verifiedFileIdentity: LumeBundleFileIdentity
     public let version: SemanticVersion
     public let teamIdentifier: String
     public let signingIdentifier: String
+
+    func matchesVerifiedFiles(in candidate: LumeBundle) -> Bool {
+        candidate.fileIdentity == verifiedFileIdentity
+    }
 
     init(
         bundle: LumeBundle,
@@ -69,12 +83,12 @@ public struct VerifiedLumeBundle: Hashable, Sendable {
         teamIdentifier: String,
         signingIdentifier: String
     ) throws(LumeVerificationError) {
-        guard let fileIdentity = RuntimeStorage.fileIdentity(of: bundle.url) else {
+        guard let verifiedFileIdentity = bundle.fileIdentity else {
             throw .insecureBundleLayout
         }
         self.init(
             bundle: bundle,
-            fileIdentity: fileIdentity,
+            verifiedFileIdentity: verifiedFileIdentity,
             version: version,
             teamIdentifier: teamIdentifier,
             signingIdentifier: signingIdentifier
@@ -83,13 +97,13 @@ public struct VerifiedLumeBundle: Hashable, Sendable {
 
     fileprivate init(
         bundle: LumeBundle,
-        fileIdentity: RuntimeStorage.CoordinationIdentity,
+        verifiedFileIdentity: LumeBundleFileIdentity,
         version: SemanticVersion,
         teamIdentifier: String,
         signingIdentifier: String
     ) {
         self.bundle = bundle
-        self.fileIdentity = fileIdentity
+        self.verifiedFileIdentity = verifiedFileIdentity
         self.version = version
         self.teamIdentifier = teamIdentifier
         self.signingIdentifier = signingIdentifier
@@ -107,8 +121,33 @@ public struct LumeBundle: Hashable, Sendable {
         self.url = url
     }
 
-    var executable: URL { url.appending(path: "Contents/MacOS/\(LumePin.executableName)") }
-    private var infoPlist: URL { url.appending(path: "Contents/Info.plist") }
+    private var contents: URL { url.appending(path: "Contents") }
+    private var executables: URL { contents.appending(path: "MacOS") }
+    var executable: URL { executables.appending(path: LumePin.executableName) }
+    private var infoPlist: URL { contents.appending(path: "Info.plist") }
+
+    /// Captures the critical metadata and launch path only when every item has its expected type
+    /// and none is a symbolic link. Full signature validation still runs before every launch.
+    var fileIdentity: LumeBundleFileIdentity? {
+        guard Self.isUnlinkedItem(url, kind: S_IFDIR),
+              Self.isUnlinkedItem(contents, kind: S_IFDIR),
+              Self.isUnlinkedItem(executables, kind: S_IFDIR),
+              Self.isUnlinkedItem(infoPlist, kind: S_IFREG),
+              Self.isUnlinkedItem(executable, kind: S_IFREG),
+              let bundleIdentity = RuntimeStorage.fileIdentity(of: url),
+              let contentsIdentity = RuntimeStorage.fileIdentity(of: contents),
+              let executablesIdentity = RuntimeStorage.fileIdentity(of: executables),
+              let infoPlistIdentity = RuntimeStorage.fileIdentity(of: infoPlist),
+              let executableIdentity = RuntimeStorage.fileIdentity(of: executable)
+        else { return nil }
+        return LumeBundleFileIdentity(
+            bundle: bundleIdentity,
+            contents: contentsIdentity,
+            executables: executablesIdentity,
+            infoPlist: infoPlistIdentity,
+            executable: executableIdentity
+        )
+    }
 
     static func expectedLocation(in storage: RuntimeStorage) -> URL {
         storage.url(for: .runtime).appending(path: LumePin.releaseTag).appending(path: LumePin.bundleName)
@@ -133,15 +172,7 @@ public struct LumeBundle: Hashable, Sendable {
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
             throw .bundleMissing(path: url.path)
         }
-        guard let bundleIdentity = RuntimeStorage.fileIdentity(of: url) else {
-            throw .insecureBundleLayout
-        }
-        guard Self.isUnlinkedItem(url, kind: S_IFDIR),
-              Self.isUnlinkedItem(url.appending(path: "Contents"), kind: S_IFDIR),
-              Self.isUnlinkedItem(url.appending(path: "Contents/MacOS"), kind: S_IFDIR),
-              Self.isUnlinkedItem(infoPlist, kind: S_IFREG),
-              Self.isUnlinkedItem(executable, kind: S_IFREG)
-        else { throw .insecureBundleLayout }
+        guard let verifiedFileIdentity = fileIdentity else { throw .insecureBundleLayout }
         guard let values = infoDictionary else { throw .infoPlistUnreadable }
         let identifier = values["CFBundleIdentifier"] as? String ?? ""
         guard identifier == LumePin.bundleIdentifier else {
@@ -197,12 +228,14 @@ public struct LumeBundle: Hashable, Sendable {
         guard signingIdentifier == LumePin.bundleIdentifier else {
             throw .signingIdentifierMismatch(found: SanitizedText(signingIdentifier, limit: 80))
         }
-        guard RuntimeStorage.fileIdentity(of: url) == bundleIdentity else {
+        // The Security and digest calls above inspect several paths. Reject a mixed snapshot if
+        // any critical directory, metadata file, or executable was replaced while they ran.
+        guard fileIdentity == verifiedFileIdentity else {
             throw .insecureBundleLayout
         }
         return VerifiedLumeBundle(
             bundle: self,
-            fileIdentity: bundleIdentity,
+            verifiedFileIdentity: verifiedFileIdentity,
             version: version,
             teamIdentifier: teamIdentifier,
             signingIdentifier: signingIdentifier

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeBundle.swift
@@ -58,12 +58,38 @@ extension LumeVerificationError: LocalizedError {}
 /// to launch it themselves.
 public struct VerifiedLumeBundle: Hashable, Sendable {
     let bundle: LumeBundle
+    let fileIdentity: RuntimeStorage.CoordinationIdentity
     public let version: SemanticVersion
     public let teamIdentifier: String
     public let signingIdentifier: String
 
-    init(bundle: LumeBundle, version: SemanticVersion, teamIdentifier: String, signingIdentifier: String) {
+    init(
+        bundle: LumeBundle,
+        version: SemanticVersion,
+        teamIdentifier: String,
+        signingIdentifier: String
+    ) throws(LumeVerificationError) {
+        guard let fileIdentity = RuntimeStorage.fileIdentity(of: bundle.url) else {
+            throw .insecureBundleLayout
+        }
+        self.init(
+            bundle: bundle,
+            fileIdentity: fileIdentity,
+            version: version,
+            teamIdentifier: teamIdentifier,
+            signingIdentifier: signingIdentifier
+        )
+    }
+
+    fileprivate init(
+        bundle: LumeBundle,
+        fileIdentity: RuntimeStorage.CoordinationIdentity,
+        version: SemanticVersion,
+        teamIdentifier: String,
+        signingIdentifier: String
+    ) {
         self.bundle = bundle
+        self.fileIdentity = fileIdentity
         self.version = version
         self.teamIdentifier = teamIdentifier
         self.signingIdentifier = signingIdentifier
@@ -107,6 +133,9 @@ public struct LumeBundle: Hashable, Sendable {
         guard FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory), isDirectory.boolValue else {
             throw .bundleMissing(path: url.path)
         }
+        guard let bundleIdentity = RuntimeStorage.fileIdentity(of: url) else {
+            throw .insecureBundleLayout
+        }
         guard Self.isUnlinkedItem(url, kind: S_IFDIR),
               Self.isUnlinkedItem(url.appending(path: "Contents"), kind: S_IFDIR),
               Self.isUnlinkedItem(url.appending(path: "Contents/MacOS"), kind: S_IFDIR),
@@ -131,7 +160,11 @@ public struct LumeBundle: Hashable, Sendable {
         var staticCode: SecStaticCode?
         let created = SecStaticCodeCreateWithPath(url as CFURL, [], &staticCode)
         guard created == errSecSuccess, let code = staticCode else { throw .signatureInvalid(status: created) }
-        let flags = SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate)
+        // Validate signed helpers/frameworks as well as the outer app. The current pin has no
+        // nested executable, but a future corrected build must not silently weaken this gate.
+        let flags = SecCSFlags(
+            rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate | kSecCSCheckNestedCode
+        )
         let validity = SecStaticCodeCheckValidityWithErrors(code, flags, nil, nil)
         guard validity == errSecSuccess else { throw .signatureInvalid(status: validity) }
 
@@ -164,15 +197,27 @@ public struct LumeBundle: Hashable, Sendable {
         guard signingIdentifier == LumePin.bundleIdentifier else {
             throw .signingIdentifierMismatch(found: SanitizedText(signingIdentifier, limit: 80))
         }
+        guard RuntimeStorage.fileIdentity(of: url) == bundleIdentity else {
+            throw .insecureBundleLayout
+        }
         return VerifiedLumeBundle(
             bundle: self,
+            fileIdentity: bundleIdentity,
             version: version,
             teamIdentifier: teamIdentifier,
             signingIdentifier: signingIdentifier
         )
     }
 
-    public static func verifyArchiveDigest(of file: URL, expected: String = LumePin.archiveSHA256) throws(LumeVerificationError) {
+    /// Verifies exactly the archive digest pinned by this RuntimeKit build. Production callers
+    /// cannot substitute another digest and accidentally turn the pin into caller-controlled data.
+    public static func verifyArchiveDigest(of file: URL) throws(LumeVerificationError) {
+        try verifyArchiveDigest(of: file, expected: LumePin.archiveSHA256)
+    }
+
+    /// Internal override used by tests that exercise the streaming digest implementation without
+    /// manufacturing a file whose contents match the release pin.
+    static func verifyArchiveDigest(of file: URL, expected: String) throws(LumeVerificationError) {
         let digest = try sha256(of: file, unreadable: .archiveUnreadable)
         guard digest == expected.lowercased() else { throw .digestMismatch }
     }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -105,10 +105,36 @@ public struct RuntimeStorage: Sendable {
         let inode: ino_t
     }
 
+    /// A point-in-time filesystem identity for verified runtime files. Device and inode detect
+    /// replacement; size plus nanosecond modification/status-change times also detect an
+    /// unprivileged in-place write that keeps the same inode. This is a coherence signal, not a
+    /// substitute for the full signature and digest verification performed at each launch.
+    struct VerificationIdentity: Hashable, Sendable {
+        let coordination: CoordinationIdentity
+        let byteCount: off_t
+        let modificationSeconds: Int64
+        let modificationNanoseconds: Int64
+        let statusChangeSeconds: Int64
+        let statusChangeNanoseconds: Int64
+    }
+
     static func fileIdentity(of url: URL) -> CoordinationIdentity? {
         var info = stat()
         guard lstat(url.path, &info) == 0 else { return nil }
         return CoordinationIdentity(device: info.st_dev, inode: info.st_ino)
+    }
+
+    static func verificationIdentity(of url: URL) -> VerificationIdentity? {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else { return nil }
+        return VerificationIdentity(
+            coordination: CoordinationIdentity(device: info.st_dev, inode: info.st_ino),
+            byteCount: info.st_size,
+            modificationSeconds: Int64(info.st_mtimespec.tv_sec),
+            modificationNanoseconds: Int64(info.st_mtimespec.tv_nsec),
+            statusChangeSeconds: Int64(info.st_ctimespec.tv_sec),
+            statusChangeNanoseconds: Int64(info.st_ctimespec.tv_nsec)
+        )
     }
 
     // MARK: - Verification

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -86,8 +86,9 @@ public struct RuntimeStorage: Sendable {
         ["TART_HOME": tartHome.path]
     }
 
-    /// Lume's VM and configuration locations are both explicit. Telemetry and update checks
-    /// stay off during the spike, and no host `HOME` or `PATH` is inherited.
+    /// Lume's configuration and temporary locations are explicit. Telemetry and update checks
+    /// stay off during the spike, and no host `HOME` or `PATH` is inherited. VM lifecycle commands
+    /// must separately pass `--storage` with `url(for: .vms)`; Lume has no VM-store environment key.
     public func environmentForLume() -> [String: String] {
         [
             "LUME_TELEMETRY_ENABLED": "false",
@@ -95,6 +96,19 @@ public struct RuntimeStorage: Sendable {
             "TMPDIR": url(for: .staging).path,
             "XDG_CONFIG_HOME": url(for: .lumeConfiguration).path,
         ]
+    }
+
+    /// Physical identity captured by verification and reused by runtime coordination. Paths alone
+    /// are insufficient on macOS because distinct spellings can reach the same filesystem item.
+    struct CoordinationIdentity: Hashable, Sendable {
+        let device: dev_t
+        let inode: ino_t
+    }
+
+    static func fileIdentity(of url: URL) -> CoordinationIdentity? {
+        var info = stat()
+        guard lstat(url.path, &info) == 0 else { return nil }
+        return CoordinationIdentity(device: info.st_dev, inode: info.st_ino)
     }
 
     // MARK: - Verification

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
@@ -176,7 +176,40 @@ private struct DummyLumeBundle {
         try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/echo"), to: bundle.executable)
 
         #expect(!verified.matchesVerifiedFiles(in: bundle))
-        #expect(RuntimeStorage.fileIdentity(of: fixture.url) == verified.verifiedFileIdentity.bundle)
+        #expect(RuntimeStorage.fileIdentity(of: fixture.url) == verified.verifiedFileIdentity.bundle.coordination)
+    }
+
+    @Test func verifiedTokenRejectsInPlaceWritesThatKeepTheSameInode() async throws {
+        let executableFixture = try await DummyLumeBundle(root: root.appending(path: "in-place-executable"))
+        let executableBundle = LumeBundle(url: executableFixture.url)
+        let executableToken = try VerifiedLumeBundle(
+            bundle: executableBundle,
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        let executableIdentity = RuntimeStorage.fileIdentity(of: executableBundle.executable)
+        let executableHandle = try FileHandle(forWritingTo: executableBundle.executable)
+        try executableHandle.write(contentsOf: Data([0]))
+        try executableHandle.close()
+        #expect(RuntimeStorage.fileIdentity(of: executableBundle.executable) == executableIdentity)
+        #expect(!executableToken.matchesVerifiedFiles(in: executableBundle))
+
+        let plistFixture = try await DummyLumeBundle(root: root.appending(path: "in-place-plist"))
+        let plistBundle = LumeBundle(url: plistFixture.url)
+        let plistToken = try VerifiedLumeBundle(
+            bundle: plistBundle,
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        let plistURL = plistFixture.url.appending(path: "Contents/Info.plist")
+        let plistIdentity = RuntimeStorage.fileIdentity(of: plistURL)
+        let plistHandle = try FileHandle(forWritingTo: plistURL)
+        try plistHandle.write(contentsOf: Data([0]))
+        try plistHandle.close()
+        #expect(RuntimeStorage.fileIdentity(of: plistURL) == plistIdentity)
+        #expect(!plistToken.matchesVerifiedFiles(in: plistBundle))
     }
 
     @Test func adHocSignatureCannotSatisfyThePinnedDeveloperIDRequirement() async throws {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
@@ -4,6 +4,17 @@ import Security
 import Testing
 @testable import GuesthouseRuntimeKit
 
+private func signAdHoc(_ bundle: URL, identifier: String) async throws {
+    let run = try await ProcessRunner().run(ProcessInvocation(
+        executable: URL(fileURLWithPath: "/usr/bin/codesign"),
+        arguments: ["--force", "--sign", "-", "--identifier", identifier, bundle.path],
+        timeout: .seconds(30)
+    ))
+    for await _ in run.output {}
+    let exit = await run.exit()
+    precondition(exit.succeeded, "ad-hoc signing failed")
+}
+
 private struct DummyLumeBundle {
     let url: URL
 
@@ -34,14 +45,7 @@ private struct DummyLumeBundle {
             )
         }
         if sign {
-            let run = try await ProcessRunner().run(ProcessInvocation(
-                executable: URL(fileURLWithPath: "/usr/bin/codesign"),
-                arguments: ["--force", "--sign", "-", "--identifier", identifier, url.path],
-                timeout: .seconds(30)
-            ))
-            for await _ in run.output {}
-            let exit = await run.exit()
-            precondition(exit.succeeded, "ad-hoc signing failed")
+            try await signAdHoc(url, identifier: identifier)
         }
     }
 }
@@ -168,6 +172,47 @@ private struct DummyLumeBundle {
         }
     }
 
+    @Test func invalidNestedCodeIsRejectedBeforeThePinnedRequirement() async throws {
+        let outer = try await DummyLumeBundle(root: root.appending(path: "invalid-nested-code"))
+        let helper = outer.url.appending(path: "Contents/Helpers/Helper.app")
+        let helperContents = helper.appending(path: "Contents")
+        let helperExecutable = helperContents.appending(path: "MacOS/Helper")
+        let sealedResource = helperContents.appending(path: "Resources/value.txt")
+        try FileManager.default.createDirectory(
+            at: helperExecutable.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.createDirectory(
+            at: sealedResource.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/echo"), to: helperExecutable)
+        try Data("before".utf8).write(to: sealedResource)
+        try PropertyListSerialization.data(fromPropertyList: [
+            "CFBundleIdentifier": "com.guesthouse.fixture.helper",
+            "CFBundleExecutable": "Helper",
+            "CFBundlePackageType": "APPL",
+        ], format: .xml, options: 0).write(to: helperContents.appending(path: "Info.plist"))
+        try await signAdHoc(helper, identifier: "com.guesthouse.fixture.helper")
+        try await signAdHoc(outer.url, identifier: LumePin.bundleIdentifier)
+        try Data("after-tampering".utf8).write(to: sealedResource)
+
+        var staticCode: SecStaticCode?
+        #expect(SecStaticCodeCreateWithPath(outer.url as CFURL, [], &staticCode) == errSecSuccess)
+        let code = try #require(staticCode)
+        let shallowFlags = SecCSFlags(rawValue: kSecCSCheckAllArchitectures | kSecCSStrictValidate)
+        #expect(SecStaticCodeCheckValidityWithErrors(code, shallowFlags, nil, nil) == errSecSuccess)
+
+        do {
+            _ = try LumeBundle(url: outer.url).verify()
+            Issue.record("tampered nested code must not verify")
+        } catch LumeVerificationError.signatureInvalid(let status) {
+            #expect(status != errSecSuccess)
+        } catch {
+            Issue.record("nested-code validation failed at the wrong gate: \(error)")
+        }
+    }
+
     @Test func archiveDigestIsStreamedAndCompared() throws {
         let archive = root.appending(path: "archive.bin")
         try Data("hello".utf8).write(to: archive)
@@ -177,6 +222,9 @@ private struct DummyLumeBundle {
         )
         #expect(throws: LumeVerificationError.digestMismatch) {
             try LumeBundle.verifyArchiveDigest(of: archive, expected: String(repeating: "0", count: 64))
+        }
+        #expect(throws: LumeVerificationError.digestMismatch) {
+            try LumeBundle.verifyArchiveDigest(of: archive)
         }
         #expect(throws: LumeVerificationError.archiveUnreadable) {
             try LumeBundle.verifyArchiveDigest(of: root.appending(path: "missing.bin"))

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeBundleTests.swift
@@ -160,6 +160,25 @@ private struct DummyLumeBundle {
         }
     }
 
+    @Test func verifiedTokenTracksTheCriticalMetadataAndExecutableFiles() async throws {
+        let fixture = try await DummyLumeBundle(root: root.appending(path: "identity-snapshot"))
+        let bundle = LumeBundle(url: fixture.url)
+        let verified = try VerifiedLumeBundle(
+            bundle: bundle,
+            version: LumePin.version,
+            teamIdentifier: LumePin.teamIdentifier,
+            signingIdentifier: LumePin.bundleIdentifier
+        )
+        #expect(verified.matchesVerifiedFiles(in: bundle))
+
+        let originalExecutable = fixture.url.appending(path: "Contents/MacOS/lume-before-replacement")
+        try FileManager.default.moveItem(at: bundle.executable, to: originalExecutable)
+        try FileManager.default.copyItem(at: URL(fileURLWithPath: "/bin/echo"), to: bundle.executable)
+
+        #expect(!verified.matchesVerifiedFiles(in: bundle))
+        #expect(RuntimeStorage.fileIdentity(of: fixture.url) == verified.verifiedFileIdentity.bundle)
+    }
+
     @Test func adHocSignatureCannotSatisfyThePinnedDeveloperIDRequirement() async throws {
         let adHoc = try await DummyLumeBundle(root: root.appending(path: "adhoc"), sign: true)
         do {


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Deferred Lume candidate work (#82). Preserve verifier, ownership, storage and probe regressions. Resume only on current shared dependencies; strict artifact verification, real cleanup/restart proof, human preflight and provider selection remain outstanding. No provider or hardware readiness is claimed.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Stack

Stacked on #83 → #88 → #70. Review commits `83a53a9` and `409c82a` and this PR delta. This is a verifier-safety prerequisite for #87 and #84. Refs #82.

## What this hardens

- Makes the public archive verifier accept only the SHA-256 pinned by this RuntimeKit build; the custom digest seam is internal and test-only.
- Recursively validates nested signed code as well as the outer app, with a behavioral fixture proving that a shallow check misses a tampered signed helper.
- Captures one coherent identity for the app directory, Contents, Contents/MacOS, Info.plist, and executable before static checks, then requires the same snapshot afterward.
- Removes the former outer-directory-only compatibility path so downstream launch code must consume the complete identity.
- Corrects the Lume environment contract: config/temp state is pinned by environment, while every future VM lifecycle command must separately pass an explicit `--storage` path.

This addresses the current executable-replacement finding on this PR. It detects mixed snapshots and Guesthouse-managed replacement under the shared coordinator threat model; it does not claim macOS launches through a held executable inode or eliminate mutation by a hostile process already running as the host user.

## Validation

The composed stack passes `LumeBundleTests` 12/12, 286 Core tests, 80 RuntimeKit tests, 14 app tests, and the shared macOS Xcode scheme. Xcode Cloud independently validates this exact intermediate head.

This PR neither installs nor executes Lume and does not claim a Phase-0 hardware result.