### PR TITLE
Spike: serialize access to the private Lume runtime

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeRuntimeCoordinator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeRuntimeCoordinator.swift
@@ -23,11 +23,13 @@ private enum LumeRuntimeLeaseContext {
 /// replaced between verification and launch. Probes and every future install, update, repair,
 /// or removal operation therefore share this coordinator and hold it for their whole operation.
 /// Processes running independently as the signed-in host user are outside Guesthouse's
-/// containment boundary.
+/// containment boundary. These rules implement MVP-PLAN.md §3 ("Sandbox and XPC boundary"
+/// and "Local storage") and §4 ("Runtime delivery and console").
 ///
-/// Operations may use structured child tasks, which inherit the lease context, but must not
-/// await a `Task.detached` that re-enters this coordinator. Detached tasks cannot inherit Swift
-/// task-local ownership, so awaiting such a reacquisition while holding a lease would deadlock.
+/// Operations may use child tasks that inherit the active lease context, but must not await
+/// any task that re-enters this coordinator without that context. This includes `Task.detached`
+/// and an ordinary unstructured `Task` created before the operation acquired its lease. Such a
+/// task queues behind the current owner, so awaiting its reacquisition would deadlock.
 public actor LumeRuntimeCoordinator {
     public static let shared = LumeRuntimeCoordinator()
 
@@ -62,8 +64,8 @@ public actor LumeRuntimeCoordinator {
         }
         guard !hasActiveInheritedLease else {
             // Reject every active nested acquisition, not just same-root recursion: otherwise
-            // concurrent A→B and B→A operations can deadlock. Detached tasks do not inherit this
-            // context and must never be awaited while re-entering the coordinator.
+            // concurrent A→B and B→A operations can deadlock. Tasks without inherited active
+            // lease context must never be awaited while re-entering the coordinator.
             throw LumeRuntimeCoordinationError.nestedAcquisition
         }
         let token = try await acquire(key)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeRuntimeCoordinator.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Lume/LumeRuntimeCoordinator.swift
@@ -1,0 +1,124 @@
+import Foundation
+import GuesthouseCore
+
+public enum LumeRuntimeCoordinationError: Error, Hashable, Sendable, LocalizedError {
+    case nestedAcquisition
+
+    public var userMessage: String {
+        "Guesthouse tried to acquire a Lume runtime lease while the operation already held one."
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.cancel] }
+
+    public var errorDescription: String? { userMessage }
+}
+
+private enum LumeRuntimeLeaseContext {
+    @TaskLocal static var heldLeases: [RuntimeStorage.CoordinationIdentity: UInt64] = [:]
+}
+
+/// Serializes every operation that can launch or replace Guesthouse's private Lume runtime.
+///
+/// Lume writes configuration even for help commands, and a verified app bundle must not be
+/// replaced between verification and launch. Probes and every future install, update, repair,
+/// or removal operation therefore share this coordinator and hold it for their whole operation.
+/// Processes running independently as the signed-in host user are outside Guesthouse's
+/// containment boundary.
+///
+/// Operations may use structured child tasks, which inherit the lease context, but must not
+/// await a `Task.detached` that re-enters this coordinator. Detached tasks cannot inherit Swift
+/// task-local ownership, so awaiting such a reacquisition while holding a lease would deadlock.
+public actor LumeRuntimeCoordinator {
+    public static let shared = LumeRuntimeCoordinator()
+
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<UInt64, any Error>
+    }
+
+    private struct LeaseState {
+        var owner: UInt64
+        var waiters: [Waiter]
+    }
+
+    /// Dictionary presence means the physical root's lease is held. Owner tokens distinguish an
+    /// active inherited task-local lease from stale context in an unstructured child task.
+    private var statesByRoot: [RuntimeStorage.CoordinationIdentity: LeaseState] = [:]
+    private var nextToken: UInt64 = 0
+    private let onWaiterQueued: (@Sendable () -> Void)?
+
+    init(onWaiterQueued: (@Sendable () -> Void)? = nil) {
+        self.onWaiterQueued = onWaiterQueued
+    }
+
+    public func withExclusiveAccess<T: Sendable>(
+        for storage: RuntimeStorage,
+        _ operation: @Sendable () async throws -> T
+    ) async throws -> T {
+        try Task.checkCancellation()
+        let key = try storage.coordinationIdentity()
+        let hasActiveInheritedLease = LumeRuntimeLeaseContext.heldLeases.contains { root, token in
+            statesByRoot[root]?.owner == token
+        }
+        guard !hasActiveInheritedLease else {
+            // Reject every active nested acquisition, not just same-root recursion: otherwise
+            // concurrent A→B and B→A operations can deadlock. Detached tasks do not inherit this
+            // context and must never be awaited while re-entering the coordinator.
+            throw LumeRuntimeCoordinationError.nestedAcquisition
+        }
+        let token = try await acquire(key)
+        defer { release(key, owner: token) }
+        try Task.checkCancellation()
+        var heldLeases = LumeRuntimeLeaseContext.heldLeases
+        heldLeases[key] = token
+        return try await LumeRuntimeLeaseContext.$heldLeases.withValue(heldLeases) {
+            try await operation()
+        }
+    }
+
+    private func acquire(_ key: RuntimeStorage.CoordinationIdentity) async throws -> UInt64 {
+        let token = makeToken()
+        guard statesByRoot[key] != nil else {
+            statesByRoot[key] = LeaseState(owner: token, waiters: [])
+            return token
+        }
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<UInt64, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    statesByRoot[key]?.waiters.append(Waiter(id: token, continuation: continuation))
+                    onWaiterQueued?()
+                }
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id: token, for: key) }
+        }
+    }
+
+    private func makeToken() -> UInt64 {
+        defer { nextToken &+= 1 }
+        return nextToken
+    }
+
+    private func cancelWaiter(id: UInt64, for key: RuntimeStorage.CoordinationIdentity) {
+        guard var state = statesByRoot[key],
+              let index = state.waiters.firstIndex(where: { $0.id == id })
+        else { return }
+        let waiter = state.waiters.remove(at: index)
+        statesByRoot[key] = state
+        waiter.continuation.resume(throwing: CancellationError())
+    }
+
+    private func release(_ key: RuntimeStorage.CoordinationIdentity, owner: UInt64) {
+        guard var state = statesByRoot[key], state.owner == owner else { return }
+        guard !state.waiters.isEmpty else {
+            statesByRoot.removeValue(forKey: key)
+            return
+        }
+        let next = state.waiters.removeFirst()
+        state.owner = next.id
+        statesByRoot[key] = state
+        next.continuation.resume(returning: next.id)
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -98,8 +98,8 @@ public struct RuntimeStorage: Sendable {
         ]
     }
 
-    /// Physical identity captured by verification and reused by runtime coordination. Paths alone
-    /// are insufficient on macOS because distinct spellings can reach the same filesystem item.
+    /// Stable identity for coordinating aliases that reach the same physical directory.
+    /// Paths alone are insufficient on macOS (`/tmp` and `/private/tmp` are one example).
     struct CoordinationIdentity: Hashable, Sendable {
         let device: dev_t
         let inode: ino_t
@@ -116,6 +116,14 @@ public struct RuntimeStorage: Sendable {
         let modificationNanoseconds: Int64
         let statusChangeSeconds: Int64
         let statusChangeNanoseconds: Int64
+    }
+
+    func coordinationIdentity() throws -> CoordinationIdentity {
+        try Self.verify(root)
+        guard let identity = Self.fileIdentity(of: root) else {
+            throw RuntimeStorageError.insecureDirectory(path: root.path, reason: "cannot be inspected")
+        }
+        return identity
     }
 
     static func fileIdentity(of url: URL) -> CoordinationIdentity? {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeRuntimeCoordinatorTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeRuntimeCoordinatorTests.swift
@@ -124,7 +124,16 @@ private actor TwoPartyBarrier {
             .appending(path: "LumeRuntimeCoordinatorAlias-\(UUID().uuidString)")
         let realParent = parent.appending(path: "real")
         let aliasParent = parent.appending(path: "alias")
-        try FileManager.default.createDirectory(at: realParent, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: parent,
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.createDirectory(
+            at: realParent,
+            withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700]
+        )
         try FileManager.default.createSymbolicLink(at: aliasParent, withDestinationURL: realParent)
         let firstStorage = try RuntimeStorage(root: realParent.appending(path: "storage"))
         let secondStorage = try RuntimeStorage(root: aliasParent.appending(path: "storage"))

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeRuntimeCoordinatorTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/LumeRuntimeCoordinatorTests.swift
@@ -1,0 +1,242 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+private actor TestGate {
+    private struct Waiter {
+        let id: UInt64
+        let continuation: CheckedContinuation<Void, any Error>
+    }
+
+    private var isOpen = false
+    private var nextID: UInt64 = 0
+    private var waiters: [Waiter] = []
+
+    func wait() async throws {
+        guard !isOpen else { return }
+        let id = nextID
+        nextID &+= 1
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, any Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waiters.append(Waiter(id: id, continuation: continuation))
+                }
+            }
+        } onCancel: {
+            Task { await self.cancel(id) }
+        }
+    }
+
+    private func cancel(_ id: UInt64) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        waiters.remove(at: index).continuation.resume(throwing: CancellationError())
+    }
+
+    func open() {
+        guard !isOpen else { return }
+        isOpen = true
+        let waiting = waiters
+        waiters.removeAll()
+        for waiter in waiting { waiter.continuation.resume() }
+    }
+}
+
+private actor TwoPartyBarrier {
+    private var arrivals = 0
+    private let gate = TestGate()
+
+    func arriveAndWait() async throws {
+        arrivals += 1
+        if arrivals == 2 { await gate.open() }
+        try await gate.wait()
+    }
+
+    func release() async { await gate.open() }
+}
+
+@Suite(.serialized, .timeLimit(.minutes(1))) struct LumeRuntimeCoordinatorTests {
+    private func storage(_ name: String = UUID().uuidString) throws -> RuntimeStorage {
+        try RuntimeStorage(root: FileManager.default.temporaryDirectory
+            .appending(path: "LumeRuntimeCoordinatorTests")
+            .appending(path: name))
+    }
+
+    @Test func launchAndReplacementShareTheSameRootLease() async throws {
+        let storage = try storage()
+        let releaseHolder = TestGate()
+        let holderEntered = AsyncStream.makeStream(of: Void.self)
+        var holderEvents = holderEntered.stream.makeAsyncIterator()
+        let waiterQueued = AsyncStream.makeStream(of: Void.self)
+        var waiterEvents = waiterQueued.stream.makeAsyncIterator()
+        let waiterEntered = Mutex(false)
+        let coordinator = LumeRuntimeCoordinator { waiterQueued.continuation.yield(()) }
+
+        let holder = Task {
+            try await coordinator.withExclusiveAccess(for: storage) {
+                holderEntered.continuation.yield(())
+                try await releaseHolder.wait()
+            }
+        }
+        _ = await holderEvents.next()
+        let waiter = Task {
+            try await coordinator.withExclusiveAccess(for: storage) {
+                waiterEntered.withLock { $0 = true }
+            }
+        }
+        _ = await waiterEvents.next()
+
+        #expect(!waiterEntered.withLock { $0 })
+        await releaseHolder.open()
+        _ = try await (holder.value, waiter.value)
+        #expect(waiterEntered.withLock { $0 })
+    }
+
+    @Test func independentRuntimeRootsDoNotBlockEachOther() async throws {
+        let firstStorage = try storage()
+        let secondStorage = try storage()
+        let barrier = TwoPartyBarrier()
+        let coordinator = LumeRuntimeCoordinator()
+        let watchdogFired = Mutex(false)
+        let watchdog = Task {
+            try await Task.sleep(for: .seconds(2))
+            watchdogFired.withLock { $0 = true }
+            await barrier.release()
+        }
+
+        async let first: Void = coordinator.withExclusiveAccess(for: firstStorage) {
+            try await barrier.arriveAndWait()
+        }
+        async let second: Void = coordinator.withExclusiveAccess(for: secondStorage) {
+            try await barrier.arriveAndWait()
+        }
+        _ = try await (first, second)
+        #expect(!watchdogFired.withLock { $0 }, "independent roots must enter concurrently")
+        watchdog.cancel()
+        _ = try? await watchdog.value
+    }
+
+    @Test func filesystemAliasesShareOneLease() async throws {
+        let parent = FileManager.default.temporaryDirectory
+            .appending(path: "LumeRuntimeCoordinatorAlias-\(UUID().uuidString)")
+        let realParent = parent.appending(path: "real")
+        let aliasParent = parent.appending(path: "alias")
+        try FileManager.default.createDirectory(at: realParent, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(at: aliasParent, withDestinationURL: realParent)
+        let firstStorage = try RuntimeStorage(root: realParent.appending(path: "storage"))
+        let secondStorage = try RuntimeStorage(root: aliasParent.appending(path: "storage"))
+        #expect(firstStorage.root.path != secondStorage.root.path)
+        #expect(try firstStorage.coordinationIdentity() == secondStorage.coordinationIdentity())
+
+        let releaseHolder = TestGate()
+        let holderEntered = AsyncStream.makeStream(of: Void.self)
+        var holderEvents = holderEntered.stream.makeAsyncIterator()
+        let waiterQueued = AsyncStream.makeStream(of: Void.self)
+        var waiterEvents = waiterQueued.stream.makeAsyncIterator()
+        let waiterEntered = Mutex(false)
+        let coordinator = LumeRuntimeCoordinator { waiterQueued.continuation.yield(()) }
+
+        let holder = Task {
+            try await coordinator.withExclusiveAccess(for: firstStorage) {
+                holderEntered.continuation.yield(())
+                try await releaseHolder.wait()
+            }
+        }
+        _ = await holderEvents.next()
+        let waiter = Task {
+            try await coordinator.withExclusiveAccess(for: secondStorage) {
+                waiterEntered.withLock { $0 = true }
+            }
+        }
+        _ = await waiterEvents.next()
+
+        #expect(!waiterEntered.withLock { $0 })
+        await releaseHolder.open()
+        _ = try await (holder.value, waiter.value)
+    }
+
+    @Test func canceledWaiterReturnsWhileTheHolderStillRuns() async throws {
+        let storage = try storage()
+        let releaseHolder = TestGate()
+        let holderEntered = AsyncStream.makeStream(of: Void.self)
+        var holderEvents = holderEntered.stream.makeAsyncIterator()
+        let waiterQueued = AsyncStream.makeStream(of: Void.self)
+        var waiterEvents = waiterQueued.stream.makeAsyncIterator()
+        let waiterEntered = Mutex(false)
+        let coordinator = LumeRuntimeCoordinator { waiterQueued.continuation.yield(()) }
+        let holder = Task {
+            try await coordinator.withExclusiveAccess(for: storage) {
+                holderEntered.continuation.yield(())
+                try await releaseHolder.wait()
+            }
+        }
+        _ = await holderEvents.next()
+
+        let waiter = Task {
+            try await coordinator.withExclusiveAccess(for: storage) {
+                waiterEntered.withLock { $0 = true }
+            }
+        }
+        _ = await waiterEvents.next()
+        let fallbackFired = Mutex(false)
+        let fallback = Task {
+            try await Task.sleep(for: .seconds(2))
+            fallbackFired.withLock { $0 = true }
+            await releaseHolder.open()
+        }
+        waiter.cancel()
+        await #expect(throws: CancellationError.self) { try await waiter.value }
+        #expect(!fallbackFired.withLock { $0 }, "cancellation must not wait for the current holder")
+        #expect(!waiterEntered.withLock { $0 })
+
+        fallback.cancel()
+        await releaseHolder.open()
+        try await holder.value
+        _ = try? await fallback.value
+    }
+
+    @Test func nestedLeaseFailsInsteadOfDeadlocking() async throws {
+        let storage = try storage()
+        let coordinator = LumeRuntimeCoordinator()
+        let failure = LumeRuntimeCoordinationError.nestedAcquisition
+        #expect(failure.localizedDescription == failure.userMessage)
+        #expect(failure.recoveryActions == [.cancel])
+
+        await #expect(throws: failure) {
+            try await coordinator.withExclusiveAccess(for: storage) {
+                try await coordinator.withExclusiveAccess(for: storage) {}
+            }
+        }
+        try await coordinator.withExclusiveAccess(for: storage) {}
+    }
+
+    @Test func oppositeRootOrderCannotDeadlock() async throws {
+        let first = try storage()
+        let second = try storage()
+        let coordinator = LumeRuntimeCoordinator()
+
+        await #expect(throws: LumeRuntimeCoordinationError.nestedAcquisition) {
+            try await coordinator.withExclusiveAccess(for: first) {
+                try await coordinator.withExclusiveAccess(for: second) {}
+            }
+        }
+    }
+
+    @Test func inheritedContextExpiresWithItsLease() async throws {
+        let storage = try storage()
+        let coordinator = LumeRuntimeCoordinator()
+        let mayEnter = TestGate()
+        let child = try await coordinator.withExclusiveAccess(for: storage) {
+            Task {
+                try await mayEnter.wait()
+                try await coordinator.withExclusiveAccess(for: storage) {}
+            }
+        }
+
+        await mayEnter.open()
+        try await child.value
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Deferred Lume candidate work (#82). Preserve verifier, ownership, storage and probe regressions. Resume only on current shared dependencies; strict artifact verification, real cleanup/restart proof, human preflight and provider selection remain outstanding. No provider or hardware readiness is claimed.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Stack

Stacked on #86 → #83 → #88 → #70. Review commit `9778ea1` and this PR three-file delta. #84 and #85 follow it. Refs #82.

## What this adds

- One actor-owned lease per physical runtime root, keyed by device/inode so filesystem aliases cannot bypass serialization.
- FIFO waiters with prompt cancellation removal and balanced release on success, failure, or cancellation.
- Owner tokens that distinguish active inherited task-local context from stale child-task context.
- An explicit ban on nested lease acquisition, including cross-root ordering, so A→B/B→A operations cannot deadlock.
- Deterministic gate-based tests for serialization, independent-root concurrency, aliases, cancellation, nested acquisition, and inherited-context expiry.

Future Guesthouse-managed install, update, repair, and removal operations must use this same coordinator. A detached task must never be awaited while it tries to re-enter a held coordinator; that limitation is documented on the public API.

## Validation

The composed stack passes 286 Core tests, 80 RuntimeKit tests, 14 app tests, and the shared macOS Xcode scheme. Xcode Cloud independently validates this exact intermediate head.

This PR launches no process and performs no VM operation.