### PR TITLE
Environment records: a positive guest disk, a version read before the record, and no rebuild for a newer format

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/DevelopmentEnvironment.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/DevelopmentEnvironment.swift
@@ -7,14 +7,19 @@ import Foundation
 /// deliberately absent: it is reconciled from the live VM on every launch and never trusted
 /// from disk (MVP-PLAN.md §3, "Application components").
 public struct DevelopmentEnvironment: Codable, Hashable, Sendable, Identifiable {
-    public var schemaVersion: SchemaVersion
+    public private(set) var schemaVersion: SchemaVersion
     public let id: EnvironmentID
     public var name: String
     public let createdAt: Date
-    public var preset: ResourcePreset
+    public private(set) var preset: ResourcePreset
     /// Logical guest disk capacity. Starts at the preset's value and may diverge after a resize.
-    public var guestDiskBytes: UInt64
+    /// Always positive: a development Mac with no disk is not a configuration the runtime can
+    /// be asked for, so it cannot be constructed, decoded, or assigned.
+    public private(set) var guestDiskBytes: UInt64
 
+    /// A `guestDiskBytes` of zero means the same thing as none at all: use the preset's
+    /// capacity. The preset validates its own values, so a constructed environment always
+    /// carries a disk the runtime can be asked for.
     public init(
         id: EnvironmentID = EnvironmentID(),
         name: String,
@@ -23,12 +28,44 @@ public struct DevelopmentEnvironment: Codable, Hashable, Sendable, Identifiable 
         guestDiskBytes: UInt64? = nil,
         schemaVersion: SchemaVersion = .current
     ) {
+        let disk = (guestDiskBytes ?? 0) > 0 ? guestDiskBytes! : preset.diskBytes
         self.schemaVersion = schemaVersion
         self.id = id
         self.name = name
         self.createdAt = createdAt
         self.preset = preset
-        self.guestDiskBytes = guestDiskBytes ?? preset.diskBytes
+        self.guestDiskBytes = disk
+    }
+
+    /// Decoded by hand so a persisted zero is refused rather than carried into the runtime.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        schemaVersion = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
+        id = try container.decode(EnvironmentID.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        preset = try container.decode(ResourcePreset.self, forKey: .preset)
+        let disk = try container.decode(UInt64.self, forKey: .guestDiskBytes)
+        guard disk > 0 else {
+            throw DecodingError.dataCorruptedError(forKey: .guestDiskBytes, in: container, debugDescription: "guest disk capacity must be positive")
+        }
+        guestDiskBytes = disk
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, id, name, createdAt, preset, guestDiskBytes
+    }
+
+    /// Resizes the guest disk. A resize to nothing is refused the same way construction is.
+    public mutating func setGuestDiskBytes(_ bytes: UInt64) -> Bool {
+        guard bytes > 0 else { return false }
+        guestDiskBytes = bytes
+        return true
+    }
+
+    /// Replaces the resource preset. The preset type validates itself, so this only records it.
+    public mutating func setPreset(_ preset: ResourcePreset) {
+        self.preset = preset
     }
 
     /// The Tart VM name that belongs to this environment.
@@ -38,16 +75,28 @@ public struct DevelopmentEnvironment: Codable, Hashable, Sendable, Identifiable 
     /// than a decoder's internal complaint, and a record from a newer Guesthouse is refused
     /// instead of being reinterpreted.
     public static func decode(_ data: Data, using decoder: JSONDecoder = JSONDecoder()) throws(EnvironmentRecordError) -> DevelopmentEnvironment {
-        let environment: DevelopmentEnvironment
+        // The version envelope is read on its own first. A newer record may have renamed or
+        // retyped a field this build requires, and decoding the whole record would report
+        // that as damage instead of as "written by a newer Guesthouse".
+        let envelope: VersionEnvelope
         do {
-            environment = try decoder.decode(DevelopmentEnvironment.self, from: data)
+            envelope = try decoder.decode(VersionEnvelope.self, from: data)
         } catch {
             throw .malformed
         }
-        guard environment.schemaVersion <= .current else {
-            throw .unsupportedSchemaVersion(environment.schemaVersion.rawValue)
+        guard envelope.schemaVersion <= .current else {
+            throw .unsupportedSchemaVersion(envelope.schemaVersion.rawValue)
         }
-        return environment
+        do {
+            return try decoder.decode(DevelopmentEnvironment.self, from: data)
+        } catch {
+            throw .malformed
+        }
+    }
+
+    /// Just the version field, so a record's format can be established before its shape is.
+    private struct VersionEnvelope: Decodable {
+        let schemaVersion: SchemaVersion
     }
 }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/SchemaVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/SchemaVersion.swift
@@ -21,7 +21,15 @@ public struct SchemaVersion: Hashable, Sendable, Comparable, CustomStringConvert
 
 extension SchemaVersion: Codable {
     public init(from decoder: any Decoder) throws {
-        rawValue = try decoder.singleValueContainer().decode(Int.self)
+        let container = try decoder.singleValueContainer()
+        let value = try container.decode(Int.self)
+        // Versions start at 1. Zero or a negative number is not an older format anyone can
+        // migrate from; it is a corrupt record, and reading it as the current layout would
+        // hide that.
+        guard value > 0 else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "schema version must be positive, found \(value)")
+        }
+        rawValue = value
     }
 
     public func encode(to encoder: any Encoder) throws {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/SchemaVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/SchemaVersion.swift
@@ -5,12 +5,24 @@
 public struct SchemaVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
     public let rawValue: Int
 
-    public init(_ rawValue: Int) {
+    /// Versions start at 1, so a zero or negative one is refused here as well as at decoding:
+    /// a record cannot be written carrying a version no reader will accept.
+    public init?(_ rawValue: Int) {
+        guard rawValue > 0 else { return nil }
+        self.rawValue = rawValue
+    }
+
+    private init(valid rawValue: Int) {
         self.rawValue = rawValue
     }
 
     /// The version written by this build.
-    public static let current = SchemaVersion(1)
+    public static let current = SchemaVersion(valid: 1)
+
+    /// What a document written before versioning is: it carries no version key at all. A
+    /// migration is keyed on this. It is never written: encoding it fails, so a record cannot
+    /// come to carry a version no reader would accept.
+    public static let unversioned = SchemaVersion(valid: 0)
 
     public static func < (lhs: SchemaVersion, rhs: SchemaVersion) -> Bool {
         lhs.rawValue < rhs.rawValue
@@ -29,11 +41,19 @@ extension SchemaVersion: Codable {
         guard value > 0 else {
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "schema version must be positive, found \(value)")
         }
-        rawValue = value
+        self = SchemaVersion(valid: value)
     }
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
+        // The unversioned sentinel describes a document that predates versioning; writing it
+        // would produce a record every reader, including this one, refuses.
+        guard rawValue > 0 else {
+            throw EncodingError.invalidValue(rawValue, EncodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "the unversioned sentinel is not a version a record can carry"
+            ))
+        }
         try container.encode(rawValue)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/VMSlotInventory.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Environment/VMSlotInventory.swift
@@ -115,6 +115,10 @@ extension VMSlotError: LocalizedError {
             "Export any unpublished work from a development Mac you no longer need, then delete it to make room. Exporting alone does not free a slot."
         case .unknownEnvironment:
             "Check the environment list; the record may have been removed by a repair or deletion."
+        case .corruptInventory(.unsupportedSchemaVersion):
+            // Rebuilding here would drop whatever the newer format records that this build
+            // does not know about, so the way forward is the newer Guesthouse, not a repair.
+            "Update Guesthouse and open it again. Do not repair the record with this version: rebuilding it here would discard what the newer format keeps."
         case .corruptInventory:
             "Guesthouse will inspect the virtual machines that actually exist and rebuild the record from them; nothing is started or deleted until it has."
         }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/DevelopmentEnvironmentTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/DevelopmentEnvironmentTests.swift
@@ -32,8 +32,9 @@ import Testing
         #expect(environment.tartVMName == environment.id.tartVMName)
     }
 
-    @Test func schemaVersionsCompare() {
-        #expect(SchemaVersion(1) < SchemaVersion(2))
+    @Test func schemaVersionsCompare() throws {
+        let (first, second) = (try #require(SchemaVersion(1)), try #require(SchemaVersion(2)))
+        #expect(first < second)
         #expect(SchemaVersion.current.description == "v\(SchemaVersion.current.rawValue)")
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/VMSlotInventoryTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/VMSlotInventoryTests.swift
@@ -151,6 +151,19 @@ import Testing
         #expect(throws: EnvironmentRecordError.malformed) { try DevelopmentEnvironment.decode(Data(#"{"schemaVersion":1}"#.utf8)) }
     }
 
+    @Test func aVersionThatNoReaderWouldAcceptCannotBeConstructed() {
+        #expect(SchemaVersion(0) == nil)
+        #expect(SchemaVersion(-1) == nil)
+        #expect(SchemaVersion(2)?.rawValue == 2)
+    }
+
+    @Test func theUnversionedSentinelIsNeverWritten() {
+        // It names a document that predates versioning; encoding it would produce a record
+        // this build's own decoder refuses.
+        #expect(throws: EncodingError.self) { try JSONEncoder().encode(SchemaVersion.unversioned) }
+        #expect(throws: Never.self) { try JSONEncoder().encode(SchemaVersion.current) }
+    }
+
     @Test func aPersistedSchemaVersionMustBePositive() {
         for value in ["0", "-3"] {
             #expect(throws: DecodingError.self, "version \(value)") { try JSONDecoder().decode(SchemaVersion.self, from: Data(value.utf8)) }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/VMSlotInventoryTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Environment/VMSlotInventoryTests.swift
@@ -127,6 +127,45 @@ import Testing
         }
     }
 
+    @Test func aGuestDiskIsAlwaysPositive() throws {
+        let preset = ResourcePreset.recommended
+        #expect(DevelopmentEnvironment(name: "Dev Mac", preset: preset, guestDiskBytes: 0).guestDiskBytes == preset.diskBytes, "a zero override means the preset's capacity")
+        var environment = DevelopmentEnvironment(name: "Dev Mac", preset: preset)
+        let refused = environment.setGuestDiskBytes(0)
+        #expect(refused == false)
+        #expect(environment.guestDiskBytes == preset.diskBytes, "a refused resize changes nothing")
+        let resized = environment.setGuestDiskBytes(preset.diskBytes * 2)
+        #expect(resized)
+        #expect(environment.guestDiskBytes == preset.diskBytes * 2)
+        var json = try #require(try JSONSerialization.jsonObject(with: JSONEncoder().encode(environment)) as? [String: Any])
+        json["guestDiskBytes"] = 0
+        let zeroed = try JSONSerialization.data(withJSONObject: json)
+        #expect(throws: EnvironmentRecordError.malformed) { try DevelopmentEnvironment.decode(zeroed) }
+    }
+
+    @Test func aRecordFromANewerGuesthouseIsRecognizedEvenWhenItsShapeChanged() throws {
+        // The version is read before the record, so a newer format that renamed a field is
+        // reported as "written by a newer Guesthouse", not as damage.
+        let newer = Data(#"{"schemaVersion":99,"id":"nope","renamedField":true}"#.utf8)
+        #expect(throws: EnvironmentRecordError.unsupportedSchemaVersion(99)) { try DevelopmentEnvironment.decode(newer) }
+        #expect(throws: EnvironmentRecordError.malformed) { try DevelopmentEnvironment.decode(Data(#"{"schemaVersion":1}"#.utf8)) }
+    }
+
+    @Test func aPersistedSchemaVersionMustBePositive() {
+        for value in ["0", "-3"] {
+            #expect(throws: DecodingError.self, "version \(value)") { try JSONDecoder().decode(SchemaVersion.self, from: Data(value.utf8)) }
+            let inventory = Data("{\"schemaVersion\":\(value),\"slots\":[]}".utf8)
+            #expect(throws: VMSlotError.self, "inventory \(value)") { try JSONDecoder().decode(VMSlotInventory.self, from: inventory) }
+        }
+    }
+
+    @Test func aNewerRecordIsNotOfferedARebuild() {
+        let newer = VMSlotError.corruptInventory(reason: .unsupportedSchemaVersion(99))
+        #expect(newer.recoveryMessage.contains("Update Guesthouse"))
+        #expect(!newer.recoveryMessage.contains("rebuild the record"), "rebuilding here would discard what the newer format keeps")
+        #expect(VMSlotError.corruptInventory(reason: .malformed).recoveryMessage.contains("rebuild"))
+    }
+
     @Test func structuralDecodeFailuresAreAlsoActionable() {
         for json in ["{}", "{\"slots\":3}", "{\"slots\":[{\"environmentID\":\"not-a-uuid\"}]}"] {
             let error = #expect(throws: VMSlotError.self, "\(json)") {


### PR DESCRIPTION
The automated review of #52 arrived after that PR had already been merged, so its four findings are answered here, on top of main.

- `guestDiskBytes` is `private(set)` with a validating resize, a zero override means the preset's capacity, and a persisted zero is refused by a hand-written decoder. A development Mac with no disk is not a configuration the runtime can be asked for.
- `SchemaVersion` refuses a persisted zero or negative value: that is not an older format anyone can migrate from, and reading it as the current layout would hide the damage.
- `DevelopmentEnvironment.decode` reads a version envelope first, so a record from a newer Guesthouse that renamed or retyped a required field is reported as exactly that instead of as corruption.
- A newer inventory format is told to update Guesthouse rather than offered a rebuild that would discard whatever the newer format keeps.

Tests cover each: a zero disk from every direction, a newer record whose shape changed, nonpositive schema versions, and the recovery text for a newer inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)