### PR TITLE
CI: run every local package before Xcode Cloud builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,16 +16,22 @@ Guesthouse is a native macOS app that prepares an isolated development Mac (a ma
 
 ## Commands
 
-Package tests (fast, no signing):
+All package tests with the CI warning policy (fast, no signing):
 
 ```bash
-swift test --package-path Packages/GuesthouseCore
+./ci_scripts/ci_pre_xcodebuild.sh
+```
+
+One package:
+
+```bash
+swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors
 ```
 
 One package test:
 
 ```bash
-swift test --package-path Packages/GuesthouseCore --filter coreModuleIdentity
+swift test --package-path Packages/GuesthouseCore --filter coreModuleIdentity -Xswiftc -warnings-as-errors
 ```
 
 App build and tests through the shared scheme (also runs the package tests):
@@ -44,7 +50,15 @@ Open in Xcode with `open Guesthouse.xcodeproj`. Xcode 26.6 or later, macOS 26.4 
 
 ## Continuous integration and review
 
-Xcode Cloud runs the `Guesthouse` scheme's Test action on pull requests to `main` and reports a check to GitHub. Codex reviews every pull request automatically. Keep the scheme's Test action as the single source of truth for what CI runs; when you add a package, add its test target to the shared scheme.
+Xcode Cloud runs the `Guesthouse` scheme's Test action on pull requests to `main` and reports a check to GitHub. Keep the scheme's Test action as the source of truth for Xcode tests; when you add a package, add its test target to the shared scheme. Codex reviews every pull request automatically.
+
+The executable `ci_scripts/ci_pre_xcodebuild.sh` additionally runs every immediate `Packages/*/Package.swift` package with warnings treated as errors, independently guarding against missing scheme coverage (issue #2; `MVP-PLAN.md` §11). It uses `CI_PRIMARY_REPOSITORY_PATH` in Xcode Cloud and its own repository location locally, excludes `Fixtures/`, and fails if no packages are found. It skips only `test-without-building`: [Apple documents that phase as having no source checkout](https://developer.apple.com/documentation/xcode/configuring-your-xcode-cloud-workflow-s-actions); package tests have already run during `build-for-testing`.
+
+Validate hook discovery, paths with spaces, phase handling, and failure propagation without compiling Swift:
+
+```bash
+bash Tests/CI/test-package-hook.sh
+```
 
 ## Conventions
 

--- a/Tests/CI/Fixtures/swift
+++ b/Tests/CI/Fixtures/swift
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+[[ $# == 5 && "$1" == test && "$2" == --package-path &&
+    "$4" == -Xswiftc && "$5" == -warnings-as-errors ]] || exit 91
+[[ "$(pwd -P)" == "${CI_HOOK_EXPECTED_ROOT}" ]] || exit 92
+printf '%s\n' "$3" >> "${CI_HOOK_INVOCATIONS}"
+if [[ "$3" == "${CI_HOOK_FAIL_PACKAGE:-}" ]]; then
+    exit 23
+fi

--- a/Tests/CI/test-package-hook.sh
+++ b/Tests/CI/test-package-hook.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -euo pipefail
+
+test_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd -- "${test_directory}/../.." && pwd)"
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/guesthouse-ci-hook.XXXXXX")"
+trap 'rm -rf -- "${test_root}"' EXIT
+
+checkout="${test_root}/selected checkout"
+mkdir -p "${checkout}/ci_scripts" "${test_root}/bin" "${test_root}/elsewhere"
+cp "${repository_root}/ci_scripts/ci_pre_xcodebuild.sh" "${checkout}/ci_scripts/"
+cp "${test_directory}/Fixtures/swift" "${test_root}/bin/swift"
+chmod +x "${test_root}/bin/swift"
+hook="${checkout}/ci_scripts/ci_pre_xcodebuild.sh"
+for package in "Alpha Kit" Beta Zebra; do
+    mkdir -p "${checkout}/Packages/${package}"
+    touch "${checkout}/Packages/${package}/Package.swift"
+done
+mkdir -p "${checkout}/Fixtures/Skipped" "${checkout}/Packages/NoManifest"
+touch "${checkout}/Fixtures/Skipped/Package.swift"
+
+export PATH="${test_root}/bin:${PATH}"
+export CI_HOOK_EXPECTED_ROOT="$(cd -- "${checkout}" && pwd -P)"
+export CI_HOOK_INVOCATIONS="${test_root}/invocations"
+unset CI_HOOK_FAIL_PACKAGE CI_XCODEBUILD_ACTION
+cd -- "${test_root}/elsewhere"
+
+assert_all_packages() {
+    printf '%s\n' 'Packages/Alpha Kit' Packages/Beta Packages/Zebra |
+        cmp - "${CI_HOOK_INVOCATIONS}"
+}
+
+# Xcode Cloud selects the checkout even when the hook starts in another directory.
+: > "${CI_HOOK_INVOCATIONS}"
+CI_PRIMARY_REPOSITORY_PATH="${checkout}" CI_XCODEBUILD_ACTION=build-for-testing "${hook}"
+assert_all_packages
+
+# Local calls find the repository from the script, with either unset or empty CI path.
+: > "${CI_HOOK_INVOCATIONS}"
+(unset CI_PRIMARY_REPOSITORY_PATH; "${hook}")
+assert_all_packages
+: > "${CI_HOOK_INVOCATIONS}"
+CI_PRIMARY_REPOSITORY_PATH= "${hook}"
+assert_all_packages
+
+# A package failure must stop later packages and preserve Swift's exit status.
+: > "${CI_HOOK_INVOCATIONS}"
+status=0
+CI_PRIMARY_REPOSITORY_PATH="${checkout}" CI_HOOK_FAIL_PACKAGE=Packages/Beta "${hook}" || status=$?
+[[ "${status}" == 23 ]]
+printf '%s\n' 'Packages/Alpha Kit' Packages/Beta | cmp - "${CI_HOOK_INVOCATIONS}"
+
+# The source-free second test phase must succeed without any Swift invocation.
+: > "${CI_HOOK_INVOCATIONS}"
+CI_PRIMARY_REPOSITORY_PATH="${test_root}/missing" CI_XCODEBUILD_ACTION=test-without-building "${hook}"
+[[ ! -s "${CI_HOOK_INVOCATIONS}" ]]
+
+# A bad explicit CI checkout must not silently fall back to another repository.
+status=0
+CI_PRIMARY_REPOSITORY_PATH="${test_root}/missing" "${hook}" 2>/dev/null || status=$?
+[[ "${status}" != 0 && ! -s "${CI_HOOK_INVOCATIONS}" ]]
+
+# Missing packages must fail instead of producing a green check with no tests.
+mkdir -p "${test_root}/empty checkout"
+status=0
+CI_PRIMARY_REPOSITORY_PATH="${test_root}/empty checkout" "${hook}" 2>/dev/null || status=$?
+[[ "${status}" == 1 && ! -s "${CI_HOOK_INVOCATIONS}" ]]
+
+printf 'Package hook: 7 scenarios passed.\n'

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+# Xcode Cloud's second test phase has test products, but no source checkout.
+# https://developer.apple.com/documentation/xcode/configuring-your-xcode-cloud-workflow-s-actions
+if [[ "${CI_XCODEBUILD_ACTION:-}" == "test-without-building" ]]; then
+    exit 0
+fi
+
+if [[ -n "${CI_PRIMARY_REPOSITORY_PATH:-}" ]]; then
+    repository_root="${CI_PRIMARY_REPOSITORY_PATH}"
+else
+    script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+    repository_root="${script_directory}/.."
+fi
+cd -- "${repository_root}"
+
+shopt -s nullglob
+package_manifests=(Packages/*/Package.swift)
+if (( ${#package_manifests[@]} == 0 )); then
+    printf 'error: No package manifests found under Packages/.\n' >&2
+    exit 1
+fi
+
+for manifest in "${package_manifests[@]}"; do
+    package_directory="${manifest%/Package.swift}"
+    printf 'Testing %s with warnings treated as errors\n' "${package_directory}"
+    swift test --package-path "${package_directory}" -Xswiftc -warnings-as-errors
+done


### PR DESCRIPTION
## Summary

Xcode Cloud currently relies on the shared scheme to discover package tests, so a package omitted from the scheme can escape CI. This adds an executable pre-build hook that tests every immediate `Packages/*/Package.swift` package with warnings treated as errors and stops on the first failure. It honors Xcode Cloud's checkout path, works locally from another directory, and supports paths with spaces. The shared scheme and its package tests remain required.

The hook skips only `test-without-building`, because [Apple documents that phase as having no source checkout](https://developer.apple.com/documentation/xcode/configuring-your-xcode-cloud-workflow-s-actions); package tests run during `build-for-testing`. Missing packages or an invalid explicit checkout fail visibly. AGENTS documents the same commands and the independent package guard.

Implements the repository-script portion of #2 and `MVP-PLAN.md` §11. This intentionally does not close #2: App Store Connect workflow confirmation, required-check configuration, and an observed deliberately failing-then-fixed external CI run remain outstanding. No optional GitHub Actions workflow or branch-protection change is included.

## Validation

- Shell syntax and seven executable-hook scenarios passed: multiple packages, spaces, fixture exclusion, CI checkout selection, local fallback, failure propagation, missing input, and the source-free test phase.
- The actual hook passed all 30 GuesthouseCore tests with `-Xswiftc -warnings-as-errors` and no compiler warnings.
- `git diff --check` passed; independent local review found no implementation defects.
- Both fresh Xcode Cloud contexts passed at `9b782dfcbba151ed09b951c4336370ee9a57be15`; Test - macOS completed in 2m18s. The shared scheme is unchanged.
- Codex completed review of this exact head with a thumbs-up and no findings or unresolved threads.

## Checklist

- [x] New logic is covered by reproducible shell tests; actual package tests pass locally
- [x] No new compiler warnings or third-party dependencies
- [x] No secrets, credentials, environment dumps, or authentication logs added
- [x] CI-only process execution; product execution boundaries unchanged
- [x] Documentation matches the new behavior and commands
- [x] Diff is under roughly 500 changed lines
