### PR TITLE
Define credential grammar and internal redaction state

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -1,0 +1,219 @@
+import Foundation
+import RegexBuilder
+
+extension Redactor {
+    /// Compiled patterns. `Regex` is an immutable value type but is not declared `Sendable`,
+    /// so this container vouches for it: nothing here is ever mutated after initialization.
+    struct Patterns: @unchecked Sendable {
+        /// Any of the three line terminators, CRLF first so it is never split in half.
+        let lineSeparator = #/\r\n|\n|\r/#
+        /// Control strings up to their terminator or the end of the line, then CSI introduced by
+        /// `ESC [` or U+009B; any other escape sequence, including the ones with intermediate
+        /// bytes such as `ESC ( B`; and bare C0/C1 controls, except tabs and line terminators.
+        /// OSC is the only control string that
+        /// BEL ends — ECMA-48 gives DCS, APC, PM, and SOS the ST terminator alone — so a BEL
+        /// inside one of those is payload. Ending them at it would hand the rest of the payload
+        /// to the secret rules as text, and the character in front of a token there defeats the
+        /// token rules' word boundary.
+        let terminalEscape = #/(?:\u{1B}\]|\u{9D})[^\u{07}\u{9C}\u{1B}]*(?:\u{07}|\u{9C}|\u{1B}\\)?|(?:\u{1B}[P_^X]|[\u{90}\u{9F}\u{9E}\u{98}])[^\u{9C}\u{1B}]*(?:\u{9C}|\u{1B}\\)?|(?:\u{1B}\[|\u{9B})[0-9;:?<=>]*[ -\/]*[@-~]|\u{1B}[ -\/]*[0-~]|[\u{00}-\u{08}\u{0B}\u{0C}\u{0E}-\u{1F}\u{7F}-\u{9F}]/#
+        /// A control string introducer whose payload reaches the end of the line unterminated.
+        /// The first capture is present only for an OSC, whose payload a later BEL also ends.
+        let unterminatedControlString = #/(?:(\u{1B}\]|\u{9D})[^\u{07}\u{9C}\u{1B}]*|(?:\u{1B}[P_^X]|[\u{90}\u{9F}\u{9E}\u{98}])[^\u{9C}\u{1B}]*)$/#
+        /// The two ways any control string ends: C1 ST or the two-byte ST.
+        let controlStringEnd = #/\u{9C}|\u{1B}\\/#
+        /// An OSC ends at either of those or at BEL.
+        let oscEnd = #/\u{07}|\u{9C}|\u{1B}\\/#
+        /// The continuation of a folded header: leading whitespace (folding requires it) and
+        /// anything at all after it.
+        let foldedContinuation = #/\s+\S.*/#
+        /// A line that opens with a header field name and its colon. Used the other way round
+        /// from the rules here: a line that matches is the *next header*, and everything else
+        /// standing unindented under a bare authorization label is that label's value.
+        let headerLabelStart = #/^\s*(?:\\?["'])?[A-Za-z0-9][A-Za-z0-9-]*(?:\\?["'])?\s*:/#
+        /// A PEM header. RFC 7468 labels are not only upper-case letters and spaces: they carry
+        /// hyphens, digits, and dots (`ACME-PRIVATE KEY`, `X9.42 DH PARAMETERS`), and a label
+        /// this rule cannot spell leaves the block, header and key material alike, in the clear.
+        /// The label is matched lazily and has to end on an alphanumeric, so it can never eat
+        /// the closing dashes and a second block on the same line stays its own match.
+        let pemBegin = #/-----BEGIN ([A-Za-z0-9](?:[A-Za-z0-9 ._+-]*?[A-Za-z0-9])?)-----/#
+        /// The whole header value, quoted or to the end of the line, so multi-parameter schemes
+        /// (Digest, AWS SigV4) leave nothing behind. The key may be quoted the way JSON, a
+        /// Python dictionary, or a JSON string embedded in a log line quotes it.
+        /// The same match determines continuation state before replacement. An empty value
+        /// arms the next line even when a logger prefixes or quotes the field name.
+        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:proxy|request)[ _-]?)?authorization\b(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        /// Bearer credentials outside a header line, of any length. Every token and label rule
+        /// here starts at a character that cannot be part of the word rather than at `\b`:
+        /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
+        /// `cache.<token>`, or in `payload.Authorization` is not a break, and a secret beside
+        /// one would survive. The character is captured so it can be put back. A label may also
+        /// start after an underscore, which names most of them: `refresh_token`, `access_token`.
+        let bearer = #/(^|[^A-Za-z0-9])(bearer\s+[A-Za-z0-9._~+\/=-]+)/#.ignoresCase()
+        /// A standalone authentication value can reach decoded diagnostics without its header
+        /// name. Basic is recognized only when the Base64 decodes to a user/password separator;
+        /// Digest must start with an authentication parameter assignment, not ordinary prose.
+        private static var basicValue: Regex<(Substring, Substring, Substring)> {
+            #/(basic[ \t]+)([A-Za-z0-9+\/]{2,}={0,2})(?![A-Za-z0-9+\/=])/#
+        }
+        let basicCredentialSpan = basicValue.ignoresCase()
+        let basicAuthorization = Regex {
+            #/(^|[^A-Za-z0-9])/#
+            basicValue
+        }.ignoresCase()
+        private static var digestValue: Regex<Substring> {
+            #/digest[ \t]+(?=(?:username\*?|realm|nonce|uri|response|algorithm|cnonce|opaque|qop|nc|userhash)\s*=)[^\r\n]+/#
+        }
+        let digestCredentialSpan = digestValue.ignoresCase()
+        let digestAuthorization = Regex {
+            #/(^|[^A-Za-z0-9])/#
+            digestValue
+        }.ignoresCase()
+        /// Distinctive integrated-auth blobs and signed AWS requests remain recognizable after
+        /// their header name is lost. Ordinary scheme-name prose alone is not a credential.
+        private static var specializedValue: Regex<Substring> {
+            #/(?:ntlm|negotiate)[ \t]+[A-Za-z0-9+\/_-]{8,}={0,2}|aws4-hmac-sha256[ \t]+(?=(?:credential|signedheaders|signature)\s*=)[^\r\n]+/#
+        }
+        let specializedCredentialSpan = specializedValue.ignoresCase()
+        let specializedAuthorization = Regex {
+            #/(^|[^A-Za-z0-9])/#
+            specializedValue
+        }.ignoresCase()
+        /// Classic and fine-grained GitHub tokens. Nothing at all is required in front of the
+        /// prefix, not even a delimiter: an untrusted file, branch, or cache name is glued
+        /// straight onto a token by concatenation, and `artifactghp_...` carried a complete
+        /// usable credential through a rule that only tolerated `artifact_ghp_...`. These
+        /// prefixes are the reason it is safe to drop the boundary here — text that ends in
+        /// `ghp`, `ghs`, or `github_pat` immediately before twenty alphanumerics is far rarer
+        /// than the concatenation. The API-key rule below keeps its boundary, because `sk-` is
+        /// three ordinary letters and dropping it there would redact `risk-averse-...`.
+        /// Even a short fragment is sensitive once its distinctive prefix is present.
+        let githubToken = #/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]*|github_pat_[A-Za-z0-9_]*/#
+        let wrappedTokenAtLineEnd = #/((?:ghp|gho|ghu|ghs|ghr)_|github_pat_|sk-(?:proj|svcacct|ant)-)[A-Za-z0-9_-]*$/#
+        let tokenContinuation = #/^[ \t]*[A-Za-z0-9_-]+/#
+        /// Distinctive project/provider prefixes survive filename concatenation. A generic
+        /// `sk-` still needs its boundary so ordinary hyphenated words such as `risk-averse`
+        /// remain intact.
+        let apiKey = #/(^|[^A-Za-z0-9]|(?=sk-(?:proj|svcacct|ant)-))(sk-[A-Za-z0-9_-]{16,})/#
+        let distinctiveAPIKey = #/sk-(?:proj|svcacct|ant)-[A-Za-z0-9_-]*/#
+        /// JSON Web Tokens, matched structurally: Base64URL segments (the last may be empty) of
+        /// which one decodes to a JSON object, whitespace allowed. More than three segments are
+        /// taken because a JWT can follow a label, as in `session.<jwt>`.
+        let jwt = #/(^|[^A-Za-z0-9_-])([A-Za-z0-9_-]{4,}(?:\.[A-Za-z0-9_-]*){2,})/#
+        /// Credentials embedded in URLs: `https://user:secret@host`. The authority ends at the
+        /// last `@` before a slash or whitespace, so a password containing `@` is fully covered.
+        /// It also ends at `?` and `#`, which end an authority exactly as `/` does (RFC 3986):
+        /// without them `https://example.com?email=user@example.org` reads its query's `@` as
+        /// userinfo and rewrites a legitimate link into `https://[redacted:userinfo]@example.org`.
+        /// Nothing that is really userinfo is lost, because a `?` inside one has to be
+        /// percent-encoded for the text to be a URL at all.
+        /// A URL that reached a log through JSON keeps that encoding's escaped slashes.
+        /// A network-path reference can omit the scheme (`//user:secret@host`). Its leading
+        /// delimiter must start a value, so doubled slashes inside a path or URL query do not
+        /// turn an ordinary `@` later in that value into userinfo.
+        let urlUserInfo = #/((?::|^|[\s"'(<\[{])(?:\\?\/){2})[^\s\/?#]+@/#
+        /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
+        /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
+        /// `clientSecret`. Those need a name in front of the label word, and the names come from
+        /// a closed list so that an ordinary word ending in `token` or `secret` is still not a
+        /// label. The key is quoted the way JSON, a Python dictionary, or a JSON string embedded
+        /// in a log line quotes it. An unquoted value runs to the end of the line rather than to
+        /// the first space, because a passphrase is words: `password: correct horse battery`. It
+        /// still has to start with one non-space character, so a bare label falls to the rule
+        /// below and arms the next line instead of matching an empty value here.
+        /// One vocabulary shared by inline fields, bare labels, and command options.
+        /// Explicit private-key labels are sensitive even when the value is not PEM.
+        private static var secretName: Regex<Substring> {
+            #/(?:(?:access|refresh|auth|client|app|session|user|bearer|private|shared|signing|master|id|current|new|old|previous|confirm|confirmation)[ _-]?)?(?:password|passphrase|passwd|secret|token|credentials?|api[ _-]?key|private[ _-]?key|secret[ _-]?access[ _-]?key|access[ _-]?key[ _-]?secret)/#
+        }
+        private static var secretLabel: Regex<(Substring, Substring, Substring)> {
+            Regex {
+                #/(^|[^A-Za-z0-9])(?:\\?["'])?/#
+                Capture { secretName }
+                #/\b(?:\\?["'])?\s*[:=]\s*/#
+            }
+        }
+        let labeledSecret = Regex {
+            secretLabel
+            Capture {
+                #/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*/#
+            }
+        }.ignoresCase()
+        /// The same labels with nothing after the delimiter: CLI and pretty-printed output puts
+        /// the value on the next line.
+        let secretLabelOnly = Regex {
+            secretLabel
+            Anchor.endOfSubject
+        }.ignoresCase()
+        /// The same secret named as a command-line option, which CLI diagnostics echo back
+        /// verbatim: `--password hunter2`, `--github-token opaqueCredential`. There is no `:`
+        /// or `=` to key on, so the leading dash is what makes this a secret rather than the
+        /// word `token` in a sentence. The value is one argv word, or a quoted one, rather than
+        /// the rest of the line: an echoed command line carries the options after it, and
+        /// `--token abc --verbose` must keep its second option.
+        let secretOption = Regex {
+            #/(^|\s)/#
+            Capture {
+                #/--?[A-Za-z0-9_-]*/#
+                secretName
+            }
+            #/([ \t]+|=)(?=\S)/#
+        }.ignoresCase()
+        let secretOptionOnly = Regex {
+            #/(^|\s)--?[A-Za-z0-9_-]*/#
+            secretName
+            #/[ \t]*(?:=[ \t]*)?$/#
+        }.ignoresCase()
+        /// JSON/Python-style argv diagnostics retain the option as a quoted array element.
+        /// Its value is the next element, possibly on a later line.
+        let serializedSecretOption = Regex {
+            #/(?:\\?["'])--?[A-Za-z0-9_-]*/#
+            secretName
+            #/(?:\\?["'])[ \t]*,[ \t]*/#
+        }.ignoresCase()
+        /// The explicit code fields of an OAuth device flow. Their values are opaque and their
+        /// shape is the provider's choice, so the whole value goes, not just a `XXXX-XXXX` one,
+        /// and an unquoted one runs to the end of the line the way a labeled secret's does.
+        let codeField = #/(^|[^A-Za-z0-9])(?:\\?["'])?((?:user|device)[ _-]?codes?)\b(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        /// The prose a CLI prints when it wants a code typed in — `Your one-time code is: …` —
+        /// with the value on the same line. The value is as opaque as a field's, so all of it
+        /// goes whatever its shape. The code has to be named: a line that merely contains the
+        /// word, such as `process exited with code 1`, is a diagnostic, not a prompt. The
+        /// `user_code` and `device_code` fields keep their own rule above, which keeps the field
+        /// name in the output, so they are deliberately absent here.
+        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        /// The same prompt with nothing after the delimiter: the value is on the next line. The
+        /// device-flow field names are included, because arming the next line has no output whose
+        /// shape has to be kept. A line that is nothing but `code:` is a prompt too — there is
+        /// nothing else on it for the word to belong to.
+        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|^\s*codes?)\s*[:=]\s*$/#.ignoresCase()
+        /// Device codes such as `1A2B-3C4D` and the `WDJB.MJHT` an RFC 8628 provider may print:
+        /// runs of four to eight upper-case characters joined by single separators. Applied only
+        /// on lines that mention a code (including the `user_code` and `device_code` field names
+        /// of OAuth device flows), and never when the match is part of a longer hyphenated or
+        /// dotted identifier such as a UUID or a reverse-DNS name.
+        let mentionsCode = #/\b(?:codes?|(?:user|device)[_-]code)\b/#.ignoresCase()
+        /// The trailing exclusion covers a dot that continues the identifier as well as a letter,
+        /// a digit, or a hyphen: without it `ABCD-EFGH.example.com` becomes
+        /// `[redacted:device-code].example.com`, which is the longer dotted identifier this rule
+        /// says it leaves alone. A dot that ends a sentence is not one, so `your code: AB12-CD34.`
+        /// still loses its code.
+        let deviceCode = #/(^|[^A-Za-z0-9.-])([A-Z0-9]{4,8}(?:[-.][A-Z0-9]{4,8}){1,3})(?![A-Za-z0-9-]|\.[A-Za-z0-9])/#
+        /// A prompt that names the code with no delimiter at all: `Enter the code ABC123 at the
+        /// URL shown` is the prose an RFC 8628 provider prints, and only a value that happens to
+        /// have the dotted or hyphenated shape above was removed from it. Two forms qualify: the
+        /// imperative one, which asks for the code, and a historical declaration with a copula.
+        /// Present-tense declarations also have the opaque-value rule below. Here a value has
+        /// to look like a code rather than
+        /// like the next English word: four or more characters that are all upper-case or
+        /// digits, or that carry a digit. `process exited with code 1`, `Enter the code shown
+        /// below`, and `the login code was rejected` are all left alone. The words are matched
+        /// without regard to case; the value's own alternatives are not, or every lower-case
+        /// word after the label would be a code.
+        let codePromptWithoutDelimiter = #/((?:^|[^A-Za-z0-9])(?:(?i:(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|(?i:(?:one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\s+(?:is|are|was|were|reads|equals))+)))\s+(?=[A-Za-z0-9._-]{4})(?:[A-Z0-9._-]+|[A-Za-z0-9._-]*[0-9][A-Za-z0-9._-]*)(?![A-Za-z0-9._-])/#
+        /// Present-tense declarations explicitly supply the code. Lowercase, short, and
+        /// quoted values are opaque. Historical status prose keeps the conservative rule above.
+        let declarativeCodePrompt = #/((?:^|[^A-Za-z0-9])(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?\s+(?:is|are|reads|equals))(?:\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s,;]+)|\s*$)/#.ignoresCase()
+    }
+
+    static let patterns = Patterns()
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -151,7 +151,7 @@ extension Redactor {
         /// the rest of the line: an echoed command line carries the options after it, and
         /// `--token abc --verbose` must keep its second option.
         let secretOption = Regex {
-            #/(^|\s)/#
+            #/(^|[\s\u{009F}])/#
             Capture {
                 #/--?[A-Za-z0-9_-]*/#
                 secretName
@@ -159,7 +159,7 @@ extension Redactor {
             #/([ \t]+|=)(?=\S)/#
         }.ignoresCase()
         let secretOptionOnly = Regex {
-            #/(^|\s)--?[A-Za-z0-9_-]*/#
+            #/(^|[\s\u{009F}])--?[A-Za-z0-9_-]*/#
             secretName
             #/[ \t]*(?:=[ \t]*)?$/#
         }.ignoresCase()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -110,7 +110,8 @@ extension Redactor {
         /// A network-path reference can omit the scheme (`//user:secret@host`). Its leading
         /// delimiter must start a value, so doubled slashes inside a path or URL query do not
         /// turn an ordinary `@` later in that value into userinfo.
-        let urlUserInfo = #/((?::|^|[\s"'(<\[{]|(?:^|[\s"'(<\[{])[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
+        /// Assignment names may include a command option's leading one or two dashes.
+        let urlUserInfo = #/((?::|^|[\s"'(<\[{]|(?:^|[\s"'(<\[{])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Those need a name in front of the label word, and the names come from
@@ -181,12 +182,13 @@ extension Redactor {
         /// `user_code` and `device_code` fields keep their own rule above, which keeps the field
         /// name in the output, so they are deliberately absent here.
         /// Imperative prompts can also delimit their opaque value with a colon or equals.
-        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        /// Up to two instruction words may follow `code`, as in `code shown below:`.
+        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?(?:\s+(?!\[redacted:)\S+){0,2}?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
         /// The same prompt with nothing after the delimiter: the value is on the next line. The
         /// device-flow field names are included, because arming the next line has no output whose
         /// shape has to be kept. A line that is nothing but `code:` is a prompt too — there is
         /// nothing else on it for the word to belong to.
-        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|^\s*codes?)\s*[:=]\s*$|(?:^|[^A-Za-z0-9])(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?\s*$/#.ignoresCase()
+        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?(?:\s+(?!\[redacted:)\S+){0,2}?)|^\s*codes?)\s*[:=]\s*$|(?:^|[^A-Za-z0-9])(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?\s*$/#.ignoresCase()
         /// Device codes such as `1A2B-3C4D` and the `WDJB.MJHT` an RFC 8628 provider may print:
         /// runs of four to eight upper-case characters joined by single separators. Applied only
         /// on lines that mention a code (including the `user_code` and `device_code` field names
@@ -214,7 +216,9 @@ extension Redactor {
         /// Present-tense declarations explicitly supply the code. Lowercase, short, and
         /// quoted values are opaque. Historical status prose keeps the conservative rule above.
         /// Encoded quotes span the remaining line; the value scanner preserves their suffix.
-        let declarativeCodePrompt = #/((?:^|[^A-Za-z0-9])(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?\s+(?:is|are|reads|equals))(?:\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\\+["'][^\r\n]*|[^\s,;]+)|\s*$)/#.ignoresCase()
+        /// A copula may end in a delimiter; without one, whitespace still bounds the word.
+        /// Empty delimited declarations belong to `codePromptOnly` and keep their prompt text.
+        let declarativeCodePrompt = #/((?:^|[^A-Za-z0-9])(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?\s+(?:is|are|reads|equals)(?:\s*[:=](?=\s*\S)|(?=\s|$)(?!\s*[:=])))(?:\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\\+["'][^\r\n]*|[^\s,;]+)|\s*$)/#.ignoresCase()
     }
 
     static let patterns = Patterns()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -110,7 +110,7 @@ extension Redactor {
         /// A network-path reference can omit the scheme (`//user:secret@host`). Its leading
         /// delimiter must start a value, so doubled slashes inside a path or URL query do not
         /// turn an ordinary `@` later in that value into userinfo.
-        let urlUserInfo = #/((?::|^|[\s"'(<\[{])(?:\\?\/){2})[^\s\/?#]+@/#
+        let urlUserInfo = #/((?::|^|[\s"'(<\[{]|(?:^|[\s"'(<\[{])[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Those need a name in front of the label word, and the names come from
@@ -181,12 +181,12 @@ extension Redactor {
         /// `user_code` and `device_code` fields keep their own rule above, which keeps the field
         /// name in the output, so they are deliberately absent here.
         /// Imperative prompts can also delimit their opaque value with a colon or equals.
-        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
         /// The same prompt with nothing after the delimiter: the value is on the next line. The
         /// device-flow field names are included, because arming the next line has no output whose
         /// shape has to be kept. A line that is nothing but `code:` is a prompt too — there is
         /// nothing else on it for the word to belong to.
-        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|^\s*codes?)\s*[:=]\s*$/#.ignoresCase()
+        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|^\s*codes?)\s*[:=]\s*$|(?:^|[^A-Za-z0-9])(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?\s*$/#.ignoresCase()
         /// Device codes such as `1A2B-3C4D` and the `WDJB.MJHT` an RFC 8628 provider may print:
         /// runs of four to eight upper-case characters joined by single separators. Applied only
         /// on lines that mention a code (including the `user_code` and `device_code` field names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -213,7 +213,8 @@ extension Redactor {
         let codePromptWithoutDelimiter = #/((?:^|[^A-Za-z0-9])(?:(?i:(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|(?i:(?:one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\s+(?:is|are|was|were|reads|equals))+)))\s+(?=[A-Za-z0-9._-]{4})(?:[A-Z0-9._-]+|[A-Za-z0-9._-]*[0-9][A-Za-z0-9._-]*)(?![A-Za-z0-9._-])/#
         /// Present-tense declarations explicitly supply the code. Lowercase, short, and
         /// quoted values are opaque. Historical status prose keeps the conservative rule above.
-        let declarativeCodePrompt = #/((?:^|[^A-Za-z0-9])(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?\s+(?:is|are|reads|equals))(?:\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\s,;]+)|\s*$)/#.ignoresCase()
+        /// Encoded quotes span the remaining line; the value scanner preserves their suffix.
+        let declarativeCodePrompt = #/((?:^|[^A-Za-z0-9])(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?\s+(?:is|are|reads|equals))(?:\s+("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\\+["'][^\r\n]*|[^\s,;]+)|\s*$)/#.ignoresCase()
     }
 
     static let patterns = Patterns()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -41,7 +41,7 @@ extension Redactor {
         /// Python dictionary, or a JSON string embedded in a log line quotes it.
         /// The same match determines continuation state before replacement. An empty value
         /// arms the next line even when a logger prefixes or quotes the field name.
-        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:proxy|request)[ _-]?)?authorization\b(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:proxy|request)[ _-]?)?authorization(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
         /// Bearer credentials outside a header line, of any length. Every token and label rule
         /// here starts at a character that cannot be part of the word rather than at `\b`:
         /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
@@ -88,12 +88,13 @@ extension Redactor {
         /// three ordinary letters and dropping it there would redact `risk-averse-...`.
         /// Even a short fragment is sensitive once its distinctive prefix is present.
         let githubToken = #/(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]*|github_pat_[A-Za-z0-9_]*/#
-        let wrappedTokenAtLineEnd = #/((?:ghp|gho|ghu|ghs|ghr)_|github_pat_|sk-(?:proj|svcacct|ant)-)[A-Za-z0-9_-]*$/#
+        /// At line end a boundary-delimited bare `sk-` conservatively arms wrapped-key redaction.
+        let wrappedTokenAtLineEnd = #/(?:^|[^A-Za-z0-9]|(?=(?:ghp|gho|ghu|ghs|ghr)_|github_pat_|sk-(?:proj|svcacct|ant)-))((?:ghp|gho|ghu|ghs|ghr)_|github_pat_|sk-(?:(?:proj|svcacct|ant)-)?)[A-Za-z0-9_-]*$/#
         let tokenContinuation = #/^[ \t]*[A-Za-z0-9_-]+/#
         /// Distinctive project/provider prefixes survive filename concatenation. A generic
         /// `sk-` still needs its boundary so ordinary hyphenated words such as `risk-averse`
         /// remain intact.
-        let apiKey = #/(^|[^A-Za-z0-9]|(?=sk-(?:proj|svcacct|ant)-))(sk-[A-Za-z0-9_-]{16,})/#
+        let apiKey = #/(^|[^A-Za-z0-9]|(?=sk-(?:proj|svcacct|ant)-))(sk-(?:[A-Za-z0-9_-]{16,}|[A-Za-z0-9_-]*$))/#
         let distinctiveAPIKey = #/sk-(?:proj|svcacct|ant)-[A-Za-z0-9_-]*/#
         /// JSON Web Tokens, matched structurally: Base64URL segments (the last may be empty) of
         /// which one decodes to a JSON object, whitespace allowed. More than three segments are
@@ -124,13 +125,13 @@ extension Redactor {
         /// One vocabulary shared by inline fields, bare labels, and command options.
         /// Explicit private-key labels are sensitive even when the value is not PEM.
         private static var secretName: Regex<Substring> {
-            #/(?:(?:access|refresh|auth|client|app|session|user|bearer|private|shared|signing|master|id|current|new|old|previous|confirm|confirmation)[ _-]?)?(?:password|passphrase|passwd|secret|token|credentials?|api[ _-]?key|private[ _-]?key|secret[ _-]?access[ _-]?key|access[ _-]?key[ _-]?secret)/#
+            #/(?:(?:access|refresh|auth|client|app|session|user|bearer|private|shared|signing|master|id|current|new|old|previous|confirm|confirmation)[ _-]?)?(?:password|passphrase|passwd|secret|token|credentials?|api[ _-]?key|private[ _-]?key|secret[ _-]?key|secret[ _-]?access[ _-]?key|access[ _-]?key[ _-]?secret)/#
         }
         private static var secretLabel: Regex<(Substring, Substring, Substring)> {
             Regex {
                 #/(^|[^A-Za-z0-9])(?:\\?["'])?/#
                 Capture { secretName }
-                #/\b(?:\\?["'])?\s*[:=]\s*/#
+                #/(?:\\?["'])?\s*[:=]\s*/#
             }
         }
         let labeledSecret = Regex {
@@ -174,7 +175,7 @@ extension Redactor {
         /// The explicit code fields of an OAuth device flow. Their values are opaque and their
         /// shape is the provider's choice, so the whole value goes, not just a `XXXX-XXXX` one,
         /// and an unquoted one runs to the end of the line the way a labeled secret's does.
-        let codeField = #/(^|[^A-Za-z0-9])(?:\\?["'])?((?:user|device)[ _-]?codes?)\b(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        let codeField = #/(^|[^A-Za-z0-9])(?:\\?["'])?((?:user|device)[ _-]?codes?)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
         /// The prose a CLI prints when it wants a code typed in — `Your one-time code is: …` —
         /// with the value on the same line. The value is as opaque as a field's, so all of it
         /// goes whatever its shape. The code has to be named: a line that merely contains the
@@ -183,7 +184,7 @@ extension Redactor {
         /// name in the output, so they are deliberately absent here.
         /// Imperative prompts can also delimit their opaque value with a colon or equals.
         /// Up to two instruction words may follow `code`, as in `code shown below:`.
-        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?(?:\s+(?!\[redacted:)\S+){0,2}?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+(?!\[redacted:)\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?(?:\s+(?!\[redacted:)\S+){0,2}?)\s*[:=]|^\s*codes?\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
         /// The same prompt with nothing after the delimiter: the value is on the next line. The
         /// device-flow field names are included, because arming the next line has no output whose
         /// shape has to be kept. A line that is nothing but `code:` is a prompt too — there is

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -180,12 +180,13 @@ extension Redactor {
         /// word, such as `process exited with code 1`, is a diagnostic, not a prompt. The
         /// `user_code` and `device_code` fields keep their own rule above, which keeps the field
         /// name in the output, so they are deliberately absent here.
-        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
+        /// Imperative prompts can also delimit their opaque value with a colon or equals.
+        let codePrompt = #/((?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)\s*[:=])\s*(?:"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|\S[^\r\n]*)/#.ignoresCase()
         /// The same prompt with nothing after the delimiter: the value is on the next line. The
         /// device-flow field names are included, because arming the next line has no output whose
         /// shape has to be kept. A line that is nothing but `code:` is a prompt too — there is
         /// nothing else on it for the word to belong to.
-        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|^\s*codes?)\s*[:=]\s*$/#.ignoresCase()
+        let codePromptOnly = #/(?:(?:^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:your|one[ _-]?time|verification|activation|confirmation|pairing|login|security|authorization|auth|access|user|device)[ _-]?codes?(?:\\?["'])?(?:\s+\S+){0,2}?|(?:enter|type|paste|copy|input)(?:\s+\S+){0,3}?\s+codes?)|^\s*codes?)\s*[:=]\s*$/#.ignoresCase()
         /// Device codes such as `1A2B-3C4D` and the `WDJB.MJHT` an RFC 8628 provider may print:
         /// runs of four to eight upper-case characters joined by single separators. Applied only
         /// on lines that mention a code (including the `user_code` and `device_code` field names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -1,0 +1,55 @@
+import Foundation
+import RegexBuilder
+
+/// Removes secrets from text before it can reach a log, the GUI, or a diagnostics export.
+///
+/// MVP-PLAN.md §3 ("Local storage"): private keys, tokens, device codes, authorization
+/// headers, and raw authentication output must never be persisted or exported. The redactor
+/// errs on the side of removing too much; over-redaction costs a little debuggability,
+/// under-redaction leaks a credential.
+///
+/// Each removed secret is replaced by `[redacted:<kind>]` so a reader can still see what was
+/// there and where.
+struct Redactor: Sendable {
+    /// Carried across `redact(line:state:)` calls so a secret split over many lines is
+    /// removed in full.
+    struct StreamState: Hashable, Sendable {
+        /// Which kind of control string is open, because only an OSC also ends at BEL.
+        enum ControlString: Hashable, Sendable {
+            case osc
+            case other
+        }
+
+        struct QuotedValue: Hashable, Sendable {
+            let delimiter: Character
+            let escapeDepth: Int
+            let kind: String
+        }
+
+        /// The label of the PEM block being removed, until its matching footer.
+        var pemLabel: String?
+        /// The previous line was a bare `Authorization:` label; the value follows on this line.
+        var expectingAuthorizationValue = false
+        /// That label carried no value of its own, so the next line is the value whether it is
+        /// indented or not. A header that did carry one folds only over indented lines.
+        var authorizationValueIsOnTheNextLine = false
+        /// The previous line was a bare `password:`-style label; the value follows on this line.
+        var expectingSecretValue = false
+        /// The previous line labeled a secret and gave a value that may fold onto this one.
+        var expectingSecretContinuation = false
+        /// The previous line asked for a code but carried none; the value follows on this line.
+        var expectingDeviceCode = false
+        /// A distinctive token prefix reached a line boundary; payload may continue after it.
+        var wrappedTokenKind: String?
+        /// Quoted values may wrap without indentation and remain sensitive until the quote closes.
+        var quotedValue: QuotedValue?
+        /// A terminal control string opened on an earlier line and has not been terminated yet.
+        var openControlString: ControlString?
+
+        init() {}
+    }
+
+    init() {}
+
+    static func marker(_ kind: String) -> String { "[redacted:\(kind)]" }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -24,6 +24,7 @@ struct Redactor: Sendable {
             let delimiter: Character
             let escapeDepth: Int
             let kind: String
+            var singleQuotesAreLiteral = false
         }
 
         /// The label of the PEM block being removed, until its matching footer.
@@ -52,4 +53,15 @@ struct Redactor: Sendable {
     init() {}
 
     static func marker(_ kind: String) -> String { "[redacted:\(kind)]" }
+
+    static func mergePendingContexts(from scanned: StreamState, into state: inout StreamState) {
+        state.expectingAuthorizationValue = state.expectingAuthorizationValue || scanned.expectingAuthorizationValue
+        state.authorizationValueIsOnTheNextLine = state.authorizationValueIsOnTheNextLine || scanned.authorizationValueIsOnTheNextLine
+        state.expectingSecretValue = state.expectingSecretValue || scanned.expectingSecretValue
+        state.expectingSecretContinuation = state.expectingSecretContinuation || scanned.expectingSecretContinuation
+        state.expectingDeviceCode = state.expectingDeviceCode || scanned.expectingDeviceCode
+        state.quotedValue = state.quotedValue ?? scanned.quotedValue
+        state.pemLabel = state.pemLabel ?? scanned.pemLabel
+        state.wrappedTokenKind = state.wrappedTokenKind ?? scanned.wrappedTokenKind
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -8,21 +8,43 @@ import Testing
         #expect(("filename\u{009F}" + option).contains(Redactor.patterns.secretOptionOnly))
     }
 
-    @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com"])
+    @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com",
+                      "--remote=//sample:synthetic@example.com", "run -r=//sample:synthetic@example.com"])
     func assignedNetworkPathsRecognizeTheirUserinfo(input: String) throws {
         let match = try #require(input.firstMatch(of: Redactor.patterns.urlUserInfo))
         #expect(match.0.contains("synthetic"))
         #expect(!match.1.contains("synthetic"))
     }
 
-    @Test(arguments: ["https://example.com?remote=//folder@archive", "https://example.com/path//folder@archive"])
+    @Test(arguments: ["https://example.com?remote=//folder@archive", "https://example.com/path//folder@archive",
+                      "https://example.com?--remote=//folder@archive", "https://example.com/path/-r=//folder@archive"])
     func embeddedPathsDoNotBecomeAssignmentValues(input: String) {
         #expect(!input.contains(Redactor.patterns.urlUserInfo))
     }
 
-    @Test(arguments: ["Enter the code", "Paste this code", "Copy your code"])
+    @Test(arguments: ["Enter the code", "Paste this code", "Copy your code",
+                      "Enter the code shown below:", "Paste this code displayed below:"])
     func valueLessImperativePromptsRetainContext(prompt: String) {
         #expect(prompt.contains(Redactor.patterns.codePromptOnly))
+    }
+
+    @Test(arguments: ["Enter the code shown below:", "Paste this code displayed below:"])
+    func delimitedInstructionsStillCaptureInlineValues(prompt: String) throws {
+        let match = try #require((prompt + " abcd").firstMatch(of: Redactor.patterns.codePrompt))
+        #expect(match.1 == prompt)
+        #expect(match.0.hasSuffix("abcd"))
+    }
+
+    @Test(arguments: ["Your device code is:", "Your user code is=", "device code equals : ", "user code reads = "])
+    func delimitedDeclarationsCaptureOnlyTheirOpaqueValues(prompt: String) throws {
+        let match = try #require((prompt + "abcd").firstMatch(of: Redactor.patterns.declarativeCodePrompt))
+        #expect(match.2 == "abcd")
+    }
+
+    @Test(arguments: ["device code island", "user code arguably valid", "Enter the code shown below"])
+    func nearbyProseDoesNotBecomeADelimitedPrompt(input: String) {
+        #expect(!input.contains(Redactor.patterns.declarativeCodePrompt))
+        #expect(!input.contains(Redactor.patterns.codePromptOnly))
     }
 
     @Test(arguments: ["your code is [redacted:device-code]", "Your one-time code is [redacted:device-code]"])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -2,6 +2,12 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorGrammarReviewTests {
+    @Test(arguments: ["--password", "--token", "--api-key", "--github-token"])
+    func terminalSplicesRemainOptionBoundaries(option: String) {
+        #expect(("filename\u{009F}" + option + " synthetic").contains(Redactor.patterns.secretOption))
+        #expect(("filename\u{009F}" + option).contains(Redactor.patterns.secretOptionOnly))
+    }
+
     @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com"])
     func assignedNetworkPathsRecognizeTheirUserinfo(input: String) throws {
         let match = try #require(input.firstMatch(of: Redactor.patterns.urlUserInfo))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -2,6 +2,23 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorGrammarReviewTests {
+    @Test(arguments: ["Authorization:opaque", "Proxy-Authorization:opaque", "\"Authorization\":\"opaque\""])
+    func authorizationDelimitersBoundLabelsWithoutWhitespace(input: String) {
+        #expect(input.contains(Redactor.patterns.authorizationHeader))
+        #expect(!"AuthorizationExtra:opaque".contains(Redactor.patterns.authorizationHeader))
+    }
+
+    @Test(arguments: ["device_code:first", "user_code:first", "\"device_code\":\"first\"", "'user_code':'first'"])
+    func codeFieldDelimitersBoundLabelsWithoutWhitespace(input: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.codeField))
+        #expect(match.3.contains("first"))
+    }
+
+    @Test(arguments: ["device_codesecret:first", "user_codesecret:first"])
+    func longerIdentifiersDoNotBecomeCodeFields(input: String) {
+        #expect(!input.contains(Redactor.patterns.codeField))
+    }
+
     @Test(arguments: ["--password", "--token", "--api-key", "--github-token"])
     func terminalSplicesRemainOptionBoundaries(option: String) {
         #expect(("filename\u{009F}" + option + " synthetic").contains(Redactor.patterns.secretOption))
@@ -28,7 +45,7 @@ import Testing
         #expect(prompt.contains(Redactor.patterns.codePromptOnly))
     }
 
-    @Test(arguments: ["Enter the code shown below:", "Paste this code displayed below:"])
+    @Test(arguments: ["Enter the code shown below:", "Paste this code displayed below:", "Code:", " Code="])
     func delimitedInstructionsStillCaptureInlineValues(prompt: String) throws {
         let match = try #require((prompt + " abcd").firstMatch(of: Redactor.patterns.codePrompt))
         #expect(match.1 == prompt)
@@ -41,8 +58,11 @@ import Testing
         #expect(match.2 == "abcd")
     }
 
-    @Test(arguments: ["device code island", "user code arguably valid", "Enter the code shown below"])
+    @Test(arguments: ["device code island", "user code arguably valid", "Enter the code shown below", "error code:42", "risk-averse-and-careful", "prefixsk-short", "sk- is a prefix"])
     func nearbyProseDoesNotBecomeADelimitedPrompt(input: String) {
+        #expect(!input.contains(Redactor.patterns.codePrompt))
+        #expect(!input.contains(Redactor.patterns.wrappedTokenAtLineEnd))
+        #expect(!input.contains(Redactor.patterns.apiKey))
         #expect(!input.contains(Redactor.patterns.declarativeCodePrompt))
         #expect(!input.contains(Redactor.patterns.codePromptOnly))
     }
@@ -51,5 +71,20 @@ import Testing
     func existingMarkersDoNotBecomePromptDelimiters(input: String) {
         #expect(!input.contains(Redactor.patterns.codePrompt))
         #expect(!input.contains(Redactor.patterns.codePromptOnly))
+    }
+
+    @Test(arguments: ["secret_key", "secretKey", "secret-key", "secret key", "password", "token"], [":", "="])
+    func secretLabelsUseTheirDelimiterAsTheBoundary(label: String, delimiter: String) throws {
+        let match = try #require((label + delimiter + "opaqueValue").firstMatch(of: Redactor.patterns.labeledSecret))
+        #expect(match.2 == label)
+        #expect(match.3 == "opaqueValue")
+        #expect((label + delimiter).contains(Redactor.patterns.secretLabelOnly))
+    }
+
+    @Test(arguments: ["", "file.", " ", "_"], ["", "short", "abcdefghijklmnopqrst"])
+    func genericWrappedKeysKeepTheirPrefixCapture(prefix: String, payload: String) throws {
+        let input = prefix + "sk-" + payload
+        #expect(try #require(input.firstMatch(of: Redactor.patterns.wrappedTokenAtLineEnd)).1 == "sk-")
+        #expect(try #require(input.firstMatch(of: Redactor.patterns.apiKey)).2 == "sk-" + payload)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -1,0 +1,27 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorGrammarReviewTests {
+    @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com"])
+    func assignedNetworkPathsRecognizeTheirUserinfo(input: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.urlUserInfo))
+        #expect(match.0.contains("synthetic"))
+        #expect(!match.1.contains("synthetic"))
+    }
+
+    @Test(arguments: ["https://example.com?remote=//folder@archive", "https://example.com/path//folder@archive"])
+    func embeddedPathsDoNotBecomeAssignmentValues(input: String) {
+        #expect(!input.contains(Redactor.patterns.urlUserInfo))
+    }
+
+    @Test(arguments: ["Enter the code", "Paste this code", "Copy your code"])
+    func valueLessImperativePromptsRetainContext(prompt: String) {
+        #expect(prompt.contains(Redactor.patterns.codePromptOnly))
+    }
+
+    @Test(arguments: ["your code is [redacted:device-code]", "Your one-time code is [redacted:device-code]"])
+    func existingMarkersDoNotBecomePromptDelimiters(input: String) {
+        #expect(!input.contains(Redactor.patterns.codePrompt))
+        #expect(!input.contains(Redactor.patterns.codePromptOnly))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+/// Synthetic examples exercise recognition before a public sanitizer is introduced.
+@Suite struct RedactorGrammarTests {
+    @Test(arguments: [
+        ("payload.accessToken=grammarValue", "accessToken", "grammarValue"),
+        (#"{"clientSecret":"grammar value"}"#, "clientSecret", #""grammar value""#),
+        ("private_key: grammar value", "private_key", "grammar value"),
+        ("previous-password: grammarValue", "previous-password", "grammarValue"),
+    ])
+    func secretFieldsCaptureTheCompleteValue(input: String, label: String, value: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.labeledSecret))
+        #expect(match.2 == label)
+        #expect(match.3 == value)
+    }
+
+    @Test(arguments: ["password:", #""refresh_token": "#, "payload.privateKey= "])
+    func bareSecretLabelsRemainDistinctFromInlineValues(input: String) {
+        #expect(input.contains(Redactor.patterns.secretLabelOnly))
+        #expect(!input.contains(Redactor.patterns.labeledSecret))
+    }
+
+    @Test(arguments: [
+        ("run --github-token grammarValue --verbose", "--github-token"),
+        ("run --private-key=grammarValue", "--private-key"),
+        ("run -password grammarValue", "-password"),
+    ])
+    func commandOptionsCaptureOnlyTheOptionPrefix(input: String, option: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.secretOption))
+        #expect(match.2 == option)
+        #expect(input[match.range.upperBound...].hasPrefix("grammarValue"))
+    }
+
+    @Test(arguments: ["run --password", "run --client-secret= "])
+    func missingCommandValuesAreRecognized(input: String) {
+        #expect(input.contains(Redactor.patterns.secretOptionOnly))
+        #expect(!input.contains(Redactor.patterns.secretOption))
+    }
+
+    @Test(arguments: [
+        ("payload.Authorization: Custom grammarValue", "Custom grammarValue"),
+        ("Proxy-Authorization=Digest username=sample, response=synthetic", "Digest username=sample, response=synthetic"),
+        (#"{"request_authorization":"Custom grammarValue"}"#, #""Custom grammarValue""#),
+    ])
+    func authorizationFieldsCaptureOpaqueAndMultipartValues(input: String, value: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.authorizationHeader))
+        #expect(match.2 == value)
+    }
+
+    @Test(arguments: [
+        "process exited with code 1", "Enter the code shown below",
+        "the login code was rejected", "error code: 42",
+    ])
+    func diagnosticProseDoesNotBecomeACodePrompt(input: String) {
+        #expect(!input.contains(Redactor.patterns.codePrompt))
+        #expect(!input.contains(Redactor.patterns.codePromptOnly))
+        #expect(!input.contains(Redactor.patterns.codePromptWithoutDelimiter))
+        #expect(!input.contains(Redactor.patterns.declarativeCodePrompt))
+    }
+
+    @Test(arguments: [
+        "tokenizer: ready", "secretary: available", "passwordLength=12",
+        "run --token-count 42", "run --output report.json",
+    ])
+    func ordinaryNamesDoNotMatchCredentialFieldsOrOptions(input: String) {
+        #expect(!input.contains(Redactor.patterns.labeledSecret))
+        #expect(!input.contains(Redactor.patterns.secretOption))
+        #expect(!input.contains(Redactor.patterns.secretOptionOnly))
+    }
+
+    @Test(arguments: ["ABCD-EFGH.example.com", "12345678-1234-1234-1234-123456789012"])
+    func longerIdentifiersDoNotBecomeDeviceCodes(input: String) {
+        #expect(!input.contains(Redactor.patterns.deviceCode))
+    }
+
+    @Test(arguments: ["Digest authentication supported", "Negotiate", "AWS4-HMAC-SHA256 supported"])
+    func authenticationSchemesWithoutCredentialValuesRemainUnmatched(input: String) {
+        #expect(!input.contains(Redactor.patterns.digestAuthorization))
+        #expect(!input.contains(Redactor.patterns.specializedAuthorization))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
@@ -5,6 +5,19 @@ import Testing
 /// Synthetic examples exercise recognition before a public sanitizer is introduced.
 @Suite struct RedactorGrammarTests {
     @Test(arguments: [
+        ("Enter the code: ABC123", "Enter the code:"),
+        ("Enter this code: abcdef", "Enter this code:"),
+        ("Paste a code= tiny", "Paste a code="),
+        ("Copy your code: \"synthetic value\"", "Copy your code:"),
+    ])
+    func delimitedImperativePromptsCaptureTheCompleteValue(input: String, prompt: String) throws {
+        let match = try #require(input.firstMatch(of: Redactor.patterns.codePrompt))
+        #expect(match.1 == prompt)
+        #expect(match.range.upperBound == input.endIndex)
+        #expect(prompt.contains(Redactor.patterns.codePromptOnly))
+    }
+
+    @Test(arguments: [
         ("payload.accessToken=grammarValue", "accessToken", "grammarValue"),
         (#"{"clientSecret":"grammar value"}"#, "clientSecret", #""grammar value""#),
         ("private_key: grammar value", "private_key", "grammar value"),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarTests.swift
@@ -4,6 +4,14 @@ import Testing
 
 /// Synthetic examples exercise recognition before a public sanitizer is introduced.
 @Suite struct RedactorGrammarTests {
+    @Test(arguments: ["\\\"", "\\'", "\\\\\\\""])
+    func encodedCodeValuesKeepTheirCompleteQuotedPayload(quote: String) throws {
+        let value = quote + "synthetic secret value" + quote
+        let match = try #require(("Your code is " + value).firstMatch(of: Redactor.patterns.declarativeCodePrompt))
+        let captured = try #require(match.2)
+        #expect(captured == value)
+    }
+
     @Test(arguments: [
         ("Enter the code: ABC123", "Enter the code:"),
         ("Enter this code: abcdef", "Enter this code:"),


### PR DESCRIPTION
Credential labels with tightly attached values, generic secret-key names, and wrapped API-key prefixes were missed by the grammar. This change defines the internal stream state and credential patterns with focused positive and negative grammar tests.

Part of #11 and MVP-PLAN.md §3's redacted logging boundary. This is the first prerequisite for #59; the complete streaming API, field integrations, and public exposure follow in the dependent PRs.

Validation: 54 cumulative Core tests pass with warnings treated as errors. Diff against main: 487 changed lines.

