### PR TITLE
Docs: prioritize Lume candidate work and shared infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Working on Guesthouse
 
-Guesthouse is a native macOS app that prepares an isolated development Mac (a macOS VM run by Tart), connects it to the Codex desktop app, and manages multi-repository Xcode workspaces inside that VM. The developer never needs Terminal, Homebrew, or a hand-written SSH configuration. `MVP-PLAN.md` is the specification; cite its section when a change interprets it.
+Guesthouse is a native macOS app that prepares an isolated development Mac (a macOS VM), connects it to the Codex desktop app, and manages multi-repository Xcode workspaces inside that VM. The developer never needs Terminal, Homebrew, or a hand-written SSH configuration. `MVP-PLAN.md` is the specification; cite its section when a change interprets it.
+
+Prioritize Lume candidate validation and shared infrastructure under [ADR 0002](docs/decisions/0002-prioritize-lume-and-shared-infrastructure.md). New Tart-specific work is deferred; retain its existing implementation and documentation as legacy reference. Lume remains a candidate pending strict runtime verification, human provider preflight, and a separate provider-selection decision.
 
 ## Layout
 
@@ -9,7 +11,7 @@ Guesthouse is a native macOS app that prepares an isolated development Mac (a ma
 | `Guesthouse/` | The SwiftUI app. App Sandbox and Hardened Runtime on. Product name is "Guesthouse Codex VM". | UI state is `@MainActor` (the target sets MainActor default isolation). Never launches processes. |
 | `GuesthouseRuntime/` | Embedded XPC service, non-sandboxed, Hardened Runtime on (added by issue #19). | The only place host operations run. Exposes named operations, never a generic "run a command" API. |
 | `Packages/GuesthouseCore` | Shared models, typed XPC contract, state machines, parsers, validation. | Nonisolated by default; every public type is `Sendable`. No process execution, no host mutations. |
-| `Packages/GuesthouseRuntimeKit` | Process execution and Tart adapters (added by issue #21). | Linked only by `GuesthouseRuntime`. The app target must never import it. |
+| `Packages/GuesthouseRuntimeKit` | Process execution and provider adapters (added by issue #21); shared infrastructure and Lume candidate work are active, Tart adapters are retained. | Linked only by `GuesthouseRuntime`. The app target must never import it. |
 | `Fixtures/` | Sample app and package repositories used inside the guest VM by the phase-0 gates. | Not part of the product. Excluded from CI. |
 | `docs/phase0/` | Recorded results of the phase-0 hardware experiments. | Only filled in from a real run. Never from reasoning. |
 | `docs/decisions/` | Architecture decision records. | One file per decision. |
@@ -66,7 +68,7 @@ bash Tests/CI/test-package-hook.sh
 - Core package types are `Sendable` and nonisolated. Do not add `@MainActor` to core types.
 - No third-party dependencies. If one seems necessary, open an issue that justifies it first.
 - Launch processes only in the runtime service or `GuesthouseRuntimeKit`, always with an executable URL and an argument array. Never `/bin/sh -c`, never string interpolation into a command, never an inherited environment.
-- The service chooses executable paths and flags. Requests from the GUI carry environment IDs and validated options, never paths to run or Tart flags.
+- The service chooses executable paths and flags. Requests from the GUI carry environment IDs and validated options, never paths to run or provider CLI flags, including Tart or Lume flags.
 - Treat guest output, repository content, branch names, file names, and CLI text as untrusted data. Never turn any of it into a host command.
 - Never log or persist tokens, passwords, device codes, private keys, or authorization headers. Route every log line through the redaction layer once it exists (issue #11).
 - Prefer environment UUIDs and relative guest paths over IP addresses as persistent identity.
@@ -75,7 +77,9 @@ bash Tests/CI/test-package-hook.sh
 
 ## Picking work
 
-Issues labeled `agent-ready` are self-contained and CI-verifiable; pick one whose dependencies are closed. Issues labeled `needs-hardware` are experiments a person runs on the reference Mac. Do not attempt them, do not close them, and never write their `docs/phase0/` record from reasoning. Issue #48 lists the order of work.
+Issues labeled `agent-ready` are self-contained and CI-verifiable; pick one whose dependencies are closed and whose scope follows the active Lume/shared priority. Check existing PR coverage before starting another implementation. [Issue #48](https://github.com/PicoMLX/Guesthouse/issues/48) tracks work ordering; [issue #82](https://github.com/PicoMLX/Guesthouse/issues/82) tracks the Lume candidate and its remaining provider blockers. Tart-specific ancestry does not make shared code obsolete or authorize new Tart features.
+
+Issues labeled `needs-hardware` are experiments a person runs on the reference Mac. Do not attempt them, do not close them, and never write their `docs/phase0/` record from reasoning. The priority change does not pass a gate, waive its proofs, or authorize bypassing signature verification. Review provider-specific procedures through a separate accepted provider-selection ADR and corresponding plan/gate updates before recording formal Lume gate evidence.
 
 ## Definition of done
 

--- a/MVP-PLAN.md
+++ b/MVP-PLAN.md
@@ -1,5 +1,7 @@
 # Guesthouse: GUI-first MVP technical plan
 
+> Current work prioritizes Lume candidate validation and shared infrastructure under [ADR 0002](docs/decisions/0002-prioritize-lume-and-shared-infrastructure.md). Tart-specific instructions below are retained as legacy reference; new Tart-specific work is deferred. Lume is not yet an accepted provider. A separate accepted provider-selection ADR and corresponding plan/gate updates must precede formal Lume gate evidence. Shared security, lifecycle, and proof requirements remain in force.
+
 Build a native macOS app that prepares an isolated development Mac, connects it to the existing Codex desktop app, and manages multi-repository Xcode workspaces. The developer should not need Terminal, Homebrew, an SSH configuration tutorial, or a hand-written environment manifest.
 
 The proposed implementation is a sandboxed SwiftUI app with a narrowly scoped, non-sandboxed XPC runtime service around the official Tart executable and OpenSSH. GitHub CLI and Codex CLI run inside the guest. Do not build a new chat interface, fork Tart or Codex, or implement a virtualization engine for the MVP.

--- a/docs/decisions/0002-prioritize-lume-and-shared-infrastructure.md
+++ b/docs/decisions/0002-prioritize-lume-and-shared-infrastructure.md
@@ -1,0 +1,30 @@
+# 2. Prioritize Lume candidate work and shared infrastructure
+
+Date: 2026-09-05
+
+## Status
+
+Accepted for work prioritization only. Provider selection remains pending.
+
+## Context
+
+The owner has directed active work toward Lume and shared infrastructure, with new Tart-specific work set aside. [MVP-PLAN.md](../../MVP-PLAN.md) §§1, 3, 4, and 10 still describe the Tart-based implementation plan. [Issue #48](https://github.com/PicoMLX/Guesthouse/issues/48) tracks the roadmap; [issue #82](https://github.com/PicoMLX/Guesthouse/issues/82) tracks Lume as a candidate. Work priority needs to be explicit without converting a candidate into a proven provider.
+
+Issue #82 records a 2026-09-03 observation on macOS 26.4.1: the official Lume 0.5.3 archive matched its published digest but failed strict signature verification. The [candidate runbook](https://github.com/PicoMLX/Guesthouse/blob/931dc8462299feab10b7422130a707ed89204092/docs/runbooks/lume-phase0.md) remains **not run**. Its signed XPC probe is the implemented procedure; its lifecycle and VNC sections require a separate reviewed, bounded runtime diagnostic. This decision adds no experiment or verification result.
+
+## Decision
+
+- Prioritize maintenance and review of the Lume candidate work in #82 and shared infrastructure: storage, redaction, process execution, typed XPC, ownership/recovery models, compatibility checks, and reusable GUI/workspace contracts. Respect each task's dependencies and existing PR coverage.
+- Defer new Tart-specific parser, bundle-verification, and lifecycle work tracked by [#13](https://github.com/PicoMLX/Guesthouse/issues/13), [#23](https://github.com/PicoMLX/Guesthouse/issues/23), and [#25](https://github.com/PicoMLX/Guesthouse/issues/25). Retain existing code, PRs, findings, and documentation for reference; deferral is reversible and does not mean completed or rejected.
+- Keep reusable work in mixed areas such as [#24](https://github.com/PicoMLX/Guesthouse/issues/24) and [#32](https://github.com/PicoMLX/Guesthouse/issues/32). Review their provider-specific dependencies before reuse. A historical Tart ancestor does not make shared work obsolete or make its Tart lifecycle implementation a Lume implementation.
+- Preserve the security boundaries in `MVP-PLAN.md` §§3 and 8: authenticated named XPC operations, service-chosen executables and arguments, private managed storage, strict runtime verification, redacted diagnostics, and no arbitrary host commands or shared host credentials.
+
+Lume remains a candidate. Before accepting it, obtain and pin a corrected artifact that passes strict verification, then have a person complete the signed-app/provider preflight through the reviewed diagnostic boundary. Resolve the required storage, lifecycle, bootstrap-credential, and VNC containment proofs; software tests and CLI help do not establish them. Do not weaken verification to proceed with the rejected artifact.
+
+A separate accepted provider-selection ADR must record the evidence and resulting architecture. Update the plan, gate issues, [phase-zero registry](../phase0/README.md), and [record template](../phase0/TEMPLATE.md) before recording formal Lume gate evidence. Native guest GPU/MLX capability still requires the §10 hardware proof; CPU or Simulator results do not establish it. The existing gate requirements and explicitly limited exception process remain in force.
+
+## Consequences
+
+Tart-specific instructions in the plan remain labeled legacy reference until the provider decision and corresponding updates replace them. Shared requirements continue to govern current work. Future changes should cite this decision when the old Tart work order conflicts with the active priority.
+
+No phase-zero gate passes or fails because of this decision. All nine records remain not started, and the complete-path gate still precedes splitting the later-phase epics. Issues #48 and #82 remain open tracking work and evidence; this documentation change closes neither.

--- a/docs/phase0/README.md
+++ b/docs/phase0/README.md
@@ -2,6 +2,8 @@
 
 `MVP-PLAN.md` §10 defines eight phase-zero gates plus a final complete-path run. Each is an experiment a person runs on the reference Mac. The result lives here, in one file per gate, written from [TEMPLATE.md](TEMPLATE.md).
 
+The [Lume/shared work-priority decision](../decisions/0002-prioritize-lume-and-shared-infrastructure.md) records no gate result; all nine gates remain **not started**. Provider-specific procedures require review and updates to the plan, gate issues, registry, and template after a separate accepted provider-selection ADR, before formal Lume gate evidence is recorded. Existing proof requirements and the narrow exception rules below remain unchanged.
+
 A gate record is evidence, not a plan. It is written only from an actual run, never from reasoning about what should happen. Autonomous agents do not run gates and do not fill in these files.
 
 ## Gates


### PR DESCRIPTION
## Summary

The plan and contributor instructions still direct new work toward Tart despite the owner's current Lume/shared priority. ADR 0002 records that work priority, defers new Tart-specific work while retaining existing code and findings, and adds brief notices to AGENTS, the plan, and the phase-zero index.

Lume remains a candidate pending strict artifact verification, human provider preflight, and a separate provider-selection ADR. This preserves the security and hardware-proof requirements in `MVP-PLAN.md` §§3, 8, and 10, adds no experiment result, and leaves all nine gates not started.

Related: #48 and #82; closes neither. Stacked on #93 (`issue-2-ci-package-hook`) to preserve its updated CI instructions. The PR contains only 42 additions and 4 deletions across four Markdown files.

## Validation

- The software documentation skill's strict Markdown checker passed all four files with zero errors and warnings.
- All local links resolve; linked issues and the pinned Lume runbook were verified through GitHub.
- `git diff --check` passed. Independent local review found no remaining issues.
- No runtime code or executable examples changed; package/app tests were not rerun locally for this documentation-only change.
- Both Xcode Cloud contexts passed at `ed92fe3a5bd1cbf07f1b06cf1dd5d5f48c4752d9`; Test - macOS completed in 2m19s. Codex completed review of that exact head with a thumbs-up and no findings or unresolved threads.

## Checklist

- [x] Documentation validation covers the change; no new runtime logic
- [x] No new warnings or third-party dependencies
- [x] No secrets, tokens, device codes, or key material added
- [x] Runtime execution and named-operation security boundaries preserved
- [x] Documentation updated at the relevant entry points
- [x] Diff is under roughly 500 lines
