### PR TITLE
Core: stage the runtime event envelope prerequisite

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
@@ -1,0 +1,48 @@
+/// The versioned service-to-GUI event contract for the XPC boundary (MVP-PLAN.md §3).
+///
+/// Transports must encode and decode this envelope, not a bare `RuntimeEvent`, to reject
+/// incompatible service replies before interpreting their version-specific payloads.
+public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
+    public var protocolVersion: RuntimeProtocolVersion
+    public var event: RuntimeEvent
+
+    public init(protocolVersion: RuntimeProtocolVersion = .current, event: RuntimeEvent) {
+        self.protocolVersion = protocolVersion
+        self.event = event
+    }
+
+    private enum CodingKeys: String, CodingKey { case protocolVersion, event }
+
+    /// The outer header is authoritative and required, even for a runtime-version reply.
+    /// A foreign header yields `ProtocolMismatch` before the event is decoded. A supported
+    /// header with contradictory nested version information is malformed, not a mismatch.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion)
+        guard version == .current else { throw ProtocolMismatch(service: version) }
+
+        let decodedEvent = try container.decode(RuntimeEvent.self, forKey: .event)
+        if case .runtimeVersion(let info) = decodedEvent, info.protocolVersion != version {
+            throw DecodingError.dataCorruptedError(
+                forKey: .event,
+                in: container,
+                debugDescription: "The runtime-version payload contradicts its envelope header."
+            )
+        }
+        protocolVersion = version
+        event = decodedEvent
+    }
+
+    /// Thrown before a foreign service's payload is decoded.
+    public struct ProtocolMismatch: Error, Hashable, Sendable {
+        public let service: RuntimeProtocolVersion
+
+        public init(service: RuntimeProtocolVersion) {
+            self.service = service
+        }
+
+        public var error: GuesthouseError {
+            .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: service.rawValue)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventEnvelopeTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventEnvelopeTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct RuntimeEventEnvelopeTests {
+    @Test(arguments: [
+        RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12")),
+        .accepted(OperationID()),
+        .progress(OperationID(), ProgressPhase(kind: .copying, fraction: 0.5)),
+        .log(OperationID(), RedactedLine(literal: "Started")),
+        .log(nil, RedactedLine(literal: "Service launched")),
+        .status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .running, readiness: .ready)),
+        .completed(OperationID()),
+        .failed(OperationID(), .guestNotReachable(EnvironmentID()))
+    ])
+    func eventCasesRoundTrip(event: RuntimeEvent) throws {
+        let envelope = RuntimeEventEnvelope(event: event)
+        let data = try JSONEncoder().encode(envelope)
+        let decoded = try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+
+        #expect(decoded == envelope)
+        #expect(decoded.protocolVersion == .current)
+    }
+
+    @Test
+    func wireKeysKeepVersionOutsideEvent() throws {
+        let data = try JSONEncoder().encode(RuntimeEventEnvelope(event: .completed(OperationID())))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        #expect(Set(object.keys) == ["protocolVersion", "event"])
+        #expect(object["protocolVersion"] as? Int == RuntimeProtocolVersion.current.rawValue)
+        #expect(object["event"] is [String: Any])
+    }
+
+    @Test(arguments: [0, 99])
+    func foreignVersionRejectsUnknownEventBeforePayload(serviceVersion: Int) throws {
+        // Put the event first in the encoded object: JSON key order must not affect validation.
+        let json = #"{"event":{"futureReply":{}},"protocolVersion":\#(serviceVersion)}"#
+        let mismatch = try #require(#expect(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: Data(json.utf8))
+        })
+
+        #expect(mismatch.service == RuntimeProtocolVersion(serviceVersion))
+        #expect(mismatch.error == .protocolMismatch(
+            client: RuntimeProtocolVersion.current.rawValue,
+            service: serviceVersion
+        ))
+    }
+
+    @Test
+    func currentVersionUnknownEventIsMalformed() throws {
+        let json = #"{"protocolVersion":\#(RuntimeProtocolVersion.current.rawValue),"event":{"futureReply":{}}}"#
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: Data(json.utf8))
+        })
+
+        guard case .typeMismatch = error else {
+            Issue.record("An unknown current-version event must be a malformed payload: \(error)")
+            return
+        }
+    }
+
+    @Test
+    func missingVersionRefusesOtherwiseValidEvent() throws {
+        let data = try JSONEncoder().encode(RuntimeEventEnvelope(event: .completed(OperationID())))
+        var object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        object.removeValue(forKey: "protocolVersion")
+
+        try expectMissingVersion(try JSONSerialization.data(withJSONObject: object))
+    }
+
+    @Test
+    func bareEventHasNoUnversionedFallback() throws {
+        try expectMissingVersion(try JSONEncoder().encode(RuntimeEvent.completed(OperationID())))
+    }
+
+    @Test
+    func foreignHeaderWinsOverSupportedNestedVersion() throws {
+        let envelope = RuntimeEventEnvelope(
+            protocolVersion: RuntimeProtocolVersion(99),
+            event: .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12"))
+        )
+        let data = try JSONEncoder().encode(envelope)
+
+        #expect(throws: RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        }
+    }
+
+    @Test
+    func currentHeaderWithContradictoryNestedVersionIsMalformed() throws {
+        let envelope = RuntimeEventEnvelope(event: .runtimeVersion(RuntimeVersionInfo(
+            serviceVersion: "0.1.0",
+            serviceBuild: "12",
+            protocolVersion: RuntimeProtocolVersion(99)
+        )))
+        let data = try JSONEncoder().encode(envelope)
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        })
+
+        guard case .dataCorrupted(let context) = error else {
+            Issue.record("Contradictory nested version information must be malformed: \(error)")
+            return
+        }
+        #expect(context.codingPath.map(\.stringValue) == ["event"])
+    }
+
+    private func expectMissingVersion(_ data: Data) throws {
+        let error = try #require(#expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        })
+        guard case .keyNotFound(let key, _) = error else {
+            Issue.record("An unversioned reply must fail at its missing header: \(error)")
+            return
+        }
+        #expect(key.stringValue == "protocolVersion")
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Replaced — closing without merging this historical stack.**
>
> The envelope contract and retained regressions now live on main through #146, #154/#155 and #167. The owner merged #167 on September 12, 2026, completing the last identified missing-version regression.
>
> The two-file original implementation and all eight test behaviors were compared with main `909f63fcf97721c6bcb8eb07fc464f017f6bf8ad`. All retained behavior is present or explicitly superseded by ADR 0003's structured diagnostics/fixed errors. The current protocol version is retained; legacy wire versions and raw-log payloads are not restored.
>
> The original head `acc39dffafd6eb06db7788d3b2be4397941a2df0`, branch, tests and review history remain preserved. The source scope of this prerequisite is complete. Later native/Lume/GUI adapter propagation stays tracked in #112 and reference #103, and signed host evidence remains in #19/#34. Follow the current dashboard in #48.
>
> The original description follows unchanged.

---

## Scope and stack

Contract prerequisite stacked on #67 (`09494d4`), followed by the separate native-XPC activation PR #103. Related to #9/#19 and the still-open [#58 envelope finding](https://github.com/PicoMLX/Guesthouse/pull/58#discussion_r3939830914). Implements the versioned-message boundary specified in `MVP-PLAN.md` §3.

Exactly two new files, **167 additions**: `RuntimeEventEnvelope` and dedicated Core tests. This is the exact envelope-only prerequisite already present in #58 at `f03f2bc`; later merges must coalesce the identical files, not create another envelope or reset a descendant protocol version. No broad base/spine restack and no changes to #67 itself.

The required scalar `protocolVersion` is decoded before `event`. A foreign header throws `RuntimeEventEnvelope.ProtocolMismatch(service:)`, mapping the current client and received service versions correctly. There is no unversioned fallback. The outer header is authoritative: a supported header with contradictory nested runtime-version information is malformed rather than a different negotiated protocol.

This PR stages the contract only and leaves its inherited initial version 1 unchanged. It does not claim the #58 finding fully resolved: production activation and downstream propagation must be reviewed separately.

## Verification

- Dedicated envelope suite: 8 tests passed, parameterized across all seven event cases, both scoped/unscoped log forms, foreign unknown payloads, required header/wire keys, and nested-version precedence.
- Core at the original #58 prerequisite: 330 tests passed. The combined #67 activation tree passed 531 Core tests with warnings-as-errors; these combined results are not a standalone new-head CI claim.
- No signing, installed-service launch, VM operation, new dependency, or host operation was introduced.
- At exact head `acc39df`, both Xcode Cloud Test - macOS and overall status succeeded (test completed 2026-09-05 08:16:38 UTC). [Codex completed its review with no findings](https://github.com/PicoMLX/Guesthouse/pull/102#issuecomment-5550514383), with a fresh thumbs-up and zero review threads. The PR is subscribed; no merge was performed.

## Required downstream integration

The next PR adopts protocol **6** at #67: `GuesthouseRuntime/Sources/main.swift` wraps the single `RuntimeService.handle` answer; `Guesthouse/Runtime/RuntimeTransport.swift` unwraps `XPCSession.sendEnvelope` replies and pushed messages; `RuntimeClient` preserves contract causes separately from accepted/preaccept unknown mutation outcomes. Internal `RuntimeBackend` streams remain `RuntimeEvent`.

Propagation is explicit and still pending:

| Stack layer | Exact boundary to preserve/adopt | Reserved integrated version |
| --- | --- | --- |
| #68–#70 and #88 | `GuesthouseRuntime/Sources/RuntimeService.swift`, `SessionHandler`'s explicit synchronous `message.reply` (including refusal), preserving reply-before-close/session accounting | old 2 → **7** |
| #71/#72 | Preserve shared envelope handling while retaining their Tart/storage payload additions | old 3 → **8** |
| #73–#80 | `RuntimeService.swift`: synchronous `SessionHandler` reply, `ReplyBox.reply` delayed answers, and `SessionSink` pushes; preserve exactly-once, onReply ordering, lifetime, and later import changes | old 4 → **9** |
| #81 | Same three service output sites; `RuntimeClient` reply/error and `connectionInterruptions` paths; `Guesthouse/App/AppModel.swift` mismatch presentation must stop initialization and retain inspect-first mutation recovery | old 5 → **10** |
| Lume #85/#89 | Refreshed `RuntimeService.swift` explicit synchronous reply; any surviving `Packages/GuesthouseRuntimeKit/.../RuntimeSessionResponder.swift` terminal reply; preserve newer shared transport instead of restoring the old #89 codec | old 3 → **11** |
| #83/#100 diagnostics | Audit wire compatibility; compatible diagnostic additions may retain shared version 7 | **7**, only after audit |

Never restore pre-envelope versions 2–5 during a restack. Neither repair guidance nor a malformed response is evidence that an accepted or preaccept mutation is safe to replay. No issue is closed by this prerequisite.

