### PR TITLE
Runtime: validate versioned native XPC events and preserve session failures

### DIFF
--- a/Guesthouse/Runtime/RuntimeClient.swift
+++ b/Guesthouse/Runtime/RuntimeClient.swift
@@ -55,7 +55,7 @@ actor RuntimeClient: RuntimeBackend {
         /// interruption before acceptance may offer the user.
         case reply(Result<RuntimeEvent, any Error>, Continuation, ContinuationKey, mutating: Bool)
         case incoming(RuntimeEvent)
-        case interrupted
+        case interrupted(RuntimeSessionFailure?)
         case consumerGone(ContinuationKey)
         case streamFinished(ContinuationKey)
     }
@@ -195,7 +195,7 @@ actor RuntimeClient: RuntimeBackend {
                 guard !event.isDroppableTraffic || traffic.admit() else { return }
                 inboxContinuation.yield(.incoming(event))
             },
-            interrupted: { inboxContinuation.yield(.interrupted) }
+            interrupted: { inboxContinuation.yield(.interrupted($0)) }
         )
         // The loop borrows `self` per item only, so a client nobody holds is released while
         // the loop waits, and `deinit` then ends the inbox.
@@ -222,7 +222,7 @@ actor RuntimeClient: RuntimeBackend {
             // The slot this event took at ingress is returned once it has been routed, so the
             // bound tracks what the client is actually holding.
             if event.isDroppableTraffic { traffic.release() }
-        case .interrupted: connectionDropped()
+        case .interrupted(let failure): connectionDropped(failure)
         case .consumerGone(let key): consumerGone(key)
         case .streamFinished(let key): streamFinished(key)
         }
@@ -257,13 +257,14 @@ actor RuntimeClient: RuntimeBackend {
                 settle(key)
                 continuation.finish()
             }
-        case .failure:
+        case .failure(let error):
             settle(key)
             // No operation id: the request was never accepted. A read-only query changed
             // nothing and may simply be asked again, but a mutating request may already have
             // reached the service and been journaled or started, so its outcome is unknown
             // and the user is sent to inspect state rather than offered a retry.
-            continuation.finish(throwing: RuntimeConnectionInterrupted(mayHaveMutated: mutating))
+            let failure = RuntimeSessionFailure(decoding: error)?.contextualized(mayHaveMutated: mutating)
+            continuation.finish(throwing: (failure as (any Error)?) ?? RuntimeConnectionInterrupted(mayHaveMutated: mutating))
         }
     }
 
@@ -448,7 +449,7 @@ actor RuntimeClient: RuntimeBackend {
         try? transport.send(RuntimeRequestEnvelope(request: .cancelOperation(id))) { _ in }
     }
 
-    private func connectionDropped() {
+    private func connectionDropped(_ failure: RuntimeSessionFailure?) {
         let pending = operations
         operations.removeAll()
         pendingEvents.removeAll()
@@ -460,7 +461,7 @@ actor RuntimeClient: RuntimeBackend {
         retired.removeAll()
         for (id, continuation) in pending {
             retireConsumers(of: id)
-            continuation.finish(throwing: RuntimeConnectionInterrupted(operationID: id))
+            continuation.finish(throwing: (failure?.contextualized(operationID: id) as (any Error)?) ?? RuntimeConnectionInterrupted(operationID: id))
         }
     }
 }

--- a/Guesthouse/Runtime/RuntimeSessionFailure.swift
+++ b/Guesthouse/Runtime/RuntimeSessionFailure.swift
@@ -1,0 +1,52 @@
+import Foundation
+import GuesthouseCore
+
+/// A session contract failure, separate from whether an operation may have changed the host.
+/// No failure here makes a mutation safe to replay (MVP-PLAN.md §3).
+nonisolated struct RuntimeSessionFailure: Error, Hashable, Sendable, LocalizedError {
+    enum Cause: Hashable, Sendable {
+        case protocolMismatch(RuntimeEventEnvelope.ProtocolMismatch)
+        case malformedResponse
+    }
+
+    let cause: Cause
+    let interruption: RuntimeConnectionInterrupted
+
+    init(cause: Cause, operationID: OperationID? = nil, mayHaveMutated: Bool = false) {
+        self.cause = cause
+        interruption = RuntimeConnectionInterrupted(operationID: operationID, mayHaveMutated: mayHaveMutated)
+    }
+
+    init?(decoding error: any Error) {
+        if let failure = error as? Self {
+            self = failure
+        } else if let mismatch = error as? RuntimeEventEnvelope.ProtocolMismatch {
+            self.init(cause: .protocolMismatch(mismatch))
+        } else if error is DecodingError {
+            self.init(cause: .malformedResponse)
+        } else {
+            return nil
+        }
+    }
+
+    func contextualized(operationID: OperationID? = nil, mayHaveMutated: Bool = false) -> Self {
+        Self(cause: cause, operationID: operationID, mayHaveMutated: mayHaveMutated)
+    }
+
+    var protocolMismatch: GuesthouseError? {
+        guard case .protocolMismatch(let mismatch) = cause else { return nil }
+        return mismatch.error
+    }
+
+    private var outcomeUnknown: Bool { interruption.operationID != nil || interruption.mayHaveMutated }
+
+    var errorDescription: String? {
+        let message = protocolMismatch?.userMessage
+            ?? "Guesthouse's runtime service sent a response this app cannot read. Reinstall Guesthouse to repair this."
+        return outcomeUnknown ? "\(message) \(interruption.userMessage)" : message
+    }
+
+    var recoveryActions: [RecoveryAction] {
+        outcomeUnknown ? [.inspectState, .reinstallApp, .cancel] : [.reinstallApp, .cancel]
+    }
+}

--- a/Guesthouse/Runtime/RuntimeTransport.swift
+++ b/Guesthouse/Runtime/RuntimeTransport.swift
@@ -1,5 +1,6 @@
 import Foundation
 import GuesthouseCore
+import Synchronization
 import XPC
 
 /// The thin seam between `RuntimeClient` and XPC, so the client's decoding and interruption
@@ -9,8 +10,9 @@ nonisolated protocol RuntimeTransport: Sendable {
     func send(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws
     /// Pushed events (progress, log, status) arrive through `incoming`; `interrupted` is called
     /// when the connection drops or when a pushed message cannot be decoded, which means the
-    /// peer speaks a different contract and every in-flight outcome is unknown.
-    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void)
+    /// peer's response cannot be trusted and every in-flight outcome is unknown. The optional
+    /// failure preserves contract diagnostics; nil denotes an ordinary connection loss.
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable (RuntimeSessionFailure?) -> Void)
 }
 
 /// What the transport needs of one connection to the service, so the rules around it — lazy
@@ -23,21 +25,33 @@ nonisolated protocol RuntimeSessionHandle: AnyObject, Sendable {
 
 nonisolated extension XPCSession: RuntimeSessionHandle {
     func sendEnvelope(_ envelope: RuntimeRequestEnvelope, reply: @escaping @Sendable (Result<RuntimeEvent, any Error>) -> Void) throws {
-        try send(envelope, replyHandler: reply)
+        try send(envelope) { (result: Result<RuntimeEventEnvelope, any Error>) in
+            reply(result.map(\.event))
+        }
+    }
+}
+
+/// Identity and retirement cause for one connection. The registry publishes retirement
+/// under its lock; callbacks retain only their own generation, not an unbounded history.
+nonisolated final class SessionGeneration: Sendable {
+    private let storage = Mutex<RuntimeSessionFailure?>(nil)
+    fileprivate var failure: RuntimeSessionFailure? {
+        get { storage.withLock { $0 } }
+        set { storage.withLock { $0 = newValue } }
     }
 }
 
 /// Which session the transport is talking to and what its callbacks may reach. Sessions are
-/// numbered, so a callback of a session that has been retired never touches its replacement.
+/// identified by tokens, so a retired session's callback never touches its replacement.
 /// Generic over the session type, so those rules can be tested without a live XPC connection.
 nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     private let lock = NSLock()
     private var session: Session?
-    private var generation = 0
+    private var generation = SessionGeneration()
     private var incoming: (@Sendable (RuntimeEvent) -> Void)?
-    private var interrupted: (@Sendable () -> Void)?
+    private var interrupted: (@Sendable (RuntimeSessionFailure?) -> Void)?
 
-    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable (RuntimeSessionFailure?) -> Void) {
         lock.withLock {
             self.incoming = incoming
             self.interrupted = interrupted
@@ -47,10 +61,10 @@ nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     /// The live session and its generation, creating one with `make` when there is none.
     /// `make` is given the generation, because a session's callbacks are written before the
     /// session exists and each one has to name the session it belongs to.
-    func session(_ make: (Int) throws -> Session) rethrows -> (session: Session, generation: Int) {
+    func session(_ make: (SessionGeneration) throws -> Session) rethrows -> (session: Session, generation: SessionGeneration) {
         try lock.withLock {
             if let session { return (session, generation) }
-            generation += 1
+            generation = SessionGeneration()
             let created = try make(generation)
             session = created
             return (created, generation)
@@ -68,11 +82,20 @@ nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     /// client's unbounded inbox, so nothing waits while the lock is held.
     func deliverReply(
         _ result: Result<RuntimeEvent, any Error>,
-        from generation: Int,
+        from generation: SessionGeneration,
         to reply: @Sendable (Result<RuntimeEvent, any Error>) -> Void
     ) {
         lock.withLock {
-            reply(self.generation == generation ? result : .failure(RuntimeConnectionInterrupted()))
+            // A contract failure also belongs to unanswered requests on the retired session.
+            // Retaining it on that generation avoids both erasing it and blaming a new peer.
+            if self.generation !== generation, generation.failure == nil,
+               case .failure(let error) = result, let failure = RuntimeSessionFailure(decoding: error) {
+                // Ordinary cancellation may have won the race with this reply's decoder.
+                // Preserve its known cause for this request only, never the replacement.
+                reply(.failure(failure))
+                return
+            }
+            reply(self.generation === generation ? result : .failure((generation.failure as (any Error)?) ?? RuntimeConnectionInterrupted()))
         }
     }
 
@@ -81,9 +104,9 @@ nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     /// happens entirely before it, and the event is dropped, or entirely after the event is
     /// queued behind the operations it belongs to. The handler only enqueues on the client's
     /// unbounded inbox, so nothing waits while the lock is held.
-    func deliverIncoming(_ event: RuntimeEvent, from generation: Int) {
+    func deliverIncoming(_ event: RuntimeEvent, from generation: SessionGeneration) {
         lock.withLock {
-            guard self.generation == generation else { return }
+            guard self.generation === generation else { return }
             incoming?(event)
         }
     }
@@ -96,13 +119,14 @@ nonisolated final class SessionRegistry<Session>: @unchecked Sendable {
     /// the replacement carries, and can never fail an operation that belongs to it. Nothing
     /// is reported and no session is returned when that generation was already retired, so a
     /// failure and the cancellation that follows it are reported once.
-    func retire(_ generation: Int) -> Session? {
+    func retire(_ generation: SessionGeneration, failure: RuntimeSessionFailure? = nil) -> Session? {
         lock.withLock {
-            guard self.generation == generation else { return nil }
-            self.generation += 1
+            guard self.generation === generation else { return nil }
+            generation.failure = failure
+            self.generation = SessionGeneration()
             let doomed = session
             session = nil
-            interrupted?()
+            interrupted?(failure)
             return doomed
         }
     }
@@ -117,7 +141,7 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     /// already been cancelled. Injected so the transport's rules can be tested without XPC.
     typealias Connect = @Sendable (
         _ incoming: @escaping @Sendable (RuntimeEvent) -> Void,
-        _ dropped: @escaping @Sendable (String?) -> Void
+        _ dropped: @escaping @Sendable (String?, RuntimeSessionFailure?) -> Void
     ) throws -> any RuntimeSessionHandle
 
     private let registry = SessionRegistry<any RuntimeSessionHandle>()
@@ -127,7 +151,7 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
         self.connect = connect
     }
 
-    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable (RuntimeSessionFailure?) -> Void) {
         registry.setHandlers(incoming: incoming, interrupted: interrupted)
     }
 
@@ -148,7 +172,9 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
                 // being handed the same dead session. Retiring first also orders the
                 // interruption ahead of this reply, so the operations that shared the session
                 // are told their outcome is unknown before it is delivered.
-                if case .failure = result { self.dropSession(generation: generation, reason: "reply failed") }
+                if case .failure(let error) = result {
+                    self.dropSession(generation: generation, reason: "reply failed", failure: RuntimeSessionFailure(decoding: error))
+                }
                 self.registry.deliverReply(result, from: generation, to: reply)
             }
         } catch {
@@ -156,16 +182,16 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
             // waiting for its cancellation handler, so the next request performs the
             // documented lazy reconnect rather than being handed the same dead session.
             // Retirement reports the interruption once, so a handler that follows adds nothing.
-            dropSession(generation: generation, reason: "send failed")
+            dropSession(generation: generation, reason: "send failed", failure: RuntimeSessionFailure(decoding: error))
             throw error
         }
     }
 
-    private func activeSession() throws -> (session: any RuntimeSessionHandle, generation: Int) {
+    private func activeSession() throws -> (session: any RuntimeSessionHandle, generation: SessionGeneration) {
         try registry.session { generation in
             try connect(
                 { [weak self] event in self?.registry.deliverIncoming(event, from: generation) },
-                { [weak self] reason in self?.dropSession(generation: generation, reason: reason) }
+                { [weak self] reason, failure in self?.dropSession(generation: generation, reason: reason, failure: failure) }
             )
         }
     }
@@ -173,7 +199,7 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
     /// The real connection to the embedded service.
     static func connectToService(
         incoming: @escaping @Sendable (RuntimeEvent) -> Void,
-        dropped: @escaping @Sendable (String?) -> Void
+        dropped: @escaping @Sendable (String?, RuntimeSessionFailure?) -> Void
     ) throws -> any RuntimeSessionHandle {
         // Created inactive: the session is activated once below. Creating it active and
         // activating again is an XPC API misuse that traps on first use.
@@ -181,28 +207,36 @@ nonisolated final class XPCRuntimeTransport: RuntimeTransport, @unchecked Sendab
             xpcService: serviceName,
             options: .inactive,
             incomingMessageHandler: { (message: XPCReceivedMessage) -> (any Encodable)? in
-                if let event = try? message.decode(as: RuntimeEvent.self) {
-                    incoming(event)
-                } else {
-                    // An undecodable push means a contract mismatch: treat it as a lost
-                    // connection so waiting operations report an unknown outcome.
-                    dropped("undecodable event")
-                }
+                handleIncoming(message, incoming: incoming, dropped: dropped)
                 return nil
             },
-            cancellationHandler: { _ in dropped(nil) }
+            cancellationHandler: { _ in dropped(nil, nil) }
         )
         try created.activate()
         return created
     }
 
+    /// Native Codable boundary shared by the live connection and anonymous-XPC tests.
+    static func handleIncoming(
+        _ message: XPCReceivedMessage,
+        incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+        dropped: @escaping @Sendable (String?, RuntimeSessionFailure?) -> Void
+    ) {
+        do {
+            incoming(try message.decode(as: RuntimeEventEnvelope.self).event)
+        } catch {
+            // Do not log decoder text: it can quote an untrusted payload.
+            dropped("undecodable event", RuntimeSessionFailure(decoding: error) ?? RuntimeSessionFailure(cause: .malformedResponse))
+        }
+    }
+
     /// Clears the session and reports an interruption only if the session that failed is
     /// still the current one.
-    private func dropSession(generation: Int, reason: String?) {
+    private func dropSession(generation: SessionGeneration, reason: String?, failure: RuntimeSessionFailure? = nil) {
         // The generation is retired and the interruption reported while the registry is
         // locked, so no replacement session can carry a request past that report. The
         // cancellation runs afterwards, outside the lock, because it calls this method back.
-        let doomed = registry.retire(generation)
+        let doomed = registry.retire(generation, failure: failure)
         if let doomed, let reason { doomed.cancel(reason: reason) }
     }
 }

--- a/GuesthouseRuntime/Sources/RuntimeService.swift
+++ b/GuesthouseRuntime/Sources/RuntimeService.swift
@@ -37,7 +37,7 @@ final class RuntimeService: Sendable {
     }
 
     /// One reply per request. Streaming events for long operations arrive with #25.
-    func handle(_ message: XPCReceivedMessage) -> (any Encodable)? {
+    func handle(_ message: XPCReceivedMessage) -> RuntimeEvent {
         let envelope: RuntimeRequestEnvelope
         do {
             envelope = try message.decode(as: RuntimeRequestEnvelope.self)

--- a/GuesthouseRuntime/Sources/main.swift
+++ b/GuesthouseRuntime/Sources/main.swift
@@ -15,7 +15,7 @@ let listener: XPCListener
 do {
     listener = try XPCListener(service: RuntimeService.serviceName) { request in
         request.accept { (message: XPCReceivedMessage) -> (any Encodable)? in
-            service.handle(message)
+            RuntimeEventEnvelope(event: service.handle(message))
         } cancellationHandler: { error in
             service.sessionEnded(error)
         }

--- a/GuesthouseTests/NativeRuntimeEventEnvelopeTests.swift
+++ b/GuesthouseTests/NativeRuntimeEventEnvelopeTests.swift
@@ -1,0 +1,138 @@
+import GuesthouseCore
+import Testing
+import XPC
+@testable import Guesthouse
+
+@Suite(.timeLimit(.minutes(1))) struct NativeRuntimeEventEnvelopeTests {
+    @Test(arguments: [
+        RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")),
+        .accepted(OperationID()),
+        .progress(OperationID(), ProgressPhase(kind: .copying)),
+        .log(nil, RedactedLine(literal: "Service launched")),
+        .status(EnvironmentStatus(environmentID: EnvironmentID(), vm: .running, readiness: .ready)),
+        .completed(OperationID()),
+        .failed(OperationID(), .canceled),
+    ])
+    func wrappedRepliesReachTheDomain(event: RuntimeEvent) async throws {
+        #expect(try await reply(to: RuntimeEventEnvelope(event: event)) == event)
+    }
+
+    @Test func foreignRepliesPreserveTheTypedMismatchBeforeUnknownPayloadDecoding() async throws {
+        let caught = await #expect(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
+            try await reply(to: UnknownEventEnvelope(protocolVersion: RuntimeProtocolVersion(99)))
+        }
+        let mismatch = try #require(caught)
+        #expect(mismatch.service == RuntimeProtocolVersion(99))
+        #expect(mismatch.error == .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: 99))
+    }
+
+    @Test func unknownCurrentRepliesAreMalformed() async {
+        await #expect(throws: DecodingError.self) {
+            try await reply(to: UnknownEventEnvelope(protocolVersion: .current))
+        }
+    }
+
+    @Test func malformedCurrentRepliesAreRefused() async {
+        await #expect(throws: DecodingError.self) {
+            try await reply(to: MalformedEventEnvelope())
+        }
+    }
+
+    @Test func unversionedRepliesAreRefused() async {
+        await #expect(throws: DecodingError.self) {
+            try await reply(to: RuntimeEvent.completed(OperationID()))
+        }
+    }
+
+    @Test(arguments: [
+        RuntimeEvent.progress(OperationID(), ProgressPhase(kind: .copying)),
+        .completed(OperationID()),
+    ])
+    func wrappedPushesReachTheDomain(event: RuntimeEvent) async throws {
+        let delivery = try await pushed(RuntimeEventEnvelope(event: event))
+        #expect(delivery.event == event)
+        #expect(delivery.failure == nil)
+    }
+
+    @Test func foreignPushesPreserveTheTypedMismatchBeforeUnknownPayloadDecoding() async throws {
+        let delivery = try await pushed(UnknownEventEnvelope(protocolVersion: RuntimeProtocolVersion(99)))
+        #expect(delivery.event == nil)
+        let failure = try #require(delivery.failure)
+        #expect(failure.cause == .protocolMismatch(RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))))
+    }
+
+    @Test(arguments: [
+        UnknownEventEnvelope(protocolVersion: .current),
+        MalformedEventEnvelope(),
+        RuntimeEvent.completed(OperationID()),
+    ] as [any Encodable & Sendable])
+    func malformedAndUnversionedPushesAreRefused(payload: any Encodable & Sendable) async throws {
+        let delivery = try await pushed(payload)
+        #expect(delivery.event == nil)
+        #expect(try #require(delivery.failure).cause == .malformedResponse)
+    }
+
+    /// An anonymous endpoint exercises the real XPC codec and production reply decoder;
+    /// it never names, installs, signs, or launches the embedded runtime service.
+    private func reply(to payload: any Encodable & Sendable) async throws -> RuntimeEvent {
+        let listener = XPCListener { request in
+            request.accept { (message: XPCReceivedMessage) -> (any Encodable)? in
+                #expect(throws: Never.self) {
+                    let envelope = try message.decode(as: RuntimeRequestEnvelope.self)
+                    #expect(envelope.protocolVersion == .current)
+                    #expect(envelope.request == .runtimeVersion)
+                }
+                return payload
+            }
+        }
+        defer { listener.cancel() }
+        let session = try XPCSession(endpoint: listener.endpoint)
+        defer { session.cancel(reason: "test completed") }
+        let (stream, continuation) = AsyncThrowingStream<RuntimeEvent, any Error>.makeStream()
+        try session.sendEnvelope(RuntimeRequestEnvelope(request: .runtimeVersion)) { result in
+            continuation.yield(with: result)
+            continuation.finish()
+        }
+        var iterator = stream.makeAsyncIterator()
+        return try #require(await iterator.next())
+    }
+
+    /// The push handler receives a real one-way XPC message, not a JSON stand-in.
+    private func pushed(_ payload: any Encodable & Sendable) async throws -> PushDelivery {
+        let (stream, continuation) = AsyncStream<PushDelivery>.makeStream()
+        let listener = XPCListener { request in
+            request.accept { (message: XPCReceivedMessage) -> (any Encodable)? in
+                XPCRuntimeTransport.handleIncoming(
+                    message,
+                    incoming: { continuation.yield(PushDelivery(event: $0, failure: nil)) },
+                    dropped: { _, failure in continuation.yield(PushDelivery(event: nil, failure: failure)) }
+                )
+                continuation.finish()
+                return nil
+            }
+        }
+        defer { listener.cancel() }
+        let session = try XPCSession(endpoint: listener.endpoint)
+        defer { session.cancel(reason: "test completed") }
+        try session.send(payload)
+        var deliveries: [PushDelivery] = []
+        for await delivery in stream { deliveries.append(delivery) }
+        try #require(deliveries.count == 1, "Exactly one incoming-or-dropped callback")
+        return try #require(deliveries.first)
+    }
+}
+
+private struct PushDelivery: Sendable {
+    let event: RuntimeEvent?
+    let failure: RuntimeSessionFailure?
+}
+
+private struct UnknownEventEnvelope: Encodable, Sendable {
+    let protocolVersion: RuntimeProtocolVersion
+    let event: [String: [String: String]] = ["futureEvent": [:]]
+}
+
+private struct MalformedEventEnvelope: Encodable, Sendable {
+    let protocolVersion = RuntimeProtocolVersion.current
+    let event = 73
+}

--- a/GuesthouseTests/RuntimeClientTests.swift
+++ b/GuesthouseTests/RuntimeClientTests.swift
@@ -5,7 +5,7 @@ import Testing
 
 /// A transport that answers from a script and can simulate a dropped connection.
 final class FakeTransport: RuntimeTransport, @unchecked Sendable {
-    enum Behavior { case reply(RuntimeEvent), fail, throwOnSend, acceptThenStream([RuntimeEvent]), acceptThenDrop, acceptLater }
+    enum Behavior { case reply(RuntimeEvent), fail, throwOnSend, acceptThenStream([RuntimeEvent]), acceptThenDrop, acceptThenContractFailure(RuntimeSessionFailure), acceptLater }
     private var pendingReply: (@Sendable (Result<RuntimeEvent, any Error>) -> Void)?
     private(set) var lastAcceptedID: OperationID?
 
@@ -25,7 +25,7 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
     let lock = NSLock()
     var behavior: Behavior
     var incoming: (@Sendable (RuntimeEvent) -> Void)?
-    var interrupted: (@Sendable () -> Void)?
+    var interrupted: (@Sendable (RuntimeSessionFailure?) -> Void)?
     /// Run at the start of the next send, while the client is inside the transport and so
     /// cannot drain its inbox. Lets a test enqueue callbacks in a known order, and observe
     /// what an undrained inbox holds. Consumed by the send that runs it.
@@ -38,7 +38,7 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
 
     init(_ behavior: Behavior) { self.behavior = behavior }
 
-    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable () -> Void) {
+    func setHandlers(incoming: @escaping @Sendable (RuntimeEvent) -> Void, interrupted: @escaping @Sendable (RuntimeSessionFailure?) -> Void) {
         lock.withLock { self.incoming = incoming; self.interrupted = interrupted }
     }
 
@@ -76,7 +76,10 @@ final class FakeTransport: RuntimeTransport, @unchecked Sendable {
             }
         case .acceptThenDrop:
             reply(.success(.accepted(OperationID())))
-            lock.withLock { self.interrupted }?()
+            lock.withLock { self.interrupted }?(nil)
+        case .acceptThenContractFailure(let failure):
+            reply(.success(.accepted(preparedID)))
+            lock.withLock { self.interrupted }?(failure)
         case .acceptLater:
             if case .cancelOperation = envelope.request {
                 reply(.success(.completed(OperationID())))
@@ -540,7 +543,7 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
             return
         }
         #expect(await client.isRetired(id))
-        transport.lock.withLock { transport.interrupted }?()
+        transport.lock.withLock { transport.interrupted }?(nil)
         for _ in 0..<400 where await client.isRetired(id) { try await Task.sleep(for: .milliseconds(5)) }
         #expect(await client.isRetired(id) == false, "a new session does not carry the previous session's ids")
     }
@@ -572,7 +575,7 @@ private func collected(from stream: AsyncThrowingStream<RuntimeEvent, any Error>
 final class RefusingSession: RuntimeSessionHandle, @unchecked Sendable {
     /// How the send is refused: synchronously, or through the reply an interrupted connection
     /// or an undecodable answer would deliver.
-    enum Refusal { case throwOnSend, failTheReply }
+    enum Refusal { case throwOnSend, failTheReply, contractFailure(RuntimeSessionFailure) }
     struct Refused: Error {}
     private let lock = NSLock()
     private var reasons: [String] = []
@@ -585,6 +588,7 @@ final class RefusingSession: RuntimeSessionHandle, @unchecked Sendable {
         switch refusal {
         case .throwOnSend: throw Refused()
         case .failTheReply: reply(.failure(CocoaError(.xpcConnectionInterrupted)))
+        case .contractFailure(let failure): reply(.failure(failure))
         }
     }
 
@@ -609,7 +613,7 @@ final class OpenedSessions: @unchecked Sendable {
         let sessions = OpenedSessions()
         let transport = XPCRuntimeTransport(connect: { _, _ in sessions.open() })
         let interruptions = Counter()
-        transport.setHandlers(incoming: { _ in }, interrupted: { interruptions.increment() })
+        transport.setHandlers(incoming: { _ in }, interrupted: { _ in interruptions.increment() })
         for _ in 0..<2 {
             #expect(throws: RefusingSession.Refused.self) {
                 try transport.send(RuntimeRequestEnvelope(request: .runtimeVersion)) { _ in }
@@ -627,7 +631,7 @@ final class OpenedSessions: @unchecked Sendable {
         let transport = XPCRuntimeTransport(connect: { _, _ in sessions.open(.failTheReply) })
         let interruptions = Counter()
         let failures = Counter()
-        transport.setHandlers(incoming: { _ in }, interrupted: { interruptions.increment() })
+        transport.setHandlers(incoming: { _ in }, interrupted: { _ in interruptions.increment() })
         for _ in 0..<2 {
             #expect(throws: Never.self) {
                 try transport.send(RuntimeRequestEnvelope(request: .runtimeVersion)) { result in
@@ -645,7 +649,7 @@ final class OpenedSessions: @unchecked Sendable {
 /// The transport's session rules, exercised without a live XPC connection.
 @Suite struct SessionRegistryTests {
     /// Collects a `Result` handed to a reply callback.
-    private func delivered(_ registry: SessionRegistry<NSObject>, _ result: Result<RuntimeEvent, any Error>, from generation: Int) -> Result<RuntimeEvent, any Error>? {
+    private func delivered(_ registry: SessionRegistry<NSObject>, _ result: Result<RuntimeEvent, any Error>, from generation: SessionGeneration) -> Result<RuntimeEvent, any Error>? {
         let box = Box<Result<RuntimeEvent, any Error>>()
         registry.deliverReply(result, from: generation) { box.value = $0 }
         return box.value
@@ -670,7 +674,7 @@ final class OpenedSessions: @unchecked Sendable {
         let registry = SessionRegistry<NSObject>()
         let (_, generation) = registry.session { _ in NSObject() }
         let reports = Counter()
-        registry.setHandlers(incoming: { _ in }, interrupted: { reports.increment() })
+        registry.setHandlers(incoming: { _ in }, interrupted: { _ in reports.increment() })
         _ = registry.retire(generation)
         #expect(reports.value == 1)
         _ = registry.retire(generation)
@@ -683,7 +687,7 @@ final class OpenedSessions: @unchecked Sendable {
         let order = Order()
         registry.setHandlers(
             incoming: { _ in },
-            interrupted: {
+            interrupted: { _ in
                 // A replacement is only made by taking the registry's lock, so a request
                 // racing this report has to wait for it. Without that ordering the
                 // replacement's operations are failed by an interruption that predates them.
@@ -704,7 +708,7 @@ final class OpenedSessions: @unchecked Sendable {
         let registry = SessionRegistry<NSObject>()
         let (_, generation) = registry.session { _ in NSObject() }
         let retired = DispatchSemaphore(value: 0)
-        registry.setHandlers(incoming: { _ in }, interrupted: {})
+        registry.setHandlers(incoming: { _ in }, interrupted: { _ in })
         registry.deliverReply(.success(.accepted(OperationID())), from: generation) { _ in
             DispatchQueue.global().async {
                 _ = registry.retire(generation)
@@ -733,7 +737,7 @@ final class OpenedSessions: @unchecked Sendable {
                 // behind the operations of a replacement session.
                 #expect(retired.wait(timeout: .now() + .milliseconds(300)) == .timedOut)
             },
-            interrupted: {}
+            interrupted: { _ in }
         )
         registry.deliverIncoming(.progress(OperationID(), ProgressPhase(kind: .copying)), from: generation)
         #expect(retired.wait(timeout: .now() + .seconds(5)) == .success, "the retirement completed once delivery was done")
@@ -743,7 +747,7 @@ final class OpenedSessions: @unchecked Sendable {
         let registry = SessionRegistry<NSObject>()
         let (_, generation) = registry.session { _ in NSObject() }
         let delivered = DispatchSemaphore(value: 0)
-        registry.setHandlers(incoming: { _ in delivered.signal() }, interrupted: {})
+        registry.setHandlers(incoming: { _ in delivered.signal() }, interrupted: { _ in })
         _ = registry.retire(generation)
         registry.deliverIncoming(.progress(OperationID(), ProgressPhase(kind: .copying)), from: generation)
         #expect(delivered.wait(timeout: .now()) == .timedOut)

--- a/GuesthouseTests/RuntimeSessionFailureTests.swift
+++ b/GuesthouseTests/RuntimeSessionFailureTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import Guesthouse
+
+struct RuntimeSessionFailureTests {
+    @Test(arguments: [
+        RuntimeSessionFailure.Cause.protocolMismatch(RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))),
+        .malformedResponse
+    ], [RuntimeRequest.runtimeVersion, .startEnvironment(EnvironmentID(), StartOptions())])
+    func failedReplyPreservesContractCauseAndPreacceptOutcome(cause: RuntimeSessionFailure.Cause, request: RuntimeRequest) async throws {
+        let failure = RuntimeSessionFailure(cause: cause)
+        let session = RefusingSession(.contractFailure(failure))
+        let transport = XPCRuntimeTransport(connect: { _, _ in session })
+        let client = RuntimeClient(transport: transport)
+        let caught = try #require(await #expect(throws: RuntimeSessionFailure.self) {
+            for try await _ in client.send(request) { Issue.record("A failed reply produced an event") }
+        })
+        #expect(caught.cause == cause)
+        #expect(caught.interruption.operationID == nil)
+        #expect(caught.interruption.mayHaveMutated == request.mutatesHost)
+        #expect(caught.recoveryActions.contains(.inspectState) == request.mutatesHost)
+        #expect(!caught.recoveryActions.contains(.retry))
+        #expect(session.cancelReasons == ["reply failed"], "No automatic request replay")
+    }
+
+    @Test(arguments: [
+        RuntimeSessionFailure.Cause.protocolMismatch(RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))),
+        .malformedResponse
+    ])
+    func acceptedMutationRetainsIdentityAndUnknownOutcome(cause: RuntimeSessionFailure.Cause) async throws {
+        let transport = FakeTransport(.acceptThenContractFailure(RuntimeSessionFailure(cause: cause)))
+        let client = RuntimeClient(transport: transport)
+        var iterator = client.send(.startEnvironment(EnvironmentID(), StartOptions())).makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(transport.preparedID))
+        let caught = try #require(await #expect(throws: RuntimeSessionFailure.self) {
+            try await iterator.next()
+        })
+        #expect(caught.cause == cause)
+        #expect(caught.interruption.guesthouseError == .operationOutcomeUnknown(transport.preparedID))
+        #expect(caught.recoveryActions == [.inspectState, .reinstallApp, .cancel])
+        #expect(transport.sentCount == 1, "No fabricated terminal event or automatic mutation replay")
+    }
+
+    @Test func retirementCauseStaysWithItsGenerationAndIsReportedOnce() throws {
+        let registry = SessionRegistry<NSObject>()
+        let (_, old) = registry.session { _ in NSObject() }
+        let failure = RuntimeSessionFailure(cause: .protocolMismatch(RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99))))
+        let reports = Counter()
+        let incoming = Counter()
+        registry.setHandlers(incoming: { _ in incoming.increment() }, interrupted: { received in
+            #expect(received == failure)
+            reports.increment()
+        })
+        _ = registry.retire(old, failure: failure)
+        let (_, replacement) = registry.session { _ in NSObject() }
+        #expect(registry.retire(old, failure: RuntimeSessionFailure(cause: .malformedResponse)) == nil)
+        let oldReply = Box<Result<RuntimeEvent, any Error>>()
+        registry.deliverReply(.success(.accepted(OperationID())), from: old) { oldReply.value = $0 }
+        guard case .failure(let error) = try #require(oldReply.value) else {
+            Issue.record("A late acceptance must remain an unknown outcome")
+            return
+        }
+        #expect(error as? RuntimeSessionFailure == failure)
+        let event = RuntimeEvent.completed(OperationID())
+        registry.deliverReply(.success(event), from: replacement) { result in
+            #expect((try? result.get()) == event)
+        }
+        registry.deliverIncoming(event, from: old)
+        registry.deliverIncoming(event, from: replacement)
+        #expect(incoming.value == 1)
+        #expect(reports.value == 1)
+    }
+
+    @Test(arguments: [
+        RuntimeEventEnvelope.ProtocolMismatch(service: RuntimeProtocolVersion(99)),
+        DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Malformed fixture"))
+    ] as [any Error])
+    func ordinaryRetirementDoesNotEraseALateRepliesKnownCause(error: any Error) throws {
+        let registry = SessionRegistry<NSObject>()
+        let (_, old) = registry.session { _ in NSObject() }
+        let reports = Counter()
+        registry.setHandlers(incoming: { _ in }, interrupted: { _ in reports.increment() })
+        _ = registry.retire(old)
+        let (_, replacement) = registry.session { _ in NSObject() }
+        let reply = Box<Result<RuntimeEvent, any Error>>()
+        registry.deliverReply(.failure(error), from: old) { reply.value = $0 }
+        guard case .failure(let received) = try #require(reply.value) else {
+            Issue.record("A stale failed reply must remain a failure")
+            return
+        }
+        #expect(received as? RuntimeSessionFailure == RuntimeSessionFailure(decoding: error))
+        #expect(reports.value == 1)
+        registry.deliverReply(.success(.completed(OperationID())), from: replacement) { result in
+            if case .failure = result { Issue.record("An old failure affected the replacement") }
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -9,7 +9,9 @@ public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStri
         self.rawValue = rawValue
     }
 
-    public static let current = RuntimeProtocolVersion(1)
+    // Version 6 adopts event envelopes on native XPC. Versions 2–5 were already used by
+    // pre-envelope descendants; their independent payload additions must be reconciled.
+    public static let current = RuntimeProtocolVersion(6)
 
     public static func < (lhs: RuntimeProtocolVersion, rhs: RuntimeProtocolVersion) -> Bool {
         lhs.rawValue < rhs.rawValue


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: typed/native XPC service and client (#9, #19, #20, #112). Replacements #144–#161 are now on main, including authenticated query-only service/client integration, explicit reply ownership, correlation and retirement. This replaces the earlier integration-pending banner; it does not prove every original regression, later mutation adapter, signed-peer or hardware acceptance item is complete. Finish the retained-scope audit before closing this reference. The closed #110 remains evidence, not proof that all of #112 is complete.
>
> September 10 source mapping complete (11:14 UTC): All nine files in retained head `9d5dace01e0f7a8e998ede1c1e20ca7303032456` have a retained or explicitly superseded mapping. **This is not completed test validation or permission to close this reference.**
>
> - The service's typed single wrapper maps to main's NativeRuntimeRequestHandler and consumed RawRuntimeReplyContext, with wrapped success/refusal, reply ownership and send-failure tests. The service remains query-only.
> - Prototype epoch 6/native Codable is superseded by epoch 12's bounded native dictionary and typed inner envelope. Foreign outer headers are checked before payload decoding; contradictory inner headers, unknown/scalar/bare events are refused. Native Codable decoder-error exposure is not retained.
> - All seven native event kinds and progress/terminal pushes map to the current native fixture; typed DiagnosticEvent replaces raw log under ADR 0003. Registry/transport tests retain one retirement, per-generation causes, late identity/uncertainty and replacement isolation; nonblocking lock assertions replace old timing-dependent checks.
> - The existing `mvp/native-event-regressions` follow-up at `14eeaf7b3b7cce68de13a3db8730e03402521433` supplies the native all-kind/scalar cases and six actual-owner malformed/protocol-mismatch cases before/after acceptance, including retained operation/environment context and no replay. Only two test files differ from main: 65 additions/six deletions.
>
> Source/diff checks and seven shell-only CI-hook scenarios pass. **The prepared head has no Swift/Xcode compilation, package/native test run, publication or Cloud validation.** After #167 lands, integrate main and publish this existing focused replacement. Close this reference without merging only after its reviewed replacements have merged; link their exact validation and explain the superseded boundaries above. Later signed/hardware and mutating-adapter acceptance remains in #112.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

## Scope and stack

Native-XPC activation stacked on the separate event-envelope contract prerequisite #102, which is stacked on unchanged #67 (`09494d4`). Related to #9/#19 and the still-open [#58 envelope finding](https://github.com/PicoMLX/Guesthouse/pull/58#discussion_r3939830914). Implements `MVP-PLAN.md` §3: versioned named messages and unknown outcomes after interrupted mutations.

**445 changed lines** (387 additions, 58 deletions), nine files, commit `9d5dace`. The prerequisite is 167 additions; splitting keeps each actual PR diff below roughly 500 lines. No broad base/spine restack, provider edits, or changes to original #67.

## Behavior

- Adopt wire protocol **6**. Versions 2–5 already belonged to pre-envelope descendants and must not be reused for this new shape.
- Wrap once at `GuesthouseRuntime/Sources/main.swift`'s returned reply; `RuntimeService.handle` now has the concrete domain return type `RuntimeEvent`, so every success/rejection passes that one wrapper.
- Decode `RuntimeEventEnvelope` once in native `XPCSession.sendEnvelope` replies and the pushed-message handler. Pass only the validated event to the unchanged `RuntimeBackend`/domain streams; never accept bare events as a fallback.
- Carry app-internal `RuntimeSessionFailure` through the transport/client with a typed contract cause (known mismatch or malformed response) and separate `RuntimeConnectionInterrupted` outcome context. Known operations retain their IDs; preaccept mutating requests retain `mayHaveMutated`; recovery requires inspection, not automatic replay or an invented terminal result.
- Keep retirement publication and generation gating under the registry lock. Per-session identity tokens retain only their own cause with checked-Sendable `Mutex` storage. A retired generation cannot affect its replacement. An owning failed reply keeps its cause even when retirement precedes delivery; a late typed reply after ordinary cancellation preserves that request's known cause without re-reporting retirement.

## Verification

- **531 Core tests / 33 suites passed**, warnings-as-errors. The first sandboxed run could not perform existing read-only free-space/Finder probes; an authorized unsandboxed run passed, with build caches confined to the temporary harness directory.
- **47 client/transport/native-XPC tests / five suites passed**, warnings-as-errors. A temporary SwiftPM harness symlinks the actual production and committed test files and matches the app's Swift 6/MainActor-default settings; no signed app or installed service was launched.
- Anonymous in-process native XPC tests decode current requests and exercise all seven wrapped reply cases, progress/terminal incoming messages, foreign-header/unknown-case mismatch precedence, and malformed/current/unversioned rejection. They prove Apple's actual codec preserves the exact custom `RuntimeEventEnvelope.ProtocolMismatch` error; JSON-only round trips were not used as transport proof.
- Existing control/terminal reserve, backlog ordering, cancellation, lifetime, and generation-lock tests remain passing. New deterministic tests retain accepted/preaccept unknown outcomes, isolate replacements, report retirement once, and preserve late known causes after ordinary cancellation.
- Actual `RuntimeService.swift` and `main.swift` typechecked together against Apple's XPC SDK with Swift 6 and warnings-as-errors. Independent review found the late-cause race above; it was corrected and regressed before publication. Whitespace check passed.
- No VM work, signing, privileged/installed-service launch, new dependency, or issue-body write.
- At exact head `9d5dace`, both Xcode Cloud Test - macOS and overall status succeeded (test completed 2026-09-05 08:16:32 UTC). [Codex completed its review with no findings](https://github.com/PicoMLX/Guesthouse/pull/103#issuecomment-5550517587), with a fresh thumbs-up and zero review threads. The PR is subscribed; no merge was performed.

## Required propagation and version reconciliation

The identical Core envelope already exists in #58 at `f03f2bc`; later merges must coalesce it. #58 stays the initial unreleased definition 1 until integration; this production boundary adopts 6. The #58 review finding remains open until production review and the remaining propagation are handled.

| Stack layer | Exact next integration sites | Reserved integrated version |
| --- | --- | --- |
| #68–#70 and #88 | `GuesthouseRuntime/Sources/RuntimeService.swift`: `SessionHandler` explicit synchronous `message.reply`, including refusal, preserving reply-before-close and session accounting | old 2 → **7** |
| #71/#72 | Preserve shared envelope handling with their Tart/storage payload additions | old 3 → **8** |
| #73–#80 | `RuntimeService.swift`: synchronous `SessionHandler` reply, `ReplyBox.reply` delayed answers, `SessionSink` pushes; preserve exactly-once/onReply ordering, lifetime, and later import changes | old 4 → **9** |
| #81 | Same three service encoders; `RuntimeClient` reply/error and `connectionInterruptions` paths; `Guesthouse/App/AppModel.swift` must present known mismatch and stop initialization without losing accepted/preaccept inspect-first recovery | old 5 → **10** |
| Lume #85/#89 | Refreshed `RuntimeService.swift` explicit synchronous reply; any surviving `Packages/GuesthouseRuntimeKit/.../RuntimeSessionResponder.swift` terminal reply; retain newer shared transport instead of restoring the old #89 codec | old 3 → **11** |
| #83/#100 diagnostics | Audit compatibility before retaining shared version 7 | **7**, only if wire-compatible |

Later ReplyBox/SessionSink/terminal-responder encoders and #81 UI presentation do not exist at this #67 boundary and are not claimed fixed here. Never let restacking restore pre-envelope versions 2–5. No automatic replay of an unknown mutation is authorized by a session failure.
