### PR TITLE
Implement the complete internal provisioning reducer

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
@@ -58,7 +58,8 @@ enum ProvisioningReducer: Sendable {
                 // the saved stage would offer a start for a step the runtime already ran.
                 guard checkpoint.stage >= stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
                 let write = mint()
-                let status = StageStatus.persistingCheckpoint(checkpoint, operation: interrupted, write: write)
+                // Inspection settled the operation; delayed callbacks cannot abandon this write.
+                let status = StageStatus.persistingCheckpoint(checkpoint, operation: nil, write: write)
                 return (ProvisioningState(stage: checkpoint.stage, status: status, issuedEffects: issued), [.persistCheckpoint(checkpoint, write)])
             case .stillRunning(let id):
                 if let interrupted { try requireSame(interrupted, id) }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
@@ -1,0 +1,312 @@
+import Foundation
+
+/// Pure transition function for `ProvisioningState`.
+///
+/// The rules everything else follows from:
+/// - A start is reserved synchronously with `startRequested` from `notStarted`, `resumable`, or
+///   the previous stage's `completed`, and only then may the runtime be asked; `operationStarted`
+///   is legal solely from `startRequested`. Never from a failure, an unknown outcome, or an
+///   unpersisted checkpoint, and never twice.
+/// - Failure, cancellation, interruption, and user action all lead to an inspection before
+///   anything re-runs, so a retry can never blindly repeat a step whose real outcome is unknown
+///   (MVP-PLAN.md §3, §4, §9). Inspection can be requested again at any time except while a
+///   start request is still live; each request replaces the outstanding one.
+/// - Every start request and effect carries a token, and only the callback naming the outstanding
+///   token is accepted. Lost effects can be reissued without accepting their earlier replies.
+/// - A checkpoint counts only once the journal has it (§3: "Persist ... before updating the UI").
+enum ProvisioningReducer: Sendable {
+    static func reduce(
+        _ state: ProvisioningState,
+        _ event: ProvisioningEvent
+    ) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+        let stage = state.stage
+        var issued = state.issuedEffects
+        func mint() -> EffectToken {
+            issued += 1
+            return EffectToken(issued)
+        }
+        func at(_ status: StageStatus, _ effects: [ProvisioningEffect] = []) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            (ProvisioningState(stage: stage, status: status, issuedEffects: issued), effects)
+        }
+        /// Mints the inspection's token once, so the status and the effect asking for it can
+        /// never name different inspections.
+        func inspect(operation: OperationID? = nil) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            let token = mint()
+            let status = operation.map { StageStatus.unknownOutcome($0, inspection: token) } ?? .awaitingInspection(token)
+            return at(status, [.inspectActualState(stage, token, operation: operation)])
+        }
+        /// Reserves a start for `requested`, carrying forward the durable partial work the
+        /// reservation was made from so a refusal cannot orphan it.
+        func reserve(_ requested: ProvisioningStage, resuming: ResumeEvidence?) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            guard requested == stage else { throw .stageMismatch(expected: stage, actual: requested) }
+            return at(.startRequested(request: mint(), resuming: resuming))
+        }
+        /// Check the request before interpreting its reply: even an acceptance for the wrong
+        /// stage must not abandon a newer reservation. Older records have no request identity,
+        /// so no callback can settle them; explicit inspection is their recovery path.
+        func requireRequest(_ expected: EffectToken?, _ actual: EffectToken) throws(ProvisioningTransitionError) {
+            guard let expected else { throw .illegalTransition(status: state.status.caseName, event: event.caseName) }
+            guard expected == actual else { throw .staleStartRequest(expected: expected, actual: actual) }
+        }
+        /// Applies what inspection found. `interrupted` is the operation the reducer was
+        /// tracking when contact was lost, when it knows one; a reported identity has to be
+        /// that operation, or a second one would be adopted while the first can still mutate.
+        func adopt(_ outcome: ReconciledOutcome, interrupted: OperationID?) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            switch outcome {
+            case .completed(let checkpoint):
+                // A later checkpoint is adopted: the journal is the durable truth, and pinning
+                // the saved stage would offer a start for a step the runtime already ran.
+                guard checkpoint.stage >= stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
+                let write = mint()
+                let status = StageStatus.persistingCheckpoint(checkpoint, operation: interrupted, write: write)
+                return (ProvisioningState(stage: checkpoint.stage, status: status, issuedEffects: issued), [.persistCheckpoint(checkpoint, write)])
+            case .stillRunning(let id):
+                if let interrupted { try requireSame(interrupted, id) }
+                return at(.inProgress(id))
+            case .stillNeedsUserAction(let id, let error):
+                if let interrupted { try requireSame(interrupted, id) }
+                return at(.needsUserAction(id, error))
+            case .cleanupRunning(let cleanup, let error):
+                return at(.cleanupRequired(error, cleanup: cleanup))
+            case .resumable(let evidence):
+                return at(.resumable(evidence))
+            case .failedNeedsCleanup(let error):
+                let cleanup = mint()
+                return at(.cleanupRequired(error, cleanup: cleanup), [.cleanUp(stage, cleanup)])
+            case .failed(let error):
+                return at(.recoverableFailure(error, interrupted: nil))
+            case .notStarted:
+                return at(.notStarted)
+            }
+        }
+
+        switch (state.status, event) {
+
+        case (.notStarted, .startRequested(let requested)):
+            return try reserve(requested, resuming: nil)
+
+        case (.resumable(let evidence), .startRequested(let requested)):
+            return try reserve(requested, resuming: evidence)
+
+        case (.startRejected(_, let resuming), .startRequested(let requested)):
+            return try reserve(requested, resuming: resuming)
+
+        case (.completed, .startRequested(let requested)):
+            guard let next = stage.next else { throw .alreadyReady }
+            guard requested == next else { throw .stageMismatch(expected: next, actual: requested) }
+            let request = mint()
+            return (ProvisioningState(stage: next, status: .startRequested(request: request, resuming: nil), issuedEffects: issued), [])
+
+        case (.startRequested(let request, _), .operationStarted(let id, let requested, let token)):
+            try requireRequest(request, token)
+            // This request has answered, so its reservation is no longer live. An acceptance
+            // at the wrong stage may already be mutating. Inspect its identity across all stages
+            // before reconciling the reserved stage; only that inspection can establish its stage.
+            guard requested == stage else { return inspect(operation: id) }
+            return at(.inProgress(id))
+
+        case (.startRequested(let request, let resuming), .startRequestRejected(let error, let token)):
+            try requireRequest(request, token)
+            // The refusal did nothing, so whatever durable partial work the reservation was made
+            // from is still there and still has to be resumed from once the refusal is dealt with.
+            return at(.startRejected(error, resuming: resuming))
+
+        case (.startRequested(let request, _), .startRequestInterrupted(let token)):
+            try requireRequest(request, token)
+            return inspect()
+
+        case (.startRequested(nil, _), .inspectionRequested):
+            // Only a legacy saved reservation lacks a token. Its old request cannot still be
+            // live in this coordinator, and no uncorrelated callback is accepted in its place.
+            return inspect()
+
+        case (.startRequested, .inspectionRequested):
+            // The reservation stays held: the request is still live, so the runtime may still
+            // accept it, and an inspection that reported `notStarted` would let a second start
+            // race the first. A dropped connection is reported as `startRequestInterrupted`,
+            // which ends the request and does inspect.
+            throw .inspectionWhileStartRequestLive
+
+        case (.inProgress(let current), .checkpointReached(let id, let checkpoint)),
+             (.needsUserAction(let current, _), .checkpointReached(let id, let checkpoint)):
+            // A paused operation resumes as soon as the user does the out-of-app step, which can
+            // be before the GUI reports it; refusing its checkpoint would drop a reached one.
+            try requireSame(current, id)
+            guard checkpoint.stage == stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
+            let write = mint()
+            return at(.persistingCheckpoint(checkpoint, operation: current, write: write), [.persistCheckpoint(checkpoint, write)])
+
+        case (.persistingCheckpoint(let pending, _, let write), .checkpointPersisted(let token, let persisted)):
+            try requireOutstanding(write, token)
+            guard pending == persisted else { throw .checkpointMismatch(expected: pending, actual: persisted) }
+            return at(.completed(persisted))
+
+        case (.persistingCheckpoint(_, let writer, let write), .checkpointPersistenceFailed(let token, let error)):
+            // Reality is ahead of the journal. The failure is shown with its recovery actions;
+            // the user's retry inspects, finds the checkpoint reached, and persists it again.
+            // A failed write does not settle its operation, so recovery must keep that identity.
+            try requireOutstanding(write, token)
+            return at(.recoverableFailure(error, interrupted: writer))
+
+        case (.persistingCheckpoint(_, let writer, _), .connectionInterrupted(let id)):
+            // The write's result is unknown; the journal is inspected before anything else.
+            // An interruption belonging to another operation says nothing about this write, and
+            // a write reconciliation started has no operation behind it at all, so no
+            // operation-scoped interruption is about it either: taking one as relevant would
+            // abandon a live write and make its own successful callback stale.
+            guard let writer else { throw .illegalTransition(status: state.status.caseName, event: event.caseName) }
+            try requireSame(writer, id)
+            return inspect(operation: writer)
+
+        case (.persistingCheckpoint(_, let writer, _), .userRetried),
+             (.persistingCheckpoint(_, let writer, _), .inspectionRequested):
+            // The operation that reached the checkpoint keeps its identity through the check,
+            // for the same reason every other live operation does: it may still be mutating,
+            // and an unscoped inspection would adopt a `stillRunning(B)` naming another one
+            // without `requireSame`, leaving the first unaccounted for while the reducer follows
+            // the second (MVP-PLAN.md §3). A checkpoint restored after a relaunch is exactly
+            // that case: the write is lost, the operation behind it need not be. The unscoped
+            // status is left to a reconciled write, which has no operation behind it.
+            return inspect(operation: writer)
+
+        case (.inProgress(let current), .operationFailed(let id, let error)),
+             (.needsUserAction(let current, _), .operationFailed(let id, let error)):
+            // A paused operation can still time out or die with the guest. Keeping the obsolete
+            // prompt and discarding the failure would hide why the step stopped (MVP-PLAN.md §9).
+            try requireSame(current, id)
+            return at(.recoverableFailure(error, interrupted: nil))
+
+        case (.inProgress(let current), .operationCanceled(let id)):
+            try requireSame(current, id)
+            return at(.canceled)
+
+        case (.inProgress(let current), .userActionRequired(let id, let error)):
+            try requireSame(current, id)
+            return at(.needsUserAction(id, error))
+
+        case (.needsUserAction(let current, _), .operationCanceled(let id)):
+            try requireSame(current, id)
+            return at(.canceled)
+
+        case (.needsUserAction(let current, _), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.inProgress(let current), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.unknownOutcome(let current, _), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.unknownOutcome(let current, _), .userRetried), (.unknownOutcome(let current, _), .inspectionRequested):
+            // A fresh inspection replaces the outstanding one rather than joining it: the reply
+            // to the earlier one describes a state that may already be obsolete, and its token
+            // is no longer accepted.
+            return inspect(operation: current)
+
+        case (.awaitingInspection, .userRetried), (.awaitingInspection, .inspectionRequested):
+            // Reissued rather than suppressed: an inspection whose request was never submitted,
+            // whose reply was lost, or that was still outstanding when the app was relaunched
+            // would otherwise leave no event that can produce a `reconciled` result.
+            return inspect()
+
+        case (.cleanupRequired, .userRetried):
+            // The cleanup's result is unknown; inspect rather than clean up blindly again. If
+            // it turns out to still be running, `cleanupRunning` resumes monitoring it.
+            //
+            // `connectionInterrupted` is deliberately not here. A cleanup is an effect, not an
+            // operation, so no operation-scoped interruption is about it — the same reason the
+            // checkpoint write refuses one that names another operation. Accepting any would
+            // let an interruption belonging to an unrelated operation, delivered late, replace
+            // this cleanup's token with an inspection and make its own `cleanupFinished` stale.
+            // A coordinator that loses contact while a cleanup is pending asks for the
+            // inspection by name with `inspectionRequested`, which lands in the same place.
+            return inspect()
+
+        case (.inProgress(let current), .inspectionRequested), (.needsUserAction(let current, _), .inspectionRequested):
+            // The operation is still live, so its identity is carried through the inspection:
+            // an unscoped one would adopt a `stillRunning` naming some other operation, or a
+            // `notStarted` that permits a second mutation while this one keeps going.
+            return inspect(operation: current)
+
+        case (.recoverableFailure(_, .some(let interrupted)), .inspectionRequested),
+             (.recoverableFailure(_, .some(let interrupted)), .userRetried):
+            // This failure is a check that could not answer for `interrupted`, so that
+            // operation's outcome is exactly as unknown as it was and the replacement
+            // inspection stays scoped to it. An unscoped one would adopt whatever identity the
+            // next answer happens to name while the first operation may still be mutating
+            // (MVP-PLAN.md §3).
+            return inspect(operation: interrupted)
+
+        case (_, .inspectionRequested):
+            return inspect()
+
+        case (.recoverableFailure, .userRetried), (.canceled, .userRetried):
+            return inspect()
+
+        case (.needsUserAction(let current, _), .userActionCompleted):
+            // The operation the user was asked to unblock may still be running, so the
+            // inspection stays scoped to it rather than accepting whatever it reports.
+            return inspect(operation: current)
+
+        case (.unknownOutcome(let interrupted, let inspection), .operationReconciled(let token, let operation, let outcome)):
+            try requireOutstanding(inspection, token)
+            try requireSame(interrupted, operation)
+            switch outcome {
+            case .stillRunning(let actualStage):
+                // Identity checks above make this inspection authoritative about where the
+                // operation is working, so its next checkpoint must be checked at that stage.
+                return (ProvisioningState(stage: actualStage, status: .inProgress(operation), issuedEffects: issued), [])
+            case .stillNeedsUserAction(let error, let actualStage):
+                return (ProvisioningState(stage: actualStage, status: .needsUserAction(operation, error), issuedEffects: issued), [])
+            case .quiescent(.stillRunning), .quiescent(.stillNeedsUserAction):
+                throw .illegalTransition(status: state.status.caseName, event: event.caseName)
+            case .quiescent(let reconciled):
+                return try adopt(reconciled, interrupted: interrupted)
+            }
+
+        case (.awaitingInspection(let inspection), .reconciled(let token, let outcome)):
+            try requireOutstanding(inspection, token)
+            // Nothing here knows which operation was in flight, so a reported identity is the
+            // only one there is.
+            return try adopt(outcome, interrupted: nil)
+
+        case (.awaitingInspection(let inspection), .inspectionFailed(let token, let error)):
+            // The inspection could not answer, so nothing is known that was not known before.
+            // Keeping the error rather than dropping it is what lets the coordinator show why
+            // the check failed and what to do; a retry from a recoverable failure inspects
+            // again, so no mutation can be repeated on the strength of a failed check.
+            try requireOutstanding(inspection, token)
+            return at(.recoverableFailure(error, interrupted: nil))
+
+        case (.unknownOutcome(let interrupted, let inspection), .inspectionFailed(let token, let error)):
+            // The same, except that this state knows which operation is unaccounted for. It
+            // travels with the error: a failed check settles nothing, so forgetting the
+            // operation here would let the retry's inspection adopt a different one while this
+            // one may still be mutating.
+            try requireOutstanding(inspection, token)
+            return at(.recoverableFailure(error, interrupted: interrupted))
+
+        case (.cleanupRequired(_, let cleanup), .cleanupFinished(let token)):
+            try requireOutstanding(cleanup, token)
+            return at(.notStarted)
+
+        case (.cleanupRequired(_, let cleanup), .cleanupFailed(let token, let error)):
+            try requireOutstanding(cleanup, token)
+            return at(.recoverableFailure(error, interrupted: nil))
+
+        default:
+            throw .illegalTransition(status: state.status.caseName, event: event.caseName)
+        }
+    }
+
+    private static func requireSame(_ expected: OperationID, _ actual: OperationID) throws(ProvisioningTransitionError) {
+        guard expected == actual else { throw .operationMismatch(expected: expected, actual: actual) }
+    }
+
+    private static func requireOutstanding(_ expected: EffectToken, _ actual: EffectToken) throws(ProvisioningTransitionError) {
+        guard expected == actual else { throw .staleEffect(expected: expected, actual: actual) }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct ProvisioningReducerTests {
+    typealias Reducer = ProvisioningReducer
+
+    let op = OperationID()
+    let other = OperationID()
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let failure = GuesthouseError.guestNotReachable(EnvironmentID())
+    let consoleNeeded = GuesthouseError.credentialsLocked(.guestKeychain)
+    let evidence = ResumeEvidence(summary: "restore image 62% downloaded", stagingPath: "downloads/restore.ipsw.partial")
+    let pending = EffectToken(1)
+    let next = EffectToken(2)
+
+    func checkpoint(_ stage: ProvisioningStage) -> Checkpoint { Checkpoint(stage: stage, reachedAt: now) }
+    func state(_ stage: ProvisioningStage, _ status: StageStatus) -> ProvisioningState { ProvisioningState(stage: stage, status: status) }
+
+    /// The token the reducer stamped on the effect it just asked for. The coordinator echoes it
+    /// in the callback, and so do these tests.
+    func token(of effects: [ProvisioningEffect]) throws -> EffectToken {
+        switch try #require(effects.first) {
+        case .inspectActualState(_, let token, _), .persistCheckpoint(_, let token), .cleanUp(_, let token): token
+        }
+    }
+
+    struct LegalTransition {
+        let name: String
+        let from: ProvisioningState
+        let event: ProvisioningEvent
+        let expectedStatus: String
+        let expectedEffects: [ProvisioningEffect]
+    }
+
+    var legalTransitions: [LegalTransition] {
+        [
+            .init(name: "request first stage", from: .initial, event: .startRequested(stage: .preflight), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "runtime accepts the requested start", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .operationStarted(op, stage: .preflight, request: pending), expectedStatus: "inProgress", expectedEffects: []),
+            .init(name: "runtime rejects the request: error kept, nothing ran", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .startRequestRejected(failure, request: pending), expectedStatus: "startRejected", expectedEffects: []),
+            .init(name: "a new request after a rejection needs no inspection", from: state(.preflight, .startRejected(failure, resuming: nil)), event: .startRequested(stage: .preflight), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "user cancels while a console step is pending", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .operationCanceled(op), expectedStatus: "canceled", expectedEffects: []),
+            .init(name: "request interrupted: inspect", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .startRequestInterrupted(request: pending), expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.preflight, next, operation: nil)]),
+            .init(name: "checkpoint reached waits for persistence", from: state(.preflight, .inProgress(op)), event: .checkpointReached(op, checkpoint(.preflight)), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.preflight), pending)]),
+            .init(name: "persisted checkpoint completes the stage", from: state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending)), event: .checkpointPersisted(pending, checkpoint(.preflight)), expectedStatus: "completed", expectedEffects: []),
+            .init(name: "persistence failure is shown with its recovery", from: state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending)), event: .checkpointPersistenceFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "request next stage after completion", from: state(.preflight, .completed(checkpoint(.preflight))), event: .startRequested(stage: .runtimeReady), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "request resumes from durable partial work", from: state(.runtimeReady, .resumable(evidence)), event: .startRequested(stage: .runtimeReady), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "failure is recoverable", from: state(.sshPaired, .inProgress(op)), event: .operationFailed(op, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "cancel", from: state(.sshPaired, .inProgress(op)), event: .operationCanceled(op), expectedStatus: "canceled", expectedEffects: []),
+            .init(name: "user action required", from: state(.needsGuestSetup, .inProgress(op)), event: .userActionRequired(op, consoleNeeded), expectedStatus: "needsUserAction", expectedEffects: []),
+            .init(name: "interruption becomes unknown and inspects", from: state(.macOSInstalled, .inProgress(op)), event: .connectionInterrupted(op), expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, pending, operation: op)]),
+            .init(name: "still disconnected: inspect again", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .connectionInterrupted(op), expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: op)]),
+            .init(name: "user asks to check again while unknown", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .userRetried, expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: op)]),
+            .init(name: "user asks to check again while inspecting", from: state(.macOSInstalled, .awaitingInspection(pending)), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: nil)]),
+            .init(name: "retry after failure inspects first", from: state(.sshPaired, .recoverableFailure(failure, interrupted: nil)), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.sshPaired, pending, operation: nil)]),
+            .init(name: "retry after cancel inspects first", from: state(.sshPaired, .canceled), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.sshPaired, pending, operation: nil)]),
+            .init(name: "user finished console step, inspect under the paused operation's identity", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .userActionCompleted, expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.needsGuestSetup, pending, operation: op)]),
+            .init(name: "a paused operation that fails is a recoverable failure", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .operationFailed(op, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "a paused operation's checkpoint is persisted", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .checkpointReached(op, checkpoint(.needsGuestSetup)), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.needsGuestSetup), pending)]),
+            .init(name: "a failed inspection is a recoverable failure, not a silent loop", from: state(.sshPaired, .awaitingInspection(pending)), event: .inspectionFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "reconciled: actually completed, persist it", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .quiescent(.completed(checkpoint(.macOSInstalled)))), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.macOSInstalled), next)]),
+            .init(name: "reconciled: still running, resume monitoring", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .stillRunning(stage: .macOSInstalled)), expectedStatus: "inProgress", expectedEffects: []),
+            .init(name: "reconciled: still waiting on the user", from: state(.needsGuestSetup, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .stillNeedsUserAction(consoleNeeded, stage: .needsGuestSetup)), expectedStatus: "needsUserAction", expectedEffects: []),
+            .init(name: "reconciled: resumable partial work", from: state(.runtimeReady, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .quiescent(.resumable(evidence))), expectedStatus: "resumable", expectedEffects: []),
+            .init(name: "reconciled: failed and needs cleanup", from: state(.runtimeReady, .awaitingInspection(pending)), event: .reconciled(pending, .failedNeedsCleanup(failure)), expectedStatus: "cleanupRequired", expectedEffects: [.cleanUp(.runtimeReady, next)]),
+            .init(name: "reconciled: the earlier cleanup is still running", from: state(.runtimeReady, .awaitingInspection(next)), event: .reconciled(next, .cleanupRunning(pending, failure)), expectedStatus: "cleanupRequired", expectedEffects: []),
+            .init(name: "reconciled: failed, user must act", from: state(.sshPaired, .awaitingInspection(pending)), event: .reconciled(pending, .failed(failure)), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "reconciled: nothing happened, safe to start", from: state(.sshPaired, .awaitingInspection(pending)), event: .reconciled(pending, .notStarted), expectedStatus: "notStarted", expectedEffects: []),
+            .init(name: "cleanup finished, safe to start", from: state(.runtimeReady, .cleanupRequired(failure, cleanup: pending)), event: .cleanupFinished(pending), expectedStatus: "notStarted", expectedEffects: []),
+            .init(name: "cleanup failed, back to recoverable", from: state(.runtimeReady, .cleanupRequired(failure, cleanup: pending)), event: .cleanupFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+        ]
+    }
+
+    @Test func everyLegalTransition() throws {
+        for transition in legalTransitions {
+            let (state, effects) = try Reducer.reduce(transition.from, transition.event)
+            #expect(state.status.caseName == transition.expectedStatus, Comment(rawValue: transition.name))
+            #expect(effects == transition.expectedEffects, Comment(rawValue: transition.name))
+            if case .startRequested(let stage) = transition.event {
+                #expect(state.stage == stage, Comment(rawValue: transition.name))
+            } else {
+                #expect(state.stage == transition.from.stage, Comment(rawValue: transition.name))
+            }
+            #expect(state.isConsistent, Comment(rawValue: transition.name))
+        }
+    }
+
+    @Test func nothingAdvancesUntilTheCheckpointIsPersisted() {
+        let writing = state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending))
+        #expect(throws: ProvisioningTransitionError.illegalTransition(status: "persistingCheckpoint", event: "startRequested")) {
+            try Reducer.reduce(writing, .startRequested(stage: .runtimeReady))
+        }
+        #expect(throws: ProvisioningTransitionError.checkpointMismatch(expected: checkpoint(.preflight), actual: checkpoint(.runtimeReady))) {
+            try Reducer.reduce(writing, .checkpointPersisted(pending, checkpoint(.runtimeReady)))
+        }
+    }
+
+    @Test func startingFromAFailureUnknownOrInspectionIsIllegal() {
+        for status in [StageStatus.recoverableFailure(failure, interrupted: nil), .unknownOutcome(op, inspection: pending), .awaitingInspection(pending), .cleanupRequired(failure, cleanup: pending), .needsUserAction(op, consoleNeeded), .startRequested(request: pending, resuming: nil), .inProgress(op)] {
+            #expect(throws: ProvisioningTransitionError.self, Comment(rawValue: status.caseName)) {
+                try Reducer.reduce(state(.sshPaired, status), .startRequested(stage: .sshPaired))
+            }
+        }
+        for status in [StageStatus.notStarted, .resumable(evidence), .completed(checkpoint(.sshPaired))] {
+            #expect(throws: ProvisioningTransitionError.self, Comment(rawValue: status.caseName)) {
+                try Reducer.reduce(state(.sshPaired, status), .operationStarted(other, stage: .sshPaired, request: pending))
+            }
+        }
+    }
+
+    @Test func confirmedFailureWithLeftoversReachesASafeStart() throws {
+        let verification = GuesthouseError.downloadVerificationFailed(artifact: "restore image", check: .digest)
+        var state = state(.runtimeReady, .recoverableFailure(verification, interrupted: nil))
+        let inspecting = try Reducer.reduce(state, .userRetried)
+        state = inspecting.state
+        let (afterInspection, effects) = try Reducer.reduce(state, .reconciled(try token(of: inspecting.effects), .failedNeedsCleanup(verification)))
+        #expect(effects == [.cleanUp(.runtimeReady, EffectToken(2))])
+        let clean = try Reducer.reduce(afterInspection, .cleanupFinished(try token(of: effects))).state
+        #expect(clean.status == .notStarted)
+        let reserved = try Reducer.reduce(clean, .startRequested(stage: .runtimeReady)).state
+        let started = try Reducer.reduce(reserved, .operationStarted(other, stage: .runtimeReady, request: #require(reserved.status.pendingEffect))).state
+        #expect(started.status == .inProgress(other))
+    }
+
+    @Test func stagesMustBeSequential() {
+        #expect(throws: ProvisioningTransitionError.stageMismatch(expected: .runtimeReady, actual: .sshPaired)) {
+            try Reducer.reduce(state(.preflight, .completed(checkpoint(.preflight))), .startRequested(stage: .sshPaired))
+        }
+        #expect(throws: ProvisioningTransitionError.stageMismatch(expected: .preflight, actual: .ready)) {
+            try Reducer.reduce(state(.preflight, .inProgress(op)), .checkpointReached(op, checkpoint(.ready)))
+        }
+        #expect(throws: ProvisioningTransitionError.alreadyReady) {
+            try Reducer.reduce(state(.ready, .completed(checkpoint(.ready))), .startRequested(stage: .ready))
+        }
+    }
+
+    @Test func retryingWhileInProgressOrCompletedIsIllegal() {
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(state(.preflight, .inProgress(op)), .userRetried) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(state(.preflight, .completed(checkpoint(.preflight))), .userRetried) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(.initial, .reconciled(pending, .notStarted)) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(.initial, .cleanupFinished(pending)) }
+    }
+
+    @Test func happyPathReachesReadyOnlyAfterEveryCheckpointIsPersisted() throws {
+        var state = ProvisioningState.initial
+        for stage in ProvisioningStage.allCases {
+            let id = OperationID()
+            state = try Reducer.reduce(state, .startRequested(stage: stage)).state
+            state = try Reducer.reduce(state, .operationStarted(id, stage: stage, request: #require(state.status.pendingEffect))).state
+            let reached = try Reducer.reduce(state, .checkpointReached(id, checkpoint(stage)))
+            state = reached.state
+            #expect(!state.isReady)
+            state = try Reducer.reduce(state, .checkpointPersisted(try token(of: reached.effects), checkpoint(stage))).state
+        }
+        #expect(state.isReady)
+        #expect(state.stage == .ready)
+    }
+
+    @Test func interruptedThenCompletedContinuesToNextStage() throws {
+        var state = state(.macOSInstalled, .inProgress(op))
+        let inspecting = try Reducer.reduce(state, .connectionInterrupted(op))
+        let reconciled = try Reducer.reduce(inspecting.state, .operationReconciled(try token(of: inspecting.effects), op, .quiescent(.completed(checkpoint(.macOSInstalled)))))
+        state = try Reducer.reduce(reconciled.state, .checkpointPersisted(try token(of: reconciled.effects), checkpoint(.macOSInstalled))).state
+        state = try Reducer.reduce(state, .startRequested(stage: .needsGuestSetup)).state
+        state = try Reducer.reduce(state, .operationStarted(other, stage: .needsGuestSetup, request: #require(state.status.pendingEffect))).state
+        #expect(state.stage == .needsGuestSetup)
+        #expect(state.status == .inProgress(other))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
@@ -161,6 +161,12 @@ import Testing
         var state = state(.macOSInstalled, .inProgress(op))
         let inspecting = try Reducer.reduce(state, .connectionInterrupted(op))
         let reconciled = try Reducer.reduce(inspecting.state, .operationReconciled(try token(of: inspecting.effects), op, .quiescent(.completed(checkpoint(.macOSInstalled)))))
+        #expect(reconciled.state.status == .persistingCheckpoint(checkpoint(.macOSInstalled), operation: nil, write: try token(of: reconciled.effects)))
+        for delayed in [op, other] {
+            #expect(throws: ProvisioningTransitionError.self) {
+                try Reducer.reduce(reconciled.state, .connectionInterrupted(delayed))
+            }
+        }
         state = try Reducer.reduce(reconciled.state, .checkpointPersisted(try token(of: reconciled.effects), checkpoint(.macOSInstalled))).state
         state = try Reducer.reduce(state, .startRequested(stage: .needsGuestSetup)).state
         state = try Reducer.reduce(state, .operationStarted(other, stage: .needsGuestSetup, request: #require(state.status.pendingEffect))).state


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Reference — migration pending. Do not merge this historical stack.**
>
> The owner approved this draft classification on September 8, 2026 (Pacific). Follow [the live integration dashboard in issue #48](https://github.com/PicoMLX/Guesthouse/issues/48), not the historical merge order or approvals below.
>
> Migration area: provisioning and durable state (#6, #8). Preserve effect identity, checkpoint, quiescence, persistence and recovery regressions. The old dependency chain includes superseded foundations; this work is not already on main.
>
> Preserve this branch, code, tests and review findings. Close without merging only when its entire retained scope has landed through reviewed replacements, and link those replacements. This banner does not resolve outstanding findings. The original description follows unchanged.

---

Part 3 of the five-part provisioning implementation for #6; depends on #105 and is a prerequisite for existing #56. Implements the complete pure transition function from MVP-PLAN.md §§3, 4 and 9.

The reducer remains internal until #56 activates the public API after all regression components. This is the complete finalized implementation, not a stub or an incomplete public state machine. It reserves starts before effects, correlates callbacks and inspection responses, requires operation quiescence before restart, preserves checkpoint writers, and advances only after durable checkpoint acknowledgement. Includes the full 34-entry baseline transition table and its focused reducer tests.

Measured diff against #105: 489 added lines, no deletions. `swift test --package-path Packages/GuesthouseCore`: 199 tests in 17 suites pass on 0cada64bdf0f61157a4e598c9629271057775ba4. Exact-head cloud CI and automated review are pending. No host operations were performed.

The remaining components add operation-identity/callback regressions, followed by checkpoint/cleanup/path regressions and public activation in existing #56. All 57 finalized provisioning tests are preserved exactly once across the complete stack.

Follow-up: the #106 quiescent checkpoint-writer correction is included in this exact head. A delayed operation interruption cannot abandon a reconciled persistence token after the operation is proven quiescent; directly reported checkpoints still retain live-writer identity. Deterministic regression failed before the correction and passes afterward. Fresh CI/review are requested for this new head, without reusing older approval.