### PR TITLE
Add inactive owned-child launch primitive

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChild.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChild.swift
@@ -1,0 +1,163 @@
+import Darwin
+import Foundation
+import Synchronization
+
+/// A direct child created by this owner, never a PID adopted from a later lookup.
+///
+/// The runtime must be the exclusive reaper of its children: no wildcard waits, SIGCHLD
+/// handlers, or SA_NOCLDWAIT changes during this lifetime. Targeted observation, signaling,
+/// and final reaping share one mutex. WNOWAIT keeps the child unreaped until this owner
+/// disables all future signals and calls waitpid. No process-group signals are exposed yet.
+/// A reaped direct child is NOT evidence that its descendants or private session are quiet.
+final class OwnedChild: Sendable {
+    enum Failure: Error, Equatable, Sendable {
+        case invalidInvocation
+        case systemCall(String, Int32)
+        case waitAuthorityLost(Int32)
+    }
+
+    enum SignalResult: Equatable, Sendable {
+        case delivered
+        case alreadyReaped
+        case authorityLost
+        case refused(Int32)
+    }
+
+    enum Observation: Sendable {
+        case running
+        case exited
+        case failed(Int32)
+    }
+
+    /// Injectable syscall boundary for focused authority-loss tests. Only spawn constructs
+    /// an owner; production callers cannot turn an arbitrary PID into signal authority.
+    struct SystemCalls: Sendable {
+        var observe: @Sendable (pid_t) -> Observation
+        var reap: @Sendable (pid_t) -> Result<ProcessExit.Reason, Failure>
+        var signal: @Sendable (pid_t, Int32) -> SignalResult
+
+        static let live = Self(observe: { pid in
+            var information = siginfo_t()
+            guard waitid(P_PID, id_t(pid), &information, WEXITED | WNOWAIT | WNOHANG) == 0 else {
+                return errno == EINTR ? .running : .failed(errno)
+            }
+            return information.si_pid == pid ? .exited : .running
+        }, reap: { pid in
+            var status: Int32 = 0
+            var result: pid_t
+            repeat { result = waitpid(pid, &status, WNOHANG) } while result == -1 && errno == EINTR
+            guard result == pid else { return .failure(.waitAuthorityLost(result == 0 ? EAGAIN : errno)) }
+            // Darwin's wait status layout; WIFEXITED/WTERMSIG function-like macros do not
+            // import into Swift. A WEXITED observation cannot produce a stopped status.
+            let signal = status & 0x7f
+            return .success(signal == 0 ? .status((status >> 8) & 0xff) : .signal(signal))
+        }, signal: { pid, signal in
+            kill(pid, signal) == 0 ? .delivered : .refused(errno)
+        })
+    }
+
+    private struct State {
+        var result: Result<ProcessExit.Reason, Failure>?
+        var waiters: [CheckedContinuation<Result<ProcessExit.Reason, Failure>, Never>] = []
+        var observer: Task<Void, Never>?
+    }
+
+    /// Caller-supplied correlation for a durable intent, not transferable signal authority.
+    let runID: UUID
+    let processIdentifier: pid_t
+    private let calls: SystemCalls
+    private let state = Mutex(State())
+
+    private init(runID: UUID, processIdentifier: pid_t, calls: SystemCalls) {
+        self.runID = runID
+        self.processIdentifier = processIdentifier
+        self.calls = calls
+    }
+
+    /// Completion means only that this exact direct child has been observed and reaped.
+    /// This wait deliberately ignores task cancellation. A caller can separately request a
+    /// signal, but cancellation must not abandon a child or its one reaper.
+    func waitForReapedExit() async -> Result<ProcessExit.Reason, Failure> {
+        await withCheckedContinuation { continuation in
+            let completed = state.withLock { state -> Result<ProcessExit.Reason, Failure>? in
+                if let result = state.result { return result }
+                state.waiters.append(continuation)
+                return nil
+            }
+            if let completed { continuation.resume(returning: completed) }
+        }
+    }
+
+    /// Never signals after reaping or a wait error. A delivered signal is not an exit.
+    @discardableResult
+    func signal(_ signal: Int32) -> SignalResult {
+        // Observe before signaling, including ECHILD, under the same lock as the syscall.
+        // The exclusive-reaper contract prevents PID reuse between these operations.
+        let result = state.withLock { state -> SignalResult in
+            refreshLocked(&state)
+            if let completed = state.result {
+                if case .success = completed { return .alreadyReaped }
+                return .authorityLost
+            }
+            return calls.signal(processIdentifier, signal)
+        }
+        // Publish any terminal state and resume every waiter outside the lock.
+        _ = poll()
+        return result
+    }
+
+    private func startObservation() {
+        // An unstructured owner task is intentional: the child must outlive cancellation or
+        // release of every caller. It releases itself only on observed/reaped exit or loss
+        // of wait authority. No blocking wait runs on the cooperative executor.
+        let observer = Task { [self] in
+            while !poll() { try? await Task.sleep(for: .milliseconds(10)) }
+        }
+        state.withLock { state in
+            if state.result == nil { state.observer = observer }
+        }
+    }
+
+    @discardableResult
+    private func poll() -> Bool {
+        let delivery = state.withLock { state -> (Result<ProcessExit.Reason, Failure>, [CheckedContinuation<Result<ProcessExit.Reason, Failure>, Never>])? in
+            refreshLocked(&state)
+            guard let result = state.result else { return nil }
+            let waiters = state.waiters
+            state.waiters.removeAll()
+            return (result, waiters)
+        }
+        guard let delivery else { return false }
+        for waiter in delivery.1 { waiter.resume(returning: delivery.0) }
+        return true
+    }
+
+    private func refreshLocked(_ state: inout State) {
+        guard state.result == nil else { return }
+        switch calls.observe(processIdentifier) {
+        case .running: return
+        case .failed(let error): state.result = .failure(.waitAuthorityLost(error))
+        case .exited: state.result = calls.reap(processIdentifier)
+        }
+        state.observer = nil
+    }
+
+    /// Stdio descriptors are borrowed only until spawn returns; spawn duplicates and closes
+    /// its own copies. The working-directory capability remains alive through addfchdir.
+    static func spawn(
+        runID: UUID = UUID(),
+        executable: URL, arguments: [String] = [], environment: [String: String] = [:],
+        workingDirectory: PinnedWorkingDirectory? = nil,
+        standardInput: Int32, standardOutput: Int32, standardError: Int32,
+        calls: SystemCalls = .live
+    ) throws -> OwnedChild {
+        let pid = try OwnedChildSpawn.launch(
+            executable: executable, arguments: arguments, environment: environment,
+            workingDirectory: workingDirectory,
+            descriptors: [standardInput, standardOutput, standardError]
+        )
+        let child = OwnedChild(runID: runID, processIdentifier: pid, calls: calls)
+        child.startObservation()
+        return child
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChild.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChild.swift
@@ -5,9 +5,9 @@ import Synchronization
 /// A direct child created by this owner, never a PID adopted from a later lookup.
 ///
 /// The runtime must be the exclusive reaper of its children: no wildcard waits, SIGCHLD
-/// handlers, or SA_NOCLDWAIT changes during this lifetime. Targeted observation, signaling,
-/// and final reaping share one mutex. WNOWAIT keeps the child unreaped until this owner
-/// disables all future signals and calls waitpid. No process-group signals are exposed yet.
+/// handlers, or SA_NOCLDWAIT changes during this lifetime. Signal decisions and final reaping
+/// share one mutex. Only the blocking observer reaps, preserving the child's PID until its
+/// WNOWAIT wait returns. No process-group signals are exposed yet.
 /// A reaped direct child is NOT evidence that its descendants or private session are quiet.
 final class OwnedChild: Sendable {
     enum Failure: Error, Equatable, Sendable {
@@ -18,6 +18,7 @@ final class OwnedChild: Sendable {
 
     enum SignalResult: Equatable, Sendable {
         case delivered
+        case alreadyExited
         case alreadyReaped
         case authorityLost
         case refused(Int32)
@@ -33,6 +34,7 @@ final class OwnedChild: Sendable {
     /// an owner; production callers cannot turn an arbitrary PID into signal authority.
     struct SystemCalls: Sendable {
         var observe: @Sendable (pid_t) -> Observation
+        var waitForExit: @Sendable (pid_t) -> Result<Void, Failure>
         var reap: @Sendable (pid_t) -> Result<ProcessExit.Reason, Failure>
         var signal: @Sendable (pid_t, Int32) -> SignalResult
 
@@ -42,6 +44,14 @@ final class OwnedChild: Sendable {
                 return errno == EINTR ? .running : .failed(errno)
             }
             return information.si_pid == pid ? .exited : .running
+        }, waitForExit: { pid in
+            var information = siginfo_t()
+            var result: Int32
+            repeat { result = waitid(P_PID, id_t(pid), &information, WEXITED | WNOWAIT) }
+            while result == -1 && errno == EINTR
+            guard result == 0 else { return .failure(.waitAuthorityLost(errno)) }
+            guard information.si_pid == pid else { return .failure(.waitAuthorityLost(ECHILD)) }
+            return .success(())
         }, reap: { pid in
             var status: Int32 = 0
             var result: pid_t
@@ -59,7 +69,6 @@ final class OwnedChild: Sendable {
     private struct State {
         var result: Result<ProcessExit.Reason, Failure>?
         var waiters: [CheckedContinuation<Result<ProcessExit.Reason, Failure>, Never>] = []
-        var observer: Task<Void, Never>?
     }
 
     /// Caller-supplied correlation for a durable intent, not transferable signal authority.
@@ -94,52 +103,50 @@ final class OwnedChild: Sendable {
         // Observe before signaling, including ECHILD, under the same lock as the syscall.
         // The exclusive-reaper contract prevents PID reuse between these operations.
         let result = state.withLock { state -> SignalResult in
-            refreshLocked(&state)
             if let completed = state.result {
                 if case .success = completed { return .alreadyReaped }
                 return .authorityLost
             }
-            return calls.signal(processIdentifier, signal)
+            switch calls.observe(processIdentifier) {
+            case .running: return calls.signal(processIdentifier, signal)
+            case .exited: return .alreadyExited
+            case .failed(let error):
+                state.result = .failure(.waitAuthorityLost(error))
+                return .authorityLost
+            }
         }
         // Publish any terminal state and resume every waiter outside the lock.
-        _ = poll()
+        publishCompletion()
         return result
     }
 
     private func startObservation() {
-        // An unstructured owner task is intentional: the child must outlive cancellation or
-        // release of every caller. It releases itself only on observed/reaped exit or loss
-        // of wait authority. No blocking wait runs on the cooperative executor.
-        let observer = Task { [self] in
-            while !poll() { try? await Task.sleep(for: .milliseconds(10)) }
-        }
-        state.withLock { state in
-            if state.result == nil { state.observer = observer }
+        // One noncooperative dispatch waiter retains ownership through cancellation or
+        // release of every caller, without periodic wakeups. The wait is outside the mutex
+        // so signals remain possible. Only this callback may reap: an earlier reap could let
+        // the blocking wait start or resume against a different child that reused the PID.
+        DispatchQueue(label: "GuesthouseRuntimeKit.OwnedChild.exit", qos: .utility).async { [self] in
+            let observed = calls.waitForExit(processIdentifier)
+            state.withLock { state in
+                guard state.result == nil else { return }
+                switch observed {
+                case .success: state.result = calls.reap(processIdentifier)
+                case .failure(let failure): state.result = .failure(failure)
+                }
+            }
+            publishCompletion()
         }
     }
 
-    @discardableResult
-    private func poll() -> Bool {
+    private func publishCompletion() {
         let delivery = state.withLock { state -> (Result<ProcessExit.Reason, Failure>, [CheckedContinuation<Result<ProcessExit.Reason, Failure>, Never>])? in
-            refreshLocked(&state)
             guard let result = state.result else { return nil }
             let waiters = state.waiters
             state.waiters.removeAll()
             return (result, waiters)
         }
-        guard let delivery else { return false }
+        guard let delivery else { return }
         for waiter in delivery.1 { waiter.resume(returning: delivery.0) }
-        return true
-    }
-
-    private func refreshLocked(_ state: inout State) {
-        guard state.result == nil else { return }
-        switch calls.observe(processIdentifier) {
-        case .running: return
-        case .failed(let error): state.result = .failure(.waitAuthorityLost(error))
-        case .exited: state.result = calls.reap(processIdentifier)
-        }
-        state.observer = nil
     }
 
     /// Stdio descriptors are borrowed only until spawn returns; spawn duplicates and closes

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChildSpawn.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OwnedChildSpawn.swift
@@ -1,0 +1,108 @@
+import Darwin
+import Foundation
+
+/// Pins the opened directory, not a pathname checked earlier. This capability guarantees
+/// validation-to-chdir identity, not authorization beneath a trusted workspace root.
+/// A caller requiring containment must acquire it through root-relative trusted authority.
+final class PinnedWorkingDirectory: Sendable {
+    fileprivate let descriptor: Int32
+
+    init(_ url: URL) throws {
+        guard url.isFileURL, !url.path.utf8.contains(0) else { throw OwnedChild.Failure.invalidInvocation }
+        let opened = open(url.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard opened >= 0 else { throw OwnedChild.Failure.systemCall("open directory", errno) }
+        // Never alias 0/1/2: spawn installs stdio before the fchdir action.
+        let fd = fcntl(opened, F_DUPFD_CLOEXEC, 3)
+        let duplicationError = errno
+        close(opened)
+        guard fd >= 0 else { throw OwnedChild.Failure.systemCall("pin directory", duplicationError) }
+        var information = stat()
+        guard fstat(fd, &information) == 0, information.st_mode & S_IFMT == S_IFDIR else {
+            let error = errno
+            close(fd)
+            throw OwnedChild.Failure.systemCall("validate directory", error)
+        }
+        descriptor = fd
+    }
+
+    deinit { close(descriptor) }
+}
+
+enum OwnedChildSpawn {
+    static func launch(
+        executable: URL, arguments: [String], environment: [String: String],
+        workingDirectory: PinnedWorkingDirectory?, descriptors: [Int32]
+    ) throws -> pid_t {
+        guard executable.isFileURL, !executable.path.utf8.contains(0),
+              arguments.allSatisfy({ !$0.utf8.contains(0) }),
+              environment.allSatisfy({ !$0.key.isEmpty && !$0.key.contains("=") && !$0.key.utf8.contains(0) && !$0.value.utf8.contains(0) })
+        else { throw OwnedChild.Failure.invalidInvocation }
+        // Do not mutate process-wide signal policy. Automatic/external reaping invalidates
+        // the owned-PID guarantee, so require the service's default SIGCHLD contract.
+        var disposition = sigaction()
+        guard sigaction(SIGCHLD, nil, &disposition) == 0 else {
+            throw OwnedChild.Failure.systemCall("read SIGCHLD policy", errno)
+        }
+        guard disposition.__sigaction_u.__sa_handler == nil, disposition.sa_flags & SA_NOCLDWAIT == 0 else {
+            throw OwnedChild.Failure.systemCall("exclusive reaping unavailable", EINVAL)
+        }
+
+        var actions: posix_spawn_file_actions_t?
+        try check(posix_spawn_file_actions_init(&actions), "initialize file actions")
+        defer { posix_spawn_file_actions_destroy(&actions) }
+        var attributes: posix_spawnattr_t?
+        try check(posix_spawnattr_init(&attributes), "initialize spawn attributes")
+        defer { posix_spawnattr_destroy(&attributes) }
+        var ownedDescriptors: [Int32] = []
+        defer { ownedDescriptors.forEach { close($0) } }
+        for (destination, borrowed) in descriptors.enumerated() {
+            let copy = fcntl(borrowed, F_DUPFD_CLOEXEC, 3)
+            guard copy >= 0 else { throw OwnedChild.Failure.systemCall("duplicate stdio", errno) }
+            ownedDescriptors.append(copy)
+            try check(posix_spawn_file_actions_adddup2(&actions, copy, Int32(destination)), "attach stdio")
+            try check(posix_spawn_file_actions_addclose(&actions, copy), "close child stdio copy")
+        }
+        if let workingDirectory {
+            try check(posix_spawn_file_actions_addfchdir(&actions, workingDirectory.descriptor), "bind directory")
+            try check(posix_spawn_file_actions_addclose(&actions, workingDirectory.descriptor), "close child directory")
+        }
+        var mask = sigset_t()
+        sigemptyset(&mask)
+        try check(posix_spawnattr_setsigmask(&attributes, &mask), "reset signal mask")
+        var defaults = sigset_t()
+        sigfillset(&defaults)
+        sigdelset(&defaults, SIGKILL)
+        sigdelset(&defaults, SIGSTOP)
+        try check(posix_spawnattr_setsigdefault(&attributes, &defaults), "reset signal dispositions")
+        let flags = POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSIGDEF
+        try check(posix_spawnattr_setflags(&attributes, Int16(flags)), "set spawn flags")
+        var pid: pid_t = 0
+        let status = try withCStringArray([executable.path] + arguments) { argv in
+            try withCStringArray(environment.keys.sorted().map { "\($0)=\(environment[$0]!)" }) { envp in
+                executable.path.withCString { path in
+                    withExtendedLifetime(workingDirectory) {
+                        posix_spawn(&pid, path, &actions, &attributes, argv, envp)
+                    }
+                }
+            }
+        }
+        try check(status, "spawn")
+        guard pid > 0 else { throw OwnedChild.Failure.systemCall("invalid spawned pid", EINVAL) }
+        return pid
+    }
+
+    private static func check(_ error: Int32, _ operation: String) throws {
+        guard error == 0 else { throw OwnedChild.Failure.systemCall(operation, error) }
+    }
+
+    private static func withCStringArray<T>(_ strings: [String], body: (UnsafeMutablePointer<UnsafeMutablePointer<CChar>?>) throws -> T) throws -> T {
+        var pointers: [UnsafeMutablePointer<CChar>?] = []
+        defer { pointers.forEach { free($0) } }
+        for string in strings {
+            guard let pointer = strdup(string) else { throw OwnedChild.Failure.systemCall("allocate arguments", ENOMEM) }
+            pointers.append(pointer)
+        }
+        pointers.append(nil)
+        return try pointers.withUnsafeMutableBufferPointer { try body($0.baseAddress!) }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/OwnedChildTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/OwnedChildTests.swift
@@ -1,0 +1,223 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.timeLimit(.minutes(1))) struct OwnedChildTests {
+    private func spawn(
+        _ executable: String = "/usr/bin/true", arguments: [String] = [],
+        environment: [String: String] = [:], directory: PinnedWorkingDirectory? = nil,
+        input: FileHandle? = nil, output: Pipe, error: Pipe,
+        calls: OwnedChild.SystemCalls = .live
+    ) throws -> OwnedChild {
+        // Foundation's nullDevice handle is a Process sentinel, not a borrowable Darwin fd.
+        let borrowedInput = try input ?? FileHandle(forReadingFrom: URL(fileURLWithPath: "/dev/null"))
+        return try withExtendedLifetime((borrowedInput, output, error)) {
+            try OwnedChild.spawn(executable: URL(fileURLWithPath: executable), arguments: arguments,
+                             environment: environment, workingDirectory: directory,
+                             standardInput: borrowedInput.fileDescriptor,
+                             standardOutput: output.fileHandleForWriting.fileDescriptor,
+                             standardError: error.fileHandleForWriting.fileDescriptor, calls: calls)
+        }
+    }
+
+    /// Bounded, nonblocking EOF observation: leaked writer copies fail rather than hang.
+    private func drain(_ pipe: Pipe, maximumBytes: Int = 4096) async throws -> Data {
+        let fd = pipe.fileHandleForReading.fileDescriptor
+        #expect(fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK) == 0)
+        let deadline = ContinuousClock.now + .seconds(2)
+        var result = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while ContinuousClock.now < deadline {
+            let count = read(fd, &buffer, buffer.count)
+            if count == 0 { return result }
+            if count > 0 {
+                result.append(contentsOf: buffer.prefix(count))
+                try #require(result.count <= maximumBytes)
+            } else {
+                try #require(errno == EAGAIN || errno == EINTR)
+                try await Task.sleep(for: .milliseconds(5))
+            }
+        }
+        Issue.record("The owned spawn retained a pipe writer after exit or failure")
+        return result
+    }
+
+    @Test func rapidExitIsObservedAndReapedExactlyOnce() async throws {
+        for _ in 0..<20 {
+            let reaps = Mutex(0)
+            var calls = OwnedChild.SystemCalls.live
+            calls.reap = { pid in reaps.withLock { $0 += 1 }; return OwnedChild.SystemCalls.live.reap(pid) }
+            let child = try spawn(output: Pipe(), error: Pipe(), calls: calls)
+            #expect(await child.waitForReapedExit() == .success(.status(0)))
+            #expect(await child.waitForReapedExit() == .success(.status(0)))
+            #expect(reaps.withLock { $0 } == 1)
+            #expect(child.signal(SIGKILL) == .alreadyReaped)
+        }
+    }
+
+    @Test func aCancelledWaiterDoesNotCancelOwnershipOrReaping() async throws {
+        let input = Pipe(), output = Pipe(), error = Pipe()
+        defer { try? input.fileHandleForWriting.close() }
+        let child = try spawn("/bin/cat", input: input.fileHandleForReading, output: output, error: error)
+        #expect(getpgid(child.processIdentifier) == child.processIdentifier)
+        #expect(getsid(child.processIdentifier) == child.processIdentifier)
+        let waiter = Task { await child.waitForReapedExit() }
+        waiter.cancel()
+        #expect(child.signal(0) == .delivered)
+        try input.fileHandleForWriting.close()
+        #expect(await waiter.value == .success(.status(0)))
+        #expect(child.signal(SIGTERM) == .alreadyReaped)
+    }
+
+    @Test func aDeliveredSignalIsFollowedByObservedReaping() async throws {
+        let input = Pipe()
+        defer { try? input.fileHandleForWriting.close() }
+        let child = try spawn("/bin/cat", input: input.fileHandleForReading, output: Pipe(), error: Pipe())
+        #expect(child.signal(SIGTERM) == .delivered)
+        try input.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.signal(SIGTERM)))
+    }
+
+    @Test func releasingEveryCallerStillKeepsTheReaperAlive() async throws {
+        let input = Pipe()
+        defer { try? input.fileHandleForWriting.close() }
+        let (events, continuation) = AsyncStream.makeStream(of: Bool.self)
+        var calls = OwnedChild.SystemCalls.live
+        calls.reap = { pid in
+            let result = OwnedChild.SystemCalls.live.reap(pid)
+            continuation.yield(result == .success(.status(0)))
+            continuation.finish()
+            return result
+        }
+        var child: OwnedChild? = try spawn("/bin/cat", input: input.fileHandleForReading, output: Pipe(), error: Pipe(), calls: calls)
+        weak let released = child
+        child = nil
+        #expect(released != nil)
+        try input.fileHandleForWriting.close()
+        var iterator = events.makeAsyncIterator()
+        #expect(await iterator.next() == true)
+        let deadline = ContinuousClock.now + .seconds(2)
+        while released != nil, ContinuousClock.now < deadline { try await Task.sleep(for: .milliseconds(5)) }
+        #expect(released == nil)
+    }
+
+    @Test(arguments: [ECHILD, EIO])
+    func waitErrorsPermanentlyWithdrawSignalAuthority(errorCode: Int32) async throws {
+        let signals = Mutex(0), reaps = Mutex(0)
+        var calls = OwnedChild.SystemCalls.live
+        calls.observe = { pid in
+            // Simulate a competing targeted reaper: consume this actual short-lived fixture
+            // before returning the injected authority error. No fixture is left unowned.
+            var status: Int32 = 0
+            let result = waitpid(pid, &status, WNOHANG)
+            return result == 0 ? .running : .failed(errorCode)
+        }
+        calls.reap = { _ in reaps.withLock { $0 += 1 }; return .failure(.waitAuthorityLost(ECHILD)) }
+        calls.signal = { _, _ in signals.withLock { $0 += 1 }; return .delivered }
+        let child = try spawn(output: Pipe(), error: Pipe(), calls: calls)
+        #expect(await child.waitForReapedExit() == .failure(.waitAuthorityLost(errorCode)))
+        #expect(child.signal(SIGKILL) == .authorityLost)
+        #expect(child.signal(SIGTERM) == .authorityLost)
+        #expect(signals.withLock { $0 } == 0)
+        #expect(reaps.withLock { $0 } == 0)
+    }
+
+    @Test func aRenamedWorkingDirectoryCannotRedirectTheChild() async throws {
+        let root = FileManager.default.temporaryDirectory.appending(path: "owned-cwd-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let original = root.appending(path: "original"), moved = root.appending(path: "moved")
+        let replacement = root.appending(path: "replacement")
+        try FileManager.default.createDirectory(at: original, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: replacement, withIntermediateDirectories: true)
+        try Data("owned".utf8).write(to: original.appending(path: "marker"))
+        try Data("substituted".utf8).write(to: replacement.appending(path: "marker"))
+        let pinned = try PinnedWorkingDirectory(original)
+        try FileManager.default.moveItem(at: original, to: moved)
+        try FileManager.default.createSymbolicLink(at: original, withDestinationURL: replacement)
+        let output = Pipe(), error = Pipe()
+        let child = try spawn("/bin/cat", arguments: ["marker"], directory: pinned, output: output, error: error)
+        try output.fileHandleForWriting.close()
+        try error.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+        #expect(try await drain(output) == Data("owned".utf8))
+        #expect(try await drain(error).isEmpty)
+        #expect(throws: OwnedChild.Failure.self) { try PinnedWorkingDirectory(original) }
+    }
+
+    @Test(arguments: [true, false])
+    func spawnClosesOwnedCopiesButNotBorrowedStdio(succeed: Bool) async throws {
+        let output = Pipe(), error = Pipe()
+        if succeed {
+            let child = try spawn(output: output, error: error)
+            #expect(await child.waitForReapedExit() == .success(.status(0)))
+        } else {
+            #expect(throws: OwnedChild.Failure.systemCall("spawn", ENOENT)) {
+                try spawn("/nonexistent-owned-child-fixture", output: output, error: error)
+            }
+        }
+        #expect(fcntl(output.fileHandleForWriting.fileDescriptor, F_GETFD) >= 0)
+        #expect(fcntl(error.fileHandleForWriting.fileDescriptor, F_GETFD) >= 0)
+        try output.fileHandleForWriting.close()
+        try error.fileHandleForWriting.close()
+        #expect(try await drain(output).isEmpty)
+        #expect(try await drain(error).isEmpty)
+    }
+
+    @Test func environmentIsExplicit() async throws {
+        let output = Pipe(), error = Pipe()
+        let child = try spawn("/usr/bin/env", environment: ["OWNED_FIXTURE": "present"], output: output, error: error)
+        try output.fileHandleForWriting.close()
+        try error.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+        #expect(try await drain(output) == Data("OWNED_FIXTURE=present\n".utf8))
+        #expect(try await drain(error).isEmpty)
+    }
+
+    @Test func unrelatedDescriptorsAreClosedWhileTheChildIsStillAlive() async throws {
+        let input = Pipe(), unrelated = Pipe()
+        defer { try? input.fileHandleForWriting.close() }
+        #expect(fcntl(unrelated.fileHandleForWriting.fileDescriptor, F_SETFD, 0) == 0)
+        let child = try spawn("/bin/cat", input: input.fileHandleForReading, output: Pipe(), error: Pipe())
+        try unrelated.fileHandleForWriting.close()
+        #expect(try await drain(unrelated).isEmpty)
+        #expect(child.signal(0) == .delivered)
+        try input.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+    }
+
+    @Test func ownedSpawnComposesWithBoundedReadersAndBothEOFs() async throws {
+        let output = Pipe(), error = Pipe()
+        let (stream, continuation) = AsyncStream.makeStream(of: ProcessOutput.self)
+        let truncated = Mutex(false)
+        let readers = OutputReaders(continuation: continuation, maximumBytes: 128) { truncated.withLock { $0 = true } }
+        defer { readers.detach(); continuation.finish() }
+        try readers.attach(output.fileHandleForReading, kind: .stdout)
+        try readers.attach(error.fileHandleForReading, kind: .stderr)
+        let collector = Task { var bytes = 0; for await line in stream { bytes += line.line.text.utf8.count + 1 }; return bytes }
+        let child = try spawn("/usr/bin/printf", arguments: ["%0200000d", "0"], output: output, error: error)
+        try output.fileHandleForWriting.close()
+        try error.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+        let drained = await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                continuation.resume(returning: readers.waitUntilDrained(by: .now() + 2))
+            }
+        }
+        #expect(drained == .success)
+        continuation.finish()
+        #expect(await collector.value <= 128)
+        #expect(truncated.withLock { $0 })
+    }
+
+    @Test func invalidCStringsFailBeforeSpawning() {
+        #expect(throws: OwnedChild.Failure.invalidInvocation) {
+            try spawn(arguments: ["untrusted\0suffix"], output: Pipe(), error: Pipe())
+        }
+        #expect(throws: OwnedChild.Failure.invalidInvocation) {
+            try spawn(environment: ["KEY=other": "value"], output: Pipe(), error: Pipe())
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/OwnedChildTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/OwnedChildTests.swift
@@ -108,12 +108,13 @@ import Testing
     func waitErrorsPermanentlyWithdrawSignalAuthority(errorCode: Int32) async throws {
         let signals = Mutex(0), reaps = Mutex(0)
         var calls = OwnedChild.SystemCalls.live
-        calls.observe = { pid in
+        calls.waitForExit = { pid in
             // Simulate a competing targeted reaper: consume this actual short-lived fixture
             // before returning the injected authority error. No fixture is left unowned.
             var status: Int32 = 0
-            let result = waitpid(pid, &status, WNOHANG)
-            return result == 0 ? .running : .failed(errorCode)
+            var result: pid_t
+            repeat { result = waitpid(pid, &status, 0) } while result == -1 && errno == EINTR
+            return .failure(.waitAuthorityLost(errorCode))
         }
         calls.reap = { _ in reaps.withLock { $0 += 1 }; return .failure(.waitAuthorityLost(ECHILD)) }
         calls.signal = { _, _ in signals.withLock { $0 += 1 }; return .delivered }
@@ -123,6 +124,32 @@ import Testing
         #expect(child.signal(SIGTERM) == .authorityLost)
         #expect(signals.withLock { $0 } == 0)
         #expect(reaps.withLock { $0 } == 0)
+    }
+
+    @Test func anObservedExitStaysUnreapedUntilTheBlockingWaitReturns() async throws {
+        let (events, continuation) = AsyncStream.makeStream(of: Bool.self)
+        let release = DispatchSemaphore(value: 0), reaps = Mutex(0)
+        defer { release.signal() }
+        var calls = OwnedChild.SystemCalls.live
+        calls.waitForExit = { pid in
+            let observed = OwnedChild.SystemCalls.live.waitForExit(pid)
+            continuation.yield(true)
+            release.wait() // Only this dedicated dispatch waiter blocks, never an async task.
+            return observed
+        }
+        calls.reap = { pid in
+            reaps.withLock { $0 += 1 }
+            return OwnedChild.SystemCalls.live.reap(pid)
+        }
+        let child = try spawn(output: Pipe(), error: Pipe(), calls: calls)
+        var iterator = events.makeAsyncIterator()
+        #expect(await iterator.next() == true)
+        #expect(child.signal(SIGKILL) == .alreadyExited)
+        #expect(reaps.withLock { $0 } == 0)
+        release.signal()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+        #expect(reaps.withLock { $0 } == 1)
+        #expect(child.signal(SIGKILL) == .alreadyReaped)
     }
 
     @Test func aRenamedWorkingDirectoryCannotRedirectTheChild() async throws {


### PR DESCRIPTION
<!-- guesthouse-migration-reference -->
> **Closed reference — retained scope migrated and merged. Do not merge this historical stack.**
>
> #161 and #162 now carry the complete retained direct-child ownership/cwd/descriptor and bounded-reader composition scope onto main. Both passed exact-head Xcode Cloud and completed Codex review with original-message 👍 and no unaddressed findings before the owner merged them. #108 was closed on September 9; its branch, original description, tests and review history remain preserved.
>
> #163 separately migrates the actual runner lifecycle and is awaiting fresh CI/review. #69/#21 remain open for adapter integration and truthful whole-mutation recovery. Direct-child exit and output completeness are not descendant quiescence, restart authority or mutation-success proof. This closure does not resolve those broader findings.
>
> Follow [issue #48](https://github.com/PicoMLX/Guesthouse/issues/48) for the current queue. The original description follows unchanged.

---

## Scope

Adds an inactive internal RuntimeKit prerequisite for the owned-launch work behind #69: `OwnedChild` plus a pinned working-directory capability. The current `ProcessRunner` still uses its existing launch path; this PR has no call-site activation.

Implements a bounded part of MVP-PLAN.md §3 process/trust boundaries and §4 truthful interrupted outcomes:

- Public macOS 26 `posix_spawn`/SETSID, explicit argv and environment, explicit stdio inheritance.
- Borrowed stdio descriptors are duplicated, and owned copies closed on success/failure. The same validated cwd descriptor stays pinned through child `addfchdir`.
- One Mutex serializes targeted WNOWAIT observation, direct-child signaling, and final waitpid reaping. No arbitrary PID can construct an owner; signals stop permanently after reaping or lost wait authority.
- Awaiter cancellation and caller release do not abandon the observer/reaper. The caller may persist a run UUID before spawn; that UUID is correlation, not transferable process authority.

## Deliberate limits

This is **not** ProcessRunner activation, whole-process-set quiescence, orphan cleanup, durable restart ownership, or final resolution of #69. There are no process-group signaling APIs. Reaped direct-child status must never be used to clear a mutation lease while descendants remain unproven.

Integration requires the whole runtime to prohibit wildcard/competing waits and later SIGCHLD auto-reaping changes. The launch-time policy check cannot enforce that lifetime invariant. Lost wait authority remains a distinct failure, never a fabricated exit status. The pinned directory proves validation-to-chdir identity, not authorization beneath a trusted root.

Follow-up source:
- [#69 child identity/ownership finding](https://github.com/PicoMLX/Guesthouse/pull/69#discussion_r3938745192)
- [#69 working-directory binding finding](https://github.com/PicoMLX/Guesthouse/pull/69#discussion_r3939895331)
- [#69 delivered signal is not observed quiescence](https://github.com/PicoMLX/Guesthouse/pull/69#discussion_r3939828813)

## Verification

- 3 new files, 494 inserted lines; no existing production files changed.
- Full GuesthouseRuntimeKit: 81 tests passed.
- Eleven focused ownership/cwd/fd tests passed under Thread Sanitizer with no races or new warnings.
- Final one-minute test limit and EOF-bounded fixture change: eleven focused tests passed.
- Two independent read-only reviews found no must-fix within the explicit direct-child/exclusive-reaper contract.
- Fixtures cover rapid exit/exact reaping, cancelled/released callers, authority errors, post-reap signal refusal, cwd rename-to-symlink substitution, spawn-failure fd cleanup, borrowed handle preservation, live-child inheritance isolation, bounded readers/EOF, and invalid C strings.

No provider/service/VM operation was run. No existing signal guard was removed.
