### PR TITLE
Core: extract runtime admission and atomic session registration

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
@@ -1,0 +1,149 @@
+import Foundation
+
+/// The service-side decision for one received message, before any operation runs.
+///
+/// Pure, so the handshake and validation rules are unit-tested here rather than inside the
+/// XPC service bundle. The service applies the decision: it replies, and for `replyAndClose`
+/// it marks the session refused; `SessionLifetime` below then closes that session once every
+/// reply it owes has been handed to the transport, so the rejection is always delivered first
+/// (MVP-PLAN.md §3, "Sandbox and XPC boundary").
+public enum RuntimeDispatcher: Sendable {
+    public enum Decision: Hashable, Sendable {
+        /// Reply with this event and keep the session.
+        case reply(RuntimeEvent)
+        /// Reply with this event, then close the session. Used for protocol mismatches, where
+        /// the peer is a different build of Guesthouse and nothing it sends can be trusted.
+        case replyAndClose(RuntimeEvent)
+        /// The envelope is valid; run the request.
+        case dispatch(RuntimeRequest)
+    }
+
+    /// What one session still owes its peer, so a refused session closes exactly once and
+    /// never before the rejection it was answered with has been handed to the transport.
+    ///
+    /// The service calls `began` when a message arrives, `refuse` when a decision refuses the
+    /// session, and `finished` once that message's reply has been handed over. `finished`
+    /// answers whether this was the last reply a refused session owed, which is the moment to
+    /// close it: waiting instead for another message would leave an incompatible connection
+    /// open for as long as the app runs, because a client told to stop sends nothing more.
+    public struct SessionLifetime: Sendable {
+        public private(set) var inFlight = 0
+        /// The rejection this session was answered with. The first one stands, so a later
+        /// refusal never rewrites why the session is closing.
+        public private(set) var refusal: RuntimeEvent?
+        /// The close has been taken by one caller, so no message is admitted after it.
+        public private(set) var isClosing = false
+
+        public init() {}
+
+        /// One message arrived. Returns how much else the session already owes an answer for,
+        /// or `nil` when the session is already closing.
+        ///
+        /// Admission and the decision to close are one state change, so a message can never be
+        /// admitted in the interval between `finished` answering that the session is quiet and
+        /// the cancel that follows it: such a message would have been answered and then had
+        /// its reply cut off by that cancel, which is the connection interruption the stored
+        /// rejection exists to replace.
+        public mutating func began() -> Int? {
+            guard !isClosing else { return nil }
+            inFlight += 1
+            return inFlight - 1
+        }
+
+        public mutating func refuse(_ rejection: RuntimeEvent) {
+            if refusal == nil { refusal = rejection }
+        }
+
+        /// One reply has been handed to the transport. Answers whether this caller should
+        /// close the session now: it was refused, it owes nothing further, and no other
+        /// caller has already taken the close.
+        public mutating func finished() -> Bool {
+            inFlight -= 1
+            guard refusal != nil, inFlight == 0, !isClosing else { return false }
+            isClosing = true
+            return true
+        }
+    }
+
+    /// Maximum in-flight requests per session. A well-behaved GUI issues a handful; anything
+    /// beyond this is a bug or an attempt to exhaust the service.
+    public static let maximumInFlightRequestsPerSession = 8
+
+    /// Decides what to do with a message that failed to decode as an envelope.
+    public static func undecodable() -> Decision {
+        .reply(.failed(OperationID(), .invalidRequest(.malformed)))
+    }
+
+    /// Decides what to do before the request payload is decoded: the concurrency cap costs
+    /// nothing to apply, so it is applied first and a peer over the cap never reaches the
+    /// payload decoder.
+    ///
+    /// `clientVersion` is asked only once the cap is exceeded, and only for the version
+    /// header, because a refusal is worth sending only if the peer can read it:
+    /// `tooManyInFlight` arrived with protocol 2, so a peer speaking any other version is
+    /// answered with the protocol mismatch it can act on instead of a reason its decoder
+    /// would throw away.
+    public static func admit(inFlight: Int, clientVersion: () -> RuntimeProtocolVersion?) -> Decision? {
+        guard inFlight >= maximumInFlightRequestsPerSession else { return nil }
+        // A header that will not decode says nothing about the peer's version, so it gets the
+        // one rejection every version has always understood.
+        guard let version = clientVersion() else { return undecodable() }
+        guard version == .current else {
+            return mismatch(.protocolMismatch(client: version.rawValue, service: RuntimeProtocolVersion.current.rawValue))
+        }
+        return .reply(.failed(OperationID(), .invalidRequest(.tooManyInFlight)))
+    }
+
+    /// Decides what to do with a message whose protocol version does not match this service.
+    public static func mismatch(_ error: GuesthouseError) -> Decision {
+        .replyAndClose(.failed(OperationID(), error))
+    }
+
+    /// Decides what to do with a message arriving on a session already answered with a
+    /// rejection.
+    ///
+    /// It is answered with that same rejection rather than cut off, so a request that was
+    /// already pipelined behind the refusal still receives the protocol-mismatch or
+    /// unauthorized-caller recovery instead of a bare connection interruption. Closing is not
+    /// a decision about this message at all: `SessionLifetime` closes the session once every
+    /// reply it owes, this one included, has been handed to the transport.
+    public static func refused(_ rejection: RuntimeEvent) -> Decision {
+        .reply(rejection)
+    }
+
+    /// Applies a session's refusal to a decision already made for one of its messages.
+    ///
+    /// Two requests can be admitted concurrently and both find the session unrefused; if one
+    /// of them then refuses it, the other must not go on to run. The refusal is therefore
+    /// applied to the decision immediately before it is acted on, rather than trusted from the
+    /// moment the message arrived. Only dispatch is withdrawn: a decision that runs nothing is
+    /// already an answer the peer should have.
+    /// This is only a pure transformation: a refusal snapshot can still become stale.
+    /// Concurrent dispatch must use `RuntimeSessionGate.commit` for atomic registration.
+    public static func honoring(_ refusal: RuntimeEvent?, _ decision: Decision) -> Decision {
+        guard let refusal, case .dispatch = decision else { return decision }
+        return refused(refusal)
+    }
+
+    /// Decides what to do with a decoded envelope.
+    public static func decide(_ envelope: RuntimeRequestEnvelope, inFlight: Int) -> Decision {
+        // The version needs no second look here: the envelope carries the header it decoded.
+        if let refused = admit(inFlight: inFlight, clientVersion: { envelope.protocolVersion }) { return refused }
+        do {
+            // The envelope is re-encoded and measured before anything acts on it: a payload
+            // beyond the declared maximum is refused rather than dispatched.
+            try RequestValidator.validateEncodedSize(RuntimeDispatcher.encoded(envelope))
+            try RequestValidator.validate(envelope)
+        } catch {
+            if case .protocolMismatch = error {
+                return .replyAndClose(.failed(OperationID(), error.guesthouseError))
+            }
+            return .reply(.failed(OperationID(), error.guesthouseError))
+        }
+        return .dispatch(envelope.request)
+    }
+
+    static func encoded(_ envelope: RuntimeRequestEnvelope) -> Data {
+        (try? JSONEncoder().encode(envelope)) ?? Data()
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -9,9 +9,9 @@ public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStri
         self.rawValue = rawValue
     }
 
-    // Version 6 adopts event envelopes on native XPC. Versions 2–5 were already used by
-    // pre-envelope descendants; their independent payload additions must be reconciled.
-    public static let current = RuntimeProtocolVersion(6)
+    /// Version 7 combines versioned native-XPC events (6) with `tooManyInFlight`, originally
+    /// introduced by pre-envelope version 2. Do not restore either older wire shape here.
+    public static let current = RuntimeProtocolVersion(7)
 
     public static func < (lhs: RuntimeProtocolVersion, rhs: RuntimeProtocolVersion) -> Bool {
         lhs.rawValue < rhs.rawValue

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -67,6 +67,17 @@ public struct RuntimeRequestEnvelope: Codable, Hashable, Sendable {
         public let client: RuntimeProtocolVersion
         public var error: GuesthouseError { .protocolMismatch(client: client.rawValue, service: RuntimeProtocolVersion.current.rawValue) }
     }
+
+    /// The version header on its own. Decoding this reads one integer and never looks at the
+    /// request, so a peer that is being refused before its payload is decoded can still be
+    /// answered with an error its own protocol version knows how to read.
+    public struct Header: Decodable, Hashable, Sendable {
+        public let protocolVersion: RuntimeProtocolVersion
+
+        public init(protocolVersion: RuntimeProtocolVersion) {
+            self.protocolVersion = protocolVersion
+        }
+    }
 }
 
 public struct StartOptions: Codable, Hashable, Sendable {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
@@ -1,0 +1,42 @@
+import Synchronization
+
+/// Serializes one session's reply accounting, refusal, and synchronous operation registration.
+///
+/// This is not an executor or command interface. Only an authenticated, admitted, validated
+/// request may reach `commit`. Registration must be bounded, synchronous, and in-memory: no
+/// I/O, suspension, or reentry into this gate. Future asynchronous operations must register
+/// their identity and cancellation ownership here, then do their work outside the gate.
+public final class RuntimeSessionGate: Sendable {
+    // Internal so tests can nonblockingly verify that registration shares the refusal lock.
+    let state = Mutex(RuntimeDispatcher.SessionLifetime())
+
+    public init() {}
+
+    /// Counts an incoming message, unless another caller has already taken the close.
+    public func began() -> Int? { state.withLock { $0.began() } }
+
+    /// A snapshot for early rejection only; it never authorizes dispatch.
+    public var refusal: RuntimeEvent? { state.withLock { $0.refusal } }
+
+    public func refuse(_ event: RuntimeEvent) { state.withLock { $0.refuse(event) } }
+
+    /// Checks refusal and registers the request in the same critical section.
+    ///
+    /// A refusal ordered before this call prevents registration. A later refusal cannot undo
+    /// an already registered operation. Neither refusal nor a thrown registration releases
+    /// this message's reply obligation: its caller must still call `finished` exactly once,
+    /// after handing its answer to the transport, including a failure answer after a throw.
+    public func commit(
+        _ request: RuntimeRequest,
+        register: (RuntimeRequest) throws -> RuntimeEvent
+    ) rethrows -> RuntimeEvent {
+        try state.withLock { lifetime in
+            if let refusal = lifetime.refusal { return refusal }
+            return try register(request)
+        }
+    }
+
+    /// Called once per admitted message, after its reply (if any) has been handed over.
+    /// Returns whether this caller owns cancellation of the now-quiet refused session.
+    public func finished() -> Bool { state.withLock { $0.finished() } }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -53,6 +53,8 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
 
     public enum InvalidRequestReason: String, Codable, Hashable, Sendable {
         case oversized, pathEscapesAllowedRoot, invalidVMName, unsupportedOperation, malformed
+        /// The caller has too many requests in flight on one session.
+        case tooManyInFlight
     }
 
     /// Coarse grouping for filtering diagnostics and choosing presentation.
@@ -203,6 +205,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .invalidVMName: "the virtual machine name was not valid"
         case .unsupportedOperation: "the operation is not supported by this service version"
         case .malformed: "the request could not be decoded"
+        case .tooManyInFlight: "too many requests were in flight at once"
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -8,7 +8,7 @@
       "codexDesktopVersion": "TBD",
       "codexDesktopBuild": "TBD",
       "codexDesktopPath": "TBD",
-      "runtimeProtocolVersion": 1,
+      "runtimeProtocolVersion": 2,
       "tartVersion": "2.36.0",
       "guestMacOSBuild": "25F84",
       "xcodeBuild": "17F113",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeDispatcherTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeDispatcherTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeDispatcherTests {
+    let environment = EnvironmentID()
+
+    @Test func validEnvelopeIsDispatched() {
+        let decision = RuntimeDispatcher.decide(RuntimeRequestEnvelope(request: .runtimeVersion), inFlight: 0)
+        #expect(decision == .dispatch(.runtimeVersion))
+    }
+
+    @Test func protocolMismatchRepliesAndClosesTheSession() {
+        let envelope = RuntimeRequestEnvelope(protocolVersion: RuntimeProtocolVersion(RuntimeProtocolVersion.current.rawValue + 1), request: .runtimeVersion)
+        guard case .replyAndClose(.failed(_, let error)) = RuntimeDispatcher.decide(envelope, inFlight: 0) else { Issue.record("expected replyAndClose"); return }
+        #expect(error == .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue + 1, service: RuntimeProtocolVersion.current.rawValue))
+    }
+
+    @Test func invalidOptionsAreRejectedWithoutClosing() {
+        let envelope = RuntimeRequestEnvelope(request: .startEnvironment(environment, StartOptions(ipWait: .seconds(10_000))))
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(envelope, inFlight: 0) else { Issue.record("expected reply"); return }
+        #expect(error == .invalidRequest(.malformed))
+    }
+
+    @Test func tooManyInFlightRequestsAreRefused() {
+        let envelope = RuntimeRequestEnvelope(request: .environmentStatus(environment))
+        #expect(RuntimeDispatcher.decide(envelope, inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession - 1) == .dispatch(.environmentStatus(environment)))
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(envelope, inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession) else { Issue.record("expected refusal"); return }
+        #expect(error == .invalidRequest(.tooManyInFlight))
+    }
+
+    @Test func undecodableMessagesAreMalformed() {
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.undecodable() else { Issue.record("expected reply"); return }
+        #expect(error == .invalidRequest(.malformed))
+    }
+    @Test func anOverCapPeerIsRefusedBeforeAnythingIsDecoded() {
+        #expect(RuntimeDispatcher.admit(inFlight: 0, clientVersion: { .current }) == nil)
+        guard case .reply(.failed(_, let error))? = RuntimeDispatcher.admit(inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession, clientVersion: { .current }) else {
+            Issue.record("expected a refusal at the cap"); return
+        }
+        #expect(error == .invalidRequest(.tooManyInFlight))
+    }
+
+    /// `tooManyInFlight` is a protocol 2 reason, so a peer on an older version would decode
+    /// the refusal as garbage. It gets the mismatch it can act on instead.
+    @Test func anOverCapPeerOnAnotherProtocolGetsTheMismatchItCanDecode() {
+        let older = RuntimeProtocolVersion(RuntimeProtocolVersion.current.rawValue - 1)
+        guard case .replyAndClose(.failed(_, let error))? = RuntimeDispatcher.admit(inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession, clientVersion: { older }) else {
+            Issue.record("expected the protocol mismatch"); return
+        }
+        #expect(error == .protocolMismatch(client: older.rawValue, service: RuntimeProtocolVersion.current.rawValue))
+    }
+
+    @Test func anOverCapPeerWithAnUnreadableHeaderIsRefusedAsMalformed() {
+        guard case .reply(.failed(_, let error))? = RuntimeDispatcher.admit(inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession, clientVersion: { nil }) else {
+            Issue.record("expected a refusal at the cap"); return
+        }
+        #expect(error == .invalidRequest(.malformed), "every protocol version can read this one")
+    }
+
+    /// The cap has to stay cheap: nothing about the message is read until it is exceeded.
+    @Test func theVersionHeaderIsReadOnlyOnceTheCapIsExceeded() {
+        var reads = 0
+        #expect(RuntimeDispatcher.admit(inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession - 1, clientVersion: { reads += 1; return .current }) == nil)
+        #expect(reads == 0, "an admitted request never pays for a header read")
+        _ = RuntimeDispatcher.admit(inFlight: RuntimeDispatcher.maximumInFlightRequestsPerSession, clientVersion: { reads += 1; return .current })
+        #expect(reads == 1, "the refusal reads the header once, and never the request")
+    }
+
+    @Test func aRequestPipelinedBehindARefusalIsStillAnswered() {
+        let rejection = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        #expect(RuntimeDispatcher.refused(rejection) == .reply(rejection), "the peer is told again rather than cut off")
+    }
+
+    /// The rejection is delivered before the session goes away: the request that carried it
+    /// stops counting only once its reply has been handed over, and the close happens then.
+    @Test func aRefusedSessionClosesWhenItOwesNothingFurther() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        let others = lifetime.began()
+        lifetime.refuse(.failed(OperationID(), .unauthorizedCaller))
+        let closes = lifetime.finished()
+        #expect(others == 0, "the first message finds the session quiet")
+        #expect(closes, "no other message is needed to close a refused session")
+    }
+
+    @Test func aRefusedSessionStaysOpenWhileAnotherReplyIsOutstanding() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        _ = lifetime.began()
+        let others = lifetime.began()
+        lifetime.refuse(.failed(OperationID(), .unauthorizedCaller))
+        let afterRefusal = lifetime.finished()
+        let afterLast = lifetime.finished()
+        #expect(others == 1, "the second message finds the first still outstanding")
+        #expect(!afterRefusal, "closing now would discard the answer the other request is owed")
+        #expect(afterLast, "the last reply handed over closes the session")
+    }
+
+    @Test func theFirstRefusalIsTheReasonThePeerKeepsBeingTold() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        let first = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        _ = lifetime.began()
+        lifetime.refuse(first)
+        lifetime.refuse(.failed(OperationID(), .protocolMismatch(client: 1, service: 2)))
+        #expect(lifetime.refusal == first, "a later refusal never rewrites why the session is closing")
+    }
+
+    @Test func aRefusalStopsAConcurrentlyAdmittedRequestFromRunning() {
+        let rejection = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        let dispatch = RuntimeDispatcher.Decision.dispatch(.startEnvironment(EnvironmentID(), StartOptions()))
+        #expect(RuntimeDispatcher.honoring(rejection, dispatch) == .reply(rejection), "a request admitted before the refusal must not still run")
+        #expect(RuntimeDispatcher.honoring(nil, dispatch) == dispatch, "an unrefused session dispatches as decided")
+        let answered = RuntimeDispatcher.Decision.reply(.failed(OperationID(), .invalidRequest(.malformed)))
+        #expect(RuntimeDispatcher.honoring(rejection, answered) == answered, "a decision that runs nothing is left alone")
+    }
+
+    /// Closing and admitting are one decision. A message admitted in between would be answered
+    /// and then have its reply discarded by the cancel that follows, which is exactly the
+    /// connection interruption the stored rejection exists to replace.
+    @Test func aSessionThatHasTakenItsCloseAdmitsNothingFurther() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        _ = lifetime.began()
+        lifetime.refuse(.failed(OperationID(), .unauthorizedCaller))
+        let closes = lifetime.finished()
+        let admitted = lifetime.began()
+        #expect(closes, "the last reply handed over closes the session")
+        #expect(lifetime.isClosing)
+        #expect(admitted == nil, "a message admitted after the close would race the cancel")
+        #expect(lifetime.inFlight == 0, "a message that was never admitted owes no reply")
+    }
+
+    @Test func anUnrefusedSessionIsNeverClosedByItsLifetime() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        _ = lifetime.began()
+        let closes = lifetime.finished()
+        #expect(!closes)
+        #expect(lifetime.refusal == nil)
+    }
+
+    @Test func anOversizedEnvelopeIsRefusedBeforeItIsDispatched() {
+        let huge = String(repeating: "a", count: RequestValidator.maximumEncodedSize)
+        let envelope = RuntimeRequestEnvelope(request: .importXcode(EnvironmentID(), FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app", expectedBundleIdentifier: huge)))
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(envelope, inFlight: 0) else {
+            Issue.record("expected a refusal"); return
+        }
+        #expect(error == .invalidRequest(.oversized))
+    }
+
+    /// The header is what makes the version knowable at the cap: a skewed peer's envelope
+    /// refuses to decode, but the version it announced is still readable on its own.
+    @Test func theVersionHeaderDecodesFromAnEnvelopeThatDoesNot() throws {
+        let older = RuntimeProtocolVersion(RuntimeProtocolVersion.current.rawValue - 1)
+        let encoded = try JSONEncoder().encode(RuntimeRequestEnvelope(protocolVersion: older, request: .runtimeVersion))
+        #expect(try JSONDecoder().decode(RuntimeRequestEnvelope.Header.self, from: encoded).protocolVersion == older)
+        #expect(throws: RuntimeRequestEnvelope.ProtocolMismatch.self) {
+            try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: encoded)
+        }
+    }
+
+    @Test func aMismatchClosesTheSessionAfterItsReply() {
+        guard case .replyAndClose(.failed(_, let error)) = RuntimeDispatcher.mismatch(.protocolMismatch(client: 99, service: 1)) else {
+            Issue.record("expected replyAndClose"); return
+        }
+        #expect(error == .protocolMismatch(client: 99, service: 1))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
@@ -1,0 +1,79 @@
+import Synchronization
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeSessionGateTests {
+    @Test(arguments: [GuesthouseError.unauthorizedCaller, .protocolMismatch(client: 99, service: 7)])
+    func refusalBeforeCommitPreventsRegistrationDespiteAnEarlierOpenSnapshot(error: GuesthouseError) {
+        let gate = RuntimeSessionGate()
+        let refusal = RuntimeEvent.failed(OperationID(), error)
+        #expect(gate.began() == 0)
+        #expect(gate.began() == 1)
+        let earlierSnapshot = gate.refusal
+        #expect(earlierSnapshot == nil)
+        gate.refuse(refusal)
+
+        var registrations = 0
+        let reply = gate.commit(.runtimeVersion) { _ in
+            registrations += 1
+            return .completed(OperationID())
+        }
+        #expect(reply == refusal)
+        #expect(registrations == 0)
+        #expect(gate.state.withLock { $0.inFlight } == 2, "rejection still owes both replies")
+        #expect(!gate.finished(), "the first reply must not discard the second")
+        #expect(gate.finished(), "only the last reply claims cancellation")
+        #expect(gate.began() == nil, "nothing is admitted once cancellation is claimed")
+    }
+
+    @Test func registrationRunsUnderTheSameLockAsRefusal() {
+        let gate = RuntimeSessionGate()
+        let expected = RuntimeEvent.completed(OperationID())
+        #expect(gate.began() == 0)
+        var lockWasHeld = false
+        var registeredRequest: RuntimeRequest?
+        let reply = gate.commit(.runtimeVersion) { request in
+            // Unlike a scheduling sleep, this fails deterministically if commit reads a
+            // snapshot, unlocks, and only then calls registration. It never blocks/reenters.
+            lockWasHeld = gate.state.withLockIfAvailable { _ in true } == nil
+            registeredRequest = request
+            return expected
+        }
+        #expect(lockWasHeld)
+        #expect(registeredRequest == .runtimeVersion)
+        #expect(reply == expected)
+        #expect(!gate.finished(), "an unrefused session stays open")
+    }
+
+    @Test func laterRefusalPreservesTheAlreadyRegisteredAnswerAndFirstRejection() {
+        let gate = RuntimeSessionGate()
+        let expected = RuntimeEvent.completed(OperationID())
+        let first = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        #expect(gate.began() == 0)
+        let reply = gate.commit(.runtimeVersion) { _ in expected }
+        gate.refuse(first)
+        gate.refuse(.failed(OperationID(), .protocolMismatch(client: 99, service: 7)))
+        #expect(reply == expected)
+        #expect(gate.refusal == first)
+        #expect(gate.state.withLock { $0.inFlight } == 1)
+        #expect(gate.finished())
+        #expect(gate.began() == nil)
+    }
+
+    @Test func thrownRegistrationUnlocksWithoutReleasingItsReplyObligation() {
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        #expect(throws: CancellationError.self) {
+            try gate.commit(.runtimeVersion) { _ in throw CancellationError() }
+        }
+        #expect(gate.state.withLockIfAvailable { $0.inFlight } == 1)
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        #expect(gate.finished(), "the caller still owns sending its failure then finishing")
+        #expect(gate.began() == nil)
+    }
+
+    @Test func gateHasCheckedSendableConformance() {
+        func requireSendable<T: Sendable>(_: T.Type) {}
+        requireSendable(RuntimeSessionGate.self)
+    }
+}


### PR DESCRIPTION
## Scope and stack

Extract the complete Core admission, reply-accounting, and atomic registration prerequisite from #68. Stacked on reviewed #103 (`9d5dace`), after #67 → #102 → #103; #68 will be retargeted here for the separate service/authentication activation. Related to #20 and `MVP-PLAN.md` §3 (authenticate callers, validate named requests).

**457 changed lines** (453 additions, four deletions), eight Core files, commit `aed5ec4`. The following service integration is 213 changed lines. Existing tests are preserved; no size waiver, force-push, or unrelated base restack.

## Contract

- Extract `RuntimeDispatcher`, header-only admission, the eight-request cap, `tooManyInFlight`, validation decisions, and `SessionLifetime` unchanged in behavior from #68.
- Adopt integrated wire version **7**: native event envelopes introduced at 6 plus the admission reason originally introduced by pre-envelope version 2. Never restore 2 or discard the event envelope on restack.
- Add checked-Sendable `RuntimeSessionGate`: its single `Mutex` guards lifetime/refusal and the bounded synchronous registration callback. A refusal ordered first prevents registration; registration ordered first retains its answer. The first refusal remains authoritative, outstanding replies still count, and only the last finished reply owns session cancellation.
- The callback is not a command interface or executor. Only authenticated/admitted/validated requests may reach it. It must perform no I/O, await, or gate reentry. Future async operations must register identity/cancellation ownership under the gate, then work outside it. Throws leave the reply obligation with the caller, and unlock normally.
- This prerequisite defines the primitive; #68 activates it at the service dispatch boundary. It does not independently claim to fix the [#68 refusal/dispatch finding](https://github.com/PicoMLX/Guesthouse/pull/68#discussion_r3937939698).

## Verification

- **555 Core tests / 35 suites pass**, Swift 6 and warnings-as-errors, including all 19 existing dispatcher tests and five dedicated gate tests (the refusal test covers unauthorized and version-mismatch cases).
- Deterministic coverage: refusal before commitment despite an earlier nil snapshot; same-lock registration; registration before later refusal; first-rejection preservation; outstanding reply and one-owner close accounting; cancellation-error throws unlocking without consuming the reply obligation; checked Sendable conformance.
- Reproducible test command: `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors --filter RuntimeSessionGateTests`. To verify the lock-gap regression, temporarily replace only `commit`'s body with `let refusal = state.withLock { $0.refusal }; if let refusal { return refusal }; return try register(request)` and run `--filter RuntimeSessionGateTests.registrationRunsUnderTheSameLockAsRefusal`. This compiled and failed exactly at `lockWasHeld`; restoring the committed body passes. The probe uses nonblocking `withLockIfAvailable`, not scheduler sleeps.
- Exact full Core tree matches the validated #68 composition. That composition also passes 47 actual client/native-XPC tests and service/main typechecking; those are not claimed to exercise authenticated service overlap.
- Limited claim: the primitive serializes registration against refusal. Concurrent invocation of one native authenticated handler and unauthorized host mutation have not been reproduced. Current #68 only computes runtimeVersion/unsupported terminal answers. No VM, signing, installed/privileged-service launch, or hardware verification.
- No new dependency, warning, workflow edit, or issue-body write. Fresh exact-head Xcode Cloud and Codex review are requested after publication.

## Remaining integration

#68 must preserve explicit enveloped replies before `finished`/cancel, the listener requirement, per-message authentication, one-way refusal accounting, and cap-before-full-decode. #69–#70/#88 then adopt shared 7. Tart #71/#72 reserve 8; lifecycle #73–#80 reserve 9 (synchronous replies, delayed ReplyBox replies, SessionSink pushes); #81 reserves 10 and must preserve typed mismatch in client/UI presentation; Lume #85/#89 reserve 11, including surviving terminal responder encoders. #83/#100 diagnostics may keep 7 only after a compatibility audit. See #103 for the exact downstream sites; none are modified here.
