### PR TITLE
Recognize qualified credential fields and session cookies

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -40,8 +40,9 @@ extension Redactor {
         /// (Digest, AWS SigV4) leave nothing behind. The key may be quoted the way JSON, a
         /// Python dictionary, or a JSON string embedded in a log line quotes it.
         /// The same match determines continuation state before replacement. An empty value
-        /// arms the next line even when a logger prefixes or quotes the field name.
-        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:proxy|request)[ _-]?)?authorization(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        /// arms the next line even when a logger prefixes or quotes the field name. Cookie
+        /// headers share this state: opaque session identifiers convey authority (RFC 6265 §8.4).
+        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:set-)?cookie)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
         /// Bearer credentials outside a header line, of any length. Every token and label rule
         /// here starts at a character that cannot be part of the word rather than at `\b`:
         /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
@@ -115,12 +116,13 @@ extension Redactor {
         let urlUserInfo = #/((?::|^|[\s"'(<\[{]|(?:^|[\s"'(<\[{])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
-        /// `clientSecret`. Those need a name in front of the label word, and the names come from
-        /// a closed list so that an ordinary word ending in `token` or `secret` is still not a
-        /// label. The key is quoted the way JSON, a Python dictionary, or a JSON string embedded
-        /// in a log line quotes it. An unquoted value runs to the end of the line rather than to
-        /// the first space, because a passphrase is words: `password: correct horse battery`. It
-        /// still has to start with one non-space character, so a bare label falls to the rule
+        /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names
+        /// require an uppercase secret suffix. An ordinary lowercase word ending in `token`
+        /// or `secret` is not a label. The key is quoted the way JSON, a Python dictionary, or
+        /// a JSON string embedded in a log line quotes it. An unquoted value runs to the end of
+        /// the line rather than the first space, because a passphrase is words:
+        /// `password: correct horse battery`. It still has to start with one non-space
+        /// character, so a bare label falls to the rule
         /// below and arms the next line instead of matching an empty value here.
         /// One vocabulary shared by inline fields, bare labels, and command options.
         /// Explicit private-key labels are sensitive even when the value is not PEM.
@@ -129,7 +131,8 @@ extension Redactor {
         }
         private static var secretLabel: Regex<(Substring, Substring, Substring)> {
             Regex {
-                #/(^|[^A-Za-z0-9])(?:\\?["'])?/#
+                // Preserve the consumed predecessor; only uppercase suffixes add a boundary.
+                #/(^|[^A-Za-z0-9]|(?-i:[A-Za-z0-9](?=[A-Z])))(?:\\?["'])?/#
                 Capture { secretName }
                 #/(?:\\?["'])?\s*[:=]\s*/#
             }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorCredentialFieldTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorCredentialFieldTests.swift
@@ -1,0 +1,101 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorCredentialFieldTests {
+    @Test(arguments: [
+        ("databasePassword", "e", "Password"),
+        ("sshPrivateKey", "h", "PrivateKey"),
+        ("SSHPrivateKey", "H", "PrivateKey"),
+        ("database_password", "_", "password"),
+        ("ssh-private-key", "-", "private-key"),
+    ], [":", "="])
+    func qualifiedFieldsRetainTheirBoundary(field: (name: String, boundary: String, suffix: String), delimiter: String) throws {
+        let match = try #require((field.name + delimiter + "opaqueCredential").firstMatch(of: Redactor.patterns.labeledSecret))
+        #expect(match.1 == field.boundary)
+        #expect(match.2 == field.suffix)
+        #expect(match.3 == "opaqueCredential")
+        let output = Redactor().redact(field.name + delimiter + "opaqueCredential")
+        #expect(output == field.name + ": [redacted:secret]")
+    }
+
+    @Test(arguments: ["nonToken: 42", "nonToken=opaqueCredential"])
+    func explicitCredentialSuffixDoesNotInferSemanticNegation(input: String) {
+        #expect(Redactor().redact(input) == "nonToken: [redacted:secret]")
+    }
+
+    @Test(arguments: ["databasePassword", "sshPrivateKey"], ["\"", "'"])
+    func quotedQualifiedFieldsPreserveOrdinarySiblings(name: String, quote: String) {
+        let input = "{" + quote + name + quote + ":" + quote + "opaqueCredential" + quote + ",\"tokenCount\":42}"
+        let output = Redactor().redact(input)
+        #expect(!output.contains("opaqueCredential"))
+        #expect(output.contains(name))
+        #expect(output.hasSuffix(",\"tokenCount\":42}"))
+    }
+
+    @Test(arguments: ["databasePassword:", "\"databasePassword\":", "sshPrivateKey=", "'sshPrivateKey'="])
+    func qualifiedBareLabelsArmTheirValue(input: String) {
+        #expect(input.contains(Redactor.patterns.secretLabelOnly))
+        let output = Redactor().redact(input + "\nopaqueCredential\nordinary diagnostic")
+        #expect(!output.contains("opaqueCredential"))
+        #expect(output.hasSuffix("ordinary diagnostic"))
+    }
+
+    @Test(arguments: [
+        "run --databasePassword opaqueCredential --verbose",
+        "run --ssh-private-key=opaqueCredential --verbose",
+        "[\"--sshPrivateKey\",\"opaqueCredential\",\"--verbose\"]",
+        "run --databasePassword\nopaqueCredential\n--verbose",
+    ])
+    func qualifiedOptionsShareTheSecretVocabulary(input: String) {
+        let output = Redactor().redact(input)
+        #expect(!output.contains("opaqueCredential"))
+        #expect(output.contains("--verbose"))
+    }
+
+    @Test(arguments: ["Cookie", "Set-Cookie"], [":", "="])
+    func cookieHeadersCaptureOpaqueValues(name: String, delimiter: String) throws {
+        let input = name + delimiter + "session=opaqueCredential; preference=opaqueOther"
+        let match = try #require(input.firstMatch(of: Redactor.patterns.authorizationHeader))
+        #expect(match.1.isEmpty)
+        #expect(match.2 == "session=opaqueCredential; preference=opaqueOther")
+        let output = Redactor().redact(input)
+        #expect(!output.contains("opaqueCredential"))
+        #expect(!output.contains("opaqueOther"))
+        #expect(output.contains("[redacted:authorization]"))
+        #expect(output.hasPrefix(name + ": "))
+    }
+
+    @Test(arguments: ["Cookie", "Set-Cookie"])
+    func cookieHeadersShareFoldedAndBareValueState(name: String) {
+        let folded = Redactor().redact(name + ": SID=opaqueCredential\n next=opaqueOther\nAccept: */*")
+        #expect(!folded.contains("opaqueCredential"))
+        #expect(!folded.contains("opaqueOther"))
+        #expect(folded.hasSuffix("Accept: */*"))
+        let bare = Redactor().redact(name + ":\n\nSID=opaqueCredential\nAccept: */*")
+        #expect(!bare.contains("opaqueCredential"))
+        #expect(bare.hasSuffix("Accept: */*"))
+        #expect(Redactor().redact(name + ":\nAccept: */*").hasSuffix("Accept: */*"))
+    }
+
+    @Test(arguments: ["Cookie", "Set-Cookie"], ["\"", "'"])
+    func quotedCookieHeadersPreserveClosedSiblings(name: String, quote: String) {
+        let input = "{" + quote + name + quote + ":" + quote + "SID=opaqueCredential" + quote + ",\"count\":42}"
+        let output = Redactor().redact(input)
+        #expect(!output.contains("opaqueCredential"))
+        #expect(output.hasSuffix(",\"count\":42}"))
+    }
+
+    @Test(arguments: [
+        "databasepassword=ordinary", "sshprivatekey:ordinary", "databasePasswordLength=12", "nontoken:42",
+        "tokenCount=42", "errorCode:42", "secretary:available", "CookieCount=2", "notCookie:ordinary",
+        "Set-Cookie-Count:2", "databasePassword is configured", "Cookies are supported",
+        "run --tokenCount 42", "c15e59b83ad7fcd9a95dd5534e6bb6fdd8073787",
+        "12345678-1234-1234-1234-123456789012", "2.36.0",
+    ])
+    func ordinaryNamesAndDiagnosticsRemainUnchanged(input: String) {
+        #expect(!input.contains(Redactor.patterns.labeledSecret))
+        #expect(!input.contains(Redactor.patterns.authorizationHeader))
+        #expect(!input.contains(Redactor.patterns.secretLabelOnly))
+        #expect(Redactor().redact(input + "\nordinary diagnostic") == input + "\nordinary diagnostic")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorInlinePerformanceReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorInlinePerformanceReviewTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorInlinePerformanceReviewTests {
+    @Test func manyEncodedFieldsDoNotRescanEveryRemainingSuffix() {
+        let field = #"\"password\":\"syntheticValue\""#
+        let input = Array(repeating: field, count: 1_000).joined(separator: ", ")
+        let output = Redactor().redact(input)
+        #expect(!output.contains("syntheticValue"))
+        #expect(output.components(separatedBy: "[redacted:secret]").count == 1_001)
+    }
+
+    @Test(arguments: ["password:", "Authorization:", "device_code:", "Your code is:"], ["secretTail", " unquotedTail"])
+    func ambiguousEncodedQuoteSuffixesStaySensitive(label: String, tail: String) {
+        let output = Redactor().redact(label + #" \"quoted\""# + tail)
+        #expect(!output.contains("quoted"))
+        #expect(!output.contains(tail.trimmingCharacters(in: .whitespaces)))
+    }
+
+    @Test func ordinaryEncodedValuesStillExposeTokensToRedaction() {
+        let output = Redactor().redact(#"\"status\":\"ghp_abcdefghijklmnopqrstuvwxyz\", \"path\":\"/tmp/report\""#)
+        #expect(!output.contains("abcdefghijklmnopqrstuvwxyz"))
+        #expect(output.contains(#"\"path\":\"/tmp/report\""#))
+    }
+
+    @Test(arguments: ["Authorization:", "password:", "device_code:", "Cookie:"], ["\"", "\\\""])
+    func initialQuotedFieldsKeepExplicitPhysicalContinuation(label: String, quote: String) {
+        let lines = [label + " " + quote + "synthetic" + quote + " \\", "opaque:Secret", "done"]
+        let output = Redactor().redact(lines: lines).map(\.text)
+        #expect(!output[0].contains("synthetic"))
+        #expect(!output[1].contains("opaque:Secret"))
+        #expect(output[2] == "done")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTests.swift
@@ -1,0 +1,133 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorTests {
+    let redactor = Redactor()
+
+    /// Synthetic secrets only. None of these values are real.
+    static let secrets: [(kind: String, line: String, secret: String)] = [
+        ("github classic", "remote: token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab used", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"),
+        ("github oauth", "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab", "gho_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"),
+        ("github fine-grained", "using github_pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ", "github_pat_11ABCDEFG0123456789_abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ"),
+        ("authorization header", "> Authorization: token ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"),
+        ("bearer", "curl -H 'Bearer abcdefghijklmnop.qrstuvwxyz'", "abcdefghijklmnop.qrstuvwxyz"),
+        ("api key", "OPENAI_API_KEY is sk-proj-abcdefghijklmnopqrstuvwxyz0123", "sk-proj-abcdefghijklmnopqrstuvwxyz0123"),
+        ("jwt", "session eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcdefghijklmnopqrstuv", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.abcdefghijklmnopqrstuv"),
+        ("jwt with empty claims", "token eyJhbGciOiJIUzI1NiJ9.e30.sig", "eyJhbGciOiJIUzI1NiJ9.e30.sig"),
+        ("unsecured jwt with empty signature", "value eyJhbGciOiJub25lIn0.e30. ok", "eyJhbGciOiJub25lIn0.e30."),
+        ("password with escaped quote", "password: \"correct\\\"horse battery\"", "horse battery"),
+        ("url password containing at", "cloning https://user:p@ss@example.com/repo.git", "p@ss"),
+        ("token wrapped in ansi color", "\u{1B}[31mghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab\u{1B}[0m", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"),
+        ("token wrapped in colon-parameter sgr", "\u{1B}[38:2:255:0:0mghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab\u{1B}[0m", "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab"),
+        ("url userinfo", "cloning https://ronald:hunter2secret@github.com/PicoMLX/Guesthouse.git", "hunter2secret"),
+        ("password label", "password: hunter2secret", "hunter2secret"),
+        ("passphrase label", "Passphrase=\"correct horse battery\"", "correct horse battery"),
+        ("token label", "token=abc123def456", "abc123def456"),
+        ("github device code", "! First copy your one-time code: 1A2B-3C4D", "1A2B-3C4D"),
+        ("codex device code", "Enter the code 9Z8Y-7X6W at the URL shown", "9Z8Y-7X6W"),
+    ]
+
+    @Test(arguments: secrets)
+    func secretDoesNotSurvive(kind: String, line: String, secret: String) {
+        let redacted = redactor.redact(line)
+        #expect(!redacted.contains(secret), "\(kind): \(redacted)")
+        #expect(redacted.contains("[redacted:"), "\(kind): no marker in \(redacted)")
+    }
+
+    @Test func markersNameTheKind() {
+        #expect(redactor.redact("ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab") == "[redacted:github-token]")
+        #expect(redactor.redact("password: x") == "password: [redacted:secret]")
+        #expect(redactor.redact("https://u:p@h/x") == "https://[redacted:userinfo]@h/x")
+        #expect(redactor.redact("your code: AB12-CD34.") == "your code: [redacted:device-code].")
+    }
+
+    @Test func multiLinePEMBlockIsRemovedAcrossStreamedLines() {
+        let lines = [
+            "installing key",
+            "-----BEGIN OPENSSH PRIVATE KEY-----",
+            "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW",
+            "QyNTUxOQAAACBfakekeymaterialfakekeymaterialfakekeymaterialfakekeymat",
+            "-----END OPENSSH PRIVATE KEY-----",
+            "done",
+        ]
+        var state = Redactor.StreamState()
+        let out = lines.map { redactor.redact(line: $0, state: &state).text }
+        #expect(out[0] == "installing key")
+        #expect(out[1] == "[redacted:private-key]")
+        #expect(out[2] == "[redacted:private-key]")
+        #expect(out[3] == "[redacted:private-key]")
+        #expect(out[4] == "[redacted:private-key]")
+        #expect(out[5] == "done")
+        #expect(!out.joined().contains("fakekeymaterial"))
+        #expect(state == Redactor.StreamState())
+    }
+
+    @Test func singleLinePEMIsRemovedInPlace() {
+        let out = redactor.redact("key=-----BEGIN RSA PRIVATE KEY-----MIIEow-----END RSA PRIVATE KEY----- ok")
+        #expect(out == "key=[redacted:private-key] ok")
+    }
+
+    @Test func wholeTextConvenienceHandlesPEM() {
+        let text = "a\n-----BEGIN PRIVATE KEY-----\nSECRETMATERIAL\n-----END PRIVATE KEY-----\nb"
+        let out = redactor.redact(text)
+        #expect(!out.contains("SECRETMATERIAL"))
+        #expect(out.hasPrefix("a\n"))
+        #expect(out.hasSuffix("\nb"))
+    }
+
+    @Test func falsePositiveGuard() {
+        let sha = "commit 1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b"
+        let uuid = "environment 1A2B3C4D-0000-4000-8000-000000000000"
+        let version = "Tart 2.36.0, Xcode 26.6 (17F113), protocol 1"
+        let scopes = "Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'"
+        let uuidOnCodeLine = "device code request for 1A2B3C4D-0000-4000-8000-000000000000 failed"
+        let url = "cloning https://github.com/PicoMLX/Guesthouse.git"
+        for line in [sha, uuid, version, scopes, uuidOnCodeLine, url] {
+            #expect(redactor.redact(line) == line)
+        }
+    }
+
+    @Test func redactedLineCanOnlyBeMadeFromLiteralsOrRedactor() throws {
+        let literal = RedactedLine(literal: "Started")
+        #expect(literal.text == "Started")
+        let data = try JSONEncoder().encode(literal)
+        #expect(String(decoding: data, as: UTF8.self) == "\"Started\"")
+        #expect(try JSONDecoder().decode(RedactedLine.self, from: data) == literal)
+    }
+
+    @Test func foldedAuthorizationHeaderIsRedactedAcrossLines() {
+        var state = Redactor.StreamState()
+        let first = redactor.redact(line: "Authorization:", state: &state).text
+        let second = redactor.redact(line: " Basic dXNlcjpwYXNz", state: &state).text
+        let third = redactor.redact(line: "Accept: */*", state: &state).text
+        #expect(first == "Authorization: [redacted:authorization]")
+        #expect(second == "[redacted:authorization]")
+        #expect(third == "Accept: */*")
+        #expect(state == Redactor.StreamState())
+        var fresh = Redactor.StreamState()
+        _ = redactor.redact(line: "Authorization:", state: &fresh)
+        #expect(redactor.redact(line: "Accept: */*", state: &fresh).text == "Accept: */*", "a non-credential continuation is left alone")
+    }
+
+    @Test func urlUserInfoCoversTheWholeAuthority() {
+        #expect(redactor.redact("https://user:p@ss@example.com/repo.git") == "https://[redacted:userinfo]@example.com/repo.git")
+        #expect(redactor.redact("https://example.com/a@b/c") == "https://example.com/a@b/c", "an @ in the path is not userinfo")
+    }
+
+    @Test func fieldValuesRedactBareDeviceCodes() {
+        #expect(redactor.redact(fieldValue: "AB12-CD34") == "[redacted:device-code]")
+        #expect(redactor.redact(fieldValue: "0.50.0 (AB12-CD34)") == "0.50.0 ([redacted:device-code])")
+        #expect(redactor.redact(fieldValue: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab") == "[redacted:github-token]")
+        #expect(redactor.redact(fieldValue: "2.36.0") == "2.36.0")
+        #expect(redactor.redact(fieldValue: "1A2B3C4D-0000-4000-8000-000000000000") == "1A2B3C4D-0000-4000-8000-000000000000")
+        #expect(redactor.redact("AB12-CD34") == "AB12-CD34", "log lines keep the context rule")
+    }
+
+    @Test func batchRedactionSharesStateAcrossLines() {
+        let out = redactor.redact(lines: ["-----BEGIN X-----", "material", "-----END X-----", "password=x"])
+        #expect(out.map(\.text) == [
+            "[redacted:private-key]", "[redacted:private-key]", "[redacted:private-key]", "password: [redacted:secret]",
+        ])
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

Credential fields such as databasePassword and sshPrivateKey, and Cookie or Set-Cookie headers, could reach diagnostics without being recognized. The shared grammar now recognizes an explicit camel-case credential suffix and keeps cookie values protected across folded lines while retaining their header names.

This prerequisite for #59 implements #11 and MVP-PLAN.md §3's redacted logging boundary. Lowercase ordinary words remain unchanged. The legacy nonToken fixture is deliberately updated to reflect the conservative uppercase-suffix policy, with positive and negative coverage.

Validation: 135 cumulative Core tests pass with warnings treated as errors. The 290-line change includes field, cookie, original API, and encoded-value performance regressions; 1,000 encoded fields complete without recursively rescanning the remaining input.