### PR TITLE
Redact PuTTY private-key files across physical lines

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -16,6 +16,10 @@ extension Redactor {
 
     /// Redacts one line of a stream. Pass the same `state` for every line of one stream.
     func redact(line: String, state: inout StreamState) -> RedactedLine {
+        redact(line: line, state: &state, isPhysicalLine: true)
+    }
+
+    private func redact(line: String, state: inout StreamState, isPhysicalLine: Bool) -> RedactedLine {
         // Terminal styling is dropped first so an escape sequence can never sit between a word
         // boundary and a token. Removing it joins the text on either side, which is what a label
         // split by styling needs, but it also hides the boundary every token rule requires in
@@ -27,6 +31,11 @@ extension Redactor {
         // first; what it leaves is closed up again for everything below, which is the rendering
         // a label has to be read in.
         let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
+        // Only the physical pass advances PPK framing. Alternate readings and suffix scans
+        // must neither count a body twice nor change the contexts enclosing the private key.
+        if isPhysicalLine, Self.consumePPKLine(stripped.joined, phase: &state.ppkPhase) {
+            return RedactedLine(Self.marker("private-key"))
+        }
         var text = stripped.joined
         if let quoted = state.quotedValue {
             // Inspect the original normalized text: replacement markers no longer contain the
@@ -38,7 +47,7 @@ extension Redactor {
                 // This suffix is still on the same physical line. Scan it independently so
                 // it cannot consume a next-line value or terminate the enclosing fold.
                 var suffixState = StreamState()
-                _ = redact(line: tail, state: &suffixState)
+                _ = redact(line: tail, state: &suffixState, isPhysicalLine: false)
                 if quoted.enclosingAuthorizationFold { suffixState.quotedValue?.enclosingAuthorizationFold = true }
                 if quoted.enclosingSecretFold { suffixState.quotedValue?.enclosingSecretFold = true }
                 state.quotedValue = nil
@@ -61,7 +70,7 @@ extension Redactor {
             // pending contexts before replacing that evidence with a marker.
             // Joined text has no terminal controls, so this scan has no alternate-reading recursion.
             var joinedScan = StreamState()
-            _ = redact(line: stripped.joined, state: &joinedScan)
+            _ = redact(line: stripped.joined, state: &joinedScan, isPhysicalLine: false)
             text = Self.applyPatterns(to: stripped.spliced, codeExpected: state.expectingDeviceCode, state: &boundaryScan)
                 .replacingOccurrences(of: Self.splicedBoundary, with: "")
             Self.mergePendingContexts(from: joinedScan, into: &boundaryScan)
@@ -77,7 +86,7 @@ extension Redactor {
                 // Otherwise replacing `password` first destroys the evidence that its value
                 // must be removed. Future state alone cannot protect this line's value.
                 var originalScan = StreamState()
-                let sanitized = redact(line: text, state: &originalScan).text
+                let sanitized = redact(line: text, state: &originalScan, isPhysicalLine: false).text
                 Self.mergePendingContexts(from: originalScan, into: &boundaryScan)
                 text = sanitized.hasPrefix(fragment)
                     ? Self.marker(kind) + sanitized.dropFirst(fragment.count)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
@@ -1,0 +1,45 @@
+import RegexBuilder
+
+extension Redactor {
+    /// PuTTY v2/v3 framing, not key validation: metadata and both key halves are all hidden.
+    /// https://www.puttyssh.org/0.83/htmldoc/AppendixC.html
+    /// Counts only bound the expected sequence; they never size an allocation or end protection.
+    /// A malformed sequence stays closed until the caller supplies a fresh StreamState.
+    /// Call exactly once per physical line, after removing terminal controls and their payloads.
+    static func consumePPKLine(_ line: String, phase: inout StreamState.PPKPhase) -> Bool {
+        switch phase {
+        case .inactive:
+            // The distinctive opener also survives a logger prefix or an enclosing quoted value.
+            guard let start = line.firstMatch(of: #/PuTTY-User-Key-File-([23]):/#) else { return false }
+            phase = .headers(macDigits: start.1 == "2" ? 40 : 64)
+        case .headers(let macDigits):
+            if let count = line.wholeMatch(of: #/[ \t]*Private-Lines:[ \t]*([0-9]+)[ \t]*/#),
+               let remaining = Int(count.1), remaining > 0 {
+                phase = .privateLines(remaining: remaining, macDigits: macDigits)
+            } else if line.firstMatch(of: #/^[ \t]*(?:Private-Lines|Private-MAC)(?:[: \t]|$)/#) != nil {
+                phase = .invalid
+            }
+            // Public data, comments, encryption and KDF metadata are opaque, not trusted counts.
+        case .privateLines(let remaining, let macDigits):
+            guard let body = line.wholeMatch(of: #/[ \t]*([A-Za-z0-9+\/]+={0,2})[ \t]*/#),
+                  remaining == 1 || !body.1.hasSuffix("=") else {
+                phase = .invalid
+                return true
+            }
+            phase = remaining == 1 ? .mac(digits: macDigits)
+                : .privateLines(remaining: remaining - 1, macDigits: macDigits)
+        case .mac(let digits):
+            if let mac = line.wholeMatch(of: #/[ \t]*Private-MAC:[ \t]*([0-9A-Fa-f]+)[ \t]*/#),
+               mac.1.utf8.count == digits {
+                phase = .inactive
+            } else {
+                phase = .invalid
+            }
+        case .invalid:
+            break
+        }
+        // The complete MAC line is sensitive too. Ordinary parsing resumes on the next line,
+        // without clearing any quoted, PEM, or pending context that enclosed this block.
+        return true
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -31,6 +31,17 @@ struct Redactor: Sendable {
             var enclosingSecretFold = false
         }
 
+        /// Syntax-only PPK framing; no key material is retained or decoded.
+        enum PPKPhase: Hashable, Sendable {
+            case inactive
+            case headers(macDigits: Int)
+            case privateLines(remaining: Int, macDigits: Int)
+            case mac(digits: Int)
+            case invalid
+        }
+
+        var ppkPhase = PPKPhase.inactive
+
         /// The label of the PEM block being removed, until its matching footer.
         var pemLabel: String?
         /// The previous line was a bare `Authorization:` label; the value follows on this line.

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorPPKTests {
+    private static let marker = "[redacted:private-key]"
+    // Deliberately synthetic framing: these blobs are not private keys or cryptographic MACs.
+    private static func key(version: Int = 3, encryption: String = "none") -> [String] {
+        var lines = ["PuTTY-User-Key-File-\(version): ssh-ed25519", "Encryption: \(encryption)",
+                     "Comment: synthetic fixture", "Public-Lines: 1", "cHVibGlj"]
+        if version == 3, encryption != "none" {
+            lines += ["Key-Derivation: Argon2id", "Argon2-Memory: 8", "Argon2-Passes: 1",
+                      "Argon2-Parallelism: 1", "Argon2-Salt: 0123456789abcdef"]
+        }
+        return lines + ["Private-Lines: 2", "AAAA", "BBBB",
+                        "Private-MAC: " + String(repeating: "a", count: version == 2 ? 40 : 64)]
+    }
+
+    @Test(arguments: [2, 3], ["none", "aes256-cbc"])
+    func helperConsumesCompleteFilesAndResumes(version: Int, encryption: String) {
+        var phase = Redactor.StreamState.PPKPhase.inactive
+        #expect(!Redactor.consumePPKLine("before", phase: &phase))
+        for line in Self.key(version: version, encryption: encryption) {
+            #expect(Redactor.consumePPKLine(line, phase: &phase))
+        }
+        #expect(phase == .inactive)
+        #expect(!Redactor.consumePPKLine("after", phase: &phase))
+    }
+
+    @Test(arguments: [2, 3], ["none", "aes256-cbc"])
+    func publicRoutesHideEveryLine(version: Int, encryption: String) throws {
+        let lines = Self.key(version: version, encryption: encryption)
+        let input = (lines + ["after"]).joined(separator: "\n")
+        let expected = (Array(repeating: Self.marker, count: lines.count) + ["after"]).joined(separator: "\n")
+        let redactor = Redactor()
+        #expect(redactor.redact(input) == expected)
+        #expect(redactor.redact(untrusted: input) == expected)
+        #expect(redactor.redact(fieldValue: input) == expected)
+        #expect(redactor.redact(lines: lines + ["after"]).map(\.text).joined(separator: "\n") == expected)
+        #expect(try JSONDecoder().decode(RedactedLine.self, from: JSONEncoder().encode(input)).text == expected)
+        #expect(redactor.redact(expected) == expected)
+    }
+
+    @Test(arguments: ["\n", "\r\n", "\r"])
+    func physicalLineTerminatorsAndBackToBackKeysArePreserved(separator: String) {
+        let lines = Self.key(version: 2) + Self.key() + ["after"]
+        let expected = Array(repeating: Self.marker, count: lines.count - 1) + ["after"]
+        #expect(Redactor().redact(lines.joined(separator: separator)) == expected.joined(separator: separator))
+    }
+
+    @Test(arguments: ["0", "-1", "+1", "1x", "", String(repeating: "9", count: 100)])
+    func malformedCountsStayClosedUntilTheStreamIsReset(count: String) {
+        var phase = Redactor.StreamState.PPKPhase.inactive
+        let lines = ["PuTTY-User-Key-File-3: ssh-rsa", "Private-Lines: " + count]
+            + Array(Self.key().dropFirst()) + ["after"]
+        for line in lines { #expect(Redactor.consumePPKLine(line, phase: &phase)) }
+        #expect(phase == .invalid)
+        phase = .inactive
+        #expect(!Redactor.consumePPKLine("after reset", phase: &phase))
+    }
+
+    @Test(arguments: [(1, ["AAAA", "BBBB"]), (3, ["AAAA", "BBBB"]),
+                      (2, ["AA!A", "BBBB"]), (2, ["QQ==", "BBBB"])])
+    func countsCannotReleaseShortLongOrMalformedBodies(count: Int, body: [String]) {
+        let lines = ["PuTTY-User-Key-File-3: ssh-rsa", "Private-Lines: \(count)"] + body
+            + ["Private-MAC: " + String(repeating: "a", count: 64), "after"]
+        #expect(Redactor().redact(lines: lines).allSatisfy { $0.text == Self.marker })
+    }
+
+    @Test(arguments: ["", "not-hex", String(repeating: "a", count: 40),
+                      String(repeating: "a", count: 63), String(repeating: "a", count: 65),
+                      String(repeating: "a", count: 64) + " trailing"])
+    func onlyACompleteVersionAppropriateMACLineCanClose(value: String) {
+        let lines = Array(Self.key().dropLast()) + ["Private-MAC: " + value, Self.key().last!, "after"]
+        #expect(Redactor().redact(lines: lines).allSatisfy { $0.text == Self.marker })
+    }
+
+    @Test func metadataCannotSupplyAPrematureOrEmbeddedFooter() {
+        var lines = Self.key()
+        lines[2] = "Comment: Private-MAC: " + String(repeating: "a", count: 64)
+        #expect(Redactor().redact(lines: lines + ["after"]).last?.text == "after")
+        let premature = [lines[0], lines.last!, "after"]
+        #expect(Redactor().redact(lines: premature).allSatisfy { $0.text == Self.marker })
+    }
+
+    @Test func theLargestCountDoesNotAllocateOrWrap() {
+        var phase = Redactor.StreamState.PPKPhase.inactive
+        for line in ["PuTTY-User-Key-File-3: ssh-rsa", "Private-Lines: \(Int.max)", "AAAA"] {
+            #expect(Redactor.consumePPKLine(line, phase: &phase))
+        }
+        #expect(phase == .privateLines(remaining: Int.max - 1, macDigits: 64))
+    }
+
+    @Test func incompleteFilesRemainSensitiveAndStreamsAreIndependent() {
+        let redactor = Redactor()
+        var incomplete = Redactor.StreamState()
+        for line in Self.key().dropLast() {
+            #expect(redactor.redact(line: line, state: &incomplete).text == Self.marker)
+        }
+        #expect(incomplete.ppkPhase == .mac(digits: 64))
+        #expect(redactor.redact(line: "after EOF without a MAC", state: &incomplete).text == Self.marker)
+        #expect(incomplete.ppkPhase == .invalid)
+        var independent = Redactor.StreamState()
+        #expect(redactor.redact(line: "ordinary", state: &independent).text == "ordinary")
+        incomplete = Redactor.StreamState()
+        #expect(redactor.redact(line: "after reset", state: &incomplete).text == "after reset")
+    }
+
+    @Test(arguments: ["password: \"", "-----BEGIN PRIVATE KEY-----", "Authorization:", "password:", "Your code:"])
+    func enclosingContextsAreNotClearedByAPrivateKey(prefix: String) {
+        let redactor = Redactor()
+        var state = Redactor.StreamState()
+        _ = redactor.redact(line: prefix, state: &state)
+        let outer = state
+        for line in Self.key() { #expect(redactor.redact(line: line, state: &state).text == Self.marker) }
+        #expect(state == outer)
+        #expect(redactor.redact(line: "still sensitive", state: &state).text != "still sensitive")
+    }
+
+    @Test func terminalNormalizationDoesNotCountAVisibleBodyTwice() {
+        var lines = Self.key()
+        lines[0] = "\u{1B}[31m" + lines[0] + "\u{1B}[0m"
+        lines[6] = "AA\u{1B}[31mAA"
+        let output = Redactor().redact(lines: lines + ["after"]).map(\.text)
+        #expect(output == Array(repeating: Self.marker, count: lines.count) + ["after"])
+    }
+
+    @Test func controlStringPayloadsNeitherOpenNorCloseAPrivateKey() {
+        let redactor = Redactor()
+        var state = Redactor.StreamState()
+        #expect(redactor.redact(line: "\u{1B}]" + Self.key()[0] + "\u{07}", state: &state).text == "")
+        #expect(state.ppkPhase == .inactive)
+        for line in Self.key().dropLast() { _ = redactor.redact(line: line, state: &state) }
+        #expect(redactor.redact(line: "\u{1B}]" + Self.key().last! + "\u{07}", state: &state).text == Self.marker)
+        #expect(state.ppkPhase == .invalid)
+        #expect(redactor.redact(line: Self.key().last!, state: &state).text == Self.marker)
+        #expect(redactor.redact(line: "after", state: &state).text == Self.marker)
+    }
+
+    @Test func unsupportedVersionsAndHeaderlessFragmentsDoNotArmAStream() {
+        var phase = Redactor.StreamState.PPKPhase.inactive
+        for line in ["PuTTY-User-Key-File-1: ssh-rsa", "PuTTY-User-Key-File-20: ssh-rsa", "AAAA", "Private-Lines: 2"] {
+            #expect(!Redactor.consumePPKLine(line, phase: &phase))
+        }
+        #expect(phase == .inactive)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalIntegrationReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalIntegrationReviewTests.swift
@@ -1,0 +1,40 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorTerminalIntegrationReviewTests {
+    @Test func terminalRecoveryRetainsPendingLabelsFromTheJoinedReading() {
+        let input = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload.password:"
+        let output = Redactor().redact(lines: [input, "opaqueSecret", "after"]).map(\.text)
+        #expect(output == ["[redacted:jwt]:", "[redacted:secret]", "after"])
+    }
+
+    @Test(arguments: ["password: opaqueSecret", "Authorization: Custom opaqueSecret", "user_code: opaqueSecret",
+                      "enter the code: opaqueSecret", "enter the code ABC123", "user_code is opaqueSecret"])
+    func recoveryCannotHideALabelAndExposeItsCurrentValue(suffix: String) {
+        let input = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload." + suffix
+        #expect(Redactor().redact(input) == "[redacted:jwt]")
+    }
+
+    @Test func recoveryRetainsTheOriginalPEMBlockState() {
+        let opener = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload.-----BEGIN PRIVATE KEY-----"
+        let lines = [opener, "syntheticBody", "-----END PRIVATE KEY-----", "after"]
+        #expect(Redactor().redact(lines: lines).map(\.text) == ["[redacted:jwt]", "[redacted:private-key]", "[redacted:private-key]", "after"])
+    }
+
+    @Test func recoveryCannotExposeAnInlinePEMBody() {
+        let input = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload.-----BEGIN PRIVATE KEY-----syntheticBody-----END PRIVATE KEY-----"
+        #expect(Redactor().redact(input) == "[redacted:jwt]")
+    }
+
+    @Test(arguments: ["sk-abcdefghijklmnopqrstuvwx", "ghp_abcdefghijklmnopqrstuvwx"])
+    func malformedCSIIntroducersCannotConsumeCredentialInitials(token: String) {
+        let output = Redactor().redact("filename\u{1B}[" + token)
+        #expect(!output.contains("abcdefghijklmnopqrstuvwx"))
+        #expect(output.hasPrefix("filename[redacted:"))
+    }
+
+    @Test func aJWTDoesNotHideABoundaryWithinItsFilenameSuffix() {
+        let input = "eyJhbGciOiJIUzI1NiJ9.payload.signature.filename\u{1B}[31msk-abcdefghijklmnopqrstuvwx"
+        #expect(Redactor().redact(input) == "[redacted:jwt].filename[redacted:api-key]")
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

PuTTY v2/v3 private-key files do not use PEM delimiters, so their private body could survive existing log redaction. This change masks the opener, metadata, both key halves, and MAC using bounded framing state advanced exactly once per physical input line. Malformed or incomplete framing stays protected until the stream is reset.

This prerequisite for #59 implements #11 and MVP-PLAN.md §3's redacted logging boundary. The parser recognizes framing and does not decode or validate key material. Terminal and quote rescans cannot count a private-key line twice or clear its enclosing credential context.

Validation: 248 cumulative Core tests pass with warnings treated as errors, including 13 PPK methods with 38 parameter-expanded cases and terminal interaction coverage. The change is 258 lines. All key bodies and MACs in tests are synthetic.

