### PR TITLE
Fix ambiguous credential arguments and physical-line continuations

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -38,6 +38,11 @@ extension Redactor {
         }
         var text = stripped.joined
         if let quoted = state.quotedValue {
+            // This branch masks the whole physical line, but still has to advance the
+            // independently active PEM context before returning for the enclosing quote.
+            if let label = state.pemLabel, text.contains("-----END \(label)-----") {
+                state.pemLabel = nil
+            }
             // Inspect the original normalized text: replacement markers no longer contain the
             // closing delimiter. A closing line is redacted whole, but its suffix can open a new
             // pending field. Blank/styling-only lines do not close the quoted value.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -54,6 +54,7 @@ extension Redactor {
                 if quoted.enclosingAuthorizationFold { suffixState.quotedValue?.enclosingAuthorizationFold = true }
                 if quoted.enclosingSecretFold { suffixState.quotedValue?.enclosingSecretFold = true }
                 state.quotedValue = nil
+                state.wrappedTokenKind = suffixState.wrappedTokenKind
                 state.expectingSecretValue = explicitlyContinues && (quoted.kind == "secret" || quoted.enclosingSecretFold)
                 state.secretValueExplicitlyContinues = state.expectingSecretValue
                 state.expectingSecretContinuation = quoted.enclosingSecretFold || state.expectingSecretValue
@@ -78,11 +79,14 @@ extension Redactor {
                 .replacingOccurrences(of: Self.splicedBoundary, with: "")
             Self.mergePendingContexts(from: joinedScan, into: &boundaryScan)
         }
-        let tokenAtLineEnd = stripped.joined.firstMatch(of: Self.patterns.wrappedTokenAtLineEnd)
+        let incompleteJWT = Self.incompleteJWTStartAtLineEnd(in: stripped.joined) != nil
+            || Self.incompleteJWTStartAtLineEnd(in: stripped.spliced) != nil
+        let tokenAtLineEnd = incompleteJWT ? "jwt" : stripped.joined.firstMatch(of: Self.patterns.wrappedTokenAtLineEnd)
             .map { $0.1.hasPrefix("sk-") ? "api-key" : "github-token" }
         if let kind = state.wrappedTokenKind, !text.allSatisfy(\.isWhitespace) {
             state.wrappedTokenKind = nil
-            if let continuation = text.firstMatch(of: Self.patterns.tokenContinuation) {
+            let continuationPattern = kind == "jwt" ? #/^[ \t]*[A-Za-z0-9_.-]+/# : Self.patterns.tokenContinuation
+            if let continuation = text.firstMatch(of: continuationPattern) {
                 let fragment = String(continuation.0)
                 state.wrappedTokenKind = continuation.range.upperBound == text.endIndex ? kind : nil
                 // Detect and retain every ordinary redaction BEFORE masking the continuation.
@@ -205,7 +209,10 @@ extension Redactor {
             }
             return RedactedLine(Self.marker(kind))
         }
-        let redacted = Self.applyPatterns(to: text, codeExpected: codeExpected, state: &state)
+        var redacted = Self.applyPatterns(to: text, codeExpected: codeExpected, state: &state)
+        if let start = Self.incompleteJWTStartAtLineEnd(in: redacted) {
+            redacted.replaceSubrange(start..<redacted.endIndex, with: Self.marker("jwt"))
+        }
         state.secretValueExplicitlyContinues = state.expectingSecretValue && explicitlyContinues
         return RedactedLine(redacted)
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -251,7 +251,7 @@ extension Redactor {
         var lineStart = text.startIndex
         func appendRedacted(_ line: Substring) {
             let redacted = redact(line: String(line), state: &state).text
-            result += codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: redacted, preserveAlgorithms: true) : redacted
+            result += codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: redacted) : redacted
         }
         // `\r\n` is one `Character`, so splitting on the newline character would leave a CRLF
         // stream as a single line and never apply the streaming rules to it. Each terminator is

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -40,9 +40,7 @@ extension Redactor {
         if let quoted = state.quotedValue {
             // This branch masks the whole physical line, but still has to advance the
             // independently active PEM context before returning for the enclosing quote.
-            if let label = state.pemLabel, text.contains("-----END \(label)-----") {
-                state.pemLabel = nil
-            }
+            _ = Self.redactPEMBlocks(text, label: &state.pemLabel)
             // Inspect the original normalized text: replacement markers no longer contain the
             // closing delimiter. A closing line is redacted whole, but its suffix can open a new
             // pending field. Blank/styling-only lines do not close the quoted value.
@@ -138,25 +136,10 @@ extension Redactor {
         if !blankLine {
             state.expectingSecretContinuation = secretContinuation
         }
-        if let label = state.pemLabel {
-            guard let footer = text.range(of: "-----END \(label)-----") else {
-                return RedactedLine(Self.marker("private-key"))
-            }
-            // The block ends here; whatever follows the footer is scanned like any other text,
-            // including another block that begins on the same line.
-            state.pemLabel = nil
-            text = Self.marker("private-key") + text[footer.upperBound...]
+        if let label = state.pemLabel, !text.contains("-----END \(label)-----") {
+            return RedactedLine(Self.marker("private-key"))
         }
-        while let begin = text.firstMatch(of: Self.patterns.pemBegin) {
-            let label = String(begin.1)
-            if let end = text[begin.range.upperBound...].range(of: "-----END \(label)-----") {
-                text.replaceSubrange(begin.range.lowerBound..<end.upperBound, with: Self.marker("private-key"))
-            } else {
-                state.pemLabel = label
-                text.replaceSubrange(begin.range.lowerBound..<text.endIndex, with: Self.marker("private-key"))
-                break
-            }
-        }
+        text = Self.redactPEMBlocks(text, label: &state.pemLabel)
 
         // The continuation's own text is all credential, but a PEM block it opens keeps running
         // over the lines that follow, so the block is detected above before the marker returns.
@@ -225,6 +208,28 @@ extension Redactor {
         let redacted = Self.applyPatterns(to: text, codeExpected: codeExpected, state: &state)
         state.secretValueExplicitlyContinues = state.expectingSecretValue && explicitlyContinues
         return RedactedLine(redacted)
+    }
+
+    /// Quoted and ordinary lines share the same footer-to-next-opener transition. Clearing
+    /// one block must not discard a second opener later on the same physical line.
+    private static func redactPEMBlocks(_ input: String, label: inout String?) -> String {
+        var text = input
+        if let active = label {
+            guard let footer = text.range(of: "-----END \(active)-----") else { return marker("private-key") }
+            label = nil
+            text = marker("private-key") + text[footer.upperBound...]
+        }
+        while let begin = text.firstMatch(of: patterns.pemBegin) {
+            let opened = String(begin.1)
+            if let end = text[begin.range.upperBound...].range(of: "-----END \(opened)-----") {
+                text.replaceSubrange(begin.range.lowerBound..<end.upperBound, with: marker("private-key"))
+            } else {
+                label = opened
+                text.replaceSubrange(begin.range.lowerBound..<text.endIndex, with: marker("private-key"))
+                break
+            }
+        }
+        return text
     }
 
     /// Redacts a single value that came from outside the app (a version string, a path, a

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -212,11 +212,12 @@ extension Redactor {
         var redacted = Self.applyPatterns(to: text, codeExpected: codeExpected, state: &state)
         if let start = Self.incompleteJWTStartAtLineEnd(in: redacted) {
             redacted.replaceSubrange(start..<redacted.endIndex, with: Self.marker("jwt"))
+        } else if incompleteJWT {
+            // Another rule may have replaced the JOSE header; its offsets are now ambiguous.
+            redacted = Self.marker("jwt")
         }
         state.secretValueExplicitlyContinues = state.expectingSecretValue && explicitlyContinues
-        // A different rule may have replaced the JOSE header with its own token marker.
-        // Preserve all original incomplete-token evidence, without releasing a partial payload.
-        return RedactedLine(incompleteJWT ? Self.marker("jwt") : redacted)
+        return RedactedLine(redacted)
     }
 
     /// Quoted and ordinary lines share the same footer-to-next-opener transition. Clearing

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -214,7 +214,9 @@ extension Redactor {
             redacted.replaceSubrange(start..<redacted.endIndex, with: Self.marker("jwt"))
         }
         state.secretValueExplicitlyContinues = state.expectingSecretValue && explicitlyContinues
-        return RedactedLine(redacted)
+        // A different rule may have replaced the JOSE header with its own token marker.
+        // Preserve all original incomplete-token evidence, without releasing a partial payload.
+        return RedactedLine(incompleteJWT ? Self.marker("jwt") : redacted)
     }
 
     /// Quoted and ordinary lines share the same footer-to-next-opener transition. Clearing

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
@@ -23,12 +23,32 @@ extension Redactor {
     }
 
     static func unterminatedQuote(in value: Substring, kind: String) -> StreamState.QuotedValue? {
-        let value = value.drop(while: { $0.isWhitespace })
-        let slashes = value.prefix(while: { $0 == "\\" }).count
-        let afterSlashes = value.dropFirst(slashes)
-        guard let delimiter = afterSlashes.first, delimiter == "\"" || delimiter == "'" else { return nil }
-        let quoted = StreamState.QuotedValue(delimiter: delimiter, escapeDepth: slashes, kind: kind)
-        return closingQuoteEnd(in: afterSlashes.dropFirst(), for: quoted) == nil ? quoted : nil
+        let firstValueCharacter = value.firstIndex(where: { !$0.isWhitespace }) ?? value.endIndex
+        var cursor = value.startIndex
+        while cursor < value.endIndex {
+            let start = cursor
+            var slashes = 0
+            while cursor < value.endIndex, value[cursor] == "\\" {
+                slashes += 1
+                value.formIndex(after: &cursor)
+            }
+            guard cursor < value.endIndex else { break }
+            let delimiter = value[cursor]
+            let predecessor = start == value.startIndex ? nil : value[value.index(before: start)]
+            value.formIndex(after: &cursor)
+            // Parameters can open quotes after an unquoted scheme or prefix. Apostrophes
+            // inside an ordinary word are not delimiters (for example a passphrase's "don't").
+            guard delimiter == "\"" || delimiter == "'",
+                  predecessor == nil || predecessor?.isWhitespace == true
+                    || predecessor.map({ "=:([{,".contains($0) }) == true else { continue }
+            let hasPrefix = start > firstValueCharacter
+            let quoted = StreamState.QuotedValue(delimiter: delimiter, escapeDepth: slashes, kind: kind,
+                enclosingAuthorizationFold: hasPrefix && kind == "authorization",
+                enclosingSecretFold: hasPrefix && kind == "secret")
+            guard let end = closingQuoteEnd(in: value[cursor...], for: quoted) else { return quoted }
+            cursor = end
+        }
+        return nil
     }
 
     static func closingQuoteEnd(in value: Substring, for quoted: StreamState.QuotedValue) -> String.Index? {
@@ -59,16 +79,20 @@ extension Redactor {
     static func redactSecretOptions(_ text: String, state: inout StreamState) -> String {
         var result = ""
         var cursor = text.startIndex
+        var concealOptionName = false
         while let match = text[cursor...].firstMatch(of: patterns.secretOption) {
             result += text[cursor..<match.range.lowerBound]
-            // A missing value must not consume a later option's name and leave that option's
-            // value unlabelled. Only a recognized secret option is left for another scan:
-            // an opaque password beginning with a dash must still be removed.
+            // A following secret option could also be this option's opaque value. Conceal
+            // its name but retain the original input for scanning its possible value too.
+            let optionName = concealOptionName ? marker("secret") : String(match.2)
+            concealOptionName = false
             let remainder = text[match.range.upperBound...]
             let bareOption = remainder.prefixMatch(of: patterns.secretOptionOnly) != nil
             if match.3 != "=", bareOption || remainder.prefixMatch(of: patterns.secretOption) != nil {
-                result += match.0
-                cursor = match.range.upperBound
+                result += "\(match.1)\(optionName)\(match.3)"
+                if bareOption { result += marker("secret") }
+                cursor = bareOption ? text.endIndex : match.range.upperBound
+                concealOptionName = true
                 state.expectingSecretValue = state.expectingSecretValue || bareOption
                 continue
             }
@@ -79,7 +103,7 @@ extension Redactor {
             // Canonicalize equals to a space so the generic field rule cannot treat the
             // replacement and later arguments as a single unquoted passphrase.
             let separator = match.3 == "=" ? " " : String(match.3)
-            result += "\(match.1)\(match.2)\(separator)\(marker("secret"))"
+            result += "\(match.1)\(optionName)\(separator)\(marker("secret"))"
             cursor = argument.end
         }
         return result + text[cursor...]
@@ -130,11 +154,17 @@ extension Redactor {
     static func redactSerializedOptions(_ text: String, state: inout StreamState) -> String {
         var result = ""
         var cursor = text.startIndex
+        var concealOptionName = false
         while let match = text[cursor...].firstMatch(of: patterns.serializedSecretOption) {
-            result += text[cursor..<match.range.upperBound]
+            result += text[cursor..<match.range.lowerBound]
+            if concealOptionName, let comma = match.0.lastIndex(of: ",") {
+                result += marker("secret") + match.0[comma...]
+            } else { result += match.0 }
+            concealOptionName = false
             let value = text[match.range.upperBound...]
-            // Do not consume a second secret option as a missing first option's value.
+            // Preserve both interpretations of an option-shaped opaque credential.
             if value.prefixMatch(of: patterns.serializedSecretOption) != nil {
+                concealOptionName = true
                 cursor = value.startIndex
                 continue
             }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
@@ -42,7 +42,8 @@ extension Redactor {
                   predecessor == nil || predecessor?.isWhitespace == true
                     || predecessor.map({ "=:([{,".contains($0) }) == true else { continue }
             let hasPrefix = start > firstValueCharacter
-            let quoted = StreamState.QuotedValue(delimiter: delimiter, escapeDepth: slashes, kind: kind,
+            let quoted = StreamState.QuotedValue(delimiter: delimiter,
+                escapeDepth: slashes.isMultiple(of: 2) ? 0 : slashes, kind: kind,
                 enclosingAuthorizationFold: hasPrefix && kind == "authorization",
                 enclosingSecretFold: hasPrefix && kind == "secret")
             guard let end = closingQuoteEnd(in: value[cursor...], for: quoted) else { return quoted }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Arguments.swift
@@ -138,7 +138,9 @@ extension Redactor {
                     quote = text[cursor]
                     // An encoded diagnostic quote can open at the beginning. Within a shell
                     // word, an odd backslash count escapes the quote as a literal character.
-                    quoteEscapeDepth = escapeStart == start ? escapeDepth : 0
+                    // Even leading slashes are literal shell backslashes before a raw quote;
+                    // only an odd depth denotes an escaped diagnostic delimiter.
+                    quoteEscapeDepth = escapeStart == start && !escapeDepth.isMultiple(of: 2) ? escapeDepth : 0
                 }
             } else if text[cursor].isWhitespace, escapeDepth.isMultiple(of: 2) {
                 return (cursor, nil, false)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
@@ -5,13 +5,21 @@ extension Redactor {
     /// A named JOSE parameter identifies an unfinished token at a physical boundary. Ordinary
     /// JSON claims do not arm continuation, nor does a header already inside a complete JWT.
     static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
-        guard let candidate = text.firstMatch(of: #/(^|[^A-Za-z0-9_-])([A-Za-z0-9_-]{4,})\.[A-Za-z0-9_-]*\.?$/#),
-              let start = joseHeaderStart(candidate.2),
-              let header = decodedJOSEHeader(candidate.2[start...]),
-              header["alg"] != nil || header["enc"] != nil else { return nil }
-        let covered = text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2) }
-        guard !covered.contains(where: { $0.lowerBound < start && $0.upperBound == text.endIndex }) else { return nil }
-        return start
+        guard let run = text.firstMatch(of: #/(?:^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+)$/#),
+              run.1.contains(".") else { return nil }
+        let segments = run.1.split(separator: ".", omittingEmptySubsequences: false)
+        var coveredThrough = 0
+        for index in segments.indices {
+            guard index >= coveredThrough, let start = joseHeaderStart(segments[index]),
+                  let header = decodedJOSEHeader(segments[index][start...]),
+                  header["alg"] != nil || header["enc"] != nil else { continue }
+            let required = header["enc"] == nil ? 3 : 5
+            let emptySignature = required == 3 && header["alg"] as? String == "none"
+            let available = segments.count - index - (segments.last?.isEmpty == true && !emptySignature ? 1 : 0)
+            if available < required { return start }
+            coveredThrough = index + required
+        }
+        return nil
     }
 
     /// Replaces all three JWS or five JWE segments inside a run of dot-separated segments. A dot is

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
@@ -3,21 +3,20 @@ import RegexBuilder
 
 extension Redactor {
     /// A named JOSE parameter identifies an unfinished token at a physical boundary. Ordinary
-    /// JSON claims do not arm continuation, nor does a header already inside a complete JWT.
+    /// JSON claims do not arm continuation; named competing headers remain sensitive even
+    /// inside a completed token's coverage, as in jwtRedactionRanges.
     static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
         guard let run = text.firstMatch(of: #/(?:^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+)$/#),
               run.1.contains(".") else { return nil }
         let segments = run.1.split(separator: ".", omittingEmptySubsequences: false)
-        var coveredThrough = 0
         for index in segments.indices {
-            guard index >= coveredThrough, let start = joseHeaderStart(segments[index]),
+            guard let start = joseHeaderStart(segments[index]),
                   let header = decodedJOSEHeader(segments[index][start...]),
                   header["alg"] != nil || header["enc"] != nil else { continue }
             let required = header["enc"] == nil ? 3 : 5
             let emptySignature = required == 3 && header["alg"] as? String == "none"
             let available = segments.count - index - (segments.last?.isEmpty == true && !emptySignature ? 1 : 0)
             if available < required { return start }
-            coveredThrough = index + required
         }
         return nil
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
@@ -2,6 +2,18 @@ import Foundation
 import RegexBuilder
 
 extension Redactor {
+    /// A named JOSE parameter identifies an unfinished token at a physical boundary. Ordinary
+    /// JSON claims do not arm continuation, nor does a header already inside a complete JWT.
+    static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
+        guard let candidate = text.firstMatch(of: #/(^|[^A-Za-z0-9_-])([A-Za-z0-9_-]{4,})\.[A-Za-z0-9_-]*\.?$/#),
+              let start = joseHeaderStart(candidate.2),
+              let header = decodedJOSEHeader(candidate.2[start...]),
+              header["alg"] != nil || header["enc"] != nil else { return nil }
+        let covered = text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2) }
+        guard !covered.contains(where: { $0.lowerBound < start && $0.upperBound == text.endIndex }) else { return nil }
+        return start
+    }
+
     /// Replaces all three JWS or five JWE segments inside a run of dot-separated segments. A dot is
     /// not a word boundary, so the run can begin with a label such as `session.` and can hold two
     /// adjacent tokens; every segment with at least two following it is tried as a JOSE header, and the

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -80,15 +80,26 @@ extension Redactor {
             return "\(match.1)\(match.2): \(marker("device-code"))"
         }
         text = text.replacing(p.codePrompt) { match in
-            state.quotedValue = state.quotedValue ?? unterminatedQuote(in: match.0.dropFirst(match.1.count), kind: "device-code")
-            state.expectingDeviceCode = state.expectingDeviceCode || valueStartsOnNextLine(match.0.dropFirst(match.1.count))
+            let value = match.0.dropFirst(match.1.count)
+            state.quotedValue = state.quotedValue ?? unterminatedQuote(in: value, kind: "device-code")
+            state.expectingDeviceCode = state.expectingDeviceCode || valueStartsOnNextLine(value)
+                || fieldExplicitlyContinues(value, tail: text[match.range.upperBound...])
             let punctuation = match.0.hasSuffix(".") ? "." : ""
             return "\(match.1) \(marker("device-code"))\(punctuation)"
         }
-        text = text.replacing(p.codePromptWithoutDelimiter) { match in "\(match.1) \(marker("device-code"))" }
+        text = text.replacing(p.codePromptWithoutDelimiter) { match in
+            let tail = text[match.range.upperBound...]
+            state.expectingDeviceCode = state.expectingDeviceCode
+                || (tail.allSatisfy({ $0.isWhitespace || $0 == "\\" }) && valueExplicitlyContinues(tail))
+            return "\(match.1) \(marker("device-code"))"
+        }
         text = text.replacing(p.declarativeCodePrompt) { match in
             if let value = match.2 {
                 state.quotedValue = state.quotedValue ?? unterminatedQuote(in: value, kind: "device-code")
+                state.expectingDeviceCode = state.expectingDeviceCode
+                    || fieldExplicitlyContinues(value, tail: text[match.range.upperBound...])
+                    || (text[match.range.upperBound...].allSatisfy({ $0.isWhitespace || $0 == "\\" })
+                        && valueExplicitlyContinues(text[match.range.upperBound...]))
             }
             state.expectingDeviceCode = state.expectingDeviceCode
                 || (match.2.map(valueStartsOnNextLine) ?? true)
@@ -107,7 +118,7 @@ extension Redactor {
         }
         text = protected.restoring(in: text, state: &state)
         if text.contains(p.mentionsCode) || codeExpected {
-            text = applyDeviceCodePattern(to: text)
+            text = applyDeviceCodePattern(to: text, preserveAlgorithms: !codeExpected)
         }
         return text
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -35,7 +35,20 @@ extension Redactor {
             return "\(match.1)\(name): \(marker("authorization"))"
         }
         // Each token rule captures the character in front of the token, which is put back.
-        text = text.replacing(p.bearer) { match in "\(match.1)Bearer \(marker("bearer-token"))" }
+        if text.wholeMatch(of: #/[ \t]*(?i:Bearer)[ \t]*(?:\\[ \t]*)?/#) != nil {
+            state.expectingAuthorizationValue = true
+            state.authorizationValueIsOnTheNextLine = true
+            state.authorizationValueExplicitlyContinues = valueExplicitlyContinues(text[...])
+        }
+        text = text.replacing(p.bearer) { match in
+            let tail = text[match.range.upperBound...]
+            if tail.allSatisfy({ $0.isWhitespace || $0 == "\\" }), valueExplicitlyContinues(tail) {
+                state.expectingAuthorizationValue = true
+                state.authorizationValueIsOnTheNextLine = true
+                state.authorizationValueExplicitlyContinues = true
+            }
+            return "\(match.1)Bearer \(marker("bearer-token"))"
+        }
         text = text.replacing(p.basicAuthorization) { match in
             guard isBasicCredential(match.3) else { return String(match.0) }
             state.expectingAuthorizationValue = true

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorContinuationRepairTests {
+    private let redactor = Redactor()
+
+    @Test(arguments: [
+        "run --password --token --verbose",
+        "run --password --token=syntheticValue --verbose",
+        #"["--password", "--token", "--verbose"]"#,
+        #"["--password", "--token", "syntheticValue", "--verbose"]"#,
+    ])
+    func ambiguousOptionNamesAreAlsoPossiblePasswords(input: String) {
+        let output = redactor.redact(input)
+        #expect(!output.contains("--token"))
+        #expect(!output.contains("syntheticValue"))
+        #expect(output.contains("--password"))
+    }
+
+    @Test(arguments: ["run --password", "run --password --token"])
+    func bareOptionsStillArmTheCompletePublicAPI(input: String) {
+        let output = redactor.redact(lines: [input, "syntheticNextValue", "Finished"]).map(\.text)
+        #expect(output[1] == "[redacted:secret]")
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: [
+        #"Enter the code: "syntheticFirst""#,
+        #"Your code is "syntheticFirst""#,
+        "Enter the code AB12CD34",
+        "Your code is AB12CD34",
+    ])
+    func promptsPreserveAnExplicitContinuationOutsideTheValue(prompt: String) {
+        let output = redactor.redact(lines: [prompt + " \\", "syntheticSecond", "Finished"]).map(\.text)
+        #expect(!output[0].contains("syntheticFirst"))
+        #expect(output[1] == "[redacted:device-code]")
+        #expect(output[2] == "Finished")
+        let completed = redactor.redact(lines: [prompt + " \\\\", "Finished"]).map(\.text)
+        #expect(completed[1] == "Finished")
+    }
+
+    @Test(arguments: ["supported code HMAC-SHA256", "the code uses CHACHA20-POLY1305"])
+    func mentioningCodeDoesNotTurnAnAlgorithmIntoACredential(input: String) {
+        #expect(redactor.redact(input) == input)
+        #expect(!redactor.redact("user_code: " + input).contains("SHA256"))
+        #expect(!redactor.redact("Enter the code: " + input).contains("POLY1305"))
+    }
+
+    @Test(arguments: ["Authorization: Custom token=", "password: prefix token=", "user_code: prefix value="])
+    func unquotedPrefixesDoNotHideAnOpenQuotedParameter(prefix: String) {
+        let output = redactor.redact(lines: [
+            prefix + "\"syntheticFirst", "syntheticSecond\"", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: ["Authorization: Custom token=", "password: prefix token="], ["\"", "'", #"\""#])
+    func closingAParameterDoesNotEndItsEnclosingFold(prefix: String, quote: String) {
+        let output = redactor.redact(lines: [
+            prefix + quote + "syntheticFirst", "syntheticSecond" + quote,
+            " syntheticThird", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[3] == "Finished")
+    }
+
+    @Test func anApostropheInsideAnUnquotedWordDoesNotOpenAQuote() {
+        #expect(redactor.redact(lines: ["password: don't-copy-this-synthetic-value", "Finished"]).last?.text == "Finished")
+    }
+
+    @Test(arguments: ["Authorization: Custom first", "password: first"])
+    func whitespaceOnlyLinesDoNotCloseAnEstablishedFold(first: String) {
+        let output = redactor.redact(lines: [first, " \t ", " syntheticSecond", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticSecond"))
+        #expect(output[3] == "Finished")
+    }
+
+    @Test func aPEMFooterInsideTheClosingQuoteStillEndsTheBlock() {
+        let output = redactor.redact(lines: [
+            "password: \"-----BEGIN PRIVATE KEY-----", "syntheticKeyBody",
+            "-----END PRIVATE KEY-----\"", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("syntheticKeyBody"))
+        #expect(output[3] == "Finished")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -13,6 +13,11 @@ import Testing
         #expect(output[1] == "Finished")
     }
 
+    @Test(arguments: ["artifact", "artifact_", "artifact-"])
+    func anUnambiguousFilenamePrefixBeforeIncompleteJOSEStaysVisible(prefix: String) {
+        #expect(redactor.redact(prefix + "eyJhbGciOiJIUzI1NiJ9.syntheticPayload") == prefix + "[redacted:jwt]")
+    }
+
     @Test(arguments: ["ghp_", "sk-proj-"])
     func otherTokenMarkersDoNotDestroyIncompleteJOSEEvidence(prefix: String) {
         let output = redactor.redact(lines: [prefix + "eyJhbGciOiJIUzI1NiJ9.syntheticPayload",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -6,6 +6,37 @@ import Testing
     private let redactor = Redactor()
 
     @Test(arguments: [2, 4, 6], ["\"", "'"])
+    func prefixedEvenSlashParametersCloseAtRawQuotes(depth: Int, quote: String) {
+        let output = redactor.redact(lines: ["password: prefix=" + String(repeating: "\\", count: depth)
+            + quote + "syntheticValue" + quote, "Finished"]).map(\.text)
+        #expect(!output[0].contains("syntheticValue"))
+        #expect(output[1] == "Finished")
+    }
+
+    @Test(arguments: ["ghp_", "sk-proj-"])
+    func otherTokenMarkersDoNotDestroyIncompleteJOSEEvidence(prefix: String) {
+        let output = redactor.redact(lines: [prefix + "eyJhbGciOiJIUzI1NiJ9.syntheticPayload",
+            ".syntheticSignature", "[status] Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "[status] Finished")
+    }
+
+    @Test func namedCompetingHeadersRemainSensitiveAcrossPhysicalLines() {
+        let header = "eyJhbGciOiJIUzI1NiJ9"
+        let output = redactor.redact(lines: [header + "." + header + ".syntheticPayload",
+            ".syntheticSignature", "[status] Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "[status] Finished")
+    }
+
+    @Test func aFinalJWTSignatureSegmentCanItselfWrapAgain() {
+        let output = redactor.redact(lines: ["eyJhbGciOiJIUzI1NiJ9.payload", ".syntheticSignaturePartOne",
+            "syntheticSignaturePartTwo", "[status] Finished", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(Array(output.suffix(2)) == ["[status] Finished", "Finished"])
+    }
+
+    @Test(arguments: [2, 4, 6], ["\"", "'"])
     func evenSlashShellOpenersUseOrdinaryQuoteClosers(depth: Int, quote: String) {
         let input = "run --password " + String(repeating: "\\", count: depth) + quote + "synthetic value" + quote + " --verbose"
         let output = redactor.redact(lines: [input, "Finished"]).map(\.text)
@@ -45,7 +76,7 @@ import Testing
     }
 
     @Test(arguments: ["Bearer syntheticComplete", "Bearer syntheticComplete \\\\",
-                      "eyJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiJ9.syntheticSignature"])
+                      "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.syntheticSignature"])
     func completedCredentialsDoNotArmAnotherPhysicalRecord(input: String) {
         #expect(redactor.redact(lines: [input, "Finished"]).last?.text == "Finished")
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -5,6 +5,47 @@ import Testing
 @Suite struct RedactorContinuationRepairTests {
     private let redactor = Redactor()
 
+    @Test(arguments: [2, 4, 6], ["\"", "'"])
+    func evenSlashShellOpenersUseOrdinaryQuoteClosers(depth: Int, quote: String) {
+        let input = "run --password " + String(repeating: "\\", count: depth) + quote + "synthetic value" + quote + " --verbose"
+        let output = redactor.redact(lines: [input, "Finished"]).map(\.text)
+        #expect(output[0] == "run --password [redacted:secret] --verbose")
+        #expect(output[1] == "Finished")
+    }
+
+    @Test(arguments: ["Bearer", "Bearer \\", "Bearer syntheticFirst\\", "Bearer syntheticFirst \\"])
+    func valueLessAndContinuedBearerSchemesProtectTheNextRecord(first: String) {
+        let output = redactor.redact(lines: [first, "syntheticCredential", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: ["", "artifact", "session."])
+    func jwtWrappingBeforeTheFinalSegmentRemainsSensitive(prefix: String) {
+        let header = "eyJhbGciOiJIUzI1NiJ9"
+        let output = redactor.redact(lines: [prefix + header + ".eyJzdWIiOiIxMjM0In0", ".syntheticSignature", "[status] Finished"]).map(\.text)
+        #expect(!output.joined().contains(header))
+        #expect(!output.joined().contains("syntheticSignature"))
+        #expect(output[2] == "[status] Finished")
+    }
+
+    @Test func aQuotedJWTBoundaryDoesNotConsumeTheFollowingDiagnostic() {
+        let output = redactor.redact(lines: ["password: \"eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0", ".syntheticSignature\"", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticSignature"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: ["Bearer syntheticComplete", "Bearer syntheticComplete \\\\",
+                      "eyJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiJ9.syntheticSignature"])
+    func completedCredentialsDoNotArmAnotherPhysicalRecord(input: String) {
+        #expect(redactor.redact(lines: [input, "Finished"]).last?.text == "Finished")
+    }
+
+    @Test(arguments: ["build.manifest", "eyJzdWIiOiIxMjM0In0.release", "artifact.2026."])
+    func ordinaryDotSeparatedValuesDoNotBecomeWrappedJWTs(input: String) {
+        #expect(redactor.redact(lines: [input, "Finished"]).map(\.text) == [input, "Finished"])
+    }
+
     @Test(arguments: [
         "run --password --token --verbose",
         "run --password --token=syntheticValue --verbose",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -35,6 +35,15 @@ import Testing
         #expect(output[2] == "Finished")
     }
 
+    @Test(arguments: [1, 2, 3, 4], ["", "artifact", "session."])
+    func everyIncompleteJWESegmentCountCarriesContinuation(count: Int, prefix: String) {
+        let segments = ["eyJhbGciOiJkaXIiLCJlbmMiOiJBMjU2R0NNIn0", "wrappedKey", "iv", "syntheticCiphertext", "syntheticTag"]
+        let output = redactor.redact(lines: [prefix + segments.prefix(count).joined(separator: ".") + ".",
+            segments.dropFirst(count).joined(separator: "."), "[status] Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "[status] Finished")
+    }
+
     @Test(arguments: ["Bearer syntheticComplete", "Bearer syntheticComplete \\\\",
                       "eyJhbGciOiJIUzI1NiJ9.eyJhbGciOiJIUzI1NiJ9.syntheticSignature"])
     func completedCredentialsDoNotArmAnotherPhysicalRecord(input: String) {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorContinuationRepairTests.swift
@@ -85,4 +85,16 @@ import Testing
         #expect(!output.joined().contains("syntheticKeyBody"))
         #expect(output[3] == "Finished")
     }
+
+    @Test(arguments: ["PRIVATE KEY", "RSA PRIVATE KEY"], [false, true])
+    func aPEMFooterInsideAQuoteCanOpenTheNextBlock(label: String, closeImmediately: Bool) {
+        let output = redactor.redact(lines: [
+            "password: \"-----BEGIN PRIVATE KEY-----", "syntheticFirstBody",
+            "-----END PRIVATE KEY----- -----BEGIN \(label)-----" + (closeImmediately ? "\"" : ""),
+            closeImmediately ? "syntheticSecondBody" : "close\"", "syntheticThirdBody",
+            "-----END \(label)-----", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[6] == "Finished")
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParserReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParserReviewTests.swift
@@ -42,7 +42,8 @@ import Testing
     func aBareFollowingOptionKeepsItsPendingValue(option: String) {
         var state = Redactor.StreamState()
         let input = "run --password " + option
-        #expect(Redactor.redactSecretOptions(input, state: &state) == input)
+        // The second option is also a possible opaque password, while its value stays pending.
+        #expect(Redactor.redactSecretOptions(input, state: &state) == "run --password [redacted:secret]")
         #expect(state.expectingSecretValue)
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorUntrustedCodePolicyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorUntrustedCodePolicyTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import GuesthouseCore
+
+@Test(arguments: ["HMAC-SHA256", "PBKDF2-HMAC-SHA256", "ECDSA-SHA256", "CHACHA20-POLY1305"])
+func anUntrustedDeviceCodeCannotClaimAnAlgorithmExemption(value: String) {
+    #expect(Redactor().redact(untrusted: value) == "[redacted:device-code]")
+    #expect(Redactor().redact(fieldValue: value) == "[redacted:device-code]")
+    #expect(Redactor().redact("supported code " + value) == "supported code " + value)
+}


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope and stack

Focused prerequisite for #59, stacked on #116. Implements the credential-output privacy requirement in MVP-PLAN.md §3 (Local storage) and addresses review findings on #101, #96, #114 and #97. This changes internal parser behavior before #59 exposes the complete public API.

- Hide an option-shaped password while still scanning that same text as a possible option with its own secret value, for plain and serialized argv.
- Retain explicit continuation after quoted, declarative and delimiter-free device-code prompts.
- Track quoted parameters after an unquoted field prefix, including the enclosing fold after the quote closes; ordinary in-word apostrophes remain literal.
- Advance an active PEM block when its footer appears on the closing quoted-value line.
- Preserve known algorithm names during mention-only code-shape matching, but never for untrusted text, field values, terminal-boundary scans or decoded batches (follow-on repair 2a39ab3).

Intentional test-policy change: a second secret option after an option with no unambiguous value may itself be the opaque password, so its name is now concealed. Following unrelated arguments remain visible when unambiguous. No regression cases were removed.

## Validation

- The new public-API regression suite failed on the original code with 14 assertions across five affected behaviors, while the bare-option and whitespace-only-fold checks already passed.
- Added ten test functions, including parameterized quote, continuation and ambiguous-argv cases; retained all existing test functions/cases.
- Follow-on review repair c97c668 shares PEM footer/next-opener transitions between quoted and ordinary paths; four additional cases prevent a second private-key block from being lost when the enclosing quote closes.
- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors` passes: 271 tests / 25 suites on the current prerequisite. The latest composed public API, including #118–#120, passes 373 tests / 32 suites.
- No host operations, credentials, provider activation or hardware claims.

The remaining terminal/PPK, nested-encoding, DSN, cookie and batch-decoding repairs are supplied by #118–#120 before public activation in #59. Fresh current-head CI, Codex review and original-message reaction checks are pending; an earlier-head approval is not a new-head approval.

## Repair checkpoint — 2026-09-05 21:14 UTC

Current head `c1672d3f0c8e034a886a9c8fb426aac9be42bad2`: **378 own changed lines; 271 Core tests / 25 suites pass with warnings-as-errors**.

Latest integration preserves unambiguous filename prefixes outside incomplete JOSE ranges; marker conflicts still conceal the containing record. All other repair evidence is linked in the review-thread replies.

The complete error graph passes **444 tests / 37 suites**, including unchanged original URI, filename-prefix and combining-mark assertions. The public redactor passes373 tests. Fifteen prerequisite findings received published-fix or evidence-backed policy replies; the public framing, earlier failed-assertion report, two sanitizer boundaries and locale assertion findings were also resolved with evidence.

**Not aggregate merge-ready.** Fresh review still reports three nested-encoding gaps on #119 (Unicode whitespace escapes, mixed raw quote wrappers, parenthesized values), and four public-boundary findings on #59 (validation recovery guidance, decoding scope, split strict credentials, contextual typed output). #59 has more than100 threads; the second page must be inspected. Current-head CI/reviews/reactions remain required after this push; previous green checks and thumbs-up do not clear these findings. No PR was merged.
