### PR TITLE
Preserve terminal credential context and private-key framing

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -34,8 +34,13 @@ extension Redactor {
         let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
         var recoveredContexts = StreamState()
         for reading in stripped.contexts {
+            let contextText: String
+            if let quoted = state.quotedValue {
+                guard let end = Self.closingQuoteEnd(in: reading[...], for: quoted) else { continue }
+                contextText = String(reading[end...])
+            } else { contextText = reading }
             var scanned = StreamState()
-            _ = redact(line: reading, state: &scanned, isPhysicalLine: false)
+            _ = redact(line: contextText, state: &scanned, isPhysicalLine: false)
             Self.mergePendingContexts(from: scanned, into: &recoveredContexts)
         }
         // Only the physical pass advances PPK framing. On its opening line, preserve any
@@ -43,6 +48,12 @@ extension Redactor {
         let wasReadingPPK = state.ppkPhase != .inactive
         let ppkLine = !wasReadingPPK
             ? stripped.contexts.first(where: { $0.contains(Self.patterns.ppkBegin) }) ?? stripped.joined : stripped.joined
+        if isPhysicalLine, !wasReadingPPK, let opener = ppkLine.firstMatch(of: Self.patterns.ppkBegin) {
+            // Contexts that end before this key do not enclose it. Reuse the ordinary closure
+            // transitions on that prefix without advancing physical PPK framing a second time.
+            _ = redact(line: String(ppkLine[..<opener.range.lowerBound]), state: &state,
+                       isPhysicalLine: false, codesAlwaysRedacted: codesAlwaysRedacted)
+        }
         if isPhysicalLine, Self.consumePPKLine(ppkLine, phase: &state.ppkPhase) {
             if !wasReadingPPK {
                 var joinedContext = StreamState()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -19,7 +19,8 @@ extension Redactor {
         redact(line: line, state: &state, isPhysicalLine: true)
     }
 
-    private func redact(line: String, state: inout StreamState, isPhysicalLine: Bool) -> RedactedLine {
+    private func redact(line: String, state: inout StreamState, isPhysicalLine: Bool,
+                        codesAlwaysRedacted: Bool = false) -> RedactedLine {
         // Terminal styling is dropped first so an escape sequence can never sit between a word
         // boundary and a token. Removing it joins the text on either side, which is what a label
         // split by styling needs, but it also hides the boundary every token rule requires in
@@ -33,8 +34,22 @@ extension Redactor {
         let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
         // Only the physical pass advances PPK framing. Alternate readings and suffix scans
         // must neither count a body twice nor change the contexts enclosing the private key.
-        if isPhysicalLine, Self.consumePPKLine(stripped.joined, phase: &state.ppkPhase) {
+        let ppkLine = state.ppkPhase == .inactive
+            ? stripped.contexts.first(where: { $0.contains(Self.patterns.ppkBegin) }) ?? stripped.joined : stripped.joined
+        if isPhysicalLine, Self.consumePPKLine(ppkLine, phase: &state.ppkPhase) {
             return RedactedLine(Self.marker("private-key"))
+        }
+        var recoveredContexts = StreamState()
+        for reading in stripped.contexts {
+            var scanned = StreamState()
+            _ = redact(line: reading, state: &scanned, isPhysicalLine: false)
+            Self.mergePendingContexts(from: scanned, into: &recoveredContexts)
+        }
+        defer { Self.mergePendingContexts(from: recoveredContexts, into: &state) }
+        // A restored label can refer to an opaque value with no recognizable token shape.
+        // Conservatively hide this line while preserving both ordinary and recovered state.
+        func output(_ value: String) -> RedactedLine {
+            RedactedLine(stripped.contexts.isEmpty ? value : Self.marker("secret"))
         }
         var text = stripped.joined
         if let quoted = state.quotedValue {
@@ -53,6 +68,12 @@ extension Redactor {
                 // it cannot consume a next-line value or terminate the enclosing fold.
                 var suffixState = StreamState()
                 _ = redact(line: tail, state: &suffixState, isPhysicalLine: false)
+                if stripped.spliced != stripped.joined,
+                   let alternateEnd = Self.closingQuoteEnd(in: stripped.spliced[...], for: quoted) {
+                    var alternateSuffix = StreamState()
+                    _ = redact(line: String(stripped.spliced[alternateEnd...]), state: &alternateSuffix, isPhysicalLine: false)
+                    Self.mergePendingContexts(from: alternateSuffix, into: &suffixState)
+                }
                 if quoted.enclosingAuthorizationFold { suffixState.quotedValue?.enclosingAuthorizationFold = true }
                 if quoted.enclosingSecretFold { suffixState.quotedValue?.enclosingSecretFold = true }
                 state.quotedValue = nil
@@ -65,7 +86,7 @@ extension Redactor {
                 state.expectingDeviceCode = explicitlyContinues && quoted.kind == "device-code"
                 Self.mergePendingContexts(from: suffixState, into: &state)
             }
-            return RedactedLine(text.isEmpty ? text : Self.marker(quoted.kind))
+            return output(text.isEmpty ? text : Self.marker(quoted.kind))
         }
         // What the boundary rendering armed, kept apart until this line's own pending contexts
         // have been consumed below and unioned in on the way out.
@@ -76,11 +97,13 @@ extension Redactor {
             // Joined text has no terminal controls, so this scan has no alternate-reading recursion.
             var joinedScan = StreamState()
             _ = redact(line: stripped.joined, state: &joinedScan, isPhysicalLine: false)
-            text = Self.applyPatterns(to: stripped.spliced, codeExpected: state.expectingDeviceCode, state: &boundaryScan)
+            let boundaryText = Self.applyPatterns(to: stripped.spliced, codeExpected: state.expectingDeviceCode, state: &boundaryScan)
+            text = (codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: boundaryText, preserveAlgorithms: true) : boundaryText)
                 .replacingOccurrences(of: Self.splicedBoundary, with: "")
             Self.mergePendingContexts(from: joinedScan, into: &boundaryScan)
         }
-        let tokenAtLineEnd = stripped.joined.firstMatch(of: Self.patterns.wrappedTokenAtLineEnd)
+        let tokenAtLineEnd = (stripped.joined.firstMatch(of: Self.patterns.wrappedTokenAtLineEnd)
+            ?? stripped.spliced.firstMatch(of: Self.patterns.wrappedTokenAtLineEnd))
             .map { $0.1.hasPrefix("sk-") ? "api-key" : "github-token" }
         if let kind = state.wrappedTokenKind, !text.allSatisfy(\.isWhitespace) {
             state.wrappedTokenKind = nil
@@ -140,7 +163,7 @@ extension Redactor {
         }
         if let label = state.pemLabel {
             guard let footer = text.range(of: "-----END \(label)-----") else {
-                return RedactedLine(Self.marker("private-key"))
+                return output(Self.marker("private-key"))
             }
             // The block ends here; whatever follows the footer is scanned like any other text,
             // including another block that begins on the same line.
@@ -175,7 +198,7 @@ extension Redactor {
             if wholeValueQuote == nil || authorizationFoldWasEstablished {
                 state.quotedValue?.enclosingAuthorizationFold = state.expectingAuthorizationValue
             }
-            return RedactedLine(Self.marker("authorization"))
+            return output(Self.marker("authorization"))
         }
         if secretContinuation {
             let wholeValueQuote = Self.unterminatedQuote(in: text[...], kind: "secret")
@@ -187,12 +210,12 @@ extension Redactor {
             if wholeValueQuote == nil || secretFoldWasEstablished {
                 state.quotedValue?.enclosingSecretFold = state.expectingSecretContinuation
             }
-            return RedactedLine(Self.marker("secret"))
+            return output(Self.marker("secret"))
         }
 
         // A blank line carries nothing and keeps the device-code context for the next one.
         if blankLine {
-            return RedactedLine(text)
+            return output(text)
         }
         let codeExpected = state.expectingDeviceCode
         state.expectingDeviceCode = false
@@ -220,11 +243,11 @@ extension Redactor {
             } else if valueContinues {
                 state.expectingDeviceCode = true
             }
-            return RedactedLine(Self.marker(kind))
+            return output(Self.marker(kind))
         }
         let redacted = Self.applyPatterns(to: text, codeExpected: codeExpected, state: &state)
         state.secretValueExplicitlyContinues = state.expectingSecretValue && explicitlyContinues
-        return RedactedLine(redacted)
+        return output(redacted)
     }
 
     /// Redacts a single value that came from outside the app (a version string, a path, a
@@ -245,7 +268,8 @@ extension Redactor {
         var result = ""
         var lineStart = text.startIndex
         func appendRedacted(_ line: Substring) {
-            let redacted = redact(line: String(line), state: &state).text
+            let redacted = redact(line: String(line), state: &state, isPhysicalLine: true,
+                                  codesAlwaysRedacted: codesAlwaysRedacted).text
             result += codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: redacted, preserveAlgorithms: true) : redacted
         }
         // `\r\n` is one `Character`, so splitting on the newline character would leave a CRLF

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -31,16 +31,21 @@ extension Redactor {
         // they removed leaks whichever the other would have found. The boundary rendering goes
         // first; what it leaves is closed up again for everything below, which is the rendering
         // a label has to be read in.
-        let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
+        let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString, activeQuote: state.quotedValue)
         var recoveredContexts = StreamState()
-        for reading in stripped.contexts {
-            let contextText: String
+        for reading in stripped.contexts + stripped.stateReadings {
+            guard state.ppkPhase == .inactive else { continue }
+            var start = reading.startIndex
+            if let label = state.pemLabel {
+                guard let footer = reading.range(of: "-----END \(label)-----") else { continue }
+                start = footer.upperBound
+            }
             if let quoted = state.quotedValue {
                 guard let end = Self.closingQuoteEnd(in: reading[...], for: quoted) else { continue }
-                contextText = String(reading[end...])
-            } else { contextText = reading }
+                start = max(start, end)
+            }
             var scanned = StreamState()
-            _ = redact(line: contextText, state: &scanned, isPhysicalLine: false)
+            _ = redact(line: String(reading[start...]), state: &scanned, isPhysicalLine: false)
             Self.mergePendingContexts(from: scanned, into: &recoveredContexts)
         }
         // Only the physical pass advances PPK framing. On its opening line, preserve any
@@ -77,7 +82,7 @@ extension Redactor {
             // Inspect the original normalized text: replacement markers no longer contain the
             // closing delimiter. A closing line is redacted whole, but its suffix can open a new
             // pending field. Blank/styling-only lines do not close the quoted value.
-            if let end = Self.closingQuoteEnd(in: text[...], for: quoted) {
+            if !stripped.quoteMayContinue, let end = Self.closingQuoteEnd(in: text[...], for: quoted) {
                 let tail = String(text[end...])
                 let explicitlyContinues = Self.valueExplicitlyContinues(tail[...])
                 // This suffix is still on the same physical line. Scan it independently so

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -103,7 +103,7 @@ extension Redactor {
             var joinedScan = StreamState()
             _ = redact(line: stripped.joined, state: &joinedScan, isPhysicalLine: false)
             let boundaryText = Self.applyPatterns(to: stripped.spliced, codeExpected: state.expectingDeviceCode, state: &boundaryScan)
-            text = (codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: boundaryText, preserveAlgorithms: true) : boundaryText)
+            text = (codesAlwaysRedacted ? Self.applyDeviceCodePattern(to: boundaryText) : boundaryText)
                 .replacingOccurrences(of: Self.splicedBoundary, with: "")
             Self.mergePendingContexts(from: joinedScan, into: &boundaryScan)
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -32,18 +32,25 @@ extension Redactor {
         // first; what it leaves is closed up again for everything below, which is the rendering
         // a label has to be read in.
         let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
-        // Only the physical pass advances PPK framing. Alternate readings and suffix scans
-        // must neither count a body twice nor change the contexts enclosing the private key.
-        let ppkLine = state.ppkPhase == .inactive
-            ? stripped.contexts.first(where: { $0.contains(Self.patterns.ppkBegin) }) ?? stripped.joined : stripped.joined
-        if isPhysicalLine, Self.consumePPKLine(ppkLine, phase: &state.ppkPhase) {
-            return RedactedLine(Self.marker("private-key"))
-        }
         var recoveredContexts = StreamState()
         for reading in stripped.contexts {
             var scanned = StreamState()
             _ = redact(line: reading, state: &scanned, isPhysicalLine: false)
             Self.mergePendingContexts(from: scanned, into: &recoveredContexts)
+        }
+        // Only the physical pass advances PPK framing. On its opening line, preserve any
+        // enclosing quote/PEM context in both readings before the private-key early return.
+        let wasReadingPPK = state.ppkPhase != .inactive
+        let ppkLine = !wasReadingPPK
+            ? stripped.contexts.first(where: { $0.contains(Self.patterns.ppkBegin) }) ?? stripped.joined : stripped.joined
+        if isPhysicalLine, Self.consumePPKLine(ppkLine, phase: &state.ppkPhase) {
+            if !wasReadingPPK {
+                var joinedContext = StreamState()
+                _ = redact(line: stripped.joined, state: &joinedContext, isPhysicalLine: false)
+                Self.mergePendingContexts(from: joinedContext, into: &recoveredContexts)
+            }
+            Self.mergePendingContexts(from: recoveredContexts, into: &state)
+            return RedactedLine(Self.marker("private-key"))
         }
         defer { Self.mergePendingContexts(from: recoveredContexts, into: &state) }
         // A restored label can refer to an opaque value with no recognizable token shape.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
@@ -5,6 +5,8 @@ extension Redactor {
     /// https://www.puttyssh.org/0.83/htmldoc/AppendixC.html
     /// Counts only bound the expected sequence; they never size an allocation or end protection.
     /// A malformed sequence stays closed until the caller supplies a fresh StreamState.
+    /// An embedded opener fails closed too. Framing requires original physical key lines;
+    /// arbitrary logger prefixes are not stripped from untrusted key material to guess a footer.
     /// Call exactly once per physical line, after removing terminal controls and their payloads.
     static func consumePPKLine(_ line: String, phase: inout StreamState.PPKPhase) -> Bool {
         switch phase {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PPK.swift
@@ -1,7 +1,7 @@
 import RegexBuilder
 
 extension Redactor {
-    /// PuTTY v2/v3 framing, not key validation: metadata and both key halves are all hidden.
+    /// PuTTY framing, not key validation: metadata and both key halves are all hidden.
     /// https://www.puttyssh.org/0.83/htmldoc/AppendixC.html
     /// Counts only bound the expected sequence; they never size an allocation or end protection.
     /// A malformed sequence stays closed until the caller supplies a fresh StreamState.
@@ -10,8 +10,11 @@ extension Redactor {
         switch phase {
         case .inactive:
             // The distinctive opener also survives a logger prefix or an enclosing quoted value.
-            guard let start = line.firstMatch(of: #/PuTTY-User-Key-File-([23]):/#) else { return false }
-            phase = .headers(macDigits: start.1 == "2" ? 40 : 64)
+            guard let start = line.firstMatch(of: patterns.ppkBegin) else { return false }
+            // Legacy v1 and unknown versions still identify private keys. Without a supported
+            // closing grammar, conceal the rest of this stream rather than guessing its end.
+            phase = start.1 == "2" || start.1 == "3"
+                ? .headers(macDigits: start.1 == "2" ? 40 : 64) : .invalid
         case .headers(let macDigits):
             if let count = line.wholeMatch(of: #/[ \t]*Private-Lines:[ \t]*([0-9]+)[ \t]*/#),
                let remaining = Int(count.1), remaining > 0 {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -36,6 +36,7 @@ extension Redactor {
         /// The label is matched lazily and has to end on an alphanumeric, so it can never eat
         /// the closing dashes and a second block on the same line stays its own match.
         let pemBegin = #/-----BEGIN ([A-Za-z0-9](?:[A-Za-z0-9 ._+-]*?[A-Za-z0-9])?)-----/#
+        let ppkBegin = #/PuTTY-User-Key-File-([0-9]+):/#
         /// The whole header value, quoted or to the end of the line, so multi-parameter schemes
         /// (Digest, AWS SigV4) leave nothing behind. The key may be quoted the way JSON, a
         /// Python dictionary, or a JSON string embedded in a log line quotes it.
@@ -113,7 +114,7 @@ extension Redactor {
         /// delimiter must start a value, so doubled slashes inside a path or URL query do not
         /// turn an ordinary `@` later in that value into userinfo.
         /// Assignment names may include a command option's leading one or two dashes.
-        let urlUserInfo = #/((?::|^|[\s"'(<\[{]|(?:^|[\s"'(<\[{])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
+        let urlUserInfo = #/((?::|^|[\s\u{001F}"'(<\[{]|(?:^|[\s\u{001F}"'(<\[{])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names
@@ -156,7 +157,7 @@ extension Redactor {
         /// the rest of the line: an echoed command line carries the options after it, and
         /// `--token abc --verbose` must keep its second option.
         let secretOption = Regex {
-            #/(^|[\s\u{009F}])/#
+            #/(^|[\s\u{001F}])/#
             Capture {
                 #/--?[A-Za-z0-9_-]*/#
                 secretName
@@ -164,7 +165,7 @@ extension Redactor {
             #/([ \t]+|=)(?=\S)/#
         }.ignoresCase()
         let secretOptionOnly = Regex {
-            #/(^|[\s\u{009F}])--?[A-Za-z0-9_-]*/#
+            #/(^|[\s\u{001F}])--?[A-Za-z0-9_-]*/#
             secretName
             #/[ \t]*(?:=[ \t]*)?$/#
         }.ignoresCase()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -16,11 +16,11 @@ extension Redactor {
     static func stripTerminalEscapes(
         _ line: String,
         openControlString: inout StreamState.ControlString?
-    ) -> (joined: String, spliced: String) {
+    ) -> (joined: String, spliced: String, contexts: [String]) {
         var text = line
         if let open = openControlString {
             let end = open == .osc ? patterns.oscEnd : patterns.controlStringEnd
-            guard let terminator = text.firstMatch(of: end) else { return ("", "") }
+            guard let terminator = text.firstMatch(of: end) else { return ("", "", []) }
             text = String(text[terminator.range.upperBound...])
         }
         openControlString = text.firstMatch(of: patterns.unterminatedControlString)
@@ -30,12 +30,30 @@ extension Redactor {
 
     /// Stands where an escape did, in the `spliced` reading only. It has to be a boundary to
     /// every token rule and to be removable again afterwards without taking anything the line
-    /// itself contained: `terminalEscape` matches every bare C1 control, so no scalar in this
-    /// range survives stripping and every occurrence of this one in a stripped line is one this
-    /// type put there.
-    static let splicedBoundary = "\u{009F}"
+    /// itself contained. Unit Separator is removed as a single bare control, not an APC/OSC
+    /// opener, so a second normalization cannot discard the rest of the diagnostic line.
+    static let splicedBoundary = "\u{001F}"
 
     private typealias RecoveredCredential = (range: Range<Int>, kind: String)
+
+    /// Context openers, excluding their values. Only an opener intersecting a restored CSI
+    /// byte supplies new evidence; ordinary styling inside an already-known value does not.
+    private static func terminalContextSpans(in text: String) -> [Range<String.Index>] {
+        var spans = text.matches(of: patterns.authorizationHeader).map { $0.range.lowerBound..<$0.2.startIndex }
+        spans += text.matches(of: patterns.labeledSecret).map { $0.range.lowerBound..<$0.3.startIndex }
+        spans += text.matches(of: patterns.codeField).map { $0.range.lowerBound..<$0.3.startIndex }
+        spans += text.matches(of: patterns.codePrompt).map { $0.1.startIndex..<$0.1.endIndex }
+        spans += text.matches(of: patterns.codePromptWithoutDelimiter).map { $0.1.startIndex..<$0.1.endIndex }
+        spans += text.matches(of: patterns.declarativeCodePrompt).map { $0.1.startIndex..<$0.1.endIndex }
+        spans += text.matches(of: patterns.secretLabelOnly).map(\.range)
+        spans += text.matches(of: patterns.secretOption).map(\.range)
+        spans += text.matches(of: patterns.secretOptionOnly).map(\.range)
+        spans += text.matches(of: patterns.serializedSecretOption).map(\.range)
+        spans += text.matches(of: patterns.codePromptOnly).map(\.range)
+        spans += text.matches(of: patterns.pemBegin).map(\.range)
+        spans += text.matches(of: patterns.ppkBegin).map(\.range)
+        return spans.sorted { $0.lowerBound < $1.lowerBound }
+    }
 
     /// Boundary-free spans protect token interiors; recognition still requires each rule's
     /// usual leading boundary unless an actual removed control supplied one at that position.
@@ -54,19 +72,21 @@ extension Redactor {
     }
 
     /// A CSI introducer inserted into a token can consume its next character as the command's
-    /// final byte. Keep two bounded alternate readings: parameterless CSI bodies, and all CSI
-    /// bodies. The first also works beside ordinary parameterized styling in the same token.
+    /// final byte. Keep three bounded readings: parameterless bodies, final bytes alone, and
+    /// complete CSI bodies. Final-byte-only recovery covers an introducer with parameters
+    /// immediately before a credential character that happens to be a valid CSI command.
     /// Control-string payloads remain suppressed in both. Only recognized credential spans are mapped
     /// back; none of the retained command bytes themselves can reappear in the rendered output.
-    private static func recoveredCredentialRanges(in text: String, joined: String) -> [RecoveredCredential] {
+    private static func terminalRecovery(in text: String, joined: String) -> (ranges: [RecoveredCredential], contexts: [String]) {
         var recovered: [RecoveredCredential] = []
+        var contexts: [String] = []
         let ordinary = terminalCredentialSpans(in: joined).map { span -> RecoveredCredential in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)
             return (lower..<upper, span.kind)
         }.sorted { $0.range.lowerBound < $1.range.lowerBound }
         let escapes = text.matches(of: patterns.terminalEscape)
-        for retainParameters in [false, true] {
+        for reading in 0..<3 {
             var alternate = ""
             var offsets = [0]
             var retained: [Range<Int>] = []
@@ -81,8 +101,9 @@ extension Redactor {
                 appendLiteral(text[cursor..<escape.range.lowerBound])
                 boundaries.insert(offsets.count - 1)
                 let prefix = escape.0.hasPrefix("\u{1B}[") ? 2 : (escape.0.hasPrefix("\u{009B}") ? 1 : 0)
-                let body = escape.0.dropFirst(prefix)
-                if prefix > 0, !body.isEmpty, retainParameters || body.count == 1 {
+                let completeBody = escape.0.dropFirst(prefix)
+                let body = reading == 1 ? completeBody.suffix(1) : completeBody
+                if prefix > 0, !body.isEmpty, reading != 0 || body.count == 1 {
                     let start = offsets.count - 1
                     alternate += body
                     offsets.append(contentsOf: repeatElement(joinedCount, count: body.utf8.count))
@@ -92,6 +113,18 @@ extension Redactor {
             }
             guard !retained.isEmpty else { continue }
             appendLiteral(text[cursor...])
+            var contextRetainedIndex = 0
+            for span in terminalContextSpans(in: alternate) {
+                let lower = alternate.utf8.distance(from: alternate.utf8.startIndex, to: span.lowerBound)
+                let upper = alternate.utf8.distance(from: alternate.utf8.startIndex, to: span.upperBound)
+                while contextRetainedIndex < retained.count, retained[contextRetainedIndex].upperBound <= lower {
+                    contextRetainedIndex += 1
+                }
+                if contextRetainedIndex < retained.count, retained[contextRetainedIndex].lowerBound < upper {
+                    contexts.append(alternate)
+                    break
+                }
+            }
             let recognizedStarts = Set(
                 alternate.matches(of: patterns.apiKey).map { $0.2.startIndex }
                 + alternate.matches(of: patterns.bearer).map { $0.2.startIndex }
@@ -126,7 +159,7 @@ extension Redactor {
                 merged[merged.count - 1] = (last.range.lowerBound..<max(last.range.upperBound, span.range.upperBound), last.kind)
             } else { merged.append(span) }
         }
-        return merged
+        return (merged, contexts)
     }
 
     /// Inserting a marker must never hide evidence of a larger credential recognized in the
@@ -151,7 +184,7 @@ extension Redactor {
     /// a label that styling interrupted spelled correctly. `spliced` is `joined` when no escape
     /// stood in such a place, which is every ordinary line. The spliced reading also masks credential
     /// spans recovered before a CSI final byte could destroy their recognizable header.
-    static func renderings(of text: String) -> (joined: String, spliced: String) {
+    static func renderings(of text: String) -> (joined: String, spliced: String, contexts: [String]) {
         func isTokenCharacter(_ character: Character) -> Bool {
             character.isASCII && (character.isLetter || character.isNumber || character == "_" || character == "-")
         }
@@ -174,10 +207,11 @@ extension Redactor {
         boundaryOffsets = boundaryOffsets.filter { offset in
             let boundary = joined.utf8.index(joined.utf8.startIndex, offsetBy: offset)
             return joined[..<boundary].last.map(isTokenCharacter) == true
-                && joined[boundary...].first.map(isTokenCharacter) == true
+                && joined[boundary...].first.map({ !$0.isWhitespace }) == true
         }
-        var recovered = recoveredCredentialRanges(in: text, joined: joined)
-        guard !boundaryOffsets.isEmpty || !recovered.isEmpty else { return (joined, joined) }
+        let recovery = terminalRecovery(in: text, joined: joined)
+        var recovered = recovery.ranges
+        guard !boundaryOffsets.isEmpty || !recovered.isEmpty else { return (joined, joined, recovery.contexts) }
 
         // A boundary inside a recognized token would let the first scan redact only a valid
         // prefix. Closing the boundary afterwards cannot recover the remaining suffix. Keep
@@ -252,6 +286,6 @@ extension Redactor {
             redacted += marker(span.kind)
             scanned = upper
         }
-        return (joined, redacted + spliced[scanned...])
+        return (joined, redacted + spliced[scanned...], recovery.contexts)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -36,6 +36,57 @@ extension Redactor {
 
     private typealias RecoveredCredential = (range: Range<Int>, kind: String)
 
+    /// Inspect a conservative left-erasure reading for BS/CUB corrections. This is not a
+    /// terminal emulator: recovered text is evidence only, never returned as visible output.
+    /// Counts are clamped to the existing line and control-string payloads stay opaque.
+    private static func leftCorrectedContext(in text: String, joined: String) -> String? {
+        var corrected: [(character: Character, bytes: Range<Int>)] = []
+        var joinedCount = 0
+        var cursor = text.startIndex
+        var changed = false
+        func appendLiteral(_ literal: Substring) {
+            for character in literal {
+                let end = joinedCount + character.utf8.count
+                corrected.append((character, joinedCount..<end))
+                joinedCount = end
+            }
+        }
+        for escape in text.matches(of: patterns.terminalEscape) {
+            appendLiteral(text[cursor..<escape.range.lowerBound])
+            let count: Int?
+            if escape.0 == "\u{8}" { count = 1 }
+            else if let left = escape.0.wholeMatch(of: #/(?:\u{001B}\[|\u{009B})([0-9]*)D/#) {
+                count = left.1.isEmpty ? 1 : max(1, Int(left.1) ?? Int.max)
+            } else { count = nil }
+            if let count {
+                corrected.removeLast(min(count, corrected.count))
+                changed = true
+            }
+            cursor = escape.range.upperBound
+        }
+        guard changed else { return nil }
+        appendLiteral(text[cursor...])
+        let reading = String(corrected.map(\.character))
+        if !terminalContextSpans(in: reading).isEmpty { return reading }
+        // Do not replace the whole line when the ordinary reading already covers this token.
+        // Position-aware coverage prevents an unrelated token from suppressing new evidence.
+        var offsets = corrected.flatMap { Array($0.bytes) }
+        offsets.append(corrected.last?.bytes.upperBound ?? 0)
+        let ordinary = terminalCredentialSpans(in: joined).map { span in
+            let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
+            let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)
+            return (range: lower..<upper, kind: span.kind)
+        }
+        for span in terminalCredentialSpans(in: reading) {
+            let lower = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.range.lowerBound)]
+            let upper = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.range.upperBound)]
+            if !ordinary.contains(where: { $0.kind == span.kind && $0.range.lowerBound <= lower && $0.range.upperBound >= upper }) {
+                return reading
+            }
+        }
+        return nil
+    }
+
     /// Context openers, excluding their values. Only an opener intersecting a restored CSI
     /// byte supplies new evidence; ordinary styling inside an already-known value does not.
     private static func terminalContextSpans(in text: String) -> [Range<String.Index>] {
@@ -80,6 +131,7 @@ extension Redactor {
     private static func terminalRecovery(in text: String, joined: String) -> (ranges: [RecoveredCredential], contexts: [String]) {
         var recovered: [RecoveredCredential] = []
         var contexts: [String] = []
+        if let corrected = leftCorrectedContext(in: text, joined: joined) { contexts.append(corrected) }
         let ordinary = terminalCredentialSpans(in: joined).map { span -> RecoveredCredential in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -67,11 +67,20 @@ extension Redactor {
         guard changed else { return nil }
         appendLiteral(text[cursor...])
         let reading = String(corrected.map(\.character))
-        if !terminalContextSpans(in: reading).isEmpty { return reading }
         // Do not replace the whole line when the ordinary reading already covers this token.
         // Position-aware coverage prevents an unrelated token from suppressing new evidence.
         var offsets = corrected.flatMap { Array($0.bytes) }
         offsets.append(corrected.last?.bytes.upperBound ?? 0)
+        let ordinaryContexts = terminalContextSpans(in: joined).map {
+            let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: $0.lowerBound)
+            let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: $0.upperBound)
+            return lower..<upper
+        }
+        for span in terminalContextSpans(in: reading) {
+            let lower = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.lowerBound)]
+            let upper = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.upperBound)]
+            if !ordinaryContexts.contains(where: { $0.lowerBound <= lower && $0.upperBound >= upper }) { return reading }
+        }
         let ordinary = terminalCredentialSpans(in: joined).map { span in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -15,17 +15,17 @@ extension Redactor {
     /// payload here also keeps the terminator from joining the words on either side of it.
     static func stripTerminalEscapes(
         _ line: String,
-        openControlString: inout StreamState.ControlString?
-    ) -> (joined: String, spliced: String, contexts: [String]) {
+        openControlString: inout StreamState.ControlString?, activeQuote: StreamState.QuotedValue? = nil
+    ) -> (joined: String, spliced: String, contexts: [String], stateReadings: [String], quoteMayContinue: Bool) {
         var text = line
         if let open = openControlString {
             let end = open == .osc ? patterns.oscEnd : patterns.controlStringEnd
-            guard let terminator = text.firstMatch(of: end) else { return ("", "", []) }
+            guard let terminator = text.firstMatch(of: end) else { return ("", "", [], [], activeQuote != nil) }
             text = String(text[terminator.range.upperBound...])
         }
         openControlString = text.firstMatch(of: patterns.unterminatedControlString)
             .map { $0.1 == nil ? .other : .osc }
-        return renderings(of: text)
+        return renderings(of: text, activeQuote: activeQuote)
     }
 
     /// Stands where an escape did, in the `spliced` reading only. It has to be a boundary to
@@ -39,15 +39,18 @@ extension Redactor {
     /// Inspect a conservative left-erasure reading for BS/CUB corrections. This is not a
     /// terminal emulator: recovered text is evidence only, never returned as visible output.
     /// Counts are clamped to the existing line and control-string payloads stay opaque.
-    private static func leftCorrectedContext(in text: String, joined: String) -> String? {
+    private static func leftCorrectedContext(in text: String, joined: String, overwrite: Bool) -> String? {
         var corrected: [(character: Character, bytes: Range<Int>)] = []
         var joinedCount = 0
         var cursor = text.startIndex
         var changed = false
+        var position = 0
         func appendLiteral(_ literal: Substring) {
             for character in literal {
                 let end = joinedCount + character.utf8.count
-                corrected.append((character, joinedCount..<end))
+                if position < corrected.count { corrected[position] = (character, joinedCount..<end) }
+                else { corrected.append((character, joinedCount..<end)) }
+                position += 1
                 joinedCount = end
             }
         }
@@ -59,7 +62,11 @@ extension Redactor {
                 count = left.1.isEmpty ? 1 : max(1, Int(left.1) ?? Int.max)
             } else { count = nil }
             if let count {
-                corrected.removeLast(min(count, corrected.count))
+                if overwrite { position -= min(count, position) }
+                else {
+                    corrected.removeLast(min(count, corrected.count))
+                    position = corrected.count
+                }
                 changed = true
             }
             cursor = escape.range.upperBound
@@ -69,17 +76,21 @@ extension Redactor {
         let reading = String(corrected.map(\.character))
         // Do not replace the whole line when the ordinary reading already covers this token.
         // Position-aware coverage prevents an unrelated token from suppressing new evidence.
-        var offsets = corrected.flatMap { Array($0.bytes) }
-        offsets.append(corrected.last?.bytes.upperBound ?? 0)
+        let offsets = corrected.flatMap { Array($0.bytes) }
+        func projection(_ span: Range<String.Index>) -> Range<Int> {
+            let lower = reading.utf8.distance(from: reading.utf8.startIndex, to: span.lowerBound)
+            let upper = reading.utf8.distance(from: reading.utf8.startIndex, to: span.upperBound)
+            let bytes = offsets[lower..<upper]
+            return (bytes.min() ?? 0)..<((bytes.max() ?? -1) + 1)
+        }
         let ordinaryContexts = terminalContextSpans(in: joined).map {
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: $0.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: $0.upperBound)
             return lower..<upper
         }
         for span in terminalContextSpans(in: reading) {
-            let lower = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.lowerBound)]
-            let upper = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.upperBound)]
-            if !ordinaryContexts.contains(where: { $0.lowerBound <= lower && $0.upperBound >= upper }) { return reading }
+            let range = projection(span)
+            if !ordinaryContexts.contains(where: { $0.lowerBound <= range.lowerBound && $0.upperBound >= range.upperBound }) { return reading }
         }
         let ordinary = terminalCredentialSpans(in: joined).map { span in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
@@ -87,9 +98,8 @@ extension Redactor {
             return (range: lower..<upper, kind: span.kind)
         }
         for span in terminalCredentialSpans(in: reading) {
-            let lower = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.range.lowerBound)]
-            let upper = offsets[reading.utf8.distance(from: reading.utf8.startIndex, to: span.range.upperBound)]
-            if !ordinary.contains(where: { $0.kind == span.kind && $0.range.lowerBound <= lower && $0.range.upperBound >= upper }) {
+            let range = projection(span.range)
+            if !ordinary.contains(where: { $0.kind == span.kind && $0.range.lowerBound <= range.lowerBound && $0.range.upperBound >= range.upperBound }) {
                 return reading
             }
         }
@@ -137,10 +147,15 @@ extension Redactor {
     /// immediately before a credential character that happens to be a valid CSI command.
     /// Control-string payloads remain suppressed in both. Only recognized credential spans are mapped
     /// back; none of the retained command bytes themselves can reappear in the rendered output.
-    private static func terminalRecovery(in text: String, joined: String) -> (ranges: [RecoveredCredential], contexts: [String]) {
+    private static func terminalRecovery(in text: String, joined: String, activeQuote: StreamState.QuotedValue?)
+        -> (ranges: [RecoveredCredential], contexts: [String], stateReadings: [String], quoteMayContinue: Bool) {
         var recovered: [RecoveredCredential] = []
         var contexts: [String] = []
-        if let corrected = leftCorrectedContext(in: text, joined: joined) { contexts.append(corrected) }
+        var stateReadings: [String] = []
+        var quoteMayContinue = false
+        for overwrite in [false, true] {
+            if let corrected = leftCorrectedContext(in: text, joined: joined, overwrite: overwrite) { contexts.append(corrected) }
+        }
         let ordinary = terminalCredentialSpans(in: joined).map { span -> RecoveredCredential in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)
@@ -174,6 +189,14 @@ extension Redactor {
             }
             guard !retained.isEmpty else { continue }
             appendLiteral(text[cursor...])
+            if let activeQuote, closingQuoteEnd(in: alternate[...], for: activeQuote) == nil { quoteMayContinue = true }
+            if alternate.contains(patterns.wrappedTokenAtLineEnd) && !joined.contains(patterns.wrappedTokenAtLineEnd) {
+                stateReadings.append(alternate)
+                if terminalCredentialSpans(in: alternate).isEmpty { contexts.append(alternate) }
+            }
+            if incompleteJWTStartAtLineEnd(in: alternate) != nil && incompleteJWTStartAtLineEnd(in: joined) == nil {
+                contexts.append(alternate)
+            }
             var contextRetainedIndex = 0
             for span in terminalContextSpans(in: alternate) {
                 let lower = alternate.utf8.distance(from: alternate.utf8.startIndex, to: span.lowerBound)
@@ -220,7 +243,7 @@ extension Redactor {
                 merged[merged.count - 1] = (last.range.lowerBound..<max(last.range.upperBound, span.range.upperBound), last.kind)
             } else { merged.append(span) }
         }
-        return (merged, contexts)
+        return (merged, contexts, stateReadings, quoteMayContinue)
     }
 
     /// Inserting a marker must never hide evidence of a larger credential recognized in the
@@ -245,7 +268,8 @@ extension Redactor {
     /// a label that styling interrupted spelled correctly. `spliced` is `joined` when no escape
     /// stood in such a place, which is every ordinary line. The spliced reading also masks credential
     /// spans recovered before a CSI final byte could destroy their recognizable header.
-    static func renderings(of text: String) -> (joined: String, spliced: String, contexts: [String]) {
+    static func renderings(of text: String, activeQuote: StreamState.QuotedValue? = nil)
+        -> (joined: String, spliced: String, contexts: [String], stateReadings: [String], quoteMayContinue: Bool) {
         func isTokenCharacter(_ character: Character) -> Bool {
             character.isASCII && (character.isLetter || character.isNumber || character == "_" || character == "-")
         }
@@ -270,9 +294,11 @@ extension Redactor {
             return joined[..<boundary].last.map(isTokenCharacter) == true
                 && joined[boundary...].first.map({ !$0.isWhitespace }) == true
         }
-        let recovery = terminalRecovery(in: text, joined: joined)
+        let recovery = terminalRecovery(in: text, joined: joined, activeQuote: activeQuote)
         var recovered = recovery.ranges
-        guard !boundaryOffsets.isEmpty || !recovered.isEmpty else { return (joined, joined, recovery.contexts) }
+        guard !boundaryOffsets.isEmpty || !recovered.isEmpty else {
+            return (joined, joined, recovery.contexts, recovery.stateReadings, recovery.quoteMayContinue)
+        }
 
         // A boundary inside a recognized token would let the first scan redact only a valid
         // prefix. Closing the boundary afterwards cannot recover the remaining suffix. Keep
@@ -347,6 +373,6 @@ extension Redactor {
             redacted += marker(span.kind)
             scanned = upper
         }
-        return (joined, redacted + spliced[scanned...], recovery.contexts)
+        return (joined, redacted + spliced[scanned...], recovery.contexts, recovery.stateReadings, recovery.quoteMayContinue)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -21,8 +21,8 @@ import Testing
 
     @Test(arguments: ["--password", "--token", "--api-key", "--github-token"])
     func terminalSplicesRemainOptionBoundaries(option: String) {
-        #expect(("filename\u{009F}" + option + " synthetic").contains(Redactor.patterns.secretOption))
-        #expect(("filename\u{009F}" + option).contains(Redactor.patterns.secretOptionOnly))
+        #expect(("filename\u{001F}" + option + " synthetic").contains(Redactor.patterns.secretOption))
+        #expect(("filename\u{001F}" + option).contains(Redactor.patterns.secretOptionOnly))
     }
 
     @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
@@ -137,11 +137,20 @@ import Testing
         #expect(redactor.redact(line: "after", state: &state).text == Self.marker)
     }
 
-    @Test func unsupportedVersionsAndHeaderlessFragmentsDoNotArmAStream() {
+    @Test func headerlessFragmentsDoNotArmAStream() {
         var phase = Redactor.StreamState.PPKPhase.inactive
-        for line in ["PuTTY-User-Key-File-1: ssh-rsa", "PuTTY-User-Key-File-20: ssh-rsa", "AAAA", "Private-Lines: 2"] {
+        for line in ["PuTTY key format supported", "AAAA", "Private-Lines: 2"] {
             #expect(!Redactor.consumePPKLine(line, phase: &phase))
         }
         #expect(phase == .inactive)
+    }
+
+    @Test(arguments: ["1", "20", "0"])
+    func unsupportedPrivateKeyVersionsRemainConservativelyClosed(version: String) {
+        var state = Redactor.StreamState()
+        for line in ["PuTTY-User-Key-File-\(version): ssh-rsa", "Private-Lines: 1", "syntheticKeyBody", "Private-Hash: " + String(repeating: "a", count: 40), "after"] {
+            #expect(Redactor().redact(line: line, state: &state).text == Self.marker)
+        }
+        #expect(state.ppkPhase == .invalid)
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPPKTests.swift
@@ -91,6 +91,12 @@ import Testing
         #expect(phase == .privateLines(remaining: Int.max - 1, macDigits: 64))
     }
 
+    @Test func unknownLoggerEnvelopesDoNotGuessAPrivateKeyBoundary() {
+        let lines = Self.key().enumerated().map { "[time \($0.offset)] " + $0.element }
+        #expect(Redactor().redact(lines: lines + ["Finished"]).allSatisfy { $0.text == Self.marker })
+        #expect(Redactor().redact(lines: ["Fresh stream"]).first?.text == "Fresh stream")
+    }
+
     @Test func incompleteFilesRemainSensitiveAndStreamsAreIndependent() {
         let redactor = Redactor()
         var incomplete = Redactor.StreamState()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -3,6 +3,24 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorTerminalContextRepairTests {
+    @Test func recoveredLabelsInsideAClosingQuoteDoNotOpenAnotherQuote() {
+        let output = Redactor().redact(lines: ["password: \"begin", "pass\u{1B}[word:\"", "Finished"]).map(\.text)
+        #expect(output[2] == "Finished")
+    }
+
+    @Test func unrelatedCursorEditingDoesNotCreateCredentialEvidence() {
+        let output = Redactor().redact("run --password syntheticValue --verbose buildX\u{8} completed")
+        #expect(output == "run --password [redacted:secret] --verbose buildX completed")
+    }
+
+    @Test(arguments: [("-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"), ("password: \"begin", "end\"")])
+    func enclosingContextsCanCloseBeforeAPrivateKeyOpens(context: (String, String)) {
+        let output = Redactor().redact(lines: [context.0, context.1 + " PuTTY-User-Key-File-3: ssh-rsa",
+            "Private-Lines: 1", "c3ludGhldGlj", "Private-MAC: " + String(repeating: "a", count: 64), "Finished"]).map(\.text)
+        #expect(output[1..<5].allSatisfy { $0 == "[redacted:private-key]" })
+        #expect(output[5] == "Finished")
+    }
+
     @Test(arguments: ["\u{8}", "\u{1B}[D", "\u{1B}[1D", "\u{1B}[0D", "\u{9B}1D"])
     func cursorCorrectionsCannotHideCredentialLabels(control: String) {
         #expect(!Redactor().redact("passwordX" + control + ": syntheticPassword").contains("syntheticPassword"))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorTerminalContextRepairTests {
+    @Test(arguments: ["\u{1B}[31", "\u{009B}31", "\u{1B}[1;31"])
+    func parameterizedCSIRequiresAFinalByteOnlyReading(introducer: String) {
+        let input = "eyJhbGciOiJIUzI1NiIsI" + introducer + "mtpZCI6Im5hYmMifQ.payload.syntheticSignature"
+        #expect(!Redactor().redact(input).contains("syntheticSignature"))
+    }
+
+    @Test(arguments: ["\u{0000}", "\u{1B}[31m", "\u{0008}"])
+    func networkPathUserinfoRetainsItsControlBoundary(control: String) {
+        let input = "filename" + control + "//sample:syntheticPassword@example.com"
+        #expect(!Redactor().redact(input).contains("syntheticPassword"))
+    }
+
+    @Test func renormalizingASpliceDoesNotDiscardTheRemainingLine() {
+        let first = Redactor.renderings(of: "filename\u{0000}sk-abcdefghijklmnopqrstuvwx")
+        #expect(Redactor.renderings(of: first.spliced).joined == first.joined)
+    }
+
+    @Test(arguments: ["\u{0000}", "\u{1B}[31m"])
+    func contextFreeDeviceCodeMatchingRetainsControlBoundaries(control: String) throws {
+        let input = "prefix" + control + "AB12-CD34"
+        #expect(!Redactor().redact(untrusted: input).contains("AB12-CD34"))
+        #expect(!Redactor().redact(fieldValue: input).contains("AB12-CD34"))
+        // A log without a code context retains the previous conservative shape-only policy.
+        #expect(Redactor().redact(input) == "prefixAB12-CD34")
+        #expect(Redactor().redact(untrusted: "prefix" + control + "HMAC-SHA256") == "prefixHMAC-SHA256")
+    }
+
+    @Test(arguments: ["\u{0000}", "\u{1B}[31m"])
+    func terminalBoundariesArmShortWrappedKeys(control: String) {
+        let output = Redactor().redact(lines: [
+            "filename" + control + "sk-abcdefgh", "syntheticContinuation", "Finished normally",
+        ]).map(\.text)
+        #expect(!output[0].contains("sk-abcdefgh"))
+        #expect(!output[1].contains("syntheticContinuation"))
+    }
+
+    @Test(arguments: ["\u{0000}", "\u{1B}[31m"])
+    func closingQuoteSuffixesKeepTheirTerminalOptionBoundary(control: String) {
+        let output = Redactor().redact(lines: [
+            "password: \"syntheticFirst", "syntheticLast\" filename" + control + "--password",
+            "syntheticNextValue", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[3] == "Finished")
+    }
+
+    @Test(arguments: [
+        "pass\u{1B}[word: ", "Author\u{1B}[ization: Custom ", "run --pass\u{1B}[word ",
+        "Enter the co\u{1B}[de: ", "user_co\u{1B}[de: ",
+        #"["--pass"# + "\u{1B}[" + #"word", "#,
+    ])
+    func recoveredContextLabelsHideOpaqueValues(prefix: String) {
+        #expect(!Redactor().redact(prefix + "syntheticValue").contains("syntheticValue"))
+    }
+
+    @Test(arguments: ["pass\u{1B}[word:", "Author\u{1B}[ization:", "run --pass\u{1B}[word", "Enter the co\u{1B}[de:"])
+    func recoveredContextLabelsAlsoProtectTheFollowingLine(opener: String) {
+        let output = Redactor().redact(lines: [opener, "syntheticNextValue", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticNextValue"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test func recoveredPEMOpenersProtectTheWholeBlock() {
+        let output = Redactor().redact(lines: [
+            "-----BE\u{1B}[GIN PRIVATE KEY-----", "syntheticKeyBody",
+            "-----END PRIVATE KEY-----", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("syntheticKeyBody"))
+        #expect(output[3] == "Finished")
+    }
+
+    @Test(arguments: ["\u{1B}[PuTTY-", "PuTTY-\u{1B}[User-Key-File-3:", "PuTTY-\u{1B}[31User-Key-File-3:"])
+    func recoveredPPKOpenersAdvanceFramingOnce(opener: String) {
+        let header = opener == "\u{1B}[PuTTY-" ? opener + "User-Key-File-3:" : opener
+        let output = Redactor().redact(lines: [
+            header + " ssh-rsa", "Private-Lines: 2", "c3ludGhldGlj", "Ym9keQ==",
+            "Private-MAC: " + String(repeating: "a", count: 64), "Finished",
+        ]).map(\.text)
+        #expect(output.dropLast().allSatisfy { $0 == "[redacted:private-key]" })
+        #expect(output[5] == "Finished")
+    }
+
+    @Test func controlStringPayloadsNeverBecomeRecoveredContext() {
+        let input = "before\u{1B}]password: syntheticValue\u{7} after"
+        #expect(Redactor().redact(lines: [input, "Finished"]).map(\.text) == ["before after", "Finished"])
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -89,4 +89,15 @@ import Testing
         let input = "before\u{1B}]password: syntheticValue\u{7} after"
         #expect(Redactor().redact(lines: [input, "Finished"]).map(\.text) == ["before after", "Finished"])
     }
+
+    @Test(arguments: ["password: \"", "pass\u{1B}[word: \""], [false, true])
+    func aPPKOpenerPreservesItsEnclosingCredential(prefix: String, insidePEM: Bool) {
+        let output = Redactor().redact(lines: [
+            prefix + (insidePEM ? "-----BEGIN PRIVATE KEY----- " : "") + "PuTTY-User-Key-File-3: ssh-rsa",
+            "Private-Lines: 1", "c3ludGhldGlj", "Private-MAC: " + String(repeating: "a", count: 64),
+            "syntheticContinuation" + (insidePEM ? "-----END PRIVATE KEY-----" : "") + "\"", "Finished",
+        ]).map(\.text)
+        #expect(!output.joined().contains("syntheticContinuation"))
+        #expect(output[5] == "Finished")
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -27,7 +27,7 @@ import Testing
         #expect(!Redactor().redact(fieldValue: input).contains("AB12-CD34"))
         // A log without a code context retains the previous conservative shape-only policy.
         #expect(Redactor().redact(input) == "prefixAB12-CD34")
-        #expect(Redactor().redact(untrusted: "prefix" + control + "HMAC-SHA256") == "prefixHMAC-SHA256")
+        #expect(Redactor().redact(untrusted: "prefix" + control + "HMAC-SHA256") == "prefix[redacted:device-code]")
     }
 
     @Test(arguments: ["\u{0000}", "\u{1B}[31m"])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -3,6 +3,30 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorTerminalContextRepairTests {
+    @Test(arguments: ["\u{8}", "\u{1B}[D", "\u{1B}[1D", "\u{1B}[0D", "\u{9B}1D"])
+    func cursorCorrectionsCannotHideCredentialLabels(control: String) {
+        #expect(!Redactor().redact("passwordX" + control + ": syntheticPassword").contains("syntheticPassword"))
+        let output = Redactor().redact(lines: ["passwordX" + control + ":", "syntheticValue", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticValue"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: ["passwordXYZ\u{1B}[3D", "discarded\u{1B}[999999999999999999999Dpassword"])
+    func cursorCorrectionCountsAreBoundedAndRetainCredentialEvidence(prefix: String) {
+        #expect(!Redactor().redact(prefix + ": syntheticPassword").contains("syntheticPassword"))
+    }
+
+    @Test func cursorPayloadsStayOpaqueAndOrdinaryDiagnosticsKeepTheirRendering() {
+        let input = "passwordX\u{1B}]\u{8}\u{7}: ordinaryDiagnostic"
+        #expect(Redactor().redact(input) == "passwordX: ordinaryDiagnostic")
+        #expect(Redactor().redact("buildX\u{8} completed") == "buildX completed")
+    }
+
+    @Test(arguments: ["", "ghp_abcdefghijklmnopqrst "])
+    func correctedTokenEvidenceIsNotHiddenByAnotherToken(prefix: String) {
+        #expect(!Redactor().redact(prefix + "ghx\u{8}p_syntheticOpaqueTokenValue").contains("syntheticOpaqueTokenValue"))
+    }
+
     @Test(arguments: ["\u{1B}[31", "\u{009B}31", "\u{1B}[1;31"])
     func parameterizedCSIRequiresAFinalByteOnlyReading(introducer: String) {
         let input = "eyJhbGciOiJIUzI1NiIsI" + introducer + "mtpZCI6Im5hYmMifQ.payload.syntheticSignature"

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalContextRepairTests.swift
@@ -3,6 +3,38 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorTerminalContextRepairTests {
+    @Test(arguments: ["\u{1B}[22D", "\u{9B}22D"])
+    func cursorOverwriteKeepsUntouchedTokenSuffixes(control: String) {
+        #expect(!Redactor().redact("ghx_abcdefghijklmnopqrst" + control + "p").contains("abcdefghijklmnopqrst"))
+    }
+
+    @Test(arguments: ["ghp\u{1B}[_", "ghp\u{1B}[31_", "sk\u{9B}-"])
+    func recoveredPrefixCharactersRetainNextRecordProtection(input: String) {
+        let output = Redactor().redact(lines: [input, "syntheticContinuation", "[status] Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticContinuation"))
+        #expect(output[2] == "[status] Finished")
+    }
+
+    @Test(arguments: ["\u{1B}[", "\u{9B}", "\u{1B}[31"])
+    func recoveredBackslashesCannotPrematurelyCloseActiveQuotes(control: String) {
+        let output = Redactor().redact(lines: ["password: \"first", control + "\\\"",
+            "syntheticContinuation\"", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticContinuation"))
+        #expect(output[3] == "Finished")
+    }
+
+    @Test func recoveredOpenersInsidePEMPayloadDoNotEscapeItsFooter() {
+        let output = Redactor().redact(lines: ["-----BEGIN PRIVATE KEY-----",
+            "pass\u{1B}[word: \" -----END PRIVATE KEY-----", "Finished"]).map(\.text)
+        #expect(output[2] == "Finished")
+    }
+
+    @Test func recoveredOpenersInsidePPKMetadataDoNotEscapeItsMAC() {
+        let output = Redactor().redact(lines: ["PuTTY-User-Key-File-3: ssh-rsa", "Comment: pass\u{1B}[word: \"",
+            "Private-Lines: 1", "AAAA", "Private-MAC: " + String(repeating: "a", count: 64), "Finished"]).map(\.text)
+        #expect(output[5] == "Finished")
+    }
+
     @Test func recoveredLabelsInsideAClosingQuoteDoNotOpenAnotherQuote() {
         let output = Redactor().redact(lines: ["password: \"begin", "pass\u{1B}[word:\"", "Finished"]).map(\.text)
         #expect(output[2] == "Finished")


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope and stack

Stacked on #117; this prerequisite is integrated before #59 exposes the public redaction API. Implements MVP-PLAN.md §3 (Local storage) and addresses the terminal-boundary findings on #95, #97 and #114, plus PPK opener/legacy-format findings on #116/#59.

- Add a bounded final-byte-only CSI reading alongside the existing two readings.
- Recover credential labels, prompts, argv labels and PEM/PPK openers when a CSI sequence consumed a label character. Such a recovered label conservatively conceals the current line and preserves pending context; control-string payloads are never recovered.
- Replace the internal APC sentinel with a single removable Unit Separator, retaining boundaries before network-path credentials, wrapped keys, and context-free device-code scans.
- Preserve terminal boundaries when scanning the suffix of a closing quoted value.
- Advance PPK framing exactly once per physical line, including recovered openers. Preserve enclosing quoted/PEM contexts before the private-key early return, including ordinary openers (follow-on repair 4fbb2e6). Known v2/v3 syntax can close normally; v1 and unknown versions remain concealed until a fresh StreamState instead of guessing a footer grammar. PuTTY documents v1 and its distinct Private-Hash footer in [Appendix C.5.2](https://www.puttyssh.org/0.83/htmldoc/AppendixC.html#ppk-v1).

## Validation

- Six new terminal-boundary regression functions reproduced 15 failed assertions before the fix.
- Additional parameterized cases cover consumed label characters, next-line values, PEM bodies, PPK physical-line counts and control-string payload exclusion.
- Intentional existing-fixture changes: sentinel checks now use U+001F; legacy/unknown PPK versions move from an unsupported-pass-through case to explicit fail-closed coverage. No existing cases were silently discarded.
- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: 287 tests / 26 suites on this prerequisite; the latest full API (including #119/#120) passes 373 tests / 32 suites.
- Diff: 387 changed lines. No process execution, provider activation or hardware claims.

Nested-encoding, DSN, cookie and batch-decoding repairs are supplied by #119/#120 before public activation in #59. Boundary scans of untrusted input always conceal matching device-code shapes, including algorithm-like spellings. Fresh current-head CI, review and original-message reaction checks are pending; complete-stack gates are checked separately.

## Repair checkpoint — 2026-09-05 21:14 UTC

Current head `9a8c575d8306829621d50616889c4a25bfeadb30`: **458 own changed lines; 297 Core tests / 26 suites pass with warnings-as-errors**.

Latest integration preserves unambiguous filename prefixes outside incomplete JOSE ranges; marker conflicts still conceal the containing record. All other repair evidence is linked in the review-thread replies.

The complete error graph passes **444 tests / 37 suites**, including unchanged original URI, filename-prefix and combining-mark assertions. The public redactor passes373 tests. Fifteen prerequisite findings received published-fix or evidence-backed policy replies; the public framing, earlier failed-assertion report, two sanitizer boundaries and locale assertion findings were also resolved with evidence.

**Not aggregate merge-ready.** Fresh review still reports three nested-encoding gaps on #119 (Unicode whitespace escapes, mixed raw quote wrappers, parenthesized values), and four public-boundary findings on #59 (validation recovery guidance, decoding scope, split strict credentials, contextual typed output). #59 has more than100 threads; the second page must be inspected. Current-head CI/reviews/reactions remain required after this push; previous green checks and thumbs-up do not clear these findings. No PR was merged.
