### PR TITLE
Bound nested encoded diagnostic-value redaction

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -25,7 +25,8 @@ extension Redactor {
             var nestedState = StreamState()
             let nested = applyPatterns(to: normalized, codeExpected: false, state: &nestedState,
                                        encodingDepth: encodingDepth + 1)
-            mergePendingContexts(from: nestedState, into: &quotedState)
+            // The encoded value has already closed. Its decoded, possibly truncated contents
+            // cannot acquire a value from a later unrelated physical record.
             // Do not attempt to splice decoded offsets back into multiply escaped text.
             // Hide the containing value if the decoded reading adds credential evidence.
             if nested != normalized { return (marker("secret"), quotedState) }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -21,7 +21,7 @@ extension Redactor {
             guard encodingDepth < 8 else { return (marker("secret"), StreamState()) }
             var quotedState = StreamState()
             let sanitized = applyPatterns(to: value, codeExpected: false, state: &quotedState, prepareQuotedValues: false)
-            let normalized = removingQuotedEncodingLayer(value)
+            let normalized = unwrappingCompleteDecodedString(removingQuotedEncodingLayer(value))
             var nestedState = StreamState()
             let nested = applyPatterns(to: normalized, codeExpected: false, state: &nestedState,
                                        encodingDepth: encodingDepth + 1)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -22,6 +22,7 @@ extension Redactor {
             var quotedState = StreamState()
             let sanitized = applyPatterns(to: value, codeExpected: false, state: &quotedState, prepareQuotedValues: false)
             let normalized = unwrappingCompleteDecodedString(removingQuotedEncodingLayer(value))
+                .replacing(#/\\+[nrtfv]/#, with: " ")
             var nestedState = StreamState()
             let nested = applyPatterns(to: normalized, codeExpected: false, state: &nestedState,
                                        encodingDepth: encodingDepth + 1)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -13,11 +13,22 @@ extension Redactor {
     }
 
     static func applyPatterns(to input: String, codeExpected: Bool, state: inout StreamState,
-                              prepareQuotedValues: Bool = true) -> String {
+                              prepareQuotedValues: Bool = true, encodingDepth: Int = 0) -> String {
         let p = patterns
         let protected = prepareQuotedValues ? protectEncodedQuotedValues(in: input) { value in
+            // Each recursive step removes one encoding layer from this bounded value, never
+            // rescans its siblings or a remaining suffix. Excessive nesting fails closed.
+            guard encodingDepth < 8 else { return (marker("secret"), StreamState()) }
             var quotedState = StreamState()
             let sanitized = applyPatterns(to: value, codeExpected: false, state: &quotedState, prepareQuotedValues: false)
+            let normalized = removingQuotedEncodingLayer(value)
+            var nestedState = StreamState()
+            let nested = applyPatterns(to: normalized, codeExpected: false, state: &nestedState,
+                                       encodingDepth: encodingDepth + 1)
+            mergePendingContexts(from: nestedState, into: &quotedState)
+            // Do not attempt to splice decoded offsets back into multiply escaped text.
+            // Hide the containing value if the decoded reading adds credential evidence.
+            if nested != normalized { return (marker("secret"), quotedState) }
             return (sanitized, quotedState)
         } : ProtectedQuotedValues(text: input)
         var text = protected.text

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -29,7 +29,9 @@ extension Redactor {
             // cannot acquire a value from a later unrelated physical record.
             // Do not attempt to splice decoded offsets back into multiply escaped text.
             // Hide the containing value if the decoded reading adds credential evidence.
-            if nested != normalized { return (marker("secret"), quotedState) }
+            if nested != normalized || incompleteJWTStartAtLineEnd(in: normalized) != nil {
+                return (marker("secret"), quotedState)
+            }
             return (sanitized, quotedState)
         } : ProtectedQuotedValues(text: input)
         var text = protected.text

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -52,8 +52,20 @@ extension Redactor {
             // belong to a shell/diagnostic credential and must stay in the unquoted rule.
             // Closing delimiters from outer encodings can precede the structural boundary.
             // An arbitrary suffix (including another quoted word) is still ambiguous.
-            let structuralTail = tail.drop(while: { $0.isWhitespace || "\\\"'".contains($0) })
+            let structuralTail = tail.drop(while: { "\"'".contains($0) }).drop(while: { $0.isWhitespace })
             guard structuralTail.isEmpty || structuralTail.first.map({ ",;]}".contains($0) }) == true else { continue }
+            let content = input[opener.range.upperBound..<end].dropLast(opener.1.count + 1)
+            let previous = input[..<opener.range.lowerBound].last(where: { !$0.isWhitespace })
+            // Preserve argv adjacency in the parent scan: hiding an option name behind a
+            // placeholder would detach the following value. Canonicalize only known names
+            // at an array-element boundary, not arbitrary diagnostic strings.
+            if previous == "[" || previous == ",",
+               tail.first == ",", !content.contains("="),
+               content.wholeMatch(of: patterns.secretOptionOnly) != nil {
+                result.text += input[copied..<opener.range.lowerBound] + "\"" + content + "\""
+                copied = end
+                continue
+            }
             while reserved.contains(String(identifier)) { identifier += 1 }
             let key = String(identifier)
             identifier += 1

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -2,7 +2,7 @@ import Foundation
 import RegexBuilder
 
 extension Redactor {
-    /// Decode only quoting/backslash escapes, not control escapes such as `\n`: physical
+    /// Decode quoting/backslash/solidus escapes, not controls such as `\n`: physical
     /// line framing belongs to the stream parser. Each call strictly reduces escape depth.
     static func removingQuotedEncodingLayer(_ value: String) -> String {
         var result = ""
@@ -10,7 +10,7 @@ extension Redactor {
         while cursor < value.endIndex {
             let character = value[cursor]
             value.formIndex(after: &cursor)
-            if character == "\\", cursor < value.endIndex, "\\\"'".contains(value[cursor]) {
+            if character == "\\", cursor < value.endIndex, "\\\"'/".contains(value[cursor]) {
                 result.append(value[cursor])
                 value.formIndex(after: &cursor)
             } else { result.append(character) }
@@ -55,10 +55,8 @@ extension Redactor {
         var contextCursor = cursor
         var enclosingQuote: Character?
         var escaped = false
-        while let opener = input[cursor...].firstMatch(of: #/(\\+)(["'])/#) {
-            // Advance once through the source prefix, rather than rescanning each sibling.
-            // An encoded quote cannot open or close the raw wrapper containing it.
-            while contextCursor < opener.range.lowerBound {
+        func advanceContext(to end: String.Index) {
+            while contextCursor < end {
                 let character = input[contextCursor]
                 if escaped { escaped = false }
                 else if character == "\\" { escaped = true }
@@ -69,10 +67,16 @@ extension Redactor {
                 }
                 input.formIndex(after: &contextCursor)
             }
+        }
+        while let opener = input[cursor...].firstMatch(of: #/(\\+)(["'])/#) {
+            // Visit each source character once, including raw quotes inside a protected span.
+            // An encoded delimiter itself cannot open or close its raw enclosing wrapper.
+            advanceContext(to: opener.range.lowerBound)
             guard let quote = opener.2.first,
                   let end = closingQuoteEnd(in: input[opener.range.upperBound...],
                       for: .init(delimiter: quote, escapeDepth: opener.1.count, kind: "secret")) else { break }
             cursor = end
+            advanceContext(to: end)
             let tail = input[end...].drop(while: { $0.isWhitespace })
             // A colon/equal means this is a key, not a value. Undelimited suffixes can still
             // belong to a shell/diagnostic credential and must stay in the unquoted rule.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -2,6 +2,22 @@ import Foundation
 import RegexBuilder
 
 extension Redactor {
+    /// Decode only quoting/backslash escapes, not control escapes such as `\n`: physical
+    /// line framing belongs to the stream parser. Each call strictly reduces escape depth.
+    static func removingQuotedEncodingLayer(_ value: String) -> String {
+        var result = ""
+        var cursor = value.startIndex
+        while cursor < value.endIndex {
+            let character = value[cursor]
+            value.formIndex(after: &cursor)
+            if character == "\\", cursor < value.endIndex, "\\\"'".contains(value[cursor]) {
+                result.append(value[cursor])
+                value.formIndex(after: &cursor)
+            } else { result.append(character) }
+        }
+        return result
+    }
+
     struct ProtectedQuotedValues {
         var text: String
         var values: [String: String] = [:]
@@ -34,7 +50,10 @@ extension Redactor {
             let tail = input[end...].drop(while: { $0.isWhitespace })
             // A colon/equal means this is a key, not a value. Undelimited suffixes can still
             // belong to a shell/diagnostic credential and must stay in the unquoted rule.
-            guard tail.isEmpty || tail.first.map({ ",;]}".contains($0) }) == true else { continue }
+            // Closing delimiters from outer encodings can precede the structural boundary.
+            // An arbitrary suffix (including another quoted word) is still ambiguous.
+            let structuralTail = tail.drop(while: { $0.isWhitespace || "\\\"'".contains($0) })
+            guard structuralTail.isEmpty || structuralTail.first.map({ ",;]}".contains($0) }) == true else { continue }
             while reserved.contains(String(identifier)) { identifier += 1 }
             let key = String(identifier)
             identifier += 1

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -52,7 +52,23 @@ extension Redactor {
         var cursor = input.startIndex
         var copied = cursor
         var identifier = 0
+        var contextCursor = cursor
+        var enclosingQuote: Character?
+        var escaped = false
         while let opener = input[cursor...].firstMatch(of: #/(\\+)(["'])/#) {
+            // Advance once through the source prefix, rather than rescanning each sibling.
+            // An encoded quote cannot open or close the raw wrapper containing it.
+            while contextCursor < opener.range.lowerBound {
+                let character = input[contextCursor]
+                if escaped { escaped = false }
+                else if character == "\\" { escaped = true }
+                else if character == enclosingQuote { enclosingQuote = nil }
+                else if enclosingQuote == nil, character == "\"" || character == "'",
+                        input[..<contextCursor].last.map({ $0.isWhitespace || "=:[{(,".contains($0) }) ?? true {
+                    enclosingQuote = character
+                }
+                input.formIndex(after: &contextCursor)
+            }
             guard let quote = opener.2.first,
                   let end = closingQuoteEnd(in: input[opener.range.upperBound...],
                       for: .init(delimiter: quote, escapeDepth: opener.1.count, kind: "secret")) else { break }
@@ -62,7 +78,13 @@ extension Redactor {
             // belong to a shell/diagnostic credential and must stay in the unquoted rule.
             // Closing delimiters from outer encodings can precede the structural boundary.
             // An arbitrary suffix (including another quoted word) is still ambiguous.
-            let structuralTail = tail.drop(while: { "\"'".contains($0) }).drop(while: { $0.isWhitespace })
+            var structuralTail = tail
+            if let closure = tail.first, closure == "\"" || closure == "'" {
+                // Only a proven, adjacent enclosing closure may precede the delimiter.
+                // A new/unmatched quote or whitespace-separated word is credential content.
+                guard input[end...].first == closure, enclosingQuote == closure else { continue }
+                structuralTail = tail.dropFirst().drop(while: { $0.isWhitespace })
+            }
             guard structuralTail.isEmpty || structuralTail.first.map({ ",;]}".contains($0) }) == true else { continue }
             let content = input[opener.range.upperBound..<end].dropLast(opener.1.count + 1)
             let previous = input[..<opener.range.lowerBound].last(where: { !$0.isWhitespace })

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -2,15 +2,18 @@ import Foundation
 import RegexBuilder
 
 extension Redactor {
-    /// Decode quoting/backslash/solidus escapes, not controls such as `\n`: physical
-    /// line framing belongs to the stream parser. Each call strictly reduces escape depth.
+    /// Decode one scan-only quoting layer. Escaped whitespace becomes a space, never a
+    /// physical record separator; original encoded output is restored or concealed whole.
     static func removingQuotedEncodingLayer(_ value: String) -> String {
         var result = ""
         var cursor = value.startIndex
         while cursor < value.endIndex {
             let character = value[cursor]
             value.formIndex(after: &cursor)
-            if character == "\\", cursor < value.endIndex, "\\\"'/".contains(value[cursor]) {
+            if character == "\\", cursor < value.endIndex, "nrtfv".contains(value[cursor]) {
+                result.append(" ")
+                value.formIndex(after: &cursor)
+            } else if character == "\\", cursor < value.endIndex, "\\\"'/".contains(value[cursor]) {
                 result.append(value[cursor])
                 value.formIndex(after: &cursor)
             } else { result.append(character) }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+QuotedValues.swift
@@ -18,6 +18,16 @@ extension Redactor {
         return result
     }
 
+    /// A completely decoded string has its own argument boundary. Only remove a wrapper
+    /// whose first matching closing quote is the end, never a quote plus sibling suffix.
+    static func unwrappingCompleteDecodedString(_ value: String) -> String {
+        guard let quote = value.first, quote == "\"" || quote == "'",
+              closingQuoteEnd(in: value.dropFirst(),
+                  for: .init(delimiter: quote, escapeDepth: 0, kind: "secret")) == value.endIndex
+        else { return value }
+        return String(value.dropFirst().dropLast())
+    }
+
     struct ProtectedQuotedValues {
         var text: String
         var values: [String: String] = [:]

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -36,4 +36,24 @@ import Testing
         let input = Array(repeating: "\"payload\": " + value, count: 200).joined(separator: ", ")
         #expect(!Redactor().redact(input).contains("syntheticValue"))
     }
+
+    @Test(arguments: [",", ";", "]", "}"])
+    func escapedDelimitersDoNotReleaseAnAmbiguousCredentialTail(delimiter: String) {
+        let input = #"password: \"first\" \"# + delimiter + " syntheticTail"
+        #expect(!Redactor().redact(input).contains("syntheticTail"))
+    }
+
+    @Test func aClosedEncodedValueCannotConsumeTheNextPhysicalRecord() throws {
+        var input = #"{"password":"#
+        for _ in 0..<2 { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        #expect(Redactor().redact(input + "\nFinished").hasSuffix("\nFinished"))
+    }
+
+    @Test(arguments: ["--password", "--token", "--api-key"])
+    func twiceRepresentedPythonArgvKeepsItsOptionValuePair(option: String) {
+        let input = "'\"[\\'" + option + "\\', \\'OpaqueSynthetic987\\', \\'--verbose\\']\"'"
+        let output = Redactor().redact(input)
+        #expect(!output.contains("OpaqueSynthetic987"))
+        #expect(output.contains("--verbose"))
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -63,4 +63,16 @@ import Testing
         for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
         #expect(!Redactor().redact(input).contains("OpaqueSynthetic987"))
     }
+
+    @Test(arguments: ["\"", "'"], ["", " "])
+    func unmatchedRawQuotesCannotReleaseACredentialTail(quote: String, separator: String) {
+        let input = #"password: \"first\""# + separator + quote + ", syntheticTail"
+        #expect(!Redactor().redact(input).contains("syntheticTail"))
+    }
+
+    @Test(arguments: [("it's ", "'"), ("some\"word ", "\"")])
+    func anInWordQuoteDoesNotProveAnEnclosingWrapper(parts: (String, String)) {
+        let input = parts.0 + #"password: \"first\""# + parts.1 + ", syntheticTail"
+        #expect(!Redactor().redact(input).contains("syntheticTail"))
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -75,4 +75,13 @@ import Testing
         let input = parts.0 + #"password: \"first\""# + parts.1 + ", syntheticTail"
         #expect(!Redactor().redact(input).contains("syntheticTail"))
     }
+
+    @Test(arguments: [3, 7, 15])
+    func encodedSerializedArraysRetainOptionValuePairing(depth: Int) {
+        let quote = String(repeating: "\\", count: depth) + "\""
+        let input = "[" + quote + "--password" + quote + ", " + quote + "syntheticPassword" + quote + ", " + quote + "--verbose" + quote + "]"
+        let output = Redactor().redact(input)
+        #expect(!output.contains("syntheticPassword"))
+        #expect(output.contains("--verbose"))
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -56,4 +56,11 @@ import Testing
         #expect(!output.contains("OpaqueSynthetic987"))
         #expect(output.contains("--verbose"))
     }
+
+    @Test(arguments: 2...5, ["--password", "--token", "--api-key"])
+    func aDecodedCompleteStringOwnsItsOptionBoundary(layers: Int, option: String) throws {
+        var input = option + " OpaqueSynthetic987"
+        for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        #expect(!Redactor().redact(input).contains("OpaqueSynthetic987"))
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -3,6 +3,17 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorNestedEncodingRepairTests {
+    @Test(arguments: 2...5, ["Bearer\tSYNTHETICVALUE", "--password\tSYNTHETICVALUE", "Enter the code\tSYNTHETICVALUE",
+                           "--password\nSYNTHETICVALUE", "--password\rSYNTHETICVALUE"])
+    func escapedWhitespaceRetainsScanOnlyCredentialBoundaries(layers: Int, credential: String) throws {
+        var input = credential
+        for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        let output = Redactor().redact(lines: [input, "Finished"]).map(\.text)
+        #expect(!output.joined().contains("SYNTHETICVALUE"))
+        #expect(output[1] == "Finished")
+        #expect(!output[0].contains("\n") && !output[0].contains("\r"))
+    }
+
     @Test func aRawWrapperClosedInsideAnEncodedValueCannotCloseAgainAfterIt() {
         let input = #"prefix=' password: \"first'stuff\"', syntheticTail"#
         #expect(!Redactor().redact(input).contains("syntheticTail"))
@@ -42,7 +53,7 @@ import Testing
     }
 
     @Test func layerDecodingDoesNotCreatePhysicalLineTerminators() {
-        #expect(Redactor.removingQuotedEncodingLayer(#"a\nb\rc\td"#) == #"a\nb\rc\td"#)
+        #expect(Redactor.removingQuotedEncodingLayer(#"a\nb\rc\td"#) == "a b c d")
     }
 
     @Test func manyNestedSiblingsStayIndependent() throws {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -3,6 +3,20 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorNestedEncodingRepairTests {
+    @Test func aRawWrapperClosedInsideAnEncodedValueCannotCloseAgainAfterIt() {
+        let input = #"prefix=' password: \"first'stuff\"', syntheticTail"#
+        #expect(!Redactor().redact(input).contains("syntheticTail"))
+    }
+
+    @Test(arguments: 2...5, ["https://user:syntheticSecret@example.com", "eyJhbGciOiJIUzI1NiJ9.syntheticPayload"])
+    func nestedURLsAndIncompleteJWTsConcealTheirClosedContainer(layers: Int, credential: String) throws {
+        var input = credential
+        for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        let output = Redactor().redact(lines: [input, "Finished"]).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[1] == "Finished")
+    }
+
     @Test(arguments: 2...5)
     func nestedEncodedFieldsStillConcealTheirOpaqueValues(layers: Int) throws {
         var input = #"{"password":"syntheticCredential","note":"ordinaryValue"}"#

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorNestedEncodingRepairTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorNestedEncodingRepairTests {
+    @Test(arguments: 2...5)
+    func nestedEncodedFieldsStillConcealTheirOpaqueValues(layers: Int) throws {
+        var input = #"{"password":"syntheticCredential","note":"ordinaryValue"}"#
+        for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        let output = Redactor().redact("payload: " + input + "\nFinished")
+        #expect(!output.contains("syntheticCredential"))
+        #expect(output.hasSuffix("\nFinished"))
+    }
+
+    @Test(arguments: 2...5)
+    func nestedOrdinaryValuesDoNotBecomeCredentials(layers: Int) throws {
+        var input = #"{"note":"ordinaryValue","count":42}"#
+        for _ in 0..<layers { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        #expect(Redactor().redact(input) == input)
+    }
+
+    @Test func excessiveNestingIsConcealedInsteadOfRecursingWithoutABound() throws {
+        var input = #"{"note":"syntheticDeepValue"}"#
+        for _ in 0..<11 { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        let output = Redactor().redact(input + "\nFinished")
+        #expect(!output.contains("syntheticDeepValue"))
+        #expect(output.hasSuffix("\nFinished"))
+    }
+
+    @Test func layerDecodingDoesNotCreatePhysicalLineTerminators() {
+        #expect(Redactor.removingQuotedEncodingLayer(#"a\nb\rc\td"#) == #"a\nb\rc\td"#)
+    }
+
+    @Test func manyNestedSiblingsStayIndependent() throws {
+        let value = String(decoding: try JSONEncoder().encode(#"{"password":"syntheticValue"}"#), as: UTF8.self)
+        let input = Array(repeating: "\"payload\": " + value, count: 200).joined(separator: ", ")
+        #expect(!Redactor().redact(input).contains("syntheticValue"))
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope and stack

Stacked on #118, before #59 exposes the complete API. Addresses the nested-encoding review finding on #96 under MVP-PLAN.md §3 (Local storage).

Closed encoded values are inspected one encoding layer at a time, bounded to eight levels. Each level scans only its own value; siblings and the remaining suffix are not recursively rescanned. If the decoded reading reveals additional credential evidence, the enclosing encoded value is concealed instead of trying to splice decoded offsets into the original text. Excessive nesting is concealed. Literal control escapes remain literal; the stream parser continues to own physical-line framing.

Outer closing quotes can precede a structural value boundary. Undelimited tails, including another nonempty quoted word, remain ambiguous and sensitive. Ordinary nested diagnostic values preserve their original rendering.

## Validation

- Four synthetic 2–5-layer JSON cases reproduced leaked opaque credentials before the fix; their ordinary-value counterparts already passed.
- Nine new test functions cover the positive/negative nesting cases, excessive nesting, control-escape framing and 200 independent nested siblings.
- Existing escaped-tail and 1,000-field performance regressions remain enabled and pass.
- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: 301 tests / 27 suites for this prerequisite; 356 tests / 32 suites for the integrated public API.
- 186 changed lines. No dependencies, host operations or hardware claims.

Follow-on review fixes in c2022ea/7a45afa preserve serialized option/value adjacency, contain nested pending state inside closed values, retain ambiguous escaped delimiter tails, and unwrap only a complete decoded string to recover its option boundary. Twelve JSON-layer/option cases reproduced the newest leak before the fix. The separate batch/DSN/cookie findings are implemented by #120; fresh review gates remain required.

## Repair checkpoint — 2026-09-05 21:14 UTC

Current head `72f86e14338aff016feee4e6a46d1d8437158f36`: **201 own changed lines; 312 Core tests / 27 suites pass with warnings-as-errors**.

Latest integration preserves unambiguous filename prefixes outside incomplete JOSE ranges; marker conflicts still conceal the containing record. All other repair evidence is linked in the review-thread replies.

The complete error graph passes **444 tests / 37 suites**, including unchanged original URI, filename-prefix and combining-mark assertions. The public redactor passes373 tests. Fifteen prerequisite findings received published-fix or evidence-backed policy replies; the public framing, earlier failed-assertion report, two sanitizer boundaries and locale assertion findings were also resolved with evidence.

**Not aggregate merge-ready.** Fresh review still reports three nested-encoding gaps on #119 (Unicode whitespace escapes, mixed raw quote wrappers, parenthesized values), and four public-boundary findings on #59 (validation recovery guidance, decoding scope, split strict credentials, contextual typed output). #59 has more than100 threads; the second page must be inspected. Current-head CI/reviews/reactions remain required after this push; previous green checks and thumbs-up do not clear these findings. No PR was merged.
