### PR TITLE
Sanitize decoded log batches and explicit credential formats

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -280,7 +280,7 @@ extension Redactor {
         var state = StreamState()
         return untrustedLines.map { line in
             let sanitized = redact(line: line, state: &state, isPhysicalLine: true, codesAlwaysRedacted: true).text
-            return RedactedLine(Self.applyDeviceCodePattern(to: sanitized, preserveAlgorithms: true))
+            return RedactedLine(Self.applyDeviceCodePattern(to: sanitized))
         }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -275,6 +275,15 @@ extension Redactor {
         return lines.map { redact(line: $0, state: &state) }
     }
 
+    /// Batch decoding owns one stream state and keeps context-free code matching enabled.
+    fileprivate func redact(untrustedLines: [String]) -> [RedactedLine] {
+        var state = StreamState()
+        return untrustedLines.map { line in
+            let sanitized = redact(line: line, state: &state, isPhysicalLine: true, codesAlwaysRedacted: true).text
+            return RedactedLine(Self.applyDeviceCodePattern(to: sanitized, preserveAlgorithms: true))
+        }
+    }
+
     private func redact(_ text: String, codesAlwaysRedacted: Bool) -> String {
         var state = StreamState()
         var result = ""
@@ -300,8 +309,8 @@ extension Redactor {
 /// A line of text that has passed through `Redactor`.
 ///
 /// Log sinks, the XPC event stream, and diagnostics exports accept only this type, so an
-/// unredacted `String` cannot reach them by accident. The only ways to obtain one are
-/// `Redactor` and a compile-time string literal.
+/// unredacted `String` cannot reach them by accident. Construction goes through `Redactor`,
+/// a compile-time literal, or the sanitizing decoding boundaries below.
 struct RedactedLine: Hashable, Sendable, CustomStringConvertible {
     let text: String
 
@@ -321,12 +330,39 @@ extension RedactedLine: Codable {
     /// Decoded text is redacted again: a serialized or XPC-provided value is not trusted to
     /// have passed through `Redactor` on the other side. The line that gave a device code its
     /// context did not survive serialization, so codes are redacted unconditionally here.
+    /// Independent records do not share stream state. Decode a physical-line transcript as
+    /// `RedactedLines`; direct array-element decoding is rejected rather than losing framing.
     init(from decoder: any Decoder) throws {
+        guard !decoder.codingPath.contains(where: { $0.intValue != nil }) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath,
+                debugDescription: "Decode physical-line batches as RedactedLines to preserve shared redaction state."))
+        }
         text = Redactor().redact(untrusted: try decoder.singleValueContainer().decode(String.self))
     }
 
     func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(text)
+    }
+}
+
+/// An encoded batch of physical lines from one stream, sanitized before typed lines escape.
+/// Decode transcripts through this type, not by independently decoding each RedactedLine.
+struct RedactedLines: Hashable, Sendable, Codable {
+    let lines: [RedactedLine]
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode([String].self)
+        guard !raw.contains(where: { $0.contains(Redactor.patterns.lineSeparator) }) else {
+            throw DecodingError.dataCorruptedError(in: container,
+                debugDescription: "A physical-line batch cannot contain embedded line terminators.")
+        }
+        lines = Redactor().redact(untrustedLines: raw)
+    }
+
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(lines)
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+API.swift
@@ -31,7 +31,8 @@ extension Redactor {
         // they removed leaks whichever the other would have found. The boundary rendering goes
         // first; what it leaves is closed up again for everything below, which is the rendering
         // a label has to be read in.
-        let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString)
+        let stripped = Self.stripTerminalEscapes(line, openControlString: &state.openControlString,
+                                               codesAlwaysRedacted: codesAlwaysRedacted || state.expectingDeviceCode)
         var recoveredContexts = StreamState()
         for reading in stripped.contexts {
             var scanned = StreamState()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -36,6 +36,9 @@ extension Redactor {
             return (sanitized, quotedState)
         } : ProtectedQuotedValues(text: input)
         var text = protected.text
+        // Retain original DSN coverage independently of replacements that can erase its
+        // transport suffix. Field parsing below still owns original continuation state.
+        let dsnText = redactingMySQLUserInfo(protected.text)
         // Recognition and continuation state use the original field, never its replacement
         // marker. Prefixes, quoting, and delimiters therefore cannot change the state policy.
         text = text.replacing(p.authorizationHeader) { match in
@@ -145,11 +148,10 @@ extension Redactor {
         if text.contains(p.codePromptOnly) {
             state.expectingDeviceCode = true
         }
-        // Establish field/prompt/quote continuation from original text before a DSN can
-        // conceal those openers. Existing userinfo markers are excluded by the DSN grammar.
-        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
-            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
-            text = String(prefix) + text[end...]
+        if dsnText != protected.text {
+            // Overlapping interpretations have incompatible replaced offsets. Conceal the
+            // containing line instead of allowing either replacement to hide the other's evidence.
+            text = text == protected.text ? dsnText : marker("userinfo")
         }
         text = protected.restoring(in: text, state: &state)
         if text.contains(p.mentionsCode) || codeExpected {
@@ -167,5 +169,12 @@ extension Redactor {
             }
             return "\(match.1)\(marker("device-code"))"
         }
+    }
+
+    private static func redactingMySQLUserInfo(_ input: String) -> String {
+        guard let end = input.matches(of: patterns.mysqlTransport).last?.range.upperBound else { return input }
+        let assigned = input[..<end].replacing(patterns.mysqlAssignedUserInfo) { "\($0.1)\(marker("userinfo"))\($0.2)" }
+        let remaining = assigned.replacing(patterns.mysqlUserInfo) { "\($0.1)\(marker("userinfo"))\($0.2)" }
+        return String(remaining) + input[end...]
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -33,14 +33,6 @@ extension Redactor {
             return (sanitized, quotedState)
         } : ProtectedQuotedValues(text: input)
         var text = protected.text
-        // Scan DSNs before introducing colon-bearing redaction markers. Scheme URLs use
-        // their dedicated authority rule below, not the schemeless DSN grammar.
-        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
-            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in
-                return "\(match.1)\(marker("userinfo"))\(match.2)"
-            }
-            text = String(prefix) + text[end...]
-        }
         // Recognition and continuation state use the original field, never its replacement
         // marker. Prefixes, quoting, and delimiters therefore cannot change the state policy.
         text = text.replacing(p.authorizationHeader) { match in
@@ -136,6 +128,12 @@ extension Redactor {
         // that follows `process exited with code 1` with a device-code marker.
         if text.contains(p.codePromptOnly) {
             state.expectingDeviceCode = true
+        }
+        // Establish field/prompt/quote continuation from original text before a DSN can
+        // conceal those openers. Existing userinfo markers are excluded by the DSN grammar.
+        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
+            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
+            text = String(prefix) + text[end...]
         }
         text = protected.restoring(in: text, state: &state)
         if text.contains(p.mentionsCode) || codeExpected {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -36,7 +36,9 @@ extension Redactor {
         // Scan DSNs before introducing colon-bearing redaction markers. Scheme URLs use
         // their dedicated authority rule below, not the schemeless DSN grammar.
         if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
-            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
+            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in
+                return "\(match.1)\(marker("userinfo"))\(match.2)"
+            }
             text = String(prefix) + text[end...]
         }
         // Recognition and continuation state use the original field, never its replacement

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -33,6 +33,12 @@ extension Redactor {
             return (sanitized, quotedState)
         } : ProtectedQuotedValues(text: input)
         var text = protected.text
+        // Scan DSNs before introducing colon-bearing redaction markers. Scheme URLs use
+        // their dedicated authority rule below, not the schemeless DSN grammar.
+        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
+            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
+            text = String(prefix) + text[end...]
+        }
         // Recognition and continuation state use the original field, never its replacement
         // marker. Prefixes, quoting, and delimiters therefore cannot change the state policy.
         text = text.replacing(p.authorizationHeader) { match in
@@ -68,11 +74,6 @@ extension Redactor {
         text = text.replacing(p.apiKey) { match in "\(match.1)\(marker("api-key"))" }
         text = text.replacing(p.jwt) { match in "\(match.1)\(redactedJWT(match.2))" }
         text = text.replacing(p.urlUserInfo) { match in "\(match.1)\(marker("userinfo"))@" }
-        // Do not repeatedly search credential-field suffixes that cannot contain a DSN.
-        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
-            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
-            text = String(prefix) + text[end...]
-        }
         // Scan argv boundaries before generic labelled values can consume following options.
         text = redactSerializedOptions(text, state: &state)
         text = redactSecretOptions(text, state: &state)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Inline.swift
@@ -42,7 +42,8 @@ extension Redactor {
                 state.authorizationValueIsOnTheNextLine || valueStartsOnNextLine(match.2) || explicit
             state.authorizationValueExplicitlyContinues = state.authorizationValueExplicitlyContinues || explicit
             let header = match.0[..<match.2.startIndex].lowercased()
-            let name = header.contains("set-cookie") ? "Set-Cookie" : header.contains("cookie") ? "Cookie" : "Authorization"
+            let compactHeader = header.filter { $0 != "-" && $0 != "_" && !$0.isWhitespace }
+            let name = compactHeader.contains("setcookie") ? "Set-Cookie" : header.contains("cookie") ? "Cookie" : "Authorization"
             return "\(match.1)\(name): \(marker("authorization"))"
         }
         // Each token rule captures the character in front of the token, which is put back.
@@ -66,6 +67,11 @@ extension Redactor {
         text = text.replacing(p.apiKey) { match in "\(match.1)\(marker("api-key"))" }
         text = text.replacing(p.jwt) { match in "\(match.1)\(redactedJWT(match.2))" }
         text = text.replacing(p.urlUserInfo) { match in "\(match.1)\(marker("userinfo"))@" }
+        // Do not repeatedly search credential-field suffixes that cannot contain a DSN.
+        if let end = text.matches(of: p.mysqlTransport).last?.range.upperBound {
+            let prefix = text[..<end].replacing(p.mysqlUserInfo) { match in "\(match.1)\(marker("userinfo"))\(match.2)" }
+            text = String(prefix) + text[end...]
+        }
         // Scan argv boundaries before generic labelled values can consume following options.
         text = redactSerializedOptions(text, state: &state)
         text = redactSecretOptions(text, state: &state)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -119,8 +119,8 @@ extension Redactor {
         /// spaces, slashes and at-signs. Bound the credential with its transport/database suffix,
         /// not a first-word or URL-authority rule. The documented default transport may be empty.
         /// https://github.com/go-sql-driver/mysql#dsn-data-source-name
-        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])[A-Za-z0-9_.-]*:[^\r\n]*(@(?:(?:tcp[46]?|unix)(?:\([^()\r\n]*\))?)?\/)/#
-        let mysqlTransport = #/@(?:(?:tcp[46]?|unix)(?:\([^()\r\n]*\))?)?\//#
+        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
+        let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -121,7 +121,8 @@ extension Redactor {
         /// https://github.com/go-sql-driver/mysql#dsn-data-source-name
         /// Common URL schemes retain their URI interpretation when the spellings overlap.
         /// Do not exempt arbitrary passwords starting `//`: those are valid unescaped DSNs.
-        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])(?!(?i:https?|ssh|git|s?ftp|ftps|file):\/\/)[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
+        /// Skip an already-concealed userinfo marker without consuming a later DSN.
+        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])(?!redacted:userinfo\]@)(?!(?i:https?|ssh|git|s?ftp|ftps|file):(?:\\?\/){2})[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
         let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -43,7 +43,7 @@ extension Redactor {
         /// The same match determines continuation state before replacement. An empty value
         /// arms the next line even when a logger prefixes or quotes the field name. Cookie
         /// headers share this state: opaque session identifiers convey authority (RFC 6265 §8.4).
-        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:set-)?cookie)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:(?:set|request)[ _-]?)?cookie)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
         /// Bearer credentials outside a header line, of any length. Every token and label rule
         /// here starts at a character that cannot be part of the word rather than at `\b`:
         /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
@@ -115,6 +115,12 @@ extension Redactor {
         /// turn an ordinary `@` later in that value into userinfo.
         /// Assignment names may include a command option's leading one or two dashes.
         let urlUserInfo = #/((?::|^|[\s\u{001F}"'(<\[{]|(?:^|[\s\u{001F}"'(<\[{])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\?\/){2})[^\s\/?#]+@/#
+        /// Go MySQL-style DSNs omit the URL scheme; passwords are not escaped and may include
+        /// spaces, slashes and at-signs. Bound the credential with its transport/database suffix,
+        /// not a first-word or URL-authority rule. The documented default transport may be empty.
+        /// https://github.com/go-sql-driver/mysql#dsn-data-source-name
+        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])[A-Za-z0-9_.-]*:[^\r\n]*(@(?:(?:tcp[46]?|unix)(?:\([^()\r\n]*\))?)?\/)/#
+        let mysqlTransport = #/@(?:(?:tcp[46]?|unix)(?:\([^()\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -119,7 +119,9 @@ extension Redactor {
         /// spaces, slashes and at-signs. Bound the credential with its transport/database suffix,
         /// not a first-word or URL-authority rule. The documented default transport may be empty.
         /// https://github.com/go-sql-driver/mysql#dsn-data-source-name
-        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
+        /// Common URL schemes retain their URI interpretation when the spellings overlap.
+        /// Do not exempt arbitrary passwords starting `//`: those are valid unescaped DSNs.
+        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])(?!(?i:https?|ssh|git|s?ftp|ftps|file):\/\/)[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
         let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -122,7 +122,7 @@ extension Redactor {
         /// Common URL schemes retain their URI interpretation when the spellings overlap.
         /// Do not exempt arbitrary passwords starting `//`: those are valid unescaped DSNs.
         /// Skip an already-concealed userinfo marker without consuming a later DSN.
-        let mysqlUserInfo = #/(^|[\s\u{001F}"'=<\[{(])(?!redacted:userinfo\]@)(?!(?i:https?|ssh|git|s?ftp|ftps|file):(?:\\?\/){2})[A-Za-z0-9_.-]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
+        let mysqlUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?)(?!\[?redacted:userinfo\]@)(?!(?:(?i:https?|wss?|ssh|git|s?ftp|ftps|file):)?(?:\\?\/){2})[^\s:=]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
         let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -43,7 +43,7 @@ extension Redactor {
         /// The same match determines continuation state before replacement. An empty value
         /// arms the next line even when a logger prefixes or quotes the field name. Cookie
         /// headers share this state: opaque session identifiers convey authority (RFC 6265 §8.4).
-        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:(?:set|request)[ _-]?)?cookie)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:(?:set|request)[ _-]?)?cookies?)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
         /// Bearer credentials outside a header line, of any length. Every token and label rule
         /// here starts at a character that cannot be part of the word rather than at `\b`:
         /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
@@ -122,8 +122,8 @@ extension Redactor {
         /// Common URL schemes retain their URI interpretation when the spellings overlap.
         /// Do not exempt arbitrary passwords starting `//`: those are valid unescaped DSNs.
         /// Skip an already-concealed userinfo marker without consuming a later DSN.
-        let mysqlUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?)(?!\[?redacted:userinfo\]@)(?!(?:(?i:https?|wss?|ssh|git|s?ftp|ftps|file):)?(?:\\?\/){2})[^\s:=]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\/)/#
-        let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^()\r\n]*\))?)?\//#
+        let mysqlUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?)(?!\[?redacted:userinfo\]@)(?!(?:(?i:https?|wss?|smb|ssh|git|s?ftp|ftps|file):)?(?:\\?\/){2})[^\s:=]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^\r\n]*\))?)?\/)/#
+        let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^\r\n]*\))?)?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -43,7 +43,7 @@ extension Redactor {
         /// The same match determines continuation state before replacement. An empty value
         /// arms the next line even when a logger prefixes or quotes the field name. Cookie
         /// headers share this state: opaque session identifiers convey authority (RFC 6265 §8.4).
-        let authorizationHeader = #/(^|[^A-Za-z0-9])(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:(?:set|request)[ _-]?)?cookies?)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
+        let authorizationHeader = #/(^|[^A-Za-z0-9_-]|[_-](?=(?:\\?["'])?(?:(?:proxy|request)[ _-]?)?authorization))(?:\\?["'])?(?:(?:(?:proxy|request)[ _-]?)?authorization|(?:(?:set|request)[ _-]?)?cookies?)(?:\\?["'])?\s*[:=]\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^\r\n]*)/#.ignoresCase()
         /// Bearer credentials outside a header line, of any length. Every token and label rule
         /// here starts at a character that cannot be part of the word rather than at `\b`:
         /// Swift's word boundary is the Unicode one, where the dot in `<token>.partial`, in
@@ -122,8 +122,9 @@ extension Redactor {
         /// Common URL schemes retain their URI interpretation when the spellings overlap.
         /// Do not exempt arbitrary passwords starting `//`: those are valid unescaped DSNs.
         /// Skip an already-concealed userinfo marker without consuming a later DSN.
-        let mysqlUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?)(?!\[?redacted:userinfo\]@)(?!(?:(?i:https?|wss?|smb|ssh|git|s?ftp|ftps|file):)?(?:\\?\/){2})[^\s:=]*:[^\r\n]*(@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^\r\n]*\))?)?\/)/#
-        let mysqlTransport = #/@(?:[A-Za-z][A-Za-z0-9_.+-]*(?:\([^\r\n]*\))?)?\//#
+        let mysqlAssignedUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:--?)?(?i:(?:mysql[_-]?)?dsn)[ \t]*=[ \t]*)(?!\[?redacted:userinfo\]@)[^:=\r\n]*:[^\r\n]*(@[^@\/()\r\n]*(?:\([^\r\n]*\))?\/)/#
+        let mysqlUserInfo = #/((?:^|[\s\u{001F}"'=<\[{(])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?)(?!\[?redacted:userinfo\]@)(?!(?:(?i:https?|wss?|smb|ssh|git|s?ftp|ftps|file):)?(?:\\?\/){2})[^\s:=]*:[^\r\n]*(@[^@\/()\r\n]*(?:\([^\r\n]*\))?\/)/#
+        let mysqlTransport = #/@[^@\/()\r\n]*(?:\([^\r\n]*\))?\//#
         /// `password: hunter2`, `passphrase=...`, `token=...`, `secret: "..."`, `"api_key":"..."`,
         /// and the camel-case keys structured diagnostics use: `accessToken`, `refreshToken`,
         /// `clientSecret`. Known qualifiers allow lowercase spelling; other camel-case names

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -52,6 +52,9 @@ extension Redactor {
         spans += text.matches(of: patterns.codePromptOnly).map(\.range)
         spans += text.matches(of: patterns.pemBegin).map(\.range)
         spans += text.matches(of: patterns.ppkBegin).map(\.range)
+        if let end = text.matches(of: patterns.mysqlTransport).last?.range.upperBound {
+            spans += text[..<end].matches(of: patterns.mysqlUserInfo).map(\.range)
+        }
         return spans.sorted { $0.lowerBound < $1.lowerBound }
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -123,7 +123,7 @@ extension Redactor {
         spans += text.matches(of: patterns.digestCredentialSpan).map { ($0.range, "authorization", true) }
         spans += text.matches(of: patterns.specializedCredentialSpan).map { ($0.range, "authorization", true) }
         spans += text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2).map { ($0, "jwt", false) } }
-        if codesAlwaysRedacted {
+        if codesAlwaysRedacted || text.contains(patterns.mentionsCode) {
             spans += text.matches(of: patterns.deviceCode).map { ($0.2.startIndex..<$0.2.endIndex, "device-code", false) }
         }
         return spans

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -15,7 +15,8 @@ extension Redactor {
     /// payload here also keeps the terminator from joining the words on either side of it.
     static func stripTerminalEscapes(
         _ line: String,
-        openControlString: inout StreamState.ControlString?
+        openControlString: inout StreamState.ControlString?,
+        codesAlwaysRedacted: Bool = false
     ) -> (joined: String, spliced: String, contexts: [String]) {
         var text = line
         if let open = openControlString {
@@ -25,7 +26,7 @@ extension Redactor {
         }
         openControlString = text.firstMatch(of: patterns.unterminatedControlString)
             .map { $0.1 == nil ? .other : .osc }
-        return renderings(of: text)
+        return renderings(of: text, codesAlwaysRedacted: codesAlwaysRedacted)
     }
 
     /// Stands where an escape did, in the `spliced` reading only. It has to be a boundary to
@@ -60,7 +61,7 @@ extension Redactor {
 
     /// Boundary-free spans protect token interiors; recognition still requires each rule's
     /// usual leading boundary unless an actual removed control supplied one at that position.
-    private static func terminalCredentialSpans(in text: String) -> [(range: Range<String.Index>, kind: String, needsBoundary: Bool)] {
+    private static func terminalCredentialSpans(in text: String, codesAlwaysRedacted: Bool = false) -> [(range: Range<String.Index>, kind: String, needsBoundary: Bool)] {
         var spans = text.matches(of: patterns.githubToken).map { ($0.range, "github-token", false) }
         spans += text.matches(of: #/sk-[A-Za-z0-9_-]{16,}/#).map { ($0.range, "api-key", true) }
         spans += text.matches(of: patterns.distinctiveAPIKey).map { ($0.range, "api-key", false) }
@@ -71,6 +72,9 @@ extension Redactor {
         spans += text.matches(of: patterns.digestCredentialSpan).map { ($0.range, "authorization", true) }
         spans += text.matches(of: patterns.specializedCredentialSpan).map { ($0.range, "authorization", true) }
         spans += text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2).map { ($0, "jwt", false) } }
+        if codesAlwaysRedacted {
+            spans += text.matches(of: patterns.deviceCode).map { ($0.2.startIndex..<$0.2.endIndex, "device-code", false) }
+        }
         return spans
     }
 
@@ -80,10 +84,10 @@ extension Redactor {
     /// immediately before a credential character that happens to be a valid CSI command.
     /// Control-string payloads remain suppressed in both. Only recognized credential spans are mapped
     /// back; none of the retained command bytes themselves can reappear in the rendered output.
-    private static func terminalRecovery(in text: String, joined: String) -> (ranges: [RecoveredCredential], contexts: [String]) {
+    private static func terminalRecovery(in text: String, joined: String, codesAlwaysRedacted: Bool) -> (ranges: [RecoveredCredential], contexts: [String]) {
         var recovered: [RecoveredCredential] = []
         var contexts: [String] = []
-        let ordinary = terminalCredentialSpans(in: joined).map { span -> RecoveredCredential in
+        let ordinary = terminalCredentialSpans(in: joined, codesAlwaysRedacted: codesAlwaysRedacted).map { span -> RecoveredCredential in
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: span.range.upperBound)
             return (lower..<upper, span.kind)
@@ -138,7 +142,7 @@ extension Redactor {
             var retainedIndex = 0
             var ordinaryIndex = 0
             var coveredEnds: [String: Int] = [:]
-            for span in terminalCredentialSpans(in: alternate).sorted(by: { $0.range.lowerBound < $1.range.lowerBound }) {
+            for span in terminalCredentialSpans(in: alternate, codesAlwaysRedacted: codesAlwaysRedacted).sorted(by: { $0.range.lowerBound < $1.range.lowerBound }) {
                 let lower = alternate.utf8.distance(from: alternate.utf8.startIndex, to: span.range.lowerBound)
                 let upper = alternate.utf8.distance(from: alternate.utf8.startIndex, to: span.range.upperBound)
                 guard !span.needsBoundary || boundaries.contains(lower) || recognizedStarts.contains(span.range.lowerBound) else { continue }
@@ -187,7 +191,7 @@ extension Redactor {
     /// a label that styling interrupted spelled correctly. `spliced` is `joined` when no escape
     /// stood in such a place, which is every ordinary line. The spliced reading also masks credential
     /// spans recovered before a CSI final byte could destroy their recognizable header.
-    static func renderings(of text: String) -> (joined: String, spliced: String, contexts: [String]) {
+    static func renderings(of text: String, codesAlwaysRedacted: Bool = false) -> (joined: String, spliced: String, contexts: [String]) {
         func isTokenCharacter(_ character: Character) -> Bool {
             character.isASCII && (character.isLetter || character.isNumber || character == "_" || character == "-")
         }
@@ -212,7 +216,7 @@ extension Redactor {
             return joined[..<boundary].last.map(isTokenCharacter) == true
                 && joined[boundary...].first.map({ !$0.isWhitespace }) == true
         }
-        let recovery = terminalRecovery(in: text, joined: joined)
+        let recovery = terminalRecovery(in: text, joined: joined, codesAlwaysRedacted: codesAlwaysRedacted)
         var recovered = recovery.ranges
         guard !boundaryOffsets.isEmpty || !recovered.isEmpty else { return (joined, joined, recovery.contexts) }
 
@@ -220,7 +224,7 @@ extension Redactor {
         // prefix. Closing the boundary afterwards cannot recover the remaining suffix. Keep
         // recognized tokens whole in both readings, while retaining boundaries before tokens
         // that need them, such as `filename<control>sk-...`.
-        let tokenRanges = terminalCredentialSpans(in: joined).map(\.range)
+        let tokenRanges = terminalCredentialSpans(in: joined, codesAlwaysRedacted: codesAlwaysRedacted).map(\.range)
         func byteRange(_ range: Range<String.Index>) -> Range<Int> {
             let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: range.lowerBound)
             let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: range.upperBound)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
@@ -26,10 +26,11 @@ import Testing
     }
 
     @Test func batchDecodingStillConcealsContextFreeDeviceCodes() throws {
-        let input = ["prefix\u{1B}[31mAB12-CD34", "Finished"]
+        let input = ["prefix\u{1B}[31mAB12-CD34", "HMAC-SHA256", "Finished"]
         let decoded = try JSONDecoder().decode(RedactedLines.self, from: JSONEncoder().encode(input))
         #expect(!decoded.lines[0].text.contains("AB12-CD34"))
-        #expect(decoded.lines[1].text == "Finished")
+        #expect(decoded.lines[1].text == "[redacted:device-code]")
+        #expect(decoded.lines[2].text == "Finished")
     }
 
     @Test(arguments: ["\n", "\r", "\r\n"])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
@@ -33,6 +33,16 @@ import Testing
         #expect(decoded.lines[2].text == "Finished")
     }
 
+    @Test(arguments: ["AB12-\u{1B}[DC34", "AB12-\u{1B}[CD34", "AB12-\u{1B}[0CD34", "AB12-\u{9B}CD34"])
+    func decodedCodesRetainTerminalConsumedCredentialCharacters(input: String) throws {
+        let decoded = try JSONDecoder().decode(RedactedLines.self, from: JSONEncoder().encode([input, "Finished"]))
+        #expect(!decoded.lines[0].text.contains("AB12"))
+        #expect(!decoded.lines[0].text.contains("34"))
+        #expect(decoded.lines[1].text == "Finished")
+        #expect(!Redactor().redact(untrusted: input).contains("AB12"))
+        #expect(!Redactor().redact(fieldValue: input).contains("AB12"))
+    }
+
     @Test(arguments: ["\n", "\r", "\r\n"])
     func batchesRejectAmbiguousEmbeddedPhysicalFraming(separator: String) throws {
         let encoded = try JSONEncoder().encode(["before" + separator + "after"])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactedLinesDecodingTests.swift
@@ -1,0 +1,44 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactedLinesDecodingTests {
+    @Test(arguments: [
+        ["-----BEGIN PRIVATE KEY-----", "syntheticKeyBody", "-----END PRIVATE KEY-----", "Finished"],
+        ["PuTTY-User-Key-File-3: ssh-rsa", "Private-Lines: 1", "c3ludGhldGlj", "Private-MAC: " + String(repeating: "a", count: 64), "Finished"],
+        ["password: \"syntheticFirst", "syntheticSecond\"", "Finished"],
+    ])
+    func batchesPreservePrivateKeyAndQuotedValueState(input: [String]) throws {
+        let encoded = try JSONEncoder().encode(input)
+        let decoded = try JSONDecoder().decode(RedactedLines.self, from: encoded)
+        #expect(decoded.lines.count == input.count)
+        #expect(decoded.lines.last?.text == "Finished")
+        #expect(!decoded.lines.map(\.text).joined().contains("synthetic"))
+        #expect(!decoded.lines.map(\.text).joined().contains("c3ludGhldGlj"))
+        #expect(try JSONDecoder().decode(RedactedLines.self, from: JSONEncoder().encode(decoded)) == decoded)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode([RedactedLine].self, from: encoded) }
+    }
+
+    @Test func nestedRecordsCannotBypassTheBatchBoundary() throws {
+        struct Record: Decodable { let line: RedactedLine }
+        let input = #"[{"line":"-----BEGIN PRIVATE KEY-----"},{"line":"syntheticKeyBody"}]"#
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode([Record].self, from: Data(input.utf8)) }
+    }
+
+    @Test func batchDecodingStillConcealsContextFreeDeviceCodes() throws {
+        let input = ["prefix\u{1B}[31mAB12-CD34", "Finished"]
+        let decoded = try JSONDecoder().decode(RedactedLines.self, from: JSONEncoder().encode(input))
+        #expect(!decoded.lines[0].text.contains("AB12-CD34"))
+        #expect(decoded.lines[1].text == "Finished")
+    }
+
+    @Test(arguments: ["\n", "\r", "\r\n"])
+    func batchesRejectAmbiguousEmbeddedPhysicalFraming(separator: String) throws {
+        let encoded = try JSONEncoder().encode(["before" + separator + "after"])
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(RedactedLines.self, from: encoded) }
+    }
+
+    @Test func emptyBatchesRemainEmpty() throws {
+        #expect(try JSONDecoder().decode(RedactedLines.self, from: Data("[]".utf8)).lines.isEmpty)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -16,7 +16,8 @@ import Testing
         #expect(Redactor().redact(input) == input)
     }
 
-    @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "tcp", ""],
+    @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "tcp", "",
+                      "cloudsql(project:region:instance)", "custom+net(address)", "registered_transport"],
           ["syntheticPassword", "synthetic@part/with: spaces", "synthetic\"quoted'value"])
     func conventionalSchemelessDSNsConcealAllUserinfo(protocolAndAddress: String, password: String) {
         let input = "dsn=alice:" + password + "@" + protocolAndAddress + "/app"

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -2,6 +2,27 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorDiagnosticFieldRepairTests {
+    @Test(arguments: ["token: rest", "password: rest", "Authorization: rest"])
+    func fieldReplacementCannotEraseOriginalDSNEvidence(field: String) {
+        let input = "alice:synthetic " + field + "@tcp(db:3306)/app"
+        #expect(!Redactor().redact(input).contains("synthetic"))
+    }
+
+    @Test(arguments: ["https", "smb", "ssh"], ["tcp(db:3306)", "9net(address)", "_net(address)", "用户(address)"])
+    func explicitlyAssignedDSNsOverrideURISchemeHeuristics(username: String, transport: String) {
+        #expect(!Redactor().redact("dsn=" + username + "://synthetic/part@" + transport + "/app").contains("synthetic"))
+    }
+
+    @Test(arguments: ["supports_cookies: true", "supports-cookies: true", "accepts_request_cookies: false"])
+    func unrecognizedCookiePropertyPrefixesStayIntact(input: String) {
+        #expect(Redactor().redact(input) == input)
+    }
+
+    @Test func aBareDSNWithSpacesIsIndistinguishableFromContactProse() {
+        // The same bytes can be a registered-transport DSN; privacy takes precedence.
+        #expect(Redactor().redact("contact: alice@example.com/profile") == "[redacted:userinfo]@example.com/profile")
+    }
+
     @Test(arguments: ["Cookie", "setCookie", "requestCookie", "set_cookie", "request-cookie", "cookies", "setCookies", "requestCookies"], ["", "\""])
     func serializedCookieAliasesConcealOpaqueSessionValues(name: String, quote: String) {
         let input = quote + name + quote + ": SID=syntheticSession"

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -18,7 +18,7 @@ import Testing
 
     @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "tcp", "",
                       "cloudsql(project:region:instance)", "custom+net(address)", "registered_transport"],
-          ["syntheticPassword", "synthetic@part/with: spaces", "synthetic\"quoted'value"])
+          ["syntheticPassword", "synthetic@part/with: spaces", "synthetic\"quoted'value", "//synthetic/part"])
     func conventionalSchemelessDSNsConcealAllUserinfo(protocolAndAddress: String, password: String) {
         let input = "dsn=alice:" + password + "@" + protocolAndAddress + "/app"
         let output = Redactor().redact(input)
@@ -26,7 +26,8 @@ import Testing
         #expect(output == "dsn=[redacted:userinfo]@" + protocolAndAddress + "/app")
     }
 
-    @Test(arguments: ["contact: alice@example.com", "tcp(db:3306)/app", "unix(/tmp/mysql.sock)/app", "https://example.com?email=alice@example.org"])
+    @Test(arguments: ["contact: alice@example.com", "tcp(db:3306)/app", "unix(/tmp/mysql.sock)/app",
+                      "https://example.com?email=alice@example.org", "HTTPS://example.com/a@b/c", "ssh://example.com/a@b/c"])
     func addressesAndEmailWithoutAPasswordDoNotBecomeDSNs(input: String) {
         #expect(Redactor().redact(input) == input)
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -35,4 +35,22 @@ import Testing
     @Test func aTerminalConsumedProtocolCharacterDoesNotHideADSNCredential() {
         #expect(!Redactor().redact("alice:syntheticPassword@\u{1B}[tcp(db:3306)/app").contains("syntheticPassword"))
     }
+
+    @Test(arguments: ["https://alice:syntheticPassword@example.com/app", "//alice:syntheticPassword@example.com/app",
+                      "alice:syntheticPassword@cloudsql(instance)/app", "https:\\/\\/alice:syntheticPassword@example.com/app"])
+    func sanitizedUserinfoSurvivesASecondRedactionPass(input: String) {
+        let first = Redactor().redact(input)
+        #expect(!first.contains("syntheticPassword"))
+        #expect(Redactor().redact(first) == first)
+    }
+
+    @Test func anEncodedURLRetainsItsSchemeAndEscapedDelimiters() {
+        let input = #"https:\/\/alice:syntheticPassword@example.com/app"#
+        #expect(Redactor().redact(input) == #"https:\/\/[redacted:userinfo]@example.com/app"#)
+    }
+
+    @Test func aPreviousMarkerCannotHideALaterDSN() {
+        let input = "[redacted:userinfo]@tcp(host)/app alice:syntheticPassword@cloudsql(instance)/app"
+        #expect(!Redactor().redact(input).contains("syntheticPassword"))
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorDiagnosticFieldRepairTests {
+    @Test(arguments: ["Cookie", "setCookie", "requestCookie", "set_cookie", "request-cookie"], ["", "\""])
+    func serializedCookieAliasesConcealOpaqueSessionValues(name: String, quote: String) {
+        let input = quote + name + quote + ": SID=syntheticSession"
+        #expect(!Redactor().redact(input).contains("syntheticSession"))
+        let output = Redactor().redact(lines: [quote + name + quote + ":", "syntheticSession", "Finished"]).map(\.text)
+        #expect(!output.joined().contains("syntheticSession"))
+        #expect(output[2] == "Finished")
+    }
+
+    @Test(arguments: ["CookieCount: 42", "setCookieCount=42", "requestCookiePolicy: required"])
+    func longerOrdinaryCookiePropertyNamesRemainVisible(input: String) {
+        #expect(Redactor().redact(input) == input)
+    }
+
+    @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "tcp", ""],
+          ["syntheticPassword", "synthetic@part/with: spaces", "synthetic\"quoted'value"])
+    func conventionalSchemelessDSNsConcealAllUserinfo(protocolAndAddress: String, password: String) {
+        let input = "dsn=alice:" + password + "@" + protocolAndAddress + "/app"
+        let output = Redactor().redact(input)
+        #expect(!output.contains("synthetic"))
+        #expect(output == "dsn=[redacted:userinfo]@" + protocolAndAddress + "/app")
+    }
+
+    @Test(arguments: ["contact: alice@example.com", "tcp(db:3306)/app", "unix(/tmp/mysql.sock)/app", "https://example.com?email=alice@example.org"])
+    func addressesAndEmailWithoutAPasswordDoNotBecomeDSNs(input: String) {
+        #expect(Redactor().redact(input) == input)
+    }
+
+    @Test func aTerminalConsumedProtocolCharacterDoesNotHideADSNCredential() {
+        #expect(!Redactor().redact("alice:syntheticPassword@\u{1B}[tcp(db:3306)/app").contains("syntheticPassword"))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -2,7 +2,7 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorDiagnosticFieldRepairTests {
-    @Test(arguments: ["Cookie", "setCookie", "requestCookie", "set_cookie", "request-cookie"], ["", "\""])
+    @Test(arguments: ["Cookie", "setCookie", "requestCookie", "set_cookie", "request-cookie", "cookies", "setCookies", "requestCookies"], ["", "\""])
     func serializedCookieAliasesConcealOpaqueSessionValues(name: String, quote: String) {
         let input = quote + name + quote + ": SID=syntheticSession"
         #expect(!Redactor().redact(input).contains("syntheticSession"))
@@ -11,12 +11,12 @@ import Testing
         #expect(output[2] == "Finished")
     }
 
-    @Test(arguments: ["CookieCount: 42", "setCookieCount=42", "requestCookiePolicy: required"])
+    @Test(arguments: ["CookieCount: 42", "setCookieCount=42", "requestCookiePolicy: required", "CookiesCount: 42", "setCookiesPolicy: required"])
     func longerOrdinaryCookiePropertyNamesRemainVisible(input: String) {
         #expect(Redactor().redact(input) == input)
     }
 
-    @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "tcp", "",
+    @Test(arguments: ["tcp(db:3306)", "tcp6([::1]:3306)", "unix(/tmp/mysql.sock)", "unix(/tmp/mysql(test).sock)", "unix(/tmp/(nested(test)).sock)", "tcp", "",
                       "cloudsql(project:region:instance)", "custom+net(address)", "registered_transport"],
           ["syntheticPassword", "synthetic@part/with: spaces", "synthetic\"quoted'value", "//synthetic/part"])
     func conventionalSchemelessDSNsConcealAllUserinfo(protocolAndAddress: String, password: String) {
@@ -59,7 +59,7 @@ import Testing
         #expect(!Redactor().redact("dsn=" + username + ":syntheticPassword@tcp(db:3306)/app").contains("syntheticPassword"))
     }
 
-    @Test(arguments: ["ws", "wss", "WS", "WSS"])
+    @Test(arguments: ["ws", "wss", "WS", "WSS", "smb", "SMB"])
     func webSocketPathsAreNotDatabaseCredentials(scheme: String) {
         let input = scheme + "://example.com/users/alice@room/events"
         #expect(Redactor().redact(input) == input)
@@ -76,5 +76,13 @@ import Testing
     @Test(arguments: ["apiToken", "oauthToken", "githubToken"])
     func qualifiedCamelCaseTokenFieldsUseTheSharedBoundaryRule(label: String) {
         #expect(!Redactor().redact(label + ": syntheticCredential").contains("syntheticCredential"))
+    }
+
+    @Test(arguments: ["\u{1B}[", "\u{9B}", "\u{1B}[31"])
+    func sameLineCodeContextParticipatesInTerminalRecovery(control: String) {
+        let output = Redactor().redact(lines: ["received device_code AB12-" + control + "DC34", "Finished"]).map(\.text)
+        #expect(!output[0].contains("AB12"))
+        #expect(!output[0].contains("C34"))
+        #expect(output[1] == "Finished")
     }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -53,4 +53,23 @@ import Testing
         let input = "[redacted:userinfo]@tcp(host)/app alice:syntheticPassword@cloudsql(instance)/app"
         #expect(!Redactor().redact(input).contains("syntheticPassword"))
     }
+
+    @Test(arguments: ["$alice", "alice+admin", "alice@example", "用户", "alice=admin", "first last", "alice'quoted", "[alice]", ""])
+    func usernamePunctuationCannotPreventPasswordConcealment(username: String) {
+        #expect(!Redactor().redact("dsn=" + username + ":syntheticPassword@tcp(db:3306)/app").contains("syntheticPassword"))
+    }
+
+    @Test(arguments: ["ws", "wss", "WS", "WSS"])
+    func webSocketPathsAreNotDatabaseCredentials(scheme: String) {
+        let input = scheme + "://example.com/users/alice@room/events"
+        #expect(Redactor().redact(input) == input)
+    }
+
+    @Test(arguments: ["password", "passphrase", "Authorization", "device_code"])
+    func aDSNInsideAQuotedFieldKeepsPhysicalContinuation(label: String) {
+        let lines = [label + ": \"syntheticFirst alice:p@tcp/db", "syntheticSecond\"", "Finished"]
+        let output = Redactor().redact(lines: lines).map(\.text)
+        #expect(!output.joined().contains("synthetic"))
+        #expect(output[2] == "Finished")
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorDiagnosticFieldRepairTests.swift
@@ -72,4 +72,9 @@ import Testing
         #expect(!output.joined().contains("synthetic"))
         #expect(output[2] == "Finished")
     }
+
+    @Test(arguments: ["apiToken", "oauthToken", "githubToken"])
+    func qualifiedCamelCaseTokenFieldsUseTheSharedBoundaryRule(label: String) {
+        #expect(!Redactor().redact(label + ": syntheticCredential").contains("syntheticCredential"))
+    }
 }


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope and stack

Stacked on #119, before public activation in #59. Addresses the remaining decoded-line-collection, schemeless-DSN and serialized-cookie findings under MVP-PLAN.md §3 (Local storage).

- `RedactedLines` decodes a batch of physical lines through one shared StreamState, with context-free device-code matching enabled. It supports empty batches and sanitized round trips. Embedded CR/LF/CRLF entries are rejected because each array entry must be one physical record.
- Independent `RedactedLine` decoding under an indexed coding path is rejected. This intentionally makes raw `[RedactedLine]` and arrays of records containing such lines fail closed; callers must decode an ordered transcript as `RedactedLines`. Independently delivered events still require source-owned stream redaction; this change does not invent context across unrelated decoder calls. Public batch access is activated and tested without `@testable` in #59.
- Cookie/Set-Cookie aliases include `setCookie`, `requestCookie`, underscore and hyphen spellings while retaining boundaries before ordinary longer property names.
- Conventional and custom-transport MySQL DSNs conceal userinfo, including passwords with spaces, slashes, quotes and at-signs. The credential search is gated and bounded by recognized transport endings so ordinary credential-field suffixes without a DSN are not repeatedly searched. Format reference: [go-sql-driver/mysql DSN documentation](https://github.com/go-sql-driver/mysql#dsn-data-source-name). Terminal-recovered transport characters are covered too.

## Validation

`swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors` passes: 320 tests / 29 suites on this prerequisite; 356 tests / 32 suites on the integrated public API. Thirteen new regression functions cover framing, nested-record rejection, batch round trips, device codes, cookie boundaries, DSN formats and ordinary address/email preservation. Existing performance and escaped-tail regressions remain enabled.

240 changed lines. No existing tests were removed, no dependencies added, no host/provider operations performed. Changing unsafe collection decoding to throw is intentional, not a silent wire-format migration; downstream log-batch consumers must use the explicit transcript boundary.

Follow-on repairs cover registered network tokens, slash-prefixed passwords, common URI scheme disambiguation, escaped URL delimiters, stable already-redacted userinfo and a prior marker followed by another credential. Untrusted and batch device-code matching does not exempt algorithm names. Current head: 6ebea62; fresh review/CI gates are checked on this exact head.

## Repair checkpoint — 2026-09-05 21:14 UTC

Current head `af463742f01e38004380b2bba52338c3b967137a`: **273 own changed lines; 335 Core tests / 29 suites pass with warnings-as-errors**.

Latest integration preserves unambiguous filename prefixes outside incomplete JOSE ranges; marker conflicts still conceal the containing record. All other repair evidence is linked in the review-thread replies.

The complete error graph passes **444 tests / 37 suites**, including unchanged original URI, filename-prefix and combining-mark assertions. The public redactor passes373 tests. Fifteen prerequisite findings received published-fix or evidence-backed policy replies; the public framing, earlier failed-assertion report, two sanitizer boundaries and locale assertion findings were also resolved with evidence.

**Not aggregate merge-ready.** Fresh review still reports three nested-encoding gaps on #119 (Unicode whitespace escapes, mixed raw quote wrappers, parenthesized values), and four public-boundary findings on #59 (validation recovery guidance, decoding scope, split strict credentials, contextual typed output). #59 has more than100 threads; the second page must be inspected. Current-head CI/reviews/reactions remain required after this push; previous green checks and thumbs-up do not clear these findings. No PR was merged.
