### PR TITLE
test: extract merged parser regression coverage from #95

### DIFF
--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParsingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParsingTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+/// Synthetic credentials only; every streaming case owns its state.
+@Suite struct RedactorParsingTests {
+    @Test(arguments: [("Zg", [UInt8(102)]), ("_w", [UInt8(255)]), ("-w", [UInt8(251)])])
+    func base64URLAcceptsUnpaddedAndURLSafeSegments(input: String, bytes: [UInt8]) {
+        #expect(Redactor.decodedBase64URL(input[...]) == Data(bytes))
+    }
+
+    @Test(arguments: ["a", "a*b-"])
+    func malformedBase64URLIsRejected(input: String) {
+        #expect(Redactor.decodedBase64URL(input[...]) == nil)
+    }
+
+    @Test(arguments: [(#"{"alg":"HS256"}"#, 3), (#" {"enc":"A256GCM"} "#, 5)])
+    func joseHeadersDistinguishSignedAndEncryptedTokens(header: String, count: Int) {
+        let encoded = Data(header.utf8).base64EncodedString()
+        #expect(Redactor.joseSegmentCount(encoded[...]) == count)
+        #expect(Redactor.joseSegmentCount("WzFd"[...]) == nil)
+    }
+
+    @Test(arguments: [
+        ("artifacteyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA.c2ln.tmp", "artifact[redacted:jwt].tmp"),
+        ("eyJlbmMiOiJBMjU2R0NNIn0.key.iv.cipher.tag.tmp", "[redacted:jwt].tmp"),
+        ("eyJlbmMiOiJBMjU2R0NNIn0.key.iv", "[redacted:jwt]"),
+        ("release.version.123", "release.version.123"),
+    ])
+    func joseReplacementPreservesSurroundingNames(input: String, expected: String) {
+        #expect(Redactor.redactedJWT(input[...]) == expected)
+    }
+
+    @Test(arguments: [#"first\ second --verbose"#, #"first" two"third --verbose"#, #"\"first second\" --verbose"#])
+    func shellArgumentsIncludeEscapedWhitespaceAndAdjacentQuotes(input: String) {
+        let argument = Redactor.secretArgument(in: input, from: input.startIndex)
+        #expect(input[argument.end...] == " --verbose")
+        #expect(argument.quoted == nil)
+        #expect(!argument.continuesLine)
+    }
+
+    @Test(arguments: ["run --password 'synthetic value' --verbose", "run --token=syntheticValue --verbose"])
+    func commandRedactionPreservesFollowingOptions(input: String) {
+        var state = Redactor.StreamState()
+        let output = Redactor.redactSecretOptions(input, state: &state)
+        #expect(!output.contains("synthetic"))
+        #expect(output.hasSuffix("[redacted:secret] --verbose"))
+        #expect(state.quotedValue == nil)
+    }
+
+    @Test func shellLineContinuationRetainsPendingValue() {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactSecretOptions("run --password synthetic\\", state: &state) == "run --password [redacted:secret]")
+        #expect(state.expectingSecretValue)
+    }
+
+    @Test func encodedQuotesCloseOnlyAtTheirMatchingEscapeDepth() throws {
+        let quote = try #require(Redactor.unterminatedQuote(in: #"\"synthetic"#[...], kind: "secret"))
+        let continuation = #"literal" value\" --verbose"#
+        let end = try #require(Redactor.closingQuoteEnd(in: continuation[...], for: quote))
+        #expect(continuation[end...] == " --verbose")
+        #expect(quote.escapeDepth == 1)
+    }
+
+    @Test func serializedArgumentsPreserveSiblingsAndPendingValues() {
+        var state = Redactor.StreamState()
+        let output = Redactor.redactSerializedOptions(#"["--password", "synthetic value", "--verbose"]"#, state: &state)
+        #expect(output == #"["--password", [redacted:secret], "--verbose"]"#)
+        #expect(!state.expectingSecretValue)
+        _ = Redactor.redactSerializedOptions(#"["--password","#, state: &state)
+        #expect(state.expectingSecretValue)
+    }
+}


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Current validation — 2026-09-05 23:16 UTC

Head`3a997ceb70151894faab366cc960a97ad674f8fd`: **CI SUCCESS, Codex review completed, original PR-message THUMBS_UP, zero unresolved threads**. Local73 Core tests/9suites pass with warnings-as-errors;73 changed lines. This test-only prerequisite is ready on current evidence. #95 remains held for its own new findings; approval of this PR does not approve the rest of the stack.
<!-- /guesthouse-current-validation -->

Part of #11; implements the regression coverage for MVP-PLAN.md §3 (redacted logging).

This test-only prerequisite extracts nine existing parser test methods from #95 onto the merged #94/#101 helper layer. It changes no production code. Coverage includes Base64URL/JOSE parsing, quoted shell arguments, continuation state, and serialized options.

The extraction keeps the security-sensitive terminal PR #95 within the repository's roughly 500-line review limit without deleting or weakening any test. #95 retains the complete original test file and adds its two terminal-specific methods on top. New merge order: this PR → #95 → #96 → the existing stack described in #59.

Validation at `3a997ceb70151894faab366cc960a97ad674f8fd`: 73 Core tests / 9 suites pass with warnings-as-errors; 73 changed lines. Fresh Xcode Cloud and Codex approval remain required. The downstream #95 head separately passes 98 tests / 11 suites. No PR was merged and no hardware evidence is claimed.