### PR TITLE
Isolate scalar terminal grammar and bounded stream state

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
@@ -29,7 +29,9 @@ enum TerminalControlGrammar {
             let csiStart = Regex { ChoiceOf { Regex { esc; "[" }; "\u{9B}" } }
             let csiBody = Regex { ZeroOrMore { ChoiceOf { ignored; #/[ -?]/# } } }
             let escBody = Regex { ZeroOrMore { ChoiceOf { ignored; #/[ -\/]/# } } }
-            let abort = Regex { Lookahead { ChoiceOf { "\u{1B}"; Anchor.endOfSubject } } }
+            // A C1 or non-ASCII scalar cannot finish an ASCII CSI/ESC command. Leave the
+            // interrupting scalar for its own rule, but discard the whole old command.
+            let abort = Regex { Lookahead { ChoiceOf { #/[\r\n\u{1B}\u{80}-\u{10FFFF}]/#; Anchor.endOfSubject } } }
             let st = Regex { esc; "\\" }
             let oscPayload = #/[^\u{07}\u{18}\u{1A}\u{9C}\u{1B}]*/#
             let otherPayload = #/[^\u{18}\u{1A}\u{9C}\u{1B}]*/#
@@ -61,11 +63,20 @@ enum TerminalControlGrammar {
     /// class is retained, never an unbounded parameter or payload buffer. Synthetic control
     /// prefixes are consumed by the same grammar and cannot become visible text.
     static func prepare(_ line: String, pending: inout Pending?) -> String {
-        var text = line
+        // A physical record may still carry its framing. Preserve it separately so it
+        // cannot make an unfinished control body look like an ordinary field value.
+        var recordEnd = line.endIndex
+        while recordEnd > line.startIndex {
+            let previous = line.unicodeScalars.index(before: recordEnd)
+            guard line.unicodeScalars[previous] == "\r" || line.unicodeScalars[previous] == "\n" else { break }
+            recordEnd = previous
+        }
+        let framing = String(line[recordEnd...])
+        var text = String(line[..<recordEnd])
         switch pending {
         case .osc, .other:
             let end = pending == .osc ? patterns.oscEnd : patterns.stringEnd
-            guard let terminator = text.firstMatch(of: end) else { return "" }
+            guard let terminator = text.firstMatch(of: end) else { return framing }
             text = String(text[terminator.range.upperBound...])
         case .csi:
             text = "\u{1B}[" + text
@@ -75,14 +86,20 @@ enum TerminalControlGrammar {
         }
         pending = nil
         // Never discover a nested introducer by rescanning an already consumed payload.
-        guard let last = text.matches(of: escape).last, last.range.upperBound == text.endIndex else { return text }
+        // Retain only the most recent match, not an array proportional to control count.
+        var remaining = text[...]
+        var last: Regex<Substring>.Match?
+        while let match = remaining.firstMatch(of: escape) {
+            last = match
+            remaining = remaining[match.range.upperBound...]
+        }
+        guard let last, last.range.upperBound == text.endIndex else { return text + framing }
         if last.0.wholeMatch(of: patterns.unfinishedOSC) != nil { pending = .osc }
         else if last.0.wholeMatch(of: patterns.unfinishedOther) != nil { pending = .other }
         else if last.0.wholeMatch(of: patterns.unfinishedCSI) != nil { pending = .csi }
         else if last.0.wholeMatch(of: patterns.unfinishedEscape) != nil {
             pending = .escape(intermediate: last.0.unicodeScalars.contains { (0x20...0x2F).contains($0.value) })
         }
-        return pending == nil ? text : String(text[..<last.range.lowerBound])
+        return (pending == nil ? text : String(text[..<last.range.lowerBound])) + framing
     }
 }
-

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
@@ -1,0 +1,88 @@
+import Foundation
+import RegexBuilder
+
+/// Scalar-level control framing, not a terminal emulator. It never executes commands or
+/// interprets a control-string payload as visible text. Stream state has constant size.
+enum TerminalControlGrammar {
+    enum Pending: Hashable, Sendable {
+        case osc, other, csi
+        case escape(intermediate: Bool)
+    }
+
+    // Regex values are immutable but not Sendable; only this immutable container is shared.
+    private struct Patterns: @unchecked Sendable {
+        let escape: Regex<Substring>
+        let unfinishedCSI: Regex<Substring>
+        let unfinishedEscape: Regex<Substring>
+        let unfinishedOSC: Regex<Substring>
+        let unfinishedOther: Regex<Substring>
+        let stringEnd: Regex<Substring>
+        let oscEnd: Regex<Substring>
+
+        init() {
+            // Keep physical CR/LF framing outside CSI/ESC bodies. Other executable C0 bytes
+            // and DEL do not leave the escape/CSI state. CAN/SUB and a fresh ESC cancel it.
+            let ignored = #/[\u{00}-\u{09}\u{0B}\u{0C}\u{0E}-\u{17}\u{19}\u{1C}-\u{1F}\u{7F}]/#
+            let esc = Regex { "\u{1B}"; ZeroOrMore { ignored } }
+            let oscStart = Regex { ChoiceOf { Regex { esc; "]" }; "\u{9D}" } }
+            let otherStart = Regex { ChoiceOf { Regex { esc; #/[P_^X]/# }; #/[\u{90}\u{9F}\u{9E}\u{98}]/# } }
+            let csiStart = Regex { ChoiceOf { Regex { esc; "[" }; "\u{9B}" } }
+            let csiBody = Regex { ZeroOrMore { ChoiceOf { ignored; #/[ -?]/# } } }
+            let escBody = Regex { ZeroOrMore { ChoiceOf { ignored; #/[ -\/]/# } } }
+            let abort = Regex { Lookahead { ChoiceOf { "\u{1B}"; Anchor.endOfSubject } } }
+            let st = Regex { esc; "\\" }
+            let oscPayload = #/[^\u{07}\u{18}\u{1A}\u{9C}\u{1B}]*/#
+            let otherPayload = #/[^\u{18}\u{1A}\u{9C}\u{1B}]*/#
+            escape = Regex {
+                ChoiceOf {
+                    Regex { oscStart; oscPayload; Optionally { ChoiceOf { #/[\u{07}\u{18}\u{1A}\u{9C}]/#; st } } }
+                    Regex { otherStart; otherPayload; Optionally { ChoiceOf { #/[\u{18}\u{1A}\u{9C}]/#; st } } }
+                    Regex { csiStart; csiBody; ChoiceOf { #/[\u{18}\u{1A}@-~]/#; abort } }
+                    Regex { esc; escBody; ChoiceOf { #/[\u{18}\u{1A}0-~]/#; abort } }
+                    #/[\u{00}-\u{08}\u{0B}\u{0C}\u{0E}-\u{1F}\u{7F}-\u{9F}]/#
+                }
+            }.matchingSemantics(.unicodeScalar)
+            unfinishedCSI = Regex { csiStart; csiBody; Anchor.endOfSubject }.matchingSemantics(.unicodeScalar)
+            unfinishedEscape = Regex { esc; escBody; Anchor.endOfSubject }.matchingSemantics(.unicodeScalar)
+            unfinishedOSC = Regex { oscStart; oscPayload; Anchor.endOfSubject }.matchingSemantics(.unicodeScalar)
+            unfinishedOther = Regex { otherStart; otherPayload; Anchor.endOfSubject }.matchingSemantics(.unicodeScalar)
+            stringEnd = Regex { ChoiceOf { #/[\u{18}\u{1A}\u{9C}]/#; st; Lookahead { "\u{1B}" } } }.matchingSemantics(.unicodeScalar)
+            oscEnd = Regex { ChoiceOf { #/[\u{07}\u{18}\u{1A}\u{9C}]/#; st; Lookahead { "\u{1B}" } } }.matchingSemantics(.unicodeScalar)
+        }
+    }
+
+    private static let patterns = Patterns()
+    static var escape: Regex<Substring> { patterns.escape }
+
+    static func normalize(_ text: String) -> String { text.replacing(escape, with: "") }
+
+    /// Returns a physical record suitable for the evidence renderer. Incomplete control
+    /// suffixes cannot become fake field values. For a continued command only its parser
+    /// class is retained, never an unbounded parameter or payload buffer. Synthetic control
+    /// prefixes are consumed by the same grammar and cannot become visible text.
+    static func prepare(_ line: String, pending: inout Pending?) -> String {
+        var text = line
+        switch pending {
+        case .osc, .other:
+            let end = pending == .osc ? patterns.oscEnd : patterns.stringEnd
+            guard let terminator = text.firstMatch(of: end) else { return "" }
+            text = String(text[terminator.range.upperBound...])
+        case .csi:
+            text = "\u{1B}[" + text
+        case .escape(let intermediate):
+            text = (intermediate ? "\u{1B}(" : "\u{1B}") + text
+        case nil: break
+        }
+        pending = nil
+        // Never discover a nested introducer by rescanning an already consumed payload.
+        guard let last = text.matches(of: escape).last, last.range.upperBound == text.endIndex else { return text }
+        if last.0.wholeMatch(of: patterns.unfinishedOSC) != nil { pending = .osc }
+        else if last.0.wholeMatch(of: patterns.unfinishedOther) != nil { pending = .other }
+        else if last.0.wholeMatch(of: patterns.unfinishedCSI) != nil { pending = .csi }
+        else if last.0.wholeMatch(of: patterns.unfinishedEscape) != nil {
+            pending = .escape(intermediate: last.0.unicodeScalars.contains { (0x20...0x2F).contains($0.value) })
+        }
+        return pending == nil ? text : String(text[..<last.range.lowerBound])
+    }
+}
+

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlGrammarTests.swift
@@ -2,6 +2,32 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct TerminalControlGrammarTests {
+    @Test(arguments: ["\u{9C}", "\u{85}", "\u{80}", "é", "\u{301}"], ["\u{1B}(", "\u{1B}[31"])
+    func anInterruptingScalarCannotExposeAReconstructedPrefix(interruption: String, opener: String) {
+        var pending: TerminalControlGrammar.Pending?
+        _ = TerminalControlGrammar.prepare(opener, pending: &pending)
+        let expected = interruption.unicodeScalars.first!.value > 0x9F ? interruption + "after" : "after"
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(interruption + "after", pending: &pending)) == expected)
+        #expect(pending == nil)
+    }
+
+    @Test(arguments: ["\r", "\n", "\r\n"], [("\u{1B}[31", "m"), ("\u{9B}31", "m"), ("\u{1B}(", "B"), ("\u{1B}", "c")])
+    func trailingPhysicalFramingDoesNotReleaseAnIncompleteCommand(framing: String, parts: (String, String)) {
+        var pending: TerminalControlGrammar.Pending?
+        #expect(TerminalControlGrammar.prepare("password: " + parts.0 + framing, pending: &pending) == "password: " + framing)
+        #expect(pending != nil)
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(parts.1 + "syntheticPassword" + framing, pending: &pending))
+                == "syntheticPassword" + framing)
+        #expect(pending == nil)
+    }
+
+    @Test func controlDenseRecordsRetainOnlyTheirUnfinishedSuffix() {
+        var pending: TerminalControlGrammar.Pending?
+        let controls = String(repeating: "\u{0}", count: 100_000)
+        #expect(TerminalControlGrammar.prepare(controls + "\u{1B}[31", pending: &pending) == controls)
+        #expect(pending == .csi)
+    }
+
     @Test(arguments: ["\u{1B}[", "\u{9B}", "\u{1B}\u{0}["], ["31", " 31", "1 2", "31\u{0}", ""])
     func incompleteCSIIsNotAnOrdinaryFieldValue(start: String, body: String) {
         var pending: TerminalControlGrammar.Pending?

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlGrammarTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlGrammarTests.swift
@@ -1,0 +1,127 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct TerminalControlGrammarTests {
+    @Test(arguments: ["\u{1B}[", "\u{9B}", "\u{1B}\u{0}["], ["31", " 31", "1 2", "31\u{0}", ""])
+    func incompleteCSIIsNotAnOrdinaryFieldValue(start: String, body: String) {
+        var pending: TerminalControlGrammar.Pending?
+        #expect(TerminalControlGrammar.prepare("password: " + start + body, pending: &pending) == "password: ")
+        #expect(pending == .csi)
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare("msyntheticPassword", pending: &pending)) == "syntheticPassword")
+        #expect(pending == nil)
+    }
+
+    @Test(arguments: [("\u{1B}", "c"), ("\u{1B}(", "B"), ("\u{1B}\u{0}(", "B")])
+    func incompleteGenericEscapesResumeWithoutExposingIntermediates(parts: (String, String)) {
+        var pending: TerminalControlGrammar.Pending?
+        #expect(TerminalControlGrammar.prepare("password: " + parts.0, pending: &pending) == "password: ")
+        #expect(pending != nil)
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(parts.1 + "syntheticPassword", pending: &pending)) == "syntheticPassword")
+        #expect(pending == nil)
+    }
+
+    @Test(arguments: ["\u{18}", "\u{1A}", "\u{1B}[m"])
+    func cancellationEndsAnIncompleteCSI(cancel: String) {
+        var pending: TerminalControlGrammar.Pending?
+        _ = TerminalControlGrammar.prepare("\u{1B}[31", pending: &pending)
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(cancel + "after", pending: &pending)) == "after")
+        #expect(pending == nil)
+    }
+
+    @Test func pendingStateDoesNotAccumulateParameters() {
+        var pending: TerminalControlGrammar.Pending?
+        _ = TerminalControlGrammar.prepare("\u{1B}[", pending: &pending)
+        #expect(TerminalControlGrammar.prepare(String(repeating: "1", count: 10_000), pending: &pending).isEmpty)
+        #expect(pending == .csi)
+        #expect(TerminalControlGrammar.prepare("", pending: &pending).isEmpty)
+        #expect(pending == .csi)
+    }
+
+    @Test(arguments: ["\u{1B}[0m", "\u{9B}0m", "\u{1B}(B"], ["\u{301}", "\u{FE0F}"])
+    func combiningScalarsCannotChangeTheControlGrammar(control: String, suffix: String) {
+        #expect(TerminalControlGrammar.normalize("red" + control + suffix + "text") == "red" + suffix + "text")
+    }
+
+    @Test(arguments: ["\u{1B}]", "\u{1B}\u{0}]", "\u{9D}"], ["\u{90}", "\u{98}", "\u{9E}", "\u{9F}"])
+    func nestedPayloadIntroducersCannotArmPendingState(opener: String, nested: String) {
+        var pending: TerminalControlGrammar.Pending?
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(opener + "title" + nested + "payload\u{7}after", pending: &pending)) == "after")
+        #expect(pending == nil)
+        #expect(TerminalControlGrammar.prepare("Finished", pending: &pending) == "Finished")
+    }
+
+    @Test(arguments: [("\u{1B}]", "\u{7}"), ("\u{1B}P", "\u{1B}\\"), ("\u{1B}\u{0}_", "\u{9C}")])
+    func controlStringStateKeepsItsOwnTerminator(parts: (String, String)) {
+        var pending: TerminalControlGrammar.Pending?
+        #expect(TerminalControlGrammar.prepare("before" + parts.0 + "payload", pending: &pending) == "before")
+        #expect(pending != nil)
+        #expect(TerminalControlGrammar.prepare("hidden", pending: &pending) == "")
+        #expect(TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(parts.1 + "after", pending: &pending)) == "after")
+        #expect(pending == nil)
+    }
+
+    @Test func ordinaryPhysicalFramingIsPreserved() {
+        #expect(TerminalControlGrammar.normalize("a\t\u{8}b\r\n") == "a\tb\r\n")
+    }
+    @Test(arguments: ["\u{1B}[", "\u{9B}"], ["\u{0}31", "3\u{0}1", "31\u{7}", "31\u{8}", "31\u{9}", "31 \u{0}", " 31", "1 2", "? 3"])
+    func embeddedControlsDoNotSplitCSI(introducer: String, body: String) {
+        let result = renderings(of: "pass" + introducer + body + "mword: syntheticPassword")
+        #expect(result.joined == "password: syntheticPassword")
+    }
+
+    @Test(arguments: ["\u{18}", "\u{1A}"])
+    func cancellationIsNotAnIgnoredCSIByte(cancel: String) {
+        #expect(stripTerminalEscapes("pass\u{1B}[31" + cancel + "word: syntheticPassword") == "password: syntheticPassword")
+    }
+
+    @Test func aNewEscapeCancelsAnIncompleteCSI() {
+        #expect(stripTerminalEscapes("pass\u{1B}[31\u{1B}[0mword: syntheticPassword") == "password: syntheticPassword")
+    }
+
+    @Test(arguments: ["\u{0}", "\u{7}", "\u{9}", "\u{7F}"], ["", "("])
+    func embeddedGenericControlsStayInsideTheirCommand(control: String, intermediate: String) {
+        #expect(renderings(of: "pass\u{1B}" + intermediate + control + "wword: syntheticPassword").joined
+                == "password: syntheticPassword")
+    }
+
+    @Test(arguments: ["\u{1B}]", "\u{9D}"], ["\u{90}", "\u{98}", "\u{9E}", "\u{9F}"])
+    func consumedOSCPayloadCannotArmAnotherControlString(opener: String, nested: String) {
+        var open: TerminalControlGrammar.Pending?
+        #expect(stripTerminalEscapes(opener + "title" + nested + "payload\u{7}after", openControlString: &open).joined == "after")
+        #expect(open == nil)
+        #expect(stripTerminalEscapes("Finished", openControlString: &open).joined == "Finished")
+        _ = stripTerminalEscapes(opener + "title" + nested + "payload\u{7}\u{1B}Ppending", openControlString: &open)
+        #expect(open == .other)
+    }
+
+    @Test(arguments: ["\u{1B}]", "\u{1B}P", "\u{1B}_", "\u{1B}^", "\u{1B}X", "\u{9D}", "\u{90}", "\u{9F}", "\u{9E}", "\u{98}"], ["\u{18}", "\u{1A}", "\u{1B}c", "\u{1B}[m"])
+    func cancelledControlStringsReleaseVisibleDiagnostics(opener: String, cancel: String) {
+        var open: TerminalControlGrammar.Pending?
+        #expect(stripTerminalEscapes("before" + opener + "payload" + cancel + "after", openControlString: &open).joined == "beforeafter")
+        #expect(open == nil)
+        _ = stripTerminalEscapes(opener + "payload", openControlString: &open)
+        #expect(stripTerminalEscapes(cancel + "after", openControlString: &open).joined == "after")
+        #expect(open == nil)
+        #expect(stripTerminalEscapes("Finished", openControlString: &open).joined == "Finished")
+    }
+
+    @Test(arguments: [("\u{1B}]", "\u{7}"), ("\u{1B}P", "\u{1B}\\")])
+    func controlStringsRemainHiddenUntilTheirOwnTerminator(opener: String, terminator: String) {
+        var open: TerminalControlGrammar.Pending?
+        #expect(stripTerminalEscapes("before" + opener + "payload", openControlString: &open).joined == "before")
+        #expect(open != nil)
+        #expect(stripTerminalEscapes("hidden", openControlString: &open).joined == "")
+        #expect(stripTerminalEscapes(terminator + "after", openControlString: &open).joined == "after")
+        #expect(open == nil)
+    }
+
+
+    private struct Rendering { let joined: String }
+    private func renderings(of text: String) -> Rendering {
+        Rendering(joined: TerminalControlGrammar.normalize(text))
+    }
+    private func stripTerminalEscapes(_ text: String) -> String { TerminalControlGrammar.normalize(text) }
+    private func stripTerminalEscapes(_ text: String, openControlString: inout TerminalControlGrammar.Pending?) -> Rendering {
+        Rendering(joined: TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(text, pending: &openControlString)))
+    }
+}


### PR DESCRIPTION
Part of #11 and MVP-PLAN.md §3 redacted logging. Stacked on test-only #123; this is the bounded terminal grammar prerequisite consumed by #95, not an independently activated public redactor.

Adds a Unicode-scalar escape grammar and constant-size pending state for OSC/DCS/APC/PM/SOS, incomplete CSI, and generic ESC commands across physical records. Incomplete control suffixes cannot become fake credential field values. Pending payload/parameter buffers are not retained. Normalization does not execute terminal commands or claim a complete terminal emulator.

Seven existing normalization-only regression methods are transferred from #95 with their argument cases/assertions preserved through a thin grammar test adapter; #95 retains credential-recovery tests. New coverage checks cross-record CSI/ESC, cancellation, ignored controls in introducers, combining scalars, nested payload ownership and bounded parameter state.

<!-- guesthouse-current-validation -->
## Current validation — 2026-09-06 01:52 UTC

Head `bbfd4337b1fe9029aa5fa016d486089291de89e8`: **258 changed lines;91 Core tests /10 suites pass with warnings-as-errors.** Exact-head Xcode Cloud is SUCCESS; Codex completed on this head and gave the original PR message a thumbs-up at01:14:09. Zero unresolved inline threads; standalone comments checked. CLEAN/MERGEABLE against #123, SUBSCRIBED.

**Ready after #123.** This clears the isolated terminal grammar only. New #125 consumes it and still has three unresolved evidence-recovery findings; #95/#96 remain held. #95 and #96 now normally inherit this head. No PRs were merged by maintenance and no hardware acceptance is claimed.
<!-- /guesthouse-current-validation -->

Intended order: #123 → this PR → #125 → #95 → #96 → the remaining graph in #59. This keeps the new parser/state work separately reviewable while repairing #95's scalar-framing and cross-record findings.