### PR TITLE
Bound cross-record terminal evidence

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalSpans.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalSpans.swift
@@ -15,6 +15,9 @@ extension Redactor {
         spans += text.matches(of: patterns.specializedCredentialSpan).map { ($0.range, "authorization", true) }
         spans += text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2).map { ($0, "jwt", false) } }
         spans += text.matches(of: patterns.urlUserInfo).map { ($0.1.endIndex..<$0.range.upperBound, "userinfo", false) }
+        if text.contains(patterns.mentionsCode) {
+            spans += text.matches(of: patterns.deviceCode).map { ($0.2.startIndex..<$0.2.endIndex, "device-code", false) }
+        }
         return spans
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalSpans.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalSpans.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+extension Redactor {
+    /// Boundary-free spans protect token interiors; recognition still requires each rule's
+    /// usual leading boundary unless an actual removed control supplied one at that position.
+    static func terminalCredentialSpans(in text: String) -> [(range: Range<String.Index>, kind: String, needsBoundary: Bool)] {
+        var spans = text.matches(of: patterns.githubToken).map { ($0.range, "github-token", false) }
+        spans += text.matches(of: #/sk-[A-Za-z0-9_-]{16,}/#).map { ($0.range, "api-key", true) }
+        spans += text.matches(of: patterns.distinctiveAPIKey).map { ($0.range, "api-key", false) }
+        spans += text.matches(of: #/bearer\s+[A-Za-z0-9._~+\/=-]+/#.ignoresCase()).map { ($0.range, "bearer-token", true) }
+        spans += text.matches(of: patterns.basicCredentialSpan).compactMap { match in
+            isBasicCredential(match.2) ? (match.range, "authorization", true) : nil
+        }
+        spans += text.matches(of: patterns.digestCredentialSpan).map { ($0.range, "authorization", true) }
+        spans += text.matches(of: patterns.specializedCredentialSpan).map { ($0.range, "authorization", true) }
+        spans += text.matches(of: patterns.jwt).flatMap { jwtRedactionRanges($0.2).map { ($0, "jwt", false) } }
+        spans += text.matches(of: patterns.urlUserInfo).map { ($0.1.endIndex..<$0.range.upperBound, "userinfo", false) }
+        return spans
+    }
+
+
+    /// Inserting a marker must never hide evidence of a larger credential recognized in the
+    /// ordinary reading (for example a five-segment JWE or a longer Bearer value).
+    static func expandingRecoveredRanges(_ recovered: [(range: Range<Int>, kind: String)], through ordinary: [Range<Int>]) -> [(range: Range<Int>, kind: String)] {
+        let spans = (recovered.map { (range: $0.range, kind: Optional($0.kind)) } + ordinary.map { (range: $0, kind: nil as String?) })
+            .sorted { $0.range.lowerBound < $1.range.lowerBound }
+        var clusters: [(range: Range<Int>, kind: String?)] = []
+        for span in spans {
+            if let last = clusters.last, span.range.lowerBound < last.range.upperBound {
+                clusters[clusters.count - 1] = (last.range.lowerBound..<max(last.range.upperBound, span.range.upperBound),
+                                                last.kind ?? span.kind)
+            } else { clusters.append(span) }
+        }
+        return clusters.compactMap { span in span.kind.map { (span.range, $0) } }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
@@ -1,19 +1,56 @@
 import Foundation
 
-/// A fixed set of scan-only readings, with bounded lookbehind across unfinished commands.
-/// No prefix or recovered command byte is ever returned as visible diagnostic text.
+/// Scan-only terminal evidence. Every command independently chooses a reading; no recovered
+/// byte becomes visible. Ambiguity exceeding the fixed budget quarantines the rest of a stream.
 enum TerminalControlEvidence {
     enum Reading: Int, CaseIterable, Sendable {
-        case joined, parameterless, final, complete
+        case joined, parameterless, final, intermediates, complete
     }
 
+    static let maximumAlternatives = 64
+    static let quarantineMarker = "[redacted:terminal-ambiguity]"
+
     struct Continuation: Hashable, Sendable {
-        let pending: TerminalControlGrammar.Pending
-        /// At most four suffixes, each at most 64 Unicode scalars (256 UTF-8 bytes).
+        let pending: TerminalControlGrammar.Pending?
+        /// At most 64 distinct suffixes of at most 64 Unicode scalars (256 UTF-8 bytes).
         let prefixes: [String]
-        fileprivate init(pending: TerminalControlGrammar.Pending, prefixes: [String]) {
+        let commandSuffix: String
+        let quarantined: Bool
+        fileprivate init(pending: TerminalControlGrammar.Pending?, prefixes: [String],
+                         commandSuffix: String, quarantined: Bool = false) {
             self.pending = pending
             self.prefixes = prefixes
+            self.commandSuffix = commandSuffix
+            self.quarantined = quarantined
+        }
+    }
+
+    /// Offsets project each UTF-8 boundary back to the control-stripped visible record.
+    struct Projection: Hashable, Sendable {
+        var text: String
+        var offsets: [Int]
+        var retained: [Range<Int>]
+        var boundaries: Set<Int> = [0]
+
+        fileprivate init(prefix: String) {
+            text = prefix
+            offsets = Array(repeating: 0, count: prefix.utf8.count + 1)
+            retained = prefix.isEmpty ? [] : [0..<prefix.utf8.count]
+        }
+
+        fileprivate mutating func append(literal: Substring) {
+            var count = offsets.last ?? 0
+            text += literal
+            for _ in literal.utf8 { count += 1; offsets.append(count) }
+        }
+
+        fileprivate mutating func append(body: String) {
+            boundaries.insert(offsets.count - 1)
+            guard !body.isEmpty else { return }
+            let start = offsets.count - 1
+            text += body
+            offsets.append(contentsOf: repeatElement(offsets.last ?? 0, count: body.utf8.count))
+            retained.append(start..<(offsets.count - 1))
         }
     }
 
@@ -32,43 +69,70 @@ enum TerminalControlEvidence {
         case .joined: return ""
         case .parameterless: return complete.count == 1 ? complete : ""
         case .final: return String(complete.suffix(1))
+        case .intermediates:
+            // CSI parameters and intermediates are distinct grammar classes. Removing
+            // numeric parameters must not discard option punctuation such as a dash.
+            return prefix > 0 ? String(String.UnicodeScalarView(complete.unicodeScalars.filter {
+                !(0x30...0x3F).contains($0.value)
+            })) : complete
         case .complete: return complete
+        }
+    }
+
+    /// Nil means that no safe bounded enumeration is possible. Do not silently drop
+    /// alternatives: the missing reading might be the only one containing the credential.
+    static func projections(in text: String, prefixes: [String] = []) -> [Projection]? {
+        var results = Array(Set(prefixes.isEmpty ? [""] : prefixes)).sorted().map { Projection(prefix: $0) }
+        guard results.count <= maximumAlternatives else { return nil }
+        var remaining = text[...]
+        while let escape = remaining.firstMatch(of: TerminalControlGrammar.escape) {
+            let literal = remaining[..<escape.range.lowerBound]
+            let bodies = Array(Set(Reading.allCases.map { body(of: escape.0, reading: $0) })).sorted()
+            var next: [Projection] = []
+            var seen: Set<Projection> = []
+            for var result in results {
+                result.append(literal: literal)
+                for body in bodies {
+                    var candidate = result
+                    candidate.append(body: body)
+                    if seen.insert(candidate).inserted {
+                        guard next.count < maximumAlternatives else { return nil }
+                        next.append(candidate)
+                    }
+                }
+            }
+            results = next
+            remaining = remaining[escape.range.upperBound...]
+        }
+        return results.map { result in
+            var result = result
+            result.append(literal: remaining)
+            return result
         }
     }
 
     static func prepare(_ line: String, continuation: inout Continuation?) -> (text: String, prefixes: [String]) {
         let prefixes = continuation?.prefixes ?? []
         var pending = continuation?.pending
-        let text = TerminalControlGrammar.prepare(line, pending: &pending)
+        var commandSuffix = continuation?.commandSuffix ?? ""
+        func quarantine() -> (text: String, prefixes: [String]) {
+            // An ambiguous opener might own unindented later records (PEM/quoted secrets).
+            // Only a fresh StreamState can release this fail-closed state, never guest text.
+            continuation = Continuation(pending: nil, prefixes: [], commandSuffix: "", quarantined: true)
+            return (quarantineMarker, [])
+        }
+        guard continuation?.quarantined != true else { return quarantine() }
+        let text = TerminalControlGrammar.prepare(line, pending: &pending, commandSuffix: &commandSuffix)
+        guard let readings = projections(in: text, prefixes: prefixes) else { return quarantine() }
         continuation = pending.map { command in
-            let carriesPrefix: Bool
-            switch command {
-            case .csi, .escape: carriesPrefix = true
-            case .osc, .other: carriesPrefix = false
+            let suffixes = readings.map { reading in
+                let scalars = reading.text.unicodeScalars
+                let end = scalars.lastIndex(where: { $0 != "\r" && $0 != "\n" })
+                    .map { scalars.index(after: $0) } ?? scalars.startIndex
+                return String(String.UnicodeScalarView(scalars[..<end].suffix(64)))
             }
-            return Continuation(pending: command, prefixes: carriesPrefix ? Reading.allCases.map { reading in
-                suffix(in: text, prefix: prefixes.indices.contains(reading.rawValue) ? prefixes[reading.rawValue] : "", reading: reading)
-            } : [])
+            return Continuation(pending: command, prefixes: Array(Set(suffixes)).sorted(), commandSuffix: commandSuffix)
         }
         return (text, prefixes)
-    }
-
-    private static func suffix(in text: String, prefix: String, reading: Reading) -> String {
-        // Physical line framing is not part of the credential prefix being carried.
-        let end = text.unicodeScalars.lastIndex(where: { $0 != "\r" && $0 != "\n" })
-            .map { text.unicodeScalars.index(after: $0) } ?? text.startIndex
-        var remaining = text[..<end]
-        var result = prefix
-        func append(_ literal: Substring) {
-            let tail = String(String.UnicodeScalarView(literal.unicodeScalars.suffix(64)))
-            result = String(String.UnicodeScalarView((result + tail).unicodeScalars.suffix(64)))
-        }
-        while let escape = remaining.firstMatch(of: TerminalControlGrammar.escape) {
-            append(remaining[..<escape.range.lowerBound])
-            append(body(of: escape.0, reading: reading)[...])
-            remaining = remaining[escape.range.upperBound...]
-        }
-        append(remaining)
-        return result
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// A fixed set of scan-only readings, with bounded lookbehind across unfinished commands.
+/// No prefix or recovered command byte is ever returned as visible diagnostic text.
+enum TerminalControlEvidence {
+    enum Reading: Int, CaseIterable, Sendable {
+        case joined, parameterless, final, complete
+    }
+
+    struct Continuation: Hashable, Sendable {
+        let pending: TerminalControlGrammar.Pending
+        /// At most four suffixes, each at most 64 Unicode scalars (256 UTF-8 bytes).
+        let prefixes: [String]
+        fileprivate init(pending: TerminalControlGrammar.Pending, prefixes: [String]) {
+            self.pending = pending
+            self.prefixes = prefixes
+        }
+    }
+
+    static func body(of escape: Substring, reading: Reading) -> String {
+        guard reading != .joined else { return "" }
+        let command = String(String.UnicodeScalarView(escape.unicodeScalars.filter {
+            !((0...0x1A).contains($0.value) || (0x1C...0x1F).contains($0.value) || $0.value == 0x7F)
+        }))
+        let prefix = command.hasPrefix("\u{1B}[") ? 2 : (command.hasPrefix("\u{9B}") ? 1 : 0)
+        if prefix > 0, let final = escape.unicodeScalars.last, !(0x40...0x7E).contains(final.value) { return "" }
+        // Opaque OSC/DCS/APC/PM/SOS payloads can never become generic-command evidence.
+        let generic = command.wholeMatch(of: #/\u{1B}(?![\[\]P_^X])[ -\/]*[0-~]/#) != nil
+        guard prefix > 0 || generic else { return "" }
+        let complete = String(command.dropFirst(generic ? 1 : prefix))
+        switch reading {
+        case .joined: return ""
+        case .parameterless: return complete.count == 1 ? complete : ""
+        case .final: return String(complete.suffix(1))
+        case .complete: return complete
+        }
+    }
+
+    static func prepare(_ line: String, continuation: inout Continuation?) -> (text: String, prefixes: [String]) {
+        let prefixes = continuation?.prefixes ?? []
+        var pending = continuation?.pending
+        let text = TerminalControlGrammar.prepare(line, pending: &pending)
+        continuation = pending.map { command in
+            let carriesPrefix: Bool
+            switch command {
+            case .csi, .escape: carriesPrefix = true
+            case .osc, .other: carriesPrefix = false
+            }
+            return Continuation(pending: command, prefixes: carriesPrefix ? Reading.allCases.map { reading in
+                suffix(in: text, prefix: prefixes.indices.contains(reading.rawValue) ? prefixes[reading.rawValue] : "", reading: reading)
+            } : [])
+        }
+        return (text, prefixes)
+    }
+
+    private static func suffix(in text: String, prefix: String, reading: Reading) -> String {
+        // Physical line framing is not part of the credential prefix being carried.
+        let end = text.unicodeScalars.lastIndex(where: { $0 != "\r" && $0 != "\n" })
+            .map { text.unicodeScalars.index(after: $0) } ?? text.startIndex
+        var remaining = text[..<end]
+        var result = prefix
+        func append(_ literal: Substring) {
+            let tail = String(String.UnicodeScalarView(literal.unicodeScalars.suffix(64)))
+            result = String(String.UnicodeScalarView((result + tail).unicodeScalars.suffix(64)))
+        }
+        while let escape = remaining.firstMatch(of: TerminalControlGrammar.escape) {
+            append(remaining[..<escape.range.lowerBound])
+            append(body(of: escape.0, reading: reading)[...])
+            remaining = remaining[escape.range.upperBound...]
+        }
+        append(remaining)
+        return result
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlGrammar.swift
@@ -63,6 +63,13 @@ enum TerminalControlGrammar {
     /// class is retained, never an unbounded parameter or payload buffer. Synthetic control
     /// prefixes are consumed by the same grammar and cannot become visible text.
     static func prepare(_ line: String, pending: inout Pending?) -> String {
+        var commandSuffix = ""
+        return prepare(line, pending: &pending, commandSuffix: &commandSuffix)
+    }
+
+    /// Evidence callers retain at most 64 parameter/intermediate scalars. Opaque string
+    /// payloads are never retained. The grammar-only overload still needs just its class.
+    static func prepare(_ line: String, pending: inout Pending?, commandSuffix: inout String) -> String {
         // A physical record may still carry its framing. Preserve it separately so it
         // cannot make an unfinished control body look like an ordinary field value.
         var recordEnd = line.endIndex
@@ -79,12 +86,13 @@ enum TerminalControlGrammar {
             guard let terminator = text.firstMatch(of: end) else { return framing }
             text = String(text[terminator.range.upperBound...])
         case .csi:
-            text = "\u{1B}[" + text
+            text = "\u{1B}[" + commandSuffix + text
         case .escape(let intermediate):
-            text = (intermediate ? "\u{1B}(" : "\u{1B}") + text
+            text = "\u{1B}" + (commandSuffix.isEmpty && intermediate ? "(" : commandSuffix) + text
         case nil: break
         }
         pending = nil
+        commandSuffix = ""
         // Never discover a nested introducer by rescanning an already consumed payload.
         // Retain only the most recent match, not an array proportional to control count.
         var remaining = text[...]
@@ -99,6 +107,13 @@ enum TerminalControlGrammar {
         else if last.0.wholeMatch(of: patterns.unfinishedCSI) != nil { pending = .csi }
         else if last.0.wholeMatch(of: patterns.unfinishedEscape) != nil {
             pending = .escape(intermediate: last.0.unicodeScalars.contains { (0x20...0x2F).contains($0.value) })
+        }
+        switch pending {
+        case .csi, .escape:
+            // Introducers and ignored controls are outside the printable command body.
+            let body = last.0.unicodeScalars.filter { (0x20...0x3F).contains($0.value) }
+            commandSuffix = String(String.UnicodeScalarView(body.suffix(64)))
+        case .osc, .other, nil: break
         }
         return (pending == nil ? text : String(text[..<last.range.lowerBound])) + framing
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalSpanTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalSpanTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorTerminalSpanTests {
+    @Test(arguments: ["sk-abcdefghijklmnop", "Bearer syntheticCredential"])
+    func tokenSpansKeepTheirBoundaryRequirement(_ token: String) throws {
+        let text = "filename" + token
+        let span = try #require(Redactor.terminalCredentialSpans(in: text).first)
+        #expect(text[span.range] == token)
+        #expect(span.needsBoundary)
+    }
+
+    @Test func distinctiveGitHubSpansDoNotRequireAnExternalBoundary() throws {
+        let text = "filenameghp_syntheticCredential"
+        let span = try #require(Redactor.terminalCredentialSpans(in: text).first)
+        #expect(text[span.range] == "ghp_syntheticCredential")
+        #expect(!span.needsBoundary)
+    }
+
+    @Test func recoveredRangesExpandThroughOverlappingOrdinaryProtection() {
+        let result = Redactor.expandingRecoveredRanges([(2..<4, "secret")], through: [0..<3, 3..<8])
+        #expect(result.map(\.range) == [0..<8])
+        #expect(result.map(\.kind) == ["secret"])
+    }
+
+    @Test func adjacentOrdinaryRangesDoNotInventExtraRecoveredProtection() {
+        let result = Redactor.expandingRecoveredRanges([(0..<2, "secret")], through: [2..<8])
+        #expect(result.map(\.range) == [0..<2])
+        #expect(result.map(\.kind) == ["secret"])
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalSpanTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorTerminalSpanTests.swift
@@ -2,6 +2,14 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorTerminalSpanTests {
+    @Test func contextualCodeEvidenceContainsOnlyTheCodeSpan() throws {
+        let text = "The login code was rejected; retry AB12-CD34."
+        let span = try #require(Redactor.terminalCredentialSpans(in: text).first { $0.kind == "device-code" })
+        #expect(text[span.range] == "AB12-CD34")
+        #expect(!span.needsBoundary)
+        #expect(!Redactor.terminalCredentialSpans(in: "Build revision AB12-CD34.").contains { $0.kind == "device-code" })
+    }
+
     @Test(arguments: ["sk-abcdefghijklmnop", "Bearer syntheticCredential"])
     func tokenSpansKeepTheirBoundaryRequirement(_ token: String) throws {
         let text = "filename" + token

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
@@ -1,0 +1,68 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct TerminalControlEvidenceTests {
+    @Test(arguments: [
+        ("\u{1B}--p", "--p"), ("\u{1B}\u{0}--p", "--p"),
+        ("\u{1B}[31k", "31k"), ("\u{9B}31k", "31k"),
+    ])
+    func completeReadingKeepsIntermediatesAndFinal(input: String, expected: String) {
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .complete) == expected)
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .joined) == "")
+    }
+
+    @Test(arguments: [("\u{1B}[31k", "k"), ("\u{1B}--p", "p"), ("\u{1B}(B", "B")])
+    func finalReadingDoesNotRetainParameters(input: String, expected: String) {
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .final) == expected)
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .parameterless) == "")
+    }
+
+    @Test(arguments: ["\u{1B}]payload\u{7}", "\u{1B}Ppayload\u{1B}\\",
+                      "\u{1B}_payload\u{9C}", "\u{1B}[31\u{18}", "\u{1B}[31"])
+    func payloadAndAbortedCommandsAreNeverEvidence(_ input: String) {
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .complete) == "")
+        #expect(TerminalControlEvidence.body(of: input[...], reading: .final) == "")
+    }
+
+    @Test(arguments: ["\u{1B}[31", "\u{9B}31", "\u{1B}", "\u{1B}("], ["", "\r", "\n", "\r\n"])
+    func prefixesCrossACommandButNeverBecomeVisible(command: String, framing: String) throws {
+        var state: TerminalControlEvidence.Continuation?
+        let first = TerminalControlEvidence.prepare("s" + command + framing, continuation: &state)
+        #expect(first.text == "s" + framing)
+        #expect(first.prefixes == [])
+        let pending = try #require(state)
+        #expect(pending.prefixes == ["s", "s", "s", "s"])
+        let next = TerminalControlEvidence.prepare("k-abcdefghijklmnop", continuation: &state)
+        #expect(next.prefixes == ["s", "s", "s", "s"])
+        #expect(!next.text.hasPrefix("s"))
+        #expect(state == nil)
+    }
+
+    @Test func successiveCommandsKeepIndependentFixedReadings() throws {
+        var state: TerminalControlEvidence.Continuation?
+        _ = TerminalControlEvidence.prepare("s\u{1B}[31", continuation: &state)
+        _ = TerminalControlEvidence.prepare("k\u{1B}[32", continuation: &state)
+        #expect(try #require(state).prefixes == ["s", "sk", "sk", "sk"])
+        _ = TerminalControlEvidence.prepare(String(repeating: "1", count: 10_000), continuation: &state)
+        #expect(try #require(state).prefixes == ["s", "sk", "sk", "sk"])
+    }
+
+    @Test(arguments: ["a", "🧪", "\u{301}"])
+    func lookbehindIsBoundedInScalarsAndBytes(_ scalar: String) throws {
+        var state: TerminalControlEvidence.Continuation?
+        _ = TerminalControlEvidence.prepare(String(repeating: scalar, count: 10_000) + "\u{1B}[", continuation: &state)
+        let prefixes = try #require(state).prefixes
+        #expect(prefixes.count == 4)
+        #expect(prefixes.allSatisfy { $0.unicodeScalars.count <= 64 && $0.utf8.count <= 256 })
+    }
+
+    @Test func controlStringsDoNotCarryVisiblePrefixesThroughTheirPayload() throws {
+        var state: TerminalControlEvidence.Continuation?
+        _ = TerminalControlEvidence.prepare("s\u{1B}]payload", continuation: &state)
+        #expect(try #require(state).prefixes == [])
+        let next = TerminalControlEvidence.prepare("hidden\u{7}after", continuation: &state)
+        #expect(next.text == "after")
+        #expect(next.prefixes == [])
+        #expect(state == nil)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
@@ -2,6 +2,30 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct TerminalControlEvidenceTests {
+
+    @Test(arguments: [("\u{1B}]", "\u{7}"), ("\u{1B}P", "\u{1B}\\"),
+                      ("\u{1B}_", "\u{9C}"), ("\u{1B}^", "\u{9C}"), ("\u{1B}X", "\u{9C}")])
+    func visiblePrefixesSurviveOpaquePayloads(parts: (String, String)) throws {
+        var state: TerminalControlEvidence.Continuation?
+        _ = TerminalControlEvidence.prepare("s" + parts.0 + "opaque", continuation: &state)
+        #expect(try #require(state).prefixes == ["s"])
+        #expect(TerminalControlEvidence.prepare("hidden", continuation: &state).text == "")
+        let next = TerminalControlEvidence.prepare("hidden" + parts.1 + "k-proj-synthetic", continuation: &state)
+        #expect(next.prefixes.contains("s"))
+        #expect(next.text == "k-proj-synthetic")
+        #expect(state == nil)
+    }
+
+    @Test(arguments: [("\u{1B}--", "password syntheticOpaque", "--p"),
+                      ("\u{1B}[31", "word:", "31w"), ("\u{9B}31", "word:", "31w")])
+    func completeCommandBodiesSurvivePhysicalBoundaries(parts: (String, String, String)) throws {
+        var state: TerminalControlEvidence.Continuation?
+        _ = TerminalControlEvidence.prepare(parts.0, continuation: &state)
+        let next = TerminalControlEvidence.prepare(parts.1, continuation: &state)
+        let escape = try #require(next.text.firstMatch(of: TerminalControlGrammar.escape))
+        #expect(TerminalControlEvidence.body(of: escape.0, reading: .complete) == parts.2)
+        #expect(state == nil)
+    }
     @Test(arguments: [
         ("\u{1B}--p", "--p"), ("\u{1B}\u{0}--p", "--p"),
         ("\u{1B}[31k", "31k"), ("\u{9B}31k", "31k"),
@@ -31,20 +55,21 @@ import Testing
         #expect(first.text == "s" + framing)
         #expect(first.prefixes == [])
         let pending = try #require(state)
-        #expect(pending.prefixes == ["s", "s", "s", "s"])
+        #expect(pending.prefixes == ["s"])
         let next = TerminalControlEvidence.prepare("k-abcdefghijklmnop", continuation: &state)
-        #expect(next.prefixes == ["s", "s", "s", "s"])
+        #expect(next.prefixes == ["s"])
         #expect(!next.text.hasPrefix("s"))
         #expect(state == nil)
     }
 
-    @Test func successiveCommandsKeepIndependentFixedReadings() throws {
+    @Test func successiveCommandsKeepIndependentMixedReadings() throws {
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare("s\u{1B}[31", continuation: &state)
         _ = TerminalControlEvidence.prepare("k\u{1B}[32", continuation: &state)
-        #expect(try #require(state).prefixes == ["s", "sk", "sk", "sk"])
+        #expect(Set(try #require(state).prefixes) == ["s", "sk", "s31k"])
         _ = TerminalControlEvidence.prepare(String(repeating: "1", count: 10_000), continuation: &state)
-        #expect(try #require(state).prefixes == ["s", "sk", "sk", "sk"])
+        #expect(Set(try #require(state).prefixes) == ["s", "sk", "s31k"])
+        #expect(try #require(state).commandSuffix == String(repeating: "1", count: 64))
     }
 
     @Test(arguments: ["a", "🧪", "\u{301}"])
@@ -52,17 +77,53 @@ import Testing
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare(String(repeating: scalar, count: 10_000) + "\u{1B}[", continuation: &state)
         let prefixes = try #require(state).prefixes
-        #expect(prefixes.count == 4)
+        #expect(prefixes.count == 1)
         #expect(prefixes.allSatisfy { $0.unicodeScalars.count <= 64 && $0.utf8.count <= 256 })
     }
 
-    @Test func controlStringsDoNotCarryVisiblePrefixesThroughTheirPayload() throws {
+    @Test func controlStringsCarryOnlyVisiblePrefixesNeverTheirPayload() throws {
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare("s\u{1B}]payload", continuation: &state)
-        #expect(try #require(state).prefixes == [])
+        #expect(try #require(state).prefixes == ["s"])
         let next = TerminalControlEvidence.prepare("hidden\u{7}after", continuation: &state)
         #expect(next.text == "after")
-        #expect(next.prefixes == [])
+        #expect(next.prefixes == ["s"])
+        #expect(state == nil)
+    }
+
+    @Test(arguments: ["\u{1B}--pass\u{1B}[31word syntheticOpaque",
+                      "\u{1B}--passw\u{1B}[31ord syntheticOpaque"])
+    func commandsChooseDifferentReadingsWithoutLosingProjection(_ input: String) throws {
+        let readings = try #require(TerminalControlEvidence.projections(in: input))
+        let mixed = try #require(readings.first { $0.text == "--password syntheticOpaque" })
+        #expect(mixed.offsets.count == mixed.text.utf8.count + 1)
+        #expect(mixed.offsets.last == TerminalControlGrammar.normalize(input).utf8.count)
+        #expect(mixed.retained.count == 2)
+    }
+
+    @Test func opaqueCommandsDoNotMultiplyEquivalentReadings() throws {
+        let input = String(repeating: "\u{1B}]hidden\u{7}", count: 100) + "visible"
+        let readings = try #require(TerminalControlEvidence.projections(in: input))
+        #expect(readings.count == 1)
+        #expect(readings[0].text == "visible")
+        #expect(readings[0].retained.isEmpty)
+    }
+
+    @Test func intermediateEvidenceKeepsPunctuationButNotCSIParameters() {
+        #expect(TerminalControlEvidence.body(of: "\u{1B}[32-a"[...], reading: .intermediates) == "-a")
+    }
+
+    @Test func ambiguityOverflowQuarantinesSubsequentRecords() throws {
+        let input = String(repeating: "\u{1B}[31m", count: 8) + "password:"
+        #expect(TerminalControlEvidence.projections(in: input) == nil)
+        var state: TerminalControlEvidence.Continuation?
+        #expect(TerminalControlEvidence.prepare(input, continuation: &state).text == "[redacted:terminal-ambiguity]")
+        #expect(try #require(state).quarantined)
+        #expect(TerminalControlEvidence.prepare("syntheticOpaque", continuation: &state).text == "[redacted:terminal-ambiguity]")
+        #expect(try #require(state).prefixes.isEmpty)
+        #expect(try #require(state).commandSuffix.isEmpty)
+        state = nil
+        #expect(TerminalControlEvidence.prepare("Finished", continuation: &state).text == "Finished")
         #expect(state == nil)
     }
 }


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Current validation — 2026-09-06 03:01 UTC

Head `258469e5ae736dc281139dc6c5ccf3e6783ad3cf`: **364 own changed lines;109 Core tests /12 suites pass with warnings-as-errors.** CI SUCCESS, completed exact-head review and original-message Codex thumbs-up02:38:10. All inline threads resolved; no standalone findings. **Ready after #123 and #124.**

All three initial defects are fixed: visible prefixes survive opaque-string records without payload replay; unfinished command bodies retain bounded actual evidence; each command independently contributes candidate readings. At most64 candidates are considered, each with64-scalar lookbehind and a64-scalar pending command suffix. Overflow quarantines the rest of that StreamState; only a fresh state releases it. This deliberately trades diagnostic availability for confidentiality. #126 now isolates the unchanged range/context projection consumer before #95; it does not change this approved head.

Merge order: #123 → #124 → #125 → #126 → #95 → #96 → #114 → #115 → #97 → #98 → #116 → #117 → #118 → #119 → #120 → #59.

The complete **585-test /46-suite** redactor/error composition at `2c2b82036f1f5712d73156772fccc66da7a6ba15` is LOCAL ONLY, not a published downstream head. #115 onward still needs normal restacking and its remaining repairs. #122/#53's individual approval does not clear inherited holds. No PRs were merged, history rewritten, host/VM/auth operations performed, or hardware acceptance claimed.
<!-- /guesthouse-current-validation -->

Part of #11 and MVP-PLAN.md §3 redacted logging. Stacked on #124; this isolates the bounded terminal-evidence state needed by #95's cross-record credential-prefix and generic-intermediate findings.

Adds independently combined scan-only readings and bounded continuation evidence. Opaque OSC/DCS/APC/PM/SOS payloads are never replayed; visible prefixes before them remain available to later scans. Candidate overflow fails closed for the remainder of the stream. Carried prefixes and command bytes never become visible output. This helper does not activate the public redactor or claim complete terminal emulation.

The helper now also owns the existing credential-span and coverage-projection routines extracted from #95, plus contextual device-code evidence and focused span tests. Current head-specific gates are recorded above.

Merge order: #123 → #124 → this PR → #95 → #96 → the remaining graph in #59. No PR merges, history rewrites, dependencies added, host/VM operations or hardware claims.
