### PR TITLE
Extract bounded terminal rendering and retained credential context

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -7,22 +7,8 @@ extension Redactor {
     struct Patterns: @unchecked Sendable {
         /// Any of the three line terminators, CRLF first so it is never split in half.
         let lineSeparator = #/\r\n|\n|\r/#
-        /// Control strings up to their terminator or the end of the line, then CSI introduced by
-        /// `ESC [` or U+009B; any other escape sequence, including the ones with intermediate
-        /// bytes such as `ESC ( B`; and bare C0/C1 controls, except tabs and line terminators.
-        /// OSC is the only control string that
-        /// BEL ends — ECMA-48 gives DCS, APC, PM, and SOS the ST terminator alone — so a BEL
-        /// inside one of those is payload. Ending them at it would hand the rest of the payload
-        /// to the secret rules as text, and the character in front of a token there defeats the
-        /// token rules' word boundary.
-        let terminalEscape = #/(?:\u{1B}\]|\u{9D})[^\u{07}\u{9C}\u{1B}]*(?:\u{07}|\u{9C}|\u{1B}\\)?|(?:\u{1B}[P_^X]|[\u{90}\u{9F}\u{9E}\u{98}])[^\u{9C}\u{1B}]*(?:\u{9C}|\u{1B}\\)?|(?:\u{1B}\[|\u{9B})[0-9;:?<=>]*[ -\/]*[@-~]|\u{1B}[ -\/]*[0-~]|[\u{00}-\u{08}\u{0B}\u{0C}\u{0E}-\u{1F}\u{7F}-\u{9F}]/#
-        /// A control string introducer whose payload reaches the end of the line unterminated.
-        /// The first capture is present only for an OSC, whose payload a later BEL also ends.
-        let unterminatedControlString = #/(?:(\u{1B}\]|\u{9D})[^\u{07}\u{9C}\u{1B}]*|(?:\u{1B}[P_^X]|[\u{90}\u{9F}\u{9E}\u{98}])[^\u{9C}\u{1B}]*)$/#
-        /// The two ways any control string ends: C1 ST or the two-byte ST.
-        let controlStringEnd = #/\u{9C}|\u{1B}\\/#
-        /// An OSC ends at either of those or at BEL.
-        let oscEnd = #/\u{07}|\u{9C}|\u{1B}\\/#
+        /// Shared scalar grammar also owns bounded cross-record control state.
+        let terminalEscape = TerminalControlGrammar.escape
         /// The continuation of a folded header: leading whitespace (folding requires it) and
         /// anything at all after it.
         let foldedContinuation = #/\s+\S.*/#
@@ -153,7 +139,7 @@ extension Redactor {
         /// the rest of the line: an echoed command line carries the options after it, and
         /// `--token abc --verbose` must keep its second option.
         let secretOption = Regex {
-            #/(^|[\s\u{009F}"'\[({<:=\u{0060},;])/#
+            #/(^|[\s\u{001F}"'\[({<:=\u{0060},;])/#
             Capture {
                 #/--?[A-Za-z0-9_-]*/#
                 secretName
@@ -161,7 +147,7 @@ extension Redactor {
             #/([ \t]+|=)(?=\S)/#
         }.ignoresCase()
         let secretOptionOnly = Regex {
-            #/(^|[\s\u{009F}"'\[({<:=\u{0060},;])--?[A-Za-z0-9_-]*/#
+            #/(^|[\s\u{001F}"'\[({<:=\u{0060},;])--?[A-Za-z0-9_-]*/#
             secretName
             #/[ \t]*(?:=[ \t]*)?$/#
         }.ignoresCase()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Terminal.swift
@@ -1,0 +1,194 @@
+import Foundation
+import RegexBuilder
+
+extension Redactor {
+    /// Removes terminal control sequences: CSI in both encodings, OSC/DCS/APC/PM/SOS strings
+    /// with their payloads, escape sequences with or without intermediate bytes, and bare C0/C1
+    /// controls. Tabs and line terminators retain their framing role; other controls are removed
+    /// before secret matching so a backspace or styling sequence cannot interrupt a credential.
+    static func stripTerminalEscapes(_ text: String) -> String {
+        var pending: TerminalControlGrammar.Pending?
+        var result = ""
+        var cursor = text.startIndex
+        // Payload may span records, but their CR/LF framing is not payload to discard.
+        for separator in text.matches(of: patterns.lineSeparator) {
+            let record = TerminalControlGrammar.prepare(String(text[cursor..<separator.range.lowerBound]), pending: &pending)
+            result += TerminalControlGrammar.normalize(record) + separator.0
+            cursor = separator.range.upperBound
+        }
+        return result + TerminalControlGrammar.normalize(TerminalControlGrammar.prepare(String(text[cursor...]), pending: &pending))
+    }
+
+    /// The same, for one line of a stream: a control string may open on one line and terminate
+    /// on a later one, and everything in between is its payload, not text to scan. Dropping that
+    /// payload here also keeps the terminator from joining the words on either side of it.
+    static func stripTerminalEscapes(
+        _ line: String,
+        openControlString: inout StreamState.ControlString?
+    ) -> (joined: String, spliced: String, contexts: [String]) {
+        let prepared = TerminalControlEvidence.prepare(line, continuation: &openControlString)
+        let result = renderings(of: prepared.text, priorPrefixes: prepared.prefixes)
+        guard openControlString?.pending != nil else { return result }
+        // A later record can finish "code" after a value already present in this prefix.
+        // Emitted bytes cannot be retracted. Hide code-shaped values now while retaining
+        // the original bounded scan-only prefix for the completing record.
+        func concealPotentialCodes(_ value: String) -> String {
+            value.replacing(patterns.deviceCode) { "\($0.1)\(marker("device-code"))" }
+        }
+        return (concealPotentialCodes(result.joined), concealPotentialCodes(result.spliced), result.contexts)
+    }
+
+    /// Stands where an escape did, in the `spliced` reading only. It has to be a boundary to
+    /// every token rule and removable without consuming the remaining diagnostic. Unit
+    /// Separator is a bare control, never a control-string introducer.
+    static let splicedBoundary = "\u{001F}"
+
+    private typealias RecoveredCredential = (range: Range<Int>, kind: String)
+
+
+    /// Joined text repairs interrupted labels; spliced text preserves control-supplied token
+    /// boundaries and conceals recovered token spans. Scan-only contexts retain restored field
+    /// evidence for the state-aware caller. Ordinary lines have identical visible readings.
+    static func renderings(of text: String, priorPrefixes: [TerminalControlEvidence.Prefix] = []) -> (joined: String, spliced: String, contexts: [String]) {
+        if priorPrefixes.isEmpty, text.firstMatch(of: patterns.terminalEscape) == nil { return (text, text, []) }
+        func isTokenCharacter(_ character: Character) -> Bool {
+            character.isASCII && (character.isLetter || character.isNumber || character == "_" || character == "-")
+        }
+        var joined = ""
+        var scanned = text.startIndex
+        var joinedByteCount = 0
+        var boundaryOffsets: [Int] = []
+        for escape in text.matches(of: patterns.terminalEscape) {
+            let literal = text[scanned..<escape.range.lowerBound]
+            joined += literal
+            joinedByteCount += literal.utf8.count
+            if boundaryOffsets.last != joinedByteCount {
+                boundaryOffsets.append(joinedByteCount)
+            }
+            scanned = escape.range.upperBound
+        }
+        joined += text[scanned...]
+        let tokenRanges = terminalCredentialSpans(in: joined).map(\.range)
+        let hasCodeContext = joined.contains(patterns.mentionsCode)
+        // Adjacent controls share one offset. Inspect surviving neighbors only after every
+        // escape is removed, so a neighboring control cannot hide a credential's boundary.
+        boundaryOffsets = boundaryOffsets.filter { offset in
+            let boundary = joined.utf8.index(joined.utf8.startIndex, offsetBy: offset)
+            let suffix = joined[boundary...]
+            return (joined[..<boundary].last.map(isTokenCharacter) == true
+                && suffix.first.map(isTokenCharacter) == true)
+                || suffix.prefixMatch(of: #/(?:\\*\/){2}/#) != nil
+                || tokenRanges.contains { $0.lowerBound < boundary && boundary < $0.upperBound }
+                || terminalHasCredentialOpener(suffix)
+                || (hasCodeContext && suffix.prefixMatch(of: patterns.deviceCode) != nil)
+        }
+        let recovery = recoveredCredentialRanges(in: text, joined: joined, priorPrefixes: priorPrefixes)
+        var recovered = recovery.ranges
+        guard !boundaryOffsets.isEmpty || !recovered.isEmpty else { return (joined, joined, recovery.contexts) }
+
+        // A boundary inside a recognized token would let the first scan redact only a valid
+        // prefix. Closing the boundary afterwards cannot recover the remaining suffix. Keep
+        // recognized tokens whole in both readings, while retaining boundaries before tokens
+        // that need them, such as `filename<control>sk-...`.
+        func byteRange(_ range: Range<String.Index>) -> Range<Int> {
+            let lower = joined.utf8.distance(from: joined.utf8.startIndex, to: range.lowerBound)
+            let upper = joined.utf8.distance(from: joined.utf8.startIndex, to: range.upperBound)
+            return lower..<upper
+        }
+        var ordinaryRanges = tokenRanges
+        var contexts = recovery.contexts
+        // A JOSE segment can spell a field/prompt name. Its marker must not hide that name
+        // while leaving the independently recognized value outside the recovered token.
+        ordinaryRanges += joined.matches(of: patterns.authorizationHeader).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.labeledSecret).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.secretLabelOnly).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.secretOptionOnly).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.codePromptOnly).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.codeField).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.codePrompt).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.codePromptWithoutDelimiter).map(\.range)
+        ordinaryRanges += joined.matches(of: patterns.declarativeCodePrompt).map(\.range)
+        // A recovered segment can also contain the BEGIN word. Protect the current PEM body
+        // before replacing it; the stream scanner separately retains its normalized state.
+        ordinaryRanges += joined.matches(of: patterns.pemBegin).map { begin in
+            let tail = joined[begin.range.upperBound...]
+            let end = tail.range(of: "-----END \(begin.1)-----")?.upperBound ?? joined.endIndex
+            return begin.range.lowerBound..<end
+        }
+        // Markers can erase an ordinary label just as surely as a recovered one. Preserve
+        // its unmasked scan-only context before expansion, including bare next-record labels.
+        if ordinaryRanges.dropFirst(tokenRanges.count).contains(where: { range in
+            recovered.contains { $0.range.overlaps(byteRange(range)) }
+        }) { contexts.append(joined) }
+        recovered = expandingRecoveredRanges(recovered, through: ordinaryRanges.map(byteRange))
+        // Removing a contextual word inside a recovered token also removes the reason
+        // the later scanner would conceal independent code-shaped values on this record.
+        if joined.matches(of: patterns.mentionsCode).contains(where: { match in
+            recovered.contains { $0.range.overlaps(byteRange(match.range)) }
+        }) {
+            recovered += joined.matches(of: patterns.deviceCode).map {
+                (byteRange($0.2.startIndex..<$0.2.endIndex), "device-code")
+            }
+        }
+        let byteRanges = (tokenRanges.map(byteRange) + recovered.map(\.range)).sorted { $0.lowerBound < $1.lowerBound }
+        var mergedRanges: [Range<Int>] = []
+        for range in byteRanges {
+            if let last = mergedRanges.last, range.lowerBound < last.upperBound {
+                mergedRanges[mergedRanges.count - 1] = last.lowerBound..<max(last.upperBound, range.upperBound)
+            } else {
+                mergedRanges.append(range)
+            }
+        }
+        var spliced = ""
+        var insertedOffsets: [Int] = []
+        var rangeIndex = 0
+        scanned = joined.startIndex
+        for offset in boundaryOffsets {
+            while rangeIndex < mergedRanges.count, mergedRanges[rangeIndex].upperBound <= offset {
+                rangeIndex += 1
+            }
+            if rangeIndex < mergedRanges.count, mergedRanges[rangeIndex].lowerBound < offset {
+                let boundary = joined.utf8.index(joined.utf8.startIndex, offsetBy: offset)
+                let suffix = joined[boundary...]
+                let contextualCode = hasCodeContext
+                    && suffix.prefixMatch(of: patterns.deviceCode) != nil
+                guard terminalHasCredentialOpener(suffix) || contextualCode else { continue }
+                // The token may have swallowed a separate label. Keep that label available
+                // to the stream scanner, but conceal even a now-short token prefix.
+                // A recovered token can cross this boundary too. Its speculative suffix
+                // must not erase the independently recognized next credential's opener.
+                recovered = recovered.map { span in
+                    span.range.lowerBound < offset && offset < span.range.upperBound
+                        ? (span.range.lowerBound..<offset, span.kind) : span
+                }
+                recovered.append((mergedRanges[rangeIndex].lowerBound..<offset, "secret"))
+            }
+            let boundary = joined.utf8.index(joined.utf8.startIndex, offsetBy: offset)
+            spliced += joined[scanned..<boundary]
+            spliced += splicedBoundary
+            insertedOffsets.append(offset)
+            scanned = boundary
+        }
+        spliced += joined[scanned...]
+        var mapped: [RecoveredCredential] = []
+        var insertedIndex = 0
+        for span in expandingRecoveredRanges(recovered, through: []) {
+            let range = span.range
+            while insertedIndex < insertedOffsets.count, insertedOffsets[insertedIndex] <= range.lowerBound { insertedIndex += 1 }
+            let lower = range.lowerBound + insertedIndex * splicedBoundary.utf8.count
+            while insertedIndex < insertedOffsets.count, insertedOffsets[insertedIndex] < range.upperBound { insertedIndex += 1 }
+            mapped.append((lower..<(range.upperBound + insertedIndex * splicedBoundary.utf8.count), span.kind))
+        }
+        var redacted = ""
+        scanned = spliced.startIndex
+        for span in mapped {
+            let range = span.range
+            let lower = spliced.utf8.index(spliced.utf8.startIndex, offsetBy: range.lowerBound)
+            let upper = spliced.utf8.index(spliced.utf8.startIndex, offsetBy: range.upperBound)
+            redacted += spliced[scanned..<lower]
+            redacted += marker(span.kind)
+            scanned = upper
+        }
+        return (joined, redacted + spliced[scanned...], contexts)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalProjection.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalProjection.swift
@@ -14,23 +14,27 @@ extension Redactor {
 
     /// A control boundary must survive when its suffix starts a separate credential.
     static func terminalHasCredentialOpener(_ suffix: Substring) -> Bool {
-        suffix.prefixMatch(of: patterns.labeledSecret) != nil
-            || suffix.prefixMatch(of: patterns.secretLabelOnly) != nil
-            || suffix.prefixMatch(of: patterns.authorizationHeader) != nil
+        terminalHasFieldOpener(suffix)
             || suffix.prefixMatch(of: patterns.bearer) != nil
             || suffix.prefixMatch(of: patterns.basicAuthorization) != nil
             || suffix.prefixMatch(of: patterns.digestAuthorization) != nil
             || suffix.prefixMatch(of: patterns.specializedAuthorization) != nil
+            || suffix.prefixMatch(of: patterns.apiKey) != nil
+            || suffix.prefixMatch(of: patterns.distinctiveAPIKey) != nil
+            || suffix.prefixMatch(of: patterns.githubToken) != nil
+            || suffix.prefixMatch(of: patterns.urlUserInfo) != nil
+    }
+
+    private static func terminalHasFieldOpener(_ suffix: Substring) -> Bool {
+        suffix.prefixMatch(of: patterns.labeledSecret) != nil
+            || suffix.prefixMatch(of: patterns.secretLabelOnly) != nil
+            || suffix.prefixMatch(of: patterns.authorizationHeader) != nil
             || suffix.prefixMatch(of: patterns.codeField) != nil
             || suffix.prefixMatch(of: patterns.codePrompt) != nil
             || suffix.prefixMatch(of: patterns.codePromptWithoutDelimiter) != nil
             || suffix.prefixMatch(of: patterns.declarativeCodePrompt) != nil
             || suffix.prefixMatch(of: patterns.codePromptOnly) != nil
             || suffix.prefixMatch(of: patterns.pemBegin) != nil
-            || suffix.prefixMatch(of: patterns.apiKey) != nil
-            || suffix.prefixMatch(of: patterns.distinctiveAPIKey) != nil
-            || suffix.prefixMatch(of: patterns.githubToken) != nil
-            || suffix.prefixMatch(of: patterns.urlUserInfo) != nil
             || suffix.prefixMatch(of: patterns.secretOption) != nil
             || suffix.prefixMatch(of: patterns.secretOptionOnly) != nil
     }
@@ -68,14 +72,26 @@ extension Redactor {
             let offsets = projection.offsets
             let retained = projection.retained
             let boundaries = projection.boundaries
+            var fieldContext = ""
+            var fieldCursor = alternate.startIndex
             // A boundary from an earlier physical record is absent from the joined text.
             // Replay its suffix so short and complete wrapped keys retain their stream state.
             for boundary in boundaries.sorted() where boundary > 0 && boundary < alternate.utf8.count {
                 let start = alternate.utf8.index(alternate.utf8.startIndex, offsetBy: boundary)
                 let suffix = alternate[start...]
+                // Supply only actual recorded boundaries before recognized fields. Other
+                // boundaries stay joined so controls inside a label cannot break it again.
+                // Build one bounded context per projection, not a copy of every suffix.
+                if terminalHasFieldOpener(suffix) {
+                    fieldContext += alternate[fieldCursor..<start] + " "
+                    fieldCursor = start
+                }
                 if suffix.hasPrefix("sk-"), suffix.prefixMatch(of: patterns.wrappedTokenAtLineEnd) != nil {
                     contexts.append(String(suffix))
                 }
+            }
+            if fieldCursor != alternate.startIndex {
+                contexts.append(fieldContext + alternate[fieldCursor...])
             }
             // Short recognizable prefixes still own a possible next-record continuation.
             let content = alternate

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalProjection.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+TerminalProjection.swift
@@ -47,7 +47,7 @@ extension Redactor {
 
     /// Recover command finals as scan-only evidence, never as visible output. Token ranges
     /// can be masked here; opaque field contexts need the caller's quote/private-key state.
-    static func recoveredCredentialRanges(in text: String, joined: String, priorPrefixes: [String])
+    static func recoveredCredentialRanges(in text: String, joined: String, priorPrefixes: [TerminalControlEvidence.Prefix])
         -> (ranges: [TerminalCredentialRange], contexts: [String]) {
         var recovered: [TerminalCredentialRange] = []
         var contexts: [String] = []
@@ -68,6 +68,15 @@ extension Redactor {
             let offsets = projection.offsets
             let retained = projection.retained
             let boundaries = projection.boundaries
+            // A boundary from an earlier physical record is absent from the joined text.
+            // Replay its suffix so short and complete wrapped keys retain their stream state.
+            for boundary in boundaries.sorted() where boundary > 0 && boundary < alternate.utf8.count {
+                let start = alternate.utf8.index(alternate.utf8.startIndex, offsetBy: boundary)
+                let suffix = alternate[start...]
+                if suffix.hasPrefix("sk-"), suffix.prefixMatch(of: patterns.wrappedTokenAtLineEnd) != nil {
+                    contexts.append(String(suffix))
+                }
+            }
             // Short recognizable prefixes still own a possible next-record continuation.
             let content = alternate
             if content.contains(patterns.wrappedTokenAtLineEnd)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -15,10 +15,7 @@ struct Redactor: Sendable {
     /// removed in full.
     struct StreamState: Hashable, Sendable {
         /// Which kind of control string is open, because only an OSC also ends at BEL.
-        enum ControlString: Hashable, Sendable {
-            case osc
-            case other
-        }
+        typealias ControlString = TerminalControlEvidence.Continuation
 
         struct QuotedValue: Hashable, Sendable {
             let delimiter: Character

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/TerminalControlEvidence.swift
@@ -29,13 +29,26 @@ enum TerminalControlEvidence {
     }
     static let quarantineMarker = "[redacted:terminal-ambiguity]"
 
+    /// A retained reading includes the removed-control boundaries that made tokens valid.
+    /// Offsets are UTF-8 offsets in this bounded scan-only text, not in the next visible line.
+    struct Prefix: Hashable, Sendable, Comparable {
+        let text: String
+        var boundaries: Set<Int> = [0]
+
+        static func < (lhs: Self, rhs: Self) -> Bool {
+            lhs.text == rhs.text
+                ? lhs.boundaries.sorted().lexicographicallyPrecedes(rhs.boundaries.sorted())
+                : lhs.text < rhs.text
+        }
+    }
+
     struct Continuation: Hashable, Sendable {
         let pending: TerminalControlGrammar.Pending?
         /// At most 64 complete prefixes of at most 64 Unicode scalars (256 UTF-8 bytes).
-        let prefixes: [String]
+        let prefixes: [Prefix]
         let commandSuffix: String
         let quarantined: Bool
-        fileprivate init(pending: TerminalControlGrammar.Pending?, prefixes: [String],
+        fileprivate init(pending: TerminalControlGrammar.Pending?, prefixes: [Prefix],
                          commandSuffix: String, quarantined: Bool = false) {
             self.pending = pending
             self.prefixes = prefixes
@@ -51,10 +64,11 @@ enum TerminalControlEvidence {
         var retained: [Range<Int>]
         var boundaries: Set<Int> = [0]
 
-        fileprivate init(prefix: String) {
-            text = prefix
-            offsets = Array(repeating: 0, count: prefix.utf8.count + 1)
-            retained = prefix.isEmpty ? [] : [0..<prefix.utf8.count]
+        fileprivate init(prefix: Prefix) {
+            text = prefix.text
+            offsets = Array(repeating: 0, count: text.utf8.count + 1)
+            retained = text.isEmpty ? [] : [0..<text.utf8.count]
+            boundaries = prefix.boundaries
         }
 
         fileprivate mutating func append(literal: Substring) {
@@ -112,16 +126,19 @@ enum TerminalControlEvidence {
 
     /// Nil means that no safe bounded enumeration is possible. Do not silently drop
     /// alternatives: the missing reading might be the only one containing the credential.
-    static func projections(in text: String, prefixes: [String] = []) -> [Projection]? {
+    static func projections(in text: String, prefixes: [Prefix] = []) -> [Projection]? {
         guard isWithinControlBudget(text) else { return nil }
         guard prefixes.count <= maximumAlternatives,
-              prefixes.allSatisfy({ $0.utf8.prefix(257).count <= 256 }) else { return nil }
+              prefixes.allSatisfy({ prefix in
+                  let bytes = prefix.text.utf8.prefix(257).count
+                  return bytes <= 256 && prefix.boundaries.allSatisfy { (0...bytes).contains($0) }
+              }) else { return nil }
         // Charge the full possible reading before copying/hashing it. Sparse controls
         // cannot multiply a long unchanged suffix beyond this aggregate byte budget.
-        let readingBytes = max(1, text.utf8.count + (prefixes.map { $0.utf8.count }.max() ?? 0))
+        let readingBytes = max(1, text.utf8.count + (prefixes.map { $0.text.utf8.count }.max() ?? 0))
         var workRemaining = maximumProjectionWorkBytes - readingBytes * max(1, prefixes.count)
         guard workRemaining >= 0 else { return nil }
-        var results = Array(Set(prefixes.isEmpty ? [""] : prefixes)).sorted().map { Projection(prefix: $0) }
+        var results = Array(Set(prefixes.isEmpty ? [Prefix(text: "")] : prefixes)).sorted().map { Projection(prefix: $0) }
         guard results.count <= maximumAlternatives else { return nil }
         var remaining = text[...]
         while let escape = remaining.firstMatch(of: TerminalControlGrammar.escape) {
@@ -186,13 +203,13 @@ enum TerminalControlEvidence {
         return text[..<end]
     }
 
-    static func prepare(_ line: String, continuation: inout Continuation?) -> (text: String, prefixes: [String]) {
+    static func prepare(_ line: String, continuation: inout Continuation?) -> (text: String, prefixes: [Prefix]) {
         // Plain records need no alternate evidence or offset arrays, regardless of length.
         if continuation == nil, line.firstMatch(of: TerminalControlGrammar.escape) == nil { return (line, []) }
         let prefixes = continuation?.prefixes ?? []
         var pending = continuation?.pending
         var commandSuffix = continuation?.commandSuffix ?? ""
-        func quarantine() -> (text: String, prefixes: [String]) {
+        func quarantine() -> (text: String, prefixes: [Prefix]) {
             // An ambiguous opener might own unindented later records (PEM/quoted secrets).
             // Only a fresh StreamState can release this fail-closed state, never guest text.
             continuation = Continuation(pending: nil, prefixes: [], commandSuffix: "", quarantined: true)
@@ -209,7 +226,10 @@ enum TerminalControlEvidence {
             contentBeforeTerminator($0.text).unicodeScalars.prefix(65).count > 64
         }) { return quarantine() }
         continuation = pending.map { command in
-            let suffixes = readings.map { String(contentBeforeTerminator($0.text)) }
+            let suffixes = readings.map { reading in
+                let content = String(contentBeforeTerminator(reading.text))
+                return Prefix(text: content, boundaries: reading.boundaries.filter { $0 <= content.utf8.count })
+            }
             return Continuation(pending: command, prefixes: Array(Set(suffixes)).sorted(), commandSuffix: commandSuffix)
         }
         return (text, prefixes)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorGrammarReviewTests.swift
@@ -21,8 +21,8 @@ import Testing
 
     @Test(arguments: ["--password", "--token", "--api-key", "--github-token"])
     func terminalSplicesRemainOptionBoundaries(option: String) {
-        #expect(("filename\u{009F}" + option + " synthetic").contains(Redactor.patterns.secretOption))
-        #expect(("filename\u{009F}" + option).contains(Redactor.patterns.secretOptionOnly))
+        #expect(("filename" + Redactor.splicedBoundary + option + " synthetic").contains(Redactor.patterns.secretOption))
+        #expect(("filename" + Redactor.splicedBoundary + option).contains(Redactor.patterns.secretOptionOnly))
     }
 
     @Test(arguments: ["remote=//sample:synthetic@example.com", "remote = //sample:synthetic@example.com",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParsingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorParsingTests.swift
@@ -41,6 +41,17 @@ import Testing
         #expect(Redactor.redactedJWT(input[...]) == expected)
     }
 
+
+    @Test func terminalRenderingRetainsTokenBoundariesWithoutSplittingTokens() {
+        let boundary = Redactor.renderings(of: "prefix\u{1B}[31mghp_demo")
+        #expect(boundary.joined == "prefixghp_demo")
+        #expect(boundary.spliced == "prefix" + Redactor.splicedBoundary + "ghp_demo")
+        let interior = Redactor.renderings(of: "ghp_de\u{1B}[31mmo")
+        #expect(interior.joined == "ghp_demo")
+        #expect(interior.spliced == interior.joined)
+        #expect(Redactor.stripTerminalEscapes("a\t\u{8}b\r\n") == "a\tb\r\n")
+    }
+
     @Test(arguments: [#"first\ second --verbose"#, #"first" two"third --verbose"#, #"\"first second\" --verbose"#])
     func shellArgumentsIncludeEscapedWhitespaceAndAdjacentQuotes(input: String) {
         let argument = Redactor.secretArgument(in: input, from: input.startIndex)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorRetainedContextTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorRetainedContextTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorRetainedContextTests {
+    @Test(arguments: ["-password:", "-token:", "-passphrase:"])
+    func recoveredTokensKeepBareCredentialContext(_ label: String) {
+        let input = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload." + label
+        let result = Redactor.renderings(of: input)
+        #expect(!result.spliced.contains("payload"))
+        #expect(result.contexts.contains { $0.contains(Redactor.patterns.secretLabelOnly)
+            || $0.contains(Redactor.patterns.secretOptionOnly) })
+    }
+
+    @Test(arguments: ["filename", "☃filename"], ["\u{0}", "\u{7}"])
+    func pendingPrefixesKeepEarlierControlBoundaries(_ prefix: String, _ control: String) throws {
+        var pending: Redactor.StreamState.ControlString?
+        _ = Redactor.stripTerminalEscapes(prefix + control + "s\u{1B}[31", openControlString: &pending)
+        #expect(pending != nil)
+        let result = Redactor.stripTerminalEscapes("mk-abcdefghijklmnop", openControlString: &pending)
+        #expect(!result.spliced.contains("abcdefghijklmnop"))
+        #expect(result.spliced.contains("[redacted:api-key]"))
+        #expect(result.contexts.contains { $0.contains(Redactor.patterns.wrappedTokenAtLineEnd) })
+        #expect(pending == nil)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorRetainedContextTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorRetainedContextTests.swift
@@ -2,6 +2,17 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorRetainedContextTests {
+    @Test(arguments: [
+        ("x\u{1B}Authorization: opaque", "x Authorization: opaque"),
+        ("x\u{1B}password: opaque", "x password: opaque"),
+        ("x\u{1B}[--password opaque", "x --password opaque"),
+        ("x\u{1B}device_code: opaque", "x device_code: opaque"),
+        ("☃x\u{1B}pass\u{1B}word: opaque", "☃x password: opaque")
+    ])
+    func recoveredFieldsHonorControlSuppliedBoundaries(_ input: String, _ context: String) {
+        #expect(Redactor.renderings(of: input).contexts.contains(context))
+    }
+
     @Test(arguments: ["-password:", "-token:", "-passphrase:"])
     func recoveredTokensKeepBareCredentialContext(_ label: String) {
         let input = "eyJhbGciOiJIUzI1NiIsI\u{1B}[mtpZCI6Im5hYmMifQ.payload." + label

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalControlEvidenceTests.swift
@@ -8,10 +8,10 @@ import Testing
     func visiblePrefixesSurviveOpaquePayloads(parts: (String, String)) throws {
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare("s" + parts.0 + "opaque", continuation: &state)
-        #expect(try #require(state).prefixes == ["s"])
+        #expect(try #require(state).prefixes.map(\.text) == ["s"])
         #expect(TerminalControlEvidence.prepare("hidden", continuation: &state).text == "")
         let next = TerminalControlEvidence.prepare("hidden" + parts.1 + "k-proj-synthetic", continuation: &state)
-        #expect(next.prefixes.contains("s"))
+        #expect(next.prefixes.map(\.text).contains("s"))
         #expect(next.text == "k-proj-synthetic")
         #expect(state == nil)
     }
@@ -53,11 +53,11 @@ import Testing
         var state: TerminalControlEvidence.Continuation?
         let first = TerminalControlEvidence.prepare("s" + command + framing, continuation: &state)
         #expect(first.text == "s" + framing)
-        #expect(first.prefixes == [])
+        #expect(first.prefixes.map(\.text) == [])
         let pending = try #require(state)
-        #expect(pending.prefixes == ["s"])
+        #expect(pending.prefixes.map(\.text) == ["s"])
         let next = TerminalControlEvidence.prepare("k-abcdefghijklmnop", continuation: &state)
-        #expect(next.prefixes == ["s"])
+        #expect(next.prefixes.map(\.text) == ["s"])
         #expect(!next.text.hasPrefix("s"))
         #expect(state == nil)
     }
@@ -66,7 +66,7 @@ import Testing
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare("s\u{1B}[31", continuation: &state)
         _ = TerminalControlEvidence.prepare("k\u{1B}[32", continuation: &state)
-        let prefixes = try #require(state).prefixes.sorted()
+        let prefixes = try #require(state).prefixes.map(\.text).sorted()
         #expect(prefixes == ["s", "s1", "s1k", "s3", "s31", "s31k", "s3k", "sk"])
         _ = TerminalControlEvidence.prepare(String(repeating: "1", count: 10_000), continuation: &state)
         #expect(try #require(state).quarantined)
@@ -77,7 +77,7 @@ import Testing
     func lookbehindIsBoundedInScalarsAndBytes(_ scalar: String) throws {
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare(String(repeating: scalar, count: 10_000) + "\u{1B}[", continuation: &state)
-        let prefixes = try #require(state).prefixes
+        let prefixes = try #require(state).prefixes.map(\.text)
         #expect(state?.quarantined == true)
         #expect(prefixes.isEmpty)
         #expect(prefixes.allSatisfy { $0.unicodeScalars.count <= 64 && $0.utf8.count <= 256 })
@@ -88,17 +88,17 @@ import Testing
         var state: TerminalControlEvidence.Continuation?
         let prefix = String(repeating: scalar, count: count)
         _ = TerminalControlEvidence.prepare(prefix + "\u{1B}[", continuation: &state)
-        #expect(try #require(state).prefixes == [prefix])
+        #expect(try #require(state).prefixes.map(\.text) == [prefix])
         #expect(state?.quarantined == false)
     }
 
     @Test func controlStringsCarryOnlyVisiblePrefixesNeverTheirPayload() throws {
         var state: TerminalControlEvidence.Continuation?
         _ = TerminalControlEvidence.prepare("s\u{1B}]payload", continuation: &state)
-        #expect(try #require(state).prefixes == ["s"])
+        #expect(try #require(state).prefixes.map(\.text) == ["s"])
         let next = TerminalControlEvidence.prepare("hidden\u{7}after", continuation: &state)
         #expect(next.text == "after")
-        #expect(next.prefixes == ["s"])
+        #expect(next.prefixes.map(\.text) == ["s"])
         #expect(state == nil)
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalCredentialProjectionTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/TerminalCredentialProjectionTests.swift
@@ -193,7 +193,7 @@ import Testing
     @Test func priorPrefixEvidenceProjectsOntoOnlyTheCurrentRecord() throws {
         let input = "\u{1B}[31k-abcdefghijklmnop"
         let joined = TerminalControlGrammar.normalize(input)
-        let span = try #require(Redactor.recoveredCredentialRanges(in: input, joined: joined, priorPrefixes: ["s"]).ranges.first)
+        let span = try #require(Redactor.recoveredCredentialRanges(in: input, joined: joined, priorPrefixes: [.init(text: "s")]).ranges.first)
         #expect(span.kind == "api-key")
         #expect(span.range == 0..<joined.utf8.count)
     }


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
### Current maintenance — 2026-09-08 15:04 UTC

Ready merge prefix remains **#123 → #124 → #125 → #126 → #129 → #95**, independently rechecked for the user's status question. **Stop before #131:** it has current-head Codex approval and no unresolved threads, but its exact-head Xcode Cloud checks are absent (confirmed via both GraphQL and gh pr checks), not green. The other eight changed heads have pending CI and fresh Codex review running at this snapshot. No new dependency-ready prefix.

Current stack: **#123 → #124 → #125 → #126 → #129 → #95 → #131 → #132 → #133 → #127 → #96 → #134 → #128 → #130 → #114 → #115 → #97 → #98 → #116 → #117 → #118 → #119 → #120 → #59 → #121 → #122 → #53**. Retarget each child to main and revalidate after its parent merges. Maintenance has not merged any PR.

| PR | Exact published head | Own changed lines | Passing Core tests/suites |
| --- | --- | ---: | --- |
| #131 | `355c67d3` | 498 | 206/17 |
| #132 | `b5e37bac` | 240 | 216/18 |
| #133 | `07bbdffe` | 72 | 220/19 |
| #127 | `4b95c7f2` | 493 | 250/21 |
| #96 | `2b4c2408` | 485 | 305/24 |
| #134 | `60dbd94f` | 82 | 310/25 |
| #128 | `7ae0a284` | 499 | 327/26 |
| #130 | `c6800400` | 466 | 383/28 |
| #114 | `8d65773e` | 392 | 426/32 |

**16 review findings were fixed, explained, exact read-back checked, and freshly verified resolved.** Repairs cover quadratic prompt-prefix rescans, split URL delimiters/frames and escape parity, escaped structured credential names (including boundary whitespace), quoted device-code decoys, incidental algorithm names, physical wrapped-key state, and stronger per-fragment/state assertions. Full final Core suites pass with warnings-as-errors, including 426 tests/32 suites through the public physical composition.

New focused prerequisites: **#133** owns bounded structured-key normalization; **#134** owns independently tested physical framing helpers. #127 now targets #133; #128 targets #134 and is reduced from 535 to **499 own changed lines**. All original implementation/test history is retained. The initial #134 extraction build exposed file-private decoder access; it was corrected and fully retested before the PR was opened, without expanding decoder visibility.

**26 findings remain at this snapshot:** #127 THREE (curly-framed prompt codes, dotted secret-option qualifiers, compact network-path URL lists), #96 THREE (stronger completed-argv/pending-state/userinfo assertions), and #128 TWENTY. The remaining physical findings include nested/ambiguous framing, partial JOSE/PEM, unindented continuations, retained record terminators, netrc, private JWK, explicit historical lowercase codes, and bounded encoded-auth fields. CI/reactions do not clear any of these. New format coverage must be source-backed; PPK already has #116 and should not be duplicated.

#115 onward still needs normal restacking and current validation. Shared/Lume work remains dependency-gated; existing issue coverage is retained, and legacy Tart #13/#23/#25 remains explicitly deferred/recoverable. Inventory: 74 open PRs /47 issues; main bc570848 unchanged. Local-only proof 4420bba remains untouched historical evidence, not current acceptance. All nine source owners are clean and published. Automation ACTIVE; no agents, VM/auth/signing/hardware operations, merges, or history rewrites. Earlier checkpoints are historical.
<!-- /guesthouse-current-validation -->

## Purpose

Stacked on #126; prerequisite of #95. Part of #11 and MVP-PLAN.md §3 (never persist credentials). This extracts the terminal renderer from #95 so the implementation and the larger existing regression batch are independently reviewable. No tests or branch history are removed.

## Repair

- Keep bare and ordinary credential-label context before recovered-token markers erase its text.
- Retain bounded UTF-8 splice boundaries alongside pending terminal prefix readings, including across physical records. Replay boundary-delimited wrapped-key evidence without making retained text visible.
- Preserve the existing 64-reading, 64-scalar-prefix, record/control/work budgets and fail-closed quarantine.

The exact #95 review inputs reproduced failures before repair. Focused parameterized regressions cover password/token/passphrase labels and ASCII/Unicode prefixes with NUL/BEL boundaries. The physical-stream companion also checks the following opaque/password and wrapped-key records.

## Validation

- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: **140 tests / 14 suites pass** on this component.
- Full #95 composition: **181 / 16 pass** before extraction.
- Component scope: **340 changed lines**; #95 becomes its separate existing terminal regression batch.
- Xcode Cloud and current-head Codex review still required. No hardware, VM, signing, or auth claims; do not merge automatically.

Merge order around this change: #123 → #124 → #125 → #126 → this PR → #95 → #127 → #96 → #128 → #114 (the physical-test boundary is being split separately). Retarget/revalidate each child after its parent merges.