### PR TITLE
Extract URL continuation framing and preserve closed diagnostics

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -116,7 +116,7 @@ extension Redactor {
             urlAuthorityPrefix
             #/[^\s\/?#]+@/#
         }
-        let partialURLAuthority = #/(?:^|[\s:"'(<\[{\u{0060}])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:(?:\\*\/)?|:?\\*\/)\\*$/#
+        let partialURLAuthority = #/(?:^|[\s,:"'(<\[{\u{0060}])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:(?:\\*\/)?|:?\\*\/)\\*$/#
         let incompleteURLUserInfo = Regex {
             urlAuthorityPrefix
             #/[^\s\/?#]*$/#

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -110,13 +110,13 @@ extension Redactor {
         private static var urlAuthorityPrefix: Regex<(Substring, Substring)> {
             // Scan the existing record; no escape-depth buffer is retained. A depth cap
             // here would leave deeper encodings unmatched and expose their credentials.
-            #/((?::|^|[\s,"'(<\[{\u{0060}]|(?:^|[\s,"'(<\[{\u{0060}])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\*\/){2})/#
+            #/((?::|^|^[ \t]*=|[\s,"'(<\[{\u{0060}]|(?:^|[\s,"'(<\[{\u{0060}])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\*\/){2})/#
         }
         let urlUserInfo = Regex {
             urlAuthorityPrefix
             #/[^\s\/?#]+@/#
         }
-        let partialURLAuthority = #/(?:^|[\s,:"'(<\[{\u{0060}])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:(?:\\*\/)?|:?\\*\/)\\*$/#
+        let partialURLAuthority = #/(?:^[ \t]*=|^|[\s,:"'(<\[{\u{0060}])(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:(?:\\*\/)?|:?\\*\/)\\*$/#
         let incompleteURLUserInfo = Regex {
             urlAuthorityPrefix
             #/[^\s\/?#]*$/#

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Patterns.swift
@@ -110,7 +110,7 @@ extension Redactor {
         private static var urlAuthorityPrefix: Regex<(Substring, Substring)> {
             // Scan the existing record; no escape-depth buffer is retained. A depth cap
             // here would leave deeper encodings unmatched and expose their credentials.
-            #/((?::|^|[\s"'(<\[{\u{0060}]|(?:^|[\s"'(<\[{\u{0060}])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\*\/){2})/#
+            #/((?::|^|[\s,"'(<\[{\u{0060}]|(?:^|[\s,"'(<\[{\u{0060}])(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)(?:\\*\/){2})/#
         }
         let urlUserInfo = Regex {
             urlAuthorityPrefix

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -37,7 +37,7 @@ extension Redactor {
             if decoded.contains(#"\u"#) {
                 nested = depth < 2 ? redactEncodedURLStrings(decoded, state: &context, depth: depth + 1) : marker("encoded-value")
             } else { nested = decoded }
-            let sanitized = redactURLContinuations(nested, state: &context, decodeStrings: false)
+            let sanitized = redactURLContinuations(nested, state: &context, decodeStrings: false, closedStringBoundary: true)
             guard sanitized != decoded else { return String(encoded) }
             let encoder = JSONEncoder()
             encoder.outputFormatting = .withoutEscapingSlashes
@@ -54,7 +54,7 @@ extension Redactor {
                 && text[..<partial.range.lowerBound].contains(#/(?:^|[^A-Za-z0-9])(?i:url|uri)["']?[ \t]*[:=][ \t]*$/#))
             || (partial.0.dropFirst().wholeMatch(of: #/[A-Za-z][A-Za-z0-9+.-]*:?/#) != nil
                 && (partial.0.hasSuffix(":")
-                    || ["http", "https", "ssh", "git", "ftp", "ftps", "ws", "wss"].contains(partial.0.dropFirst().lowercased())
+                    || ["http", "https", "ssh", "git", "ftp", "ftps", "ws", "wss"].contains(where: { $0.hasPrefix(partial.0.dropFirst().lowercased()) })
                     || text[..<partial.range.lowerBound].contains(#/(?:^|[^A-Za-z0-9])(?i:url|uri)["']?[ \t]*[:=][ \t]*$/#))
                 && text[..<partial.range.lowerBound].contains(#/(?:^|[:=])[ \t]*$/#)) {
             // Before an escape completes, even a URI's scheme/colon can be hidden.
@@ -69,7 +69,7 @@ extension Redactor {
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
     static func redactURLContinuations(_ input: String, state: inout StreamState, decodeStrings: Bool = true,
-                                       authorityStartsHere: Bool = false) -> String {
+                                       authorityStartsHere: Bool = false, closedStringBoundary: Bool = false) -> String {
         let input = decodeStrings ? redactEncodedURLStrings(input, state: &state) : input
         defer {
             if !input.allSatisfy(\.isWhitespace) {
@@ -104,7 +104,7 @@ extension Redactor {
             }
             if remaining == 0 {
                 state.expectingURLUserInfo = true
-                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state, decodeStrings: decodeStrings, authorityStartsHere: true)
+                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state, decodeStrings: decodeStrings, authorityStartsHere: true, closedStringBoundary: closedStringBoundary)
             }
         }
         if state.expectingURLUserInfo {
@@ -137,7 +137,9 @@ extension Redactor {
             state.pendingURLSlashes = partial.0.reversed().drop(while: { $0 == "\\" }).first == "/" ? 1 : 2
         }
         return text.replacing(patterns.incompleteURLUserInfo) { match in
-            if hasCompleteURLFrame(in: text, prefixEnd: match.1.endIndex) { return String(match.0) }
+            // JSON decoding removes the outer closing quote, but not its proof that
+            // this authority ends here. Userinfo has already been sanitized above.
+            if closedStringBoundary || hasCompleteURLFrame(in: text, prefixEnd: match.1.endIndex) { return String(match.0) }
             state.expectingURLUserInfo = true
             return String(match.1) + marker("userinfo")
         }
@@ -146,6 +148,9 @@ extension Redactor {
     /// Only framing outside URI userinfo's grammar can prove same-record closure.
     /// Parentheses/apostrophes are valid sub-delimiters even when they appear paired.
     private static func hasCompleteURLFrame(in text: String, prefixEnd: String.Index) -> Bool {
+        // A complete bracketed IPv6 host is not userinfo: brackets cannot extend
+        // an RFC authority's username/password. Require the entire remaining host.
+        if text[prefixEnd...].wholeMatch(of: #/\[[0-9A-Fa-f.]*:[0-9A-Fa-f:.]*(?:%[A-Za-z0-9_.-]+)?\](?::[0-9]+)?/#) != nil { return true }
         var start = prefixEnd
         while start > text.startIndex, text[..<start].last.map({ "/\\".contains($0) }) == true {
             text.formIndex(before: &start)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -6,9 +6,10 @@ extension Redactor {
         #/\[(?:[^\[\]\r\n]|\[[^\[\]\r\n]*\])*\]/#
     }
     /// RFC 8259 strings can encode URL delimiters as Unicode escapes. Decode only a
-    /// bounded, closed string, scan once, and re-encode only when it contains userinfo.
+    /// bounded, closed string, inspect at most three string layers, and re-encode
+    /// only when sanitization changes it. Deeper encoded structure fails closed.
     /// No decoded payload is retained in stream state or emitted without sanitization.
-    private static func redactEncodedURLStrings(_ input: String, state: inout StreamState) -> String {
+    private static func redactEncodedURLStrings(_ input: String, state: inout StreamState, depth: Int = 0) -> String {
         let closedString = #/"(?:[^"\\\r\n]|\\[^\r\n])*"/#
         var text = input
         if state.pendingEncodedURLString {
@@ -31,9 +32,13 @@ extension Redactor {
             guard encoded.utf8.prefix(8193).count <= 8192,
                   let decoded = try? JSONDecoder().decode(String.self, from: Data(encoded.utf8))
             else { return "\"" + marker("encoded-value") + "\"" }
-            guard decoded.contains(patterns.urlUserInfo) else { return String(encoded) }
             var context = StreamState()
-            let sanitized = redactURLContinuations(decoded, state: &context, decodeStrings: false)
+            let nested: String
+            if decoded.contains(#"\u"#) {
+                nested = depth < 2 ? redactEncodedURLStrings(decoded, state: &context, depth: depth + 1) : marker("encoded-value")
+            } else { nested = decoded }
+            let sanitized = redactURLContinuations(nested, state: &context, decodeStrings: false)
+            guard sanitized != decoded else { return String(encoded) }
             let encoder = JSONEncoder()
             encoder.outputFormatting = .withoutEscapingSlashes
             guard let data = try? encoder.encode(sanitized) else { return "\"" + marker("userinfo") + "\"" }
@@ -44,7 +49,9 @@ extension Redactor {
         if let partial = text.firstMatch(of: #/"(?:[^"\\\r\n]|\\[^\r\n])*\\?$/#),
            text[..<partial.range.lowerBound].reversed().prefix(while: { $0 == "\\" }).count.isMultiple(of: 2),
            !text.matches(of: closedString).contains(where: { $0.range.contains(partial.range.lowerBound) }),
-           partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\") {
+           partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\")
+            || (partial.0.dropFirst().wholeMatch(of: #/[A-Za-z][A-Za-z0-9+.-]*:?/#) != nil
+                && text[..<partial.range.lowerBound].contains(#/(?:^|[:=])[ \t]*$/#)) {
             // Before an escape completes, even a URI's scheme/colon can be hidden.
             // Quarantine incomplete encoded strings; only a closing quote proves an end.
             state.pendingEncodedURLString = true

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -9,6 +9,7 @@ extension Redactor {
     /// bounded, closed string, scan once, and re-encode only when it contains userinfo.
     /// No decoded payload is retained in stream state or emitted without sanitization.
     private static func redactEncodedURLStrings(_ input: String, state: inout StreamState) -> String {
+        let closedString = #/"(?:[^"\\\r\n]|\\[^\r\n])*"/#
         var text = input
         if state.pendingEncodedURLString {
             var escaped = state.encodedURLHasTrailingEscape
@@ -24,7 +25,7 @@ extension Redactor {
             state.encodedURLHasTrailingEscape = false
             text = marker("encoded-value") + text[text.index(after: closing)...]
         }
-        text = text.replacing(#/"(?:[^"\\\r\n]|\\[^\r\n])*"/#) { match in
+        text = text.replacing(closedString) { match in
             let encoded = match.0
             guard encoded.contains(#"\u"#) else { return String(encoded) }
             guard encoded.utf8.prefix(8193).count <= 8192,
@@ -41,6 +42,7 @@ extension Redactor {
         // A Unicode escape can hide every authority delimiter. Until this quoted
         // URL closes, emit a marker per record and retain only escape parity.
         if let partial = text.firstMatch(of: #/"(?:[^"\\\r\n]|\\[^\r\n])*\\?$/#),
+           !text.matches(of: closedString).contains(where: { $0.range.contains(partial.range.lowerBound) }),
            partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\") {
             // Before an escape completes, even a URI's scheme/colon can be hidden.
             // Quarantine incomplete encoded strings; only a closing quote proves an end.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -41,8 +41,9 @@ extension Redactor {
         // A Unicode escape can hide every authority delimiter. Until this quoted
         // URL closes, emit a marker per record and retain only escape parity.
         if let partial = text.firstMatch(of: #/"(?:[^"\\\r\n]|\\[^\r\n])*\\?$/#),
-           partial.0.contains(#"\u"#),
-           partial.0.contains(#/[A-Za-z][A-Za-z0-9+.-]*(?::|\\u003[aA])|\\u002[fF]/#) {
+           partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\") {
+            // Before an escape completes, even a URI's scheme/colon can be hidden.
+            // Quarantine incomplete encoded strings; only a closing quote proves an end.
             state.pendingEncodedURLString = true
             state.encodedURLHasTrailingEscape = !partial.0.reversed().prefix(while: { $0 == "\\" }).count.isMultiple(of: 2)
             text = String(text[..<partial.range.lowerBound]) + marker("encoded-value")

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -9,7 +9,7 @@ extension Redactor {
     /// bounded, closed string, inspect at most three string layers, and re-encode
     /// only when sanitization changes it. Deeper encoded structure fails closed.
     /// No decoded payload is retained in stream state or emitted without sanitization.
-    private static func redactEncodedURLStrings(_ input: String, state: inout StreamState, depth: Int = 0) -> String {
+    static func redactEncodedURLStrings(_ input: String, state: inout StreamState, depth: Int = 0) -> String {
         let closedString = #/"(?:[^"\\\r\n]|\\[^\r\n])*"/#
         var text = input
         if state.pendingEncodedURLString {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -50,6 +50,8 @@ extension Redactor {
            text[..<partial.range.lowerBound].reversed().prefix(while: { $0 == "\\" }).count.isMultiple(of: 2),
            !text.matches(of: closedString).contains(where: { $0.range.contains(partial.range.lowerBound) }),
            partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\")
+            || (partial.0 == "\""
+                && text[..<partial.range.lowerBound].contains(#/(?:^|[^A-Za-z0-9])(?i:url|uri)["']?[ \t]*[:=][ \t]*$/#))
             || (partial.0.dropFirst().wholeMatch(of: #/[A-Za-z][A-Za-z0-9+.-]*:?/#) != nil
                 && (partial.0.hasSuffix(":")
                     || ["http", "https", "ssh", "git", "ftp", "ftps", "ws", "wss"].contains(partial.0.dropFirst().lowercased())
@@ -75,7 +77,7 @@ extension Redactor {
                     && !input.reversed().drop(while: \.isWhitespace).prefix(while: { $0 == "\\" }).count.isMultiple(of: 2)
             }
         }
-        // A comma separates URLs only when the next element starts another authority.
+        // A comma/semicolon separates URLs only when the next element starts another authority.
         // Otherwise it may be part of the current URI's userinfo (or path/query).
         // A comma + authority is ambiguous even inside a query. Conceal its userinfo
         // rather than assuming that a nested URL or compact list element is public.
@@ -84,8 +86,8 @@ extension Redactor {
         }
         var cursor = input.startIndex
         var text = ""
-        for separator in input.matches(of: #/,(?=[ \t]*(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
-            text += sanitized(input[cursor..<separator.range.lowerBound]) + ","
+        for separator in input.matches(of: #/[,;](?=[ \t]*(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
+            text += sanitized(input[cursor..<separator.range.lowerBound]) + separator.0
             cursor = separator.range.upperBound
         }
         text += sanitized(input[cursor...])
@@ -165,7 +167,7 @@ extension Redactor {
         }) { return true }
         // A continued list may have lost its opener on a preceding record. A comma
         // authority boundary plus the terminal list closer still bounds its last element.
-        if text[..<start].last == ",", text[prefixEnd...].last == "]" { return true }
+        if text[..<start].last.map({ ",;".contains($0) }) == true, text[prefixEnd...].last == "]" { return true }
         let quotedRecord = text.drop(while: \.isWhitespace)
         if quotedRecord.first == "\"", quotedRecord.startIndex < start,
            let end = closingQuoteEnd(in: quotedRecord.dropFirst(),

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -4,11 +4,20 @@ extension Redactor {
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
     static func redactURLContinuations(_ input: String, state: inout StreamState) -> String {
-        // Commas separate unquoted elements inside diagnostic lists, not inside an
-        // ordinary URL path/query. Scan each flat list element at its own value boundary.
+        // A comma separates URLs only when the next element starts another authority.
+        // Otherwise it may be part of the current URI's userinfo (or path/query).
         var text = input.replacing(#/\[[^\[\]\r\n]*\]/#) { match in
-            "[" + match.0.dropFirst().dropLast().split(separator: ",", omittingEmptySubsequences: false)
-                .map { $0.replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" } }.joined(separator: ",") + "]"
+            let list = match.0.dropFirst().dropLast()
+            func sanitized(_ element: Substring) -> String {
+                String(element).replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" }
+            }
+            var cursor = list.startIndex
+            var result = "["
+            for separator in list.matches(of: #/,(?=[ \t]*(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
+                result += sanitized(list[cursor..<separator.range.lowerBound]) + ","
+                cursor = separator.range.upperBound
+            }
+            return result + sanitized(list[cursor...]) + "]"
         }
         if state.pendingURLSlashes > 0 {
             var remaining = state.pendingURLSlashes
@@ -57,6 +66,9 @@ extension Redactor {
             while start > text.startIndex, text[..<start].last.map({
                 $0.isASCII && ($0.isLetter || $0.isNumber || "+-.".contains($0))
             }) == true { text.formIndex(before: &start) }
+        }
+        if let assignment = text[..<start].firstMatch(of: #/(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*$/#) {
+            start = assignment.range.lowerBound
         }
         // The URL can be the final element of a flat diagnostic list, or part of
         // prose inside one whole-record double-quoted value. Neither frame belongs

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -5,9 +5,30 @@ extension Redactor {
     private static var URLDiagnosticList: Regex<Substring> {
         #/\[(?:[^\[\]\r\n]|\[[^\[\]\r\n]*\])*\]/#
     }
+    /// RFC 8259 strings can encode URL delimiters as Unicode escapes. Decode only a
+    /// bounded, closed string, scan once, and re-encode only when it contains userinfo.
+    /// No decoded payload is retained in stream state or emitted without sanitization.
+    private static func redactEncodedURLStrings(_ input: String) -> String {
+        input.replacing(#/"(?:[^"\\\r\n]|\\[^\r\n])*"/#) { match in
+            let encoded = match.0
+            guard encoded.contains(#"\u"#) else { return String(encoded) }
+            guard encoded.utf8.prefix(8193).count <= 8192,
+                  let decoded = try? JSONDecoder().decode(String.self, from: Data(encoded.utf8))
+            else { return "\"" + marker("encoded-value") + "\"" }
+            guard decoded.contains(patterns.urlUserInfo) else { return String(encoded) }
+            var context = StreamState()
+            let sanitized = redactURLContinuations(decoded, state: &context, decodeStrings: false)
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = .withoutEscapingSlashes
+            guard let data = try? encoder.encode(sanitized) else { return "\"" + marker("userinfo") + "\"" }
+            return String(decoding: data, as: UTF8.self)
+        }
+    }
+
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
-    static func redactURLContinuations(_ input: String, state: inout StreamState) -> String {
+    static func redactURLContinuations(_ input: String, state: inout StreamState, decodeStrings: Bool = true) -> String {
+        let input = decodeStrings ? redactEncodedURLStrings(input) : input
         defer {
             if !input.allSatisfy(\.isWhitespace) {
                 state.urlHasTrailingEscape = state.expectingURLUserInfo
@@ -16,19 +37,16 @@ extension Redactor {
         }
         // A comma separates URLs only when the next element starts another authority.
         // Otherwise it may be part of the current URI's userinfo (or path/query).
-        var text = input.replacing(URLDiagnosticList) { match in
-            let list = match.0.dropFirst().dropLast()
-            func sanitized(_ element: Substring) -> String {
-                String(element).replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" }
-            }
-            var cursor = list.startIndex
-            var result = "["
-            for separator in list.matches(of: #/,(?=[ \t]*(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
-                result += sanitized(list[cursor..<separator.range.lowerBound]) + ","
-                cursor = separator.range.upperBound
-            }
-            return result + sanitized(list[cursor...]) + "]"
+        func sanitized(_ element: Substring) -> String {
+            String(element).replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" }
         }
+        var cursor = input.startIndex
+        var text = ""
+        for separator in input.matches(of: #/,(?=[ \t]*(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
+            text += sanitized(input[cursor..<separator.range.lowerBound]) + ","
+            cursor = separator.range.upperBound
+        }
+        text += sanitized(input[cursor...])
         if state.pendingURLSlashes > 0 {
             var remaining = state.pendingURLSlashes
             state.pendingURLSlashes = 0
@@ -42,7 +60,7 @@ extension Redactor {
             }
             if remaining == 0 {
                 state.expectingURLUserInfo = true
-                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state)
+                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state, decodeStrings: decodeStrings)
             }
         }
         if state.expectingURLUserInfo {
@@ -101,6 +119,9 @@ extension Redactor {
         if text.matches(of: URLDiagnosticList).contains(where: {
             $0.range.lowerBound < start && prefixEnd < $0.range.upperBound
         }) { return true }
+        // A continued list may have lost its opener on a preceding record. A comma
+        // authority boundary plus the terminal list closer still bounds its last element.
+        if text[..<start].last == ",", text[prefixEnd...].last == "]" { return true }
         let quotedRecord = text.drop(while: \.isWhitespace)
         if quotedRecord.first == "\"", quotedRecord.startIndex < start,
            let end = closingQuoteEnd(in: quotedRecord.dropFirst(),

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -40,7 +40,9 @@ extension Redactor {
             guard !value.isEmpty else { return text }
             let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) }) ?? text.endIndex
             let at = text[value.startIndex..<end].lastIndex(of: "@")
-            state.expectingURLUserInfo = at == nil && end == text.endIndex
+            // An @ at EOL can itself belong to a password that wraps before the real @.
+            state.expectingURLUserInfo = end == text.endIndex
+                && (at == nil || at == text.index(before: end))
             let stop = at ?? end
             text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -51,6 +51,9 @@ extension Redactor {
            !text.matches(of: closedString).contains(where: { $0.range.contains(partial.range.lowerBound) }),
            partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\")
             || (partial.0.dropFirst().wholeMatch(of: #/[A-Za-z][A-Za-z0-9+.-]*:?/#) != nil
+                && (partial.0.hasSuffix(":")
+                    || ["http", "https", "ssh", "git", "ftp", "ftps", "ws", "wss"].contains(partial.0.dropFirst().lowercased())
+                    || text[..<partial.range.lowerBound].contains(#/(?:^|[^A-Za-z0-9])(?i:url|uri)["']?[ \t]*[:=][ \t]*$/#))
                 && text[..<partial.range.lowerBound].contains(#/(?:^|[:=])[ \t]*$/#)) {
             // Before an escape completes, even a URI's scheme/colon can be hidden.
             // Quarantine incomplete encoded strings; only a closing quote proves an end.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+extension Redactor {
+    /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
+    /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
+    static func redactURLContinuations(_ input: String, state: inout StreamState) -> String {
+        // Commas separate unquoted elements inside diagnostic lists, not inside an
+        // ordinary URL path/query. Scan each flat list element at its own value boundary.
+        var text = input.replacing(#/\[[^\[\]\r\n]*\]/#) { match in
+            "[" + match.0.dropFirst().dropLast().split(separator: ",", omittingEmptySubsequences: false)
+                .map { $0.replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" } }.joined(separator: ",") + "]"
+        }
+        if state.pendingURLSlashes > 0 {
+            var remaining = state.pendingURLSlashes
+            state.pendingURLSlashes = 0
+            var cursor = text.drop(while: \.isWhitespace).startIndex
+            while remaining > 0 {
+                while cursor < text.endIndex, text[cursor] == "\\" { text.formIndex(after: &cursor) }
+                guard cursor < text.endIndex else { state.pendingURLSlashes = remaining; return text }
+                guard text[cursor] == "/" else { break }
+                text.formIndex(after: &cursor)
+                remaining -= 1
+            }
+            if remaining == 0 {
+                state.expectingURLUserInfo = true
+                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state)
+            }
+        }
+        if state.expectingURLUserInfo {
+            let value = text.drop(while: \.isWhitespace)
+            guard !value.isEmpty else { return text }
+            let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) }) ?? text.endIndex
+            let at = text[value.startIndex..<end].lastIndex(of: "@")
+            state.expectingURLUserInfo = at == nil && end == text.endIndex
+            let stop = at ?? end
+            text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
+        }
+        if let partial = text.firstMatch(of: patterns.partialURLAuthority) {
+            state.pendingURLSlashes = partial.0.reversed().drop(while: { $0 == "\\" }).first == "/" ? 1 : 2
+        }
+        return text.replacing(patterns.incompleteURLUserInfo) { match in
+            if hasCompleteURLFrame(in: text, prefixEnd: match.1.endIndex) { return String(match.0) }
+            state.expectingURLUserInfo = true
+            return String(match.1) + marker("userinfo")
+        }
+    }
+
+    /// Only framing outside URI userinfo's grammar can prove same-record closure.
+    /// Parentheses/apostrophes are valid sub-delimiters even when they appear paired.
+    private static func hasCompleteURLFrame(in text: String, prefixEnd: String.Index) -> Bool {
+        var start = prefixEnd
+        while start > text.startIndex, text[..<start].last.map({ "/\\".contains($0) }) == true {
+            text.formIndex(before: &start)
+        }
+        if text[..<start].last == ":" {
+            text.formIndex(before: &start)
+            while start > text.startIndex, text[..<start].last.map({
+                $0.isASCII && ($0.isLetter || $0.isNumber || "+-.".contains($0))
+            }) == true { text.formIndex(before: &start) }
+        }
+        // The URL can be the final element of a flat diagnostic list, or part of
+        // prose inside one whole-record double-quoted value. Neither frame belongs
+        // to URI userinfo; escaped or missing closing quotes are not proof of closure.
+        if text.matches(of: #/\[[^\[\]\r\n]*\]/#).contains(where: {
+            $0.range.lowerBound < start && prefixEnd < $0.range.upperBound
+        }) { return true }
+        let quotedRecord = text.drop(while: \.isWhitespace)
+        if quotedRecord.first == "\"", quotedRecord.startIndex < start,
+           let end = closingQuoteEnd(in: quotedRecord.dropFirst(),
+               for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")),
+           prefixEnd < end, text[end...].allSatisfy(\.isWhitespace) { return true }
+        let closers: [Character: Character] = ["<": ">", "\"": "\""]
+        guard let opener = text[..<start].last, let closer = closers[opener],
+              let end = text[start...].firstIndex(of: closer),
+              text[text.index(after: end)...].allSatisfy({ $0.isWhitespace || "]})>".contains($0) }) else { return false }
+        let content = text[start..<end]
+        return !content.contains(opener) && !content.contains(closer)
+    }
+
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -1,19 +1,23 @@
 import Foundation
 
 extension Redactor {
+    /// A flat diagnostic list can contain one bracket pair inside an IPv6 host literal.
+    private static var URLDiagnosticList: Regex<Substring> {
+        #/\[(?:[^\[\]\r\n]|\[[^\[\]\r\n]*\])*\]/#
+    }
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
     static func redactURLContinuations(_ input: String, state: inout StreamState) -> String {
         // A comma separates URLs only when the next element starts another authority.
         // Otherwise it may be part of the current URI's userinfo (or path/query).
-        var text = input.replacing(#/\[[^\[\]\r\n]*\]/#) { match in
+        var text = input.replacing(URLDiagnosticList) { match in
             let list = match.0.dropFirst().dropLast()
             func sanitized(_ element: Substring) -> String {
                 String(element).replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" }
             }
             var cursor = list.startIndex
             var result = "["
-            for separator in list.matches(of: #/,(?=[ \t]*(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
+            for separator in list.matches(of: #/,(?=[ \t]*(?:(?:--?)?[A-Za-z][A-Za-z0-9_.-]*[ \t]*=[ \t]*)?(?:[A-Za-z][A-Za-z0-9+.-]*:)?(?:\\*\/){2})/#) {
                 result += sanitized(list[cursor..<separator.range.lowerBound]) + ","
                 cursor = separator.range.upperBound
             }
@@ -40,10 +44,10 @@ extension Redactor {
             guard !value.isEmpty else { return text }
             let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) }) ?? text.endIndex
             let at = text[value.startIndex..<end].lastIndex(of: "@")
-            // An @ at EOL can itself belong to a password that wraps before the real @.
+            // Every @ may belong to the password until the authority is structurally closed.
+            // Do not expose a provisional host suffix while another record can extend it.
             state.expectingURLUserInfo = end == text.endIndex
-                && (at == nil || at == text.index(before: end))
-            let stop = at ?? end
+            let stop = state.expectingURLUserInfo ? end : (at ?? end)
             text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
         }
         if let partial = text.firstMatch(of: patterns.partialURLAuthority) {
@@ -75,7 +79,7 @@ extension Redactor {
         // The URL can be the final element of a flat diagnostic list, or part of
         // prose inside one whole-record double-quoted value. Neither frame belongs
         // to URI userinfo; escaped or missing closing quotes are not proof of closure.
-        if text.matches(of: #/\[[^\[\]\r\n]*\]/#).contains(where: {
+        if text.matches(of: URLDiagnosticList).contains(where: {
             $0.range.lowerBound < start && prefixEnd < $0.range.upperBound
         }) { return true }
         let quotedRecord = text.drop(while: \.isWhitespace)
@@ -88,7 +92,7 @@ extension Redactor {
                 for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")) else { return false }
             return text[end...].allSatisfy { $0.isWhitespace || "]})>".contains($0) }
         }
-        let closers: [Character: Character] = ["<": ">", "{": "}"]
+        let closers: [Character: Character] = ["<": ">", "{": "}", "`": "`"]
         guard let opener = text[..<start].last, let closer = closers[opener],
               let end = text[start...].firstIndex(of: closer),
               text[text.index(after: end)...].allSatisfy({ $0.isWhitespace || "]})>".contains($0) }) else { return false }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -86,7 +86,7 @@ extension Redactor {
                 for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")) else { return false }
             return text[end...].allSatisfy { $0.isWhitespace || "]})>".contains($0) }
         }
-        let closers: [Character: Character] = ["<": ">"]
+        let closers: [Character: Character] = ["<": ">", "{": "}"]
         guard let opener = text[..<start].last, let closer = closers[opener],
               let end = text[start...].firstIndex(of: closer),
               text[text.index(after: end)...].allSatisfy({ $0.isWhitespace || "]})>".contains($0) }) else { return false }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -8,6 +8,12 @@ extension Redactor {
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
     static func redactURLContinuations(_ input: String, state: inout StreamState) -> String {
+        defer {
+            if !input.allSatisfy(\.isWhitespace) {
+                state.urlHasTrailingEscape = state.expectingURLUserInfo
+                    && !input.reversed().drop(while: \.isWhitespace).prefix(while: { $0 == "\\" }).count.isMultiple(of: 2)
+            }
+        }
         // A comma separates URLs only when the next element starts another authority.
         // Otherwise it may be part of the current URI's userinfo (or path/query).
         var text = input.replacing(URLDiagnosticList) { match in
@@ -42,8 +48,16 @@ extension Redactor {
         if state.expectingURLUserInfo {
             let value = text.drop(while: \.isWhitespace)
             guard !value.isEmpty else { return text }
-            let frameClosers = ">}\"`"
-            let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) || frameClosers.contains($0) }) ?? text.endIndex
+            let frameClosers = ">]}\"`"
+            var escaped = state.urlHasTrailingEscape
+            var end = value.startIndex
+            while end < text.endIndex {
+                let character = text[end]
+                let escapedQuote = character == "\"" && escaped
+                if !escapedQuote && (character.isWhitespace || "/?#".contains(character) || frameClosers.contains(character)) { break }
+                escaped = character == "\\" ? !escaped : false
+                text.formIndex(after: &end)
+            }
             let at = text[value.startIndex..<end].lastIndex(of: "@")
             // Every @ may belong to the password until the authority is structurally closed.
             // Do not expose a provisional host suffix while another record can extend it.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -52,7 +52,8 @@ extension Redactor {
 
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
-    static func redactURLContinuations(_ input: String, state: inout StreamState, decodeStrings: Bool = true) -> String {
+    static func redactURLContinuations(_ input: String, state: inout StreamState, decodeStrings: Bool = true,
+                                       authorityStartsHere: Bool = false) -> String {
         let input = decodeStrings ? redactEncodedURLStrings(input, state: &state) : input
         defer {
             if !input.allSatisfy(\.isWhitespace) {
@@ -87,7 +88,7 @@ extension Redactor {
             }
             if remaining == 0 {
                 state.expectingURLUserInfo = true
-                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state, decodeStrings: decodeStrings)
+                return String(text[..<cursor]) + redactURLContinuations(String(text[cursor...]), state: &state, decodeStrings: decodeStrings, authorityStartsHere: true)
             }
         }
         if state.expectingURLUserInfo {
@@ -110,7 +111,9 @@ extension Redactor {
             let stop = state.expectingURLUserInfo ? end : (at ?? end)
             // A non-userinfo frame closer also bounds a host-only continuation.
             // Apostrophes/parentheses remain possible password bytes, not closers.
-            if at != nil || end == text.endIndex {
+            // Only newly completed slashes prove that all authority bytes are on this
+            // record. An established opaque continuation must remain concealed.
+            if at != nil || end == text.endIndex || (!authorityStartsHere && !frameClosers.contains(text[end])) {
                 text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
             }
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -69,7 +69,12 @@ extension Redactor {
            let end = closingQuoteEnd(in: quotedRecord.dropFirst(),
                for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")),
            prefixEnd < end, text[end...].allSatisfy(\.isWhitespace) { return true }
-        let closers: [Character: Character] = ["<": ">", "\"": "\""]
+        if text[..<start].last == "\"" {
+            guard let end = closingQuoteEnd(in: text[start...],
+                for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")) else { return false }
+            return text[end...].allSatisfy { $0.isWhitespace || "]})>".contains($0) }
+        }
+        let closers: [Character: Character] = ["<": ">"]
         guard let opener = text[..<start].last, let closer = closers[opener],
               let end = text[start...].firstIndex(of: closer),
               text[text.index(after: end)...].allSatisfy({ $0.isWhitespace || "]})>".contains($0) }) else { return false }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -42,6 +42,7 @@ extension Redactor {
         // A Unicode escape can hide every authority delimiter. Until this quoted
         // URL closes, emit a marker per record and retain only escape parity.
         if let partial = text.firstMatch(of: #/"(?:[^"\\\r\n]|\\[^\r\n])*\\?$/#),
+           text[..<partial.range.lowerBound].reversed().prefix(while: { $0 == "\\" }).count.isMultiple(of: 2),
            !text.matches(of: closedString).contains(where: { $0.range.contains(partial.range.lowerBound) }),
            partial.0.contains(#"\u"#) || partial.0.hasSuffix("\\") {
             // Before an escape completes, even a URI's scheme/colon can be hidden.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -86,16 +86,14 @@ extension Redactor {
         if quotedRecord.first == "\"", quotedRecord.startIndex < start,
            let end = closingQuoteEnd(in: quotedRecord.dropFirst(),
                for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")),
-           prefixEnd < end, text[end...].allSatisfy(\.isWhitespace) { return true }
+           prefixEnd < end { return true }
         if text[..<start].last == "\"" {
-            guard let end = closingQuoteEnd(in: text[start...],
-                for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")) else { return false }
-            return text[end...].allSatisfy { $0.isWhitespace || "]})>".contains($0) }
+            return closingQuoteEnd(in: text[start...],
+                for: .init(delimiter: "\"", escapeDepth: 0, kind: "userinfo")) != nil
         }
         let closers: [Character: Character] = ["<": ">", "{": "}", "`": "`"]
         guard let opener = text[..<start].last, let closer = closers[opener],
-              let end = text[start...].firstIndex(of: closer),
-              text[text.index(after: end)...].allSatisfy({ $0.isWhitespace || "]})>".contains($0) }) else { return false }
+              let end = text[start...].firstIndex(of: closer) else { return false }
         let content = text[start..<end]
         return !content.contains(opener) && !content.contains(closer)
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -42,13 +42,18 @@ extension Redactor {
         if state.expectingURLUserInfo {
             let value = text.drop(while: \.isWhitespace)
             guard !value.isEmpty else { return text }
-            let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) }) ?? text.endIndex
+            let frameClosers = ">}\"`"
+            let end = value.firstIndex(where: { $0.isWhitespace || "/?#".contains($0) || frameClosers.contains($0) }) ?? text.endIndex
             let at = text[value.startIndex..<end].lastIndex(of: "@")
             // Every @ may belong to the password until the authority is structurally closed.
             // Do not expose a provisional host suffix while another record can extend it.
             state.expectingURLUserInfo = end == text.endIndex
             let stop = state.expectingURLUserInfo ? end : (at ?? end)
-            text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
+            // A non-userinfo frame closer also bounds a host-only continuation.
+            // Apostrophes/parentheses remain possible password bytes, not closers.
+            if at != nil || end == text.endIndex || !frameClosers.contains(text[end]) {
+                text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
+            }
         }
         if let partial = text.firstMatch(of: patterns.partialURLAuthority) {
             state.pendingURLSlashes = partial.0.reversed().drop(while: { $0 == "\\" }).first == "/" ? 1 : 2

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+URLValues.swift
@@ -8,8 +8,23 @@ extension Redactor {
     /// RFC 8259 strings can encode URL delimiters as Unicode escapes. Decode only a
     /// bounded, closed string, scan once, and re-encode only when it contains userinfo.
     /// No decoded payload is retained in stream state or emitted without sanitization.
-    private static func redactEncodedURLStrings(_ input: String) -> String {
-        input.replacing(#/"(?:[^"\\\r\n]|\\[^\r\n])*"/#) { match in
+    private static func redactEncodedURLStrings(_ input: String, state: inout StreamState) -> String {
+        var text = input
+        if state.pendingEncodedURLString {
+            var escaped = state.encodedURLHasTrailingEscape
+            var closing: String.Index?
+            for index in text.indices {
+                let character = text[index]
+                if character == "\"" && !escaped { closing = index; break }
+                escaped = character == "\\" ? !escaped : false
+            }
+            state.encodedURLHasTrailingEscape = escaped
+            guard let closing else { return marker("encoded-value") }
+            state.pendingEncodedURLString = false
+            state.encodedURLHasTrailingEscape = false
+            text = marker("encoded-value") + text[text.index(after: closing)...]
+        }
+        text = text.replacing(#/"(?:[^"\\\r\n]|\\[^\r\n])*"/#) { match in
             let encoded = match.0
             guard encoded.contains(#"\u"#) else { return String(encoded) }
             guard encoded.utf8.prefix(8193).count <= 8192,
@@ -23,12 +38,22 @@ extension Redactor {
             guard let data = try? encoder.encode(sanitized) else { return "\"" + marker("userinfo") + "\"" }
             return String(decoding: data, as: UTF8.self)
         }
+        // A Unicode escape can hide every authority delimiter. Until this quoted
+        // URL closes, emit a marker per record and retain only escape parity.
+        if let partial = text.firstMatch(of: #/"(?:[^"\\\r\n]|\\[^\r\n])*\\?$/#),
+           partial.0.contains(#"\u"#),
+           partial.0.contains(#/[A-Za-z][A-Za-z0-9+.-]*(?::|\\u003[aA])|\\u002[fF]/#) {
+            state.pendingEncodedURLString = true
+            state.encodedURLHasTrailingEscape = !partial.0.reversed().prefix(while: { $0 == "\\" }).count.isMultiple(of: 2)
+            text = String(text[..<partial.range.lowerBound]) + marker("encoded-value")
+        }
+        return text
     }
 
     /// An EOL authority may be userinfo whose @ arrives later; emitted bytes cannot be
     /// retracted. A path/query/fragment or proven diagnostic frame ends the authority.
     static func redactURLContinuations(_ input: String, state: inout StreamState, decodeStrings: Bool = true) -> String {
-        let input = decodeStrings ? redactEncodedURLStrings(input) : input
+        let input = decodeStrings ? redactEncodedURLStrings(input, state: &state) : input
         defer {
             if !input.allSatisfy(\.isWhitespace) {
                 state.urlHasTrailingEscape = state.expectingURLUserInfo
@@ -37,6 +62,8 @@ extension Redactor {
         }
         // A comma separates URLs only when the next element starts another authority.
         // Otherwise it may be part of the current URI's userinfo (or path/query).
+        // A comma + authority is ambiguous even inside a query. Conceal its userinfo
+        // rather than assuming that a nested URL or compact list element is public.
         func sanitized(_ element: Substring) -> String {
             String(element).replacing(patterns.urlUserInfo) { "\($0.1)\(marker("userinfo"))@" }
         }
@@ -83,7 +110,7 @@ extension Redactor {
             let stop = state.expectingURLUserInfo ? end : (at ?? end)
             // A non-userinfo frame closer also bounds a host-only continuation.
             // Apostrophes/parentheses remain possible password bytes, not closers.
-            if at != nil || end == text.endIndex || !frameClosers.contains(text[end]) {
+            if at != nil || end == text.endIndex {
                 text = String(text[..<value.startIndex]) + marker("userinfo") + text[stop...]
             }
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -59,6 +59,9 @@ struct Redactor: Sendable {
         var wrappedTokenKind: String?
         /// Quoted values may wrap without indentation and remain sensitive until the quote closes.
         var quotedValue: QuotedValue?
+        /// An incomplete Unicode-encoded URL string retains framing bits, never payload.
+        var pendingEncodedURLString = false
+        var encodedURLHasTrailingEscape = false
         /// A terminal control string opened on an earlier line and has not been terminated yet.
         var openControlString: ControlString?
 
@@ -81,6 +84,8 @@ struct Redactor: Sendable {
         state.expectingDeviceCodeContinuation = state.expectingDeviceCodeContinuation || scanned.expectingDeviceCodeContinuation
         state.expectingURLUserInfo = state.expectingURLUserInfo || scanned.expectingURLUserInfo
         state.urlHasTrailingEscape = state.urlHasTrailingEscape || scanned.urlHasTrailingEscape
+        state.pendingEncodedURLString = state.pendingEncodedURLString || scanned.pendingEncodedURLString
+        state.encodedURLHasTrailingEscape = state.encodedURLHasTrailingEscape || scanned.encodedURLHasTrailingEscape
         let slashCounts = [state.pendingURLSlashes, scanned.pendingURLSlashes].filter { $0 > 0 }
         state.pendingURLSlashes = slashCounts.min() ?? 0
         state.quotedValue = state.quotedValue ?? scanned.quotedValue

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -49,6 +49,8 @@ struct Redactor: Sendable {
         var expectingDeviceCodeContinuation = false
         /// An authority with a password delimiter reached a physical boundary before its @.
         var expectingURLUserInfo = false
+        /// Only escape parity is retained, never URL credential bytes.
+        var urlHasTrailingEscape = false
         /// Missing authority slashes across physical records; no credential bytes are stored.
         var pendingURLSlashes = 0
         /// A bounded, structural option/cookie name split across physical records.
@@ -78,6 +80,7 @@ struct Redactor: Sendable {
         state.expectingDeviceCode = state.expectingDeviceCode || scanned.expectingDeviceCode
         state.expectingDeviceCodeContinuation = state.expectingDeviceCodeContinuation || scanned.expectingDeviceCodeContinuation
         state.expectingURLUserInfo = state.expectingURLUserInfo || scanned.expectingURLUserInfo
+        state.urlHasTrailingEscape = state.urlHasTrailingEscape || scanned.urlHasTrailingEscape
         let slashCounts = [state.pendingURLSlashes, scanned.pendingURLSlashes].filter { $0 > 0 }
         state.pendingURLSlashes = slashCounts.min() ?? 0
         state.quotedValue = state.quotedValue ?? scanned.quotedValue

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -37,12 +37,22 @@ import Testing
                       #"prefix "https://example.com""#, #"prefix "url=https://example.com""#,
                       "prefix <url=https://example.com>", #"prefix "--url=//example.com""#,
                       "{url=https://example.com}", "prefix {url=//example.com}",
-                      "prefix `https://example.com`", "prefix `//example.com`"])
+                      "prefix `https://example.com`", "prefix `//example.com`",
+                      "prefix <https://example.com>, status=ok", "prefix <https://example.com>,status=ok",
+                      "prefix `https://example.com`,status=ok"])
     func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
         var state = Redactor.StreamState()
         #expect(Redactor.redactURLContinuations(input, state: &state) == input)
         #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
         #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test func backtickNetworkPathCanSplitItsSlashesAcrossRecords() {
+        var state = Redactor.StreamState()
+        _ = Redactor.redactURLContinuations("prefix `/", state: &state)
+        #expect(state.pendingURLSlashes == 1)
+        #expect(!Redactor.redactURLContinuations("/user:opaque@example.com/path`", state: &state).contains("opaque"))
+        #expect(state.pendingURLSlashes == 0 && !state.expectingURLUserInfo)
     }
 
     @Test(arguments: ["https://user:opaque", "(https://user:opaque)", "'https://user:opaque'",

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,6 +2,27 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [("<", ">"), ("{", "}"), ("`", "`"), ("\"", "\"")])
+    func continuedHostOnlyFramesReleaseTheFollowingRecord(_ opener: String, _ closer: String) {
+        var state = Redactor.StreamState()
+        let first = "prefix " + opener + "https:/"
+        #expect(Redactor.redactURLContinuations(first, state: &state) == first)
+        #expect(state.pendingURLSlashes == 1)
+        #expect(Redactor.redactURLContinuations("/example.com" + closer, state: &state) == "/example.com" + closer)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [">", "}", "`", "\""])
+    func continuedFramedUserinfoStillConcealsEveryCredential(_ closer: String) {
+        var state = Redactor.StreamState()
+        _ = Redactor.redactURLContinuations("https://user:syntheticFirst", state: &state)
+        #expect(Redactor.redactURLContinuations("syntheticSecond@example.com" + closer, state: &state)
+            == "[redacted:userinfo]@example.com" + closer)
+        #expect(!state.expectingURLUserInfo)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: [["https://user:syntheticFirst@", "syntheticSecond@example.com/path"],
                       ["https://user:syntheticFirst@", "syntheticMiddle@", "syntheticSecond@example.com/path"],
                       ["https://user:syntheticFirst", "syntheticMiddle@syntheticStill", "syntheticLast@example.com/path"],

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,6 +2,14 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: ["password:", "Authorization:", "device_code:"])
+    func aClosingValueQuoteCannotOpenEncodedURLQuarantine(_ label: String) {
+        var state = Redactor.StreamState()
+        let input = label + #" "synthetic" \"#
+        #expect(Redactor.redactURLContinuations(input, state: &state) == input)
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+    }
+
     @Test(arguments: [1, 2, 3, 4, 5])
     func everyFirstUnicodeEscapeBoundaryIsQuarantined(_ split: Int) {
         let escape = #"\u003a"#

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,6 +3,14 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [#"Digest username="syntheticFirst"#, #"AWS4-HMAC-SHA256 Credential="syntheticFirst"#,
+                      #"Authorization: Digest username="syntheticFirst"#, #"password: "syntheticFirst"#])
+    func ordinaryOpenCredentialQuotesRemainOwnedByTheirFieldScanner(_ input: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == input)
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+    }
+
     @Test func anEscapedFieldQuoteCannotOpenJSONValueQuarantine() {
         var state = Redactor.StreamState()
         let input = #"\"clientSecret\"#

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import GuesthouseCore
 
@@ -17,7 +18,7 @@ import Testing
         #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
     }
 
-    @Test(arguments: [1, 2, 3, 4, 5])
+    @Test(arguments: [0, 1, 2, 3, 4, 5])
     func everyFirstUnicodeEscapeBoundaryIsQuarantined(_ split: Int) {
         let escape = #"\u003a"#
         var state = Redactor.StreamState()
@@ -55,6 +56,7 @@ import Testing
     }
 
     @Test(arguments: [["url", "=//user:syntheticOpaque@example.com/path"],
+                      ["--url", "=//user:syntheticOpaque@example.com/path"],
                       ["url", "=/", "/user:syntheticOpaque@example.com/path"]])
     func continuedAssignmentsDoNotNeedTheirNameOnTheSameRecord(_ input: [String]) {
         var state = Redactor.StreamState()
@@ -74,6 +76,27 @@ import Testing
         #expect(Redactor.redactURLContinuations(input, state: &state)
             == #"{"url":"https://[redacted:userinfo]@example.com/path"}"#)
         #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+    }
+
+    @Test func nestedUnicodeURLStringsCannotExposeTheInnerCredential() {
+        var state = Redactor.StreamState()
+        let input = #""{\"url\":\"https:\\u002f\\u002fuser:syntheticOpaque\\u0040example.com\"}""#
+        let output = Redactor.redactURLContinuations(input, state: &state)
+        #expect(!output.contains("synthetic") && !output.contains("Opaque"))
+        #expect(output.contains("[redacted:"))
+        #expect(!state.pendingEncodedURLString && !state.expectingURLUserInfo)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [1, 2, 3, 5])
+    func nestedURLDecodeDepthHasAConservativeBound(_ depth: Int) throws {
+        var input = #"{"url":"https:\u002f\u002fuser:syntheticOpaque\u0040example.com"}"#
+        for _ in 0..<depth { input = String(decoding: try JSONEncoder().encode(input), as: UTF8.self) }
+        var state = Redactor.StreamState()
+        let output = Redactor.redactURLContinuations(input, state: &state)
+        #expect(!output.contains("synthetic") && !output.contains("Opaque"))
+        #expect(output.contains("[redacted:"))
+        #expect(!state.pendingEncodedURLString && !state.expectingURLUserInfo)
     }
 
     @Test(arguments: [#"{"url":"https:\u002f\u002fexample.com/path"}"#,

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,6 +3,26 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [#"{"url":""#, #"{"uri":""#, #"url = ""#])
+    func emptyURLValuesQuarantineTheFirstEncodedAuthority(_ first: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(first, state: &state).hasSuffix("[redacted:encoded-value]"))
+        #expect(state.pendingEncodedURLString)
+        let output = Redactor.redactURLContinuations(#"\u002f\u002fuser:syntheticOpaque\u0040example.com"}"#, state: &state)
+        #expect(!output.contains("synthetic") && !output.contains("Opaque"))
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [("[//one.example;//user:opaque@two.example]", "[//one.example;//[redacted:userinfo]@two.example]"),
+                      ("[//user:sec;ret@one.example;//other:opaque@two.example]", "[//[redacted:userinfo]@one.example;//[redacted:userinfo]@two.example]")])
+    func semicolonListsKeepSeparatorsOutOfUserinfo(_ input: String, _ expected: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == expected)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: [#"Digest username="syntheticFirst"#, #"AWS4-HMAC-SHA256 Credential="syntheticFirst"#,
                       #"Authorization: Digest username="syntheticFirst"#, #"password: "syntheticFirst"#])
     func ordinaryOpenCredentialQuotesRemainOwnedByTheirFieldScanner(_ input: String) {
@@ -117,6 +137,9 @@ import Testing
 
     @Test(arguments: [
         (["[https:/", "/[2001:db8::1],//user:syntheticOpaque@example.com]"]),
+        (["[https:/", "/[2001:db8::1];//user:syntheticOpaque@example.com]"]),
+        (["[https://one.example;/", "/user:syntheticOpaque@example.com]"]),
+        (["https://one.example/path;//user:syntheticFirst", "syntheticSecond@example.com/path"]),
         (["[https:/", "/[2001:db8::1],//user:syntheticFirst", "syntheticSecond@example.com/path]"]),
         ([#"prefix "https://user:syntheticFirst"#, #"syntheticSecond\"syntheticThird@example.com/path""#]),
         ([#"prefix "https://user:syntheticFirst\"#, #""syntheticThird@example.com/path""#]),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorURLFramingTests {
+    @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
+                      #""visit https://example.com""#, #""visit https://example.com:443""#])
+    func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == input)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: ["https://user:opaque", "(https://user:opaque)", "'https://user:opaque'",
+                      #""visit https://user:opaque\""#])
+    func unprovenFramesCannotReleasePotentialUserinfo(_ input: String) {
+        var state = Redactor.StreamState()
+        #expect(!Redactor.redactURLContinuations(input, state: &state).contains("opaque"))
+        #expect(state.expectingURLUserInfo)
+        #expect(Redactor.redactURLContinuations("@example.com/path", state: &state)
+            == "[redacted:userinfo]@example.com/path")
+        #expect(!state.expectingURLUserInfo)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [1, 2, 16, 256])
+    func escapeRunBoundariesKeepOnlyTheRemainingSlashCount(_ depth: Int) {
+        let escape = String(repeating: "\\", count: depth)
+        var state = Redactor.StreamState()
+        _ = Redactor.redactURLContinuations("https:" + escape + "/" + escape, state: &state)
+        #expect(state.pendingURLSlashes == 1)
+        #expect(Redactor.redactURLContinuations("/user:opaque@example.com/path", state: &state)
+            == "/[redacted:userinfo]@example.com/path")
+        #expect(state.pendingURLSlashes == 0 && !state.expectingURLUserInfo)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,6 +3,40 @@ import Testing
 
 @Suite struct RedactorURLFramingTests {
     @Test(arguments: [
+        [#"{"url":"https:\u002f"#, #"\u002fuser:syntheticOpaque\u0040example.com"}"#],
+        [#"{"url":"https:\u002f"#, #"\u002fuser:syntheticFirst\"#, #""syntheticSecond@example.com/path"}"#],
+        [#"{"url":"https\u003a\u002f"#, #"\u002Fuser:syntheticOpaque\u0040example.com/path"}"#]
+    ])
+    func incompleteUnicodeURLStringsRetainOnlyFramingBits(_ records: [String]) {
+        var state = Redactor.StreamState()
+        let output = records.map { Redactor.redactURLContinuations($0, state: &state) }.joined()
+        #expect(!output.contains("synthetic"))
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: ["/path", "?query=value", "#fragment"])
+    func continuedHostOnlyAuthoritiesEndAtEveryURLTerminator(_ terminator: String) {
+        var state = Redactor.StreamState()
+        _ = Redactor.redactURLContinuations("https:/", state: &state)
+        let next = "/example.com" + terminator
+        #expect(Redactor.redactURLContinuations(next, state: &state) == next)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [["url", "=//user:syntheticOpaque@example.com/path"],
+                      ["url", "=/", "/user:syntheticOpaque@example.com/path"]])
+    func continuedAssignmentsDoNotNeedTheirNameOnTheSameRecord(_ input: [String]) {
+        var state = Redactor.StreamState()
+        let result = input.map { Redactor.redactURLContinuations($0, state: &state) }.joined()
+        #expect(!result.contains("syntheticOpaque"))
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [
         #"{"url":"https://user:syntheticOpaque\u0040example.com/path"}"#,
         #"{"url":"https:\u002f\u002Fuser:syntheticOpaque@example.com/path"}"#,
         #"{"url":"https\u003a\u002f\u002fuser\u003asyntheticOpaque\u0040example.com\u002fpath"}"#

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,7 +2,21 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
-    @Test(arguments: [("<", ">"), ("{", "}"), ("`", "`"), ("\"", "\"")])
+    @Test(arguments: [
+        ([#"prefix "https://user:syntheticFirst"#, #"syntheticSecond\"syntheticThird@example.com/path""#]),
+        ([#"prefix "https://user:syntheticFirst\"#, #""syntheticThird@example.com/path""#]),
+        ([#"[https://one.example,/"#, #"/user:syntheticOpaque@example.com]"#]),
+        ([#"[https://one.example,\/"#, #"\/user:syntheticOpaque@example.com]"#])
+    ])
+    func continuedEscapedQuotesAndCompactListsConcealEveryCredential(_ records: [String]) {
+        var state = Redactor.StreamState()
+        let output = records.map { Redactor.redactURLContinuations($0, state: &state) }.joined()
+        #expect(!output.contains("synthetic"))
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
+    @Test(arguments: [("<", ">"), ("{", "}"), ("`", "`"), ("\"", "\""), ("[", "]")])
     func continuedHostOnlyFramesReleaseTheFollowingRecord(_ opener: String, _ closer: String) {
         var state = Redactor.StreamState()
         let first = "prefix " + opener + "https:/"

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,6 +3,28 @@ import Testing
 
 @Suite struct RedactorURLFramingTests {
     @Test(arguments: [
+        #"{"url":"https://user:syntheticOpaque\u0040example.com/path"}"#,
+        #"{"url":"https:\u002f\u002Fuser:syntheticOpaque@example.com/path"}"#,
+        #"{"url":"https\u003a\u002f\u002fuser\u003asyntheticOpaque\u0040example.com\u002fpath"}"#
+    ])
+    func unicodeEncodedURLStructureStillConcealsUserinfo(_ input: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state)
+            == #"{"url":"https://[redacted:userinfo]@example.com/path"}"#)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+    }
+
+    @Test(arguments: [#"{"url":"https:\u002f\u002fexample.com/path"}"#,
+                      #"{"name":"pass\u0077ord"}"#, #"{"message":"ordinary \u0040 character"}"#])
+    func nonCredentialUnicodeStringsKeepTheirOriginalEncoding(_ input: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == input)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+    }
+
+    @Test(arguments: [
+        (["[https:/", "/[2001:db8::1],//user:syntheticOpaque@example.com]"]),
+        (["[https:/", "/[2001:db8::1],//user:syntheticFirst", "syntheticSecond@example.com/path]"]),
         ([#"prefix "https://user:syntheticFirst"#, #"syntheticSecond\"syntheticThird@example.com/path""#]),
         ([#"prefix "https://user:syntheticFirst\"#, #""syntheticThird@example.com/path""#]),
         ([#"[https://one.example,/"#, #"/user:syntheticOpaque@example.com]"#]),
@@ -58,6 +80,8 @@ import Testing
     }
 
     @Test(arguments: [
+        ("https://user:first@one/path,//user:second@two/path", "https://[redacted:userinfo]@one/path,//[redacted:userinfo]@two/path"),
+        ("url=https://user:first@one/path,//user:second@two/path", "url=https://[redacted:userinfo]@one/path,//[redacted:userinfo]@two/path"),
         ("[url=//one:alpha@one.example,url=//two:bravo@two.example]", "[url=//[redacted:userinfo]@one.example,url=//[redacted:userinfo]@two.example]"),
         ("[https://[2001:db8::1],//user:bravo@[2001:db8::2]]", "[https://[2001:db8::1],//[redacted:userinfo]@[2001:db8::2]]")
     ])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,7 +3,9 @@ import Testing
 
 @Suite struct RedactorURLFramingTests {
     @Test(arguments: [["https://user:syntheticFirst@", "syntheticSecond@example.com/path"],
-                      ["https://user:syntheticFirst@", "syntheticMiddle@", "syntheticSecond@example.com/path"]])
+                      ["https://user:syntheticFirst@", "syntheticMiddle@", "syntheticSecond@example.com/path"],
+                      ["https://user:syntheticFirst", "syntheticMiddle@syntheticStill", "syntheticLast@example.com/path"],
+                      ["https://user:syntheticFirst@syntheticMiddle", "syntheticLast@example.com/path"]])
     func intermediateAtSignsRetainUserinfoAcrossRecords(_ records: [String]) {
         var state = Redactor.StreamState()
         let output = records.map { Redactor.redactURLContinuations($0, state: &state) }.joined()
@@ -20,11 +22,22 @@ import Testing
         #expect(!state.expectingURLUserInfo)
     }
 
+    @Test(arguments: [
+        ("[url=//one:alpha@one.example,url=//two:bravo@two.example]", "[url=//[redacted:userinfo]@one.example,url=//[redacted:userinfo]@two.example]"),
+        ("[https://[2001:db8::1],//user:bravo@[2001:db8::2]]", "[https://[2001:db8::1],//[redacted:userinfo]@[2001:db8::2]]")
+    ])
+    func assignedAndIPv6ListElementsKeepTheirOwnAuthority(_ input: String, _ expected: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == expected)
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+    }
+
     @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
                       #""visit https://example.com""#, #""visit https://example.com:443""#,
                       #"prefix "https://example.com""#, #"prefix "url=https://example.com""#,
                       "prefix <url=https://example.com>", #"prefix "--url=//example.com""#,
-                      "{url=https://example.com}", "prefix {url=//example.com}"])
+                      "{url=https://example.com}", "prefix {url=//example.com}",
+                      "prefix `https://example.com`", "prefix `//example.com`"])
     func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
         var state = Redactor.StreamState()
         #expect(Redactor.redactURLContinuations(input, state: &state) == input)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,6 +2,16 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [["https://user:syntheticFirst@", "syntheticSecond@example.com/path"],
+                      ["https://user:syntheticFirst@", "syntheticMiddle@", "syntheticSecond@example.com/path"]])
+    func intermediateAtSignsRetainUserinfoAcrossRecords(_ records: [String]) {
+        var state = Redactor.StreamState()
+        let output = records.map { Redactor.redactURLContinuations($0, state: &state) }.joined()
+        #expect(!output.contains("synthetic"))
+        #expect(!state.expectingURLUserInfo && state.pendingURLSlashes == 0)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: [("[https://user:sec,ret@example.com]", "[https://[redacted:userinfo]@example.com]"),
                       ("[//user:sec,ret@one.example,//other:opaque@two.example]", "[//[redacted:userinfo]@one.example,//[redacted:userinfo]@two.example]")])
     func commasInsideUserinfoAreNotListSeparators(_ input: String, _ expected: String) {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,6 +3,18 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: ["http", "https", "ssh", "git", "ftp", "ftps", "ws", "wss"]
+        .flatMap { scheme in (1...scheme.count).map { (scheme, $0) } })
+    func everyKnownSchemePrefixQuarantinesAnEncodedContinuation(_ scheme: String, _ split: Int) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations("\"" + scheme.prefix(split), state: &state) == "[redacted:encoded-value]")
+        #expect(state.pendingEncodedURLString)
+        let tail = String(scheme.dropFirst(split)) + #"\u003a\u002f\u002fuser:syntheticOpaque\u0040example.com""#
+        #expect(Redactor.redactURLContinuations(tail, state: &state) == "[redacted:encoded-value]")
+        #expect(!state.pendingEncodedURLString && !state.expectingURLUserInfo)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: [#"{"url":""#, #"{"uri":""#, #"url = ""#])
     func emptyURLValuesQuarantineTheFirstEncodedAuthority(_ first: String) {
         var state = Redactor.StreamState()
@@ -128,6 +140,7 @@ import Testing
     }
 
     @Test(arguments: [#"{"url":"https:\u002f\u002fexample.com/path"}"#,
+                      #"{"url":"https:\u002f\u002fexample.com"}"#, #""https:\u002f\u002fexample.com:443""#,
                       #"{"name":"pass\u0077ord"}"#, #"{"message":"ordinary \u0040 character"}"#])
     func nonCredentialUnicodeStringsKeepTheirOriginalEncoding(_ input: String) {
         var state = Redactor.StreamState()
@@ -208,6 +221,7 @@ import Testing
     }
 
     @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
+                      "https://[::1]", "https://[2001:db8::1]:443", "https://[fe80::1%en0]",
                       #""visit https://example.com""#, #""visit https://example.com:443""#,
                       #"prefix "https://example.com""#, #"prefix "url=https://example.com""#,
                       "prefix <url=https://example.com>", #"prefix "--url=//example.com""#,

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -3,7 +3,8 @@ import Testing
 
 @Suite struct RedactorURLFramingTests {
     @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
-                      #""visit https://example.com""#, #""visit https://example.com:443""#])
+                      #""visit https://example.com""#, #""visit https://example.com:443""#,
+                      #"prefix "https://example.com""#])
     func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
         var state = Redactor.StreamState()
         #expect(Redactor.redactURLContinuations(input, state: &state) == input)
@@ -12,7 +13,7 @@ import Testing
     }
 
     @Test(arguments: ["https://user:opaque", "(https://user:opaque)", "'https://user:opaque'",
-                      #""visit https://user:opaque\""#])
+                      #""visit https://user:opaque\""#, #"prefix "https://user:opaque\""#])
     func unprovenFramesCannotReleasePotentialUserinfo(_ input: String) {
         var state = Redactor.StreamState()
         #expect(!Redactor.redactURLContinuations(input, state: &state).contains("opaque"))

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,6 +2,13 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test func anEscapedFieldQuoteCannotOpenJSONValueQuarantine() {
+        var state = Redactor.StreamState()
+        let input = #"\"clientSecret\"#
+        #expect(Redactor.redactURLContinuations(input, state: &state) == input)
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+    }
+
     @Test(arguments: ["password:", "Authorization:", "device_code:"])
     func aClosingValueQuoteCannotOpenEncodedURLQuarantine(_ label: String) {
         var state = Redactor.StreamState()

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,9 +2,18 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [("[https://user:sec,ret@example.com]", "[https://[redacted:userinfo]@example.com]"),
+                      ("[//user:sec,ret@one.example,//other:opaque@two.example]", "[//[redacted:userinfo]@one.example,//[redacted:userinfo]@two.example]")])
+    func commasInsideUserinfoAreNotListSeparators(_ input: String, _ expected: String) {
+        var state = Redactor.StreamState()
+        #expect(Redactor.redactURLContinuations(input, state: &state) == expected)
+        #expect(!state.expectingURLUserInfo)
+    }
+
     @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
                       #""visit https://example.com""#, #""visit https://example.com:443""#,
-                      #"prefix "https://example.com""#])
+                      #"prefix "https://example.com""#, #"prefix "url=https://example.com""#,
+                      "prefix <url=https://example.com>", #"prefix "--url=//example.com""#])
     func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
         var state = Redactor.StreamState()
         #expect(Redactor.redactURLContinuations(input, state: &state) == input)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -13,7 +13,8 @@ import Testing
     @Test(arguments: ["[https://one.example, https://two.example]", "urls=[//one.example, //two.example]",
                       #""visit https://example.com""#, #""visit https://example.com:443""#,
                       #"prefix "https://example.com""#, #"prefix "url=https://example.com""#,
-                      "prefix <url=https://example.com>", #"prefix "--url=//example.com""#])
+                      "prefix <url=https://example.com>", #"prefix "--url=//example.com""#,
+                      "{url=https://example.com}", "prefix {url=//example.com}"])
     func provenDiagnosticFramesPreservePublicAuthorities(_ input: String) {
         var state = Redactor.StreamState()
         #expect(Redactor.redactURLContinuations(input, state: &state) == input)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorURLFramingTests.swift
@@ -2,6 +2,19 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorURLFramingTests {
+    @Test(arguments: [1, 2, 3, 4, 5])
+    func everyFirstUnicodeEscapeBoundaryIsQuarantined(_ split: Int) {
+        let escape = #"\u003a"#
+        var state = Redactor.StreamState()
+        let first = Redactor.redactURLContinuations(#"{"url":"https"# + escape.prefix(split), state: &state)
+        #expect(state.pendingEncodedURLString)
+        let next = String(escape.dropFirst(split)) + #"\u002f\u002fuser:syntheticOpaque\u0040example.com/path"}"#
+        let second = Redactor.redactURLContinuations(next, state: &state)
+        #expect(!(first + second).contains("syntheticOpaque"))
+        #expect(!state.pendingEncodedURLString && !state.encodedURLHasTrailingEscape)
+        #expect(Redactor.redactURLContinuations("Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: [
         [#"{"url":"https:\u002f"#, #"\u002fuser:syntheticOpaque\u0040example.com"}"#],
         [#"{"url":"https:\u002f"#, #"\u002fuser:syntheticFirst\"#, #""syntheticSecond@example.com/path"}"#],


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope

Supporting component for #11 and #59, stacked on #131. This internal URL helper preserves completed diagnostic frames and bounds uncertain authority/encoded-string continuations. The shared assigned-network-path grammar is in #135; #133 follows this PR and #127 consumes both helpers.

URL strings may encode delimiters before or across physical boundaries. The bounded prepass inspects at most three JSON-string layers (8,192 encoded bytes per string), conceals deeper encoded structure, and retains only framing/parity bits across records. It runs before generic quoted-value protection in #127. Closed ordinary URLs, credential-field quote ownership, escaped quote boundaries and following diagnostics have direct regressions.

Implements MVP-PLAN.md §3 (credential-free diagnostics) and §11. No public logging API, provider or hardware behavior is activated here.

## Validation

Current exact head: 243 Core tests/18 suites with warnings-as-errors; 450 own changed lines. Full physical composition in #114: 475/33. Original tests and branch history are retained. Fresh exact-head CI, Codex approval and merged prerequisites are required; see the current validation block above.