### PR TITLE
Normalize escaped structured credential keys before redaction

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -18,7 +18,7 @@ extension Redactor {
                 || label.wholeMatch(of: patterns.codePromptOnly) != nil
             else { return String(match.0) }
             // Never turn decoded control characters or quotes into new output framing.
-            let safeName = name.allSatisfy {
+            let safeName = name.first?.isWhitespace != true && name.last?.isWhitespace != true && name.allSatisfy {
                 $0.isASCII && ($0.isLetter || $0.isNumber || " _-".contains($0))
             } ? name : "secret"
             return String(match.1) + "\"" + safeName + "\""

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension Redactor {
+    /// Canonicalize encoded JSON credential names before the existing value scanner.
+    /// Only object-key positions are considered; values are never decoded or copied into
+    /// state. Unknown valid keys retain their original spelling. Malformed or oversized
+    /// encoded keys fail closed as a secret field, keeping decoding work bounded.
+    static func normalizingStructuredCredentialKeys(in input: String) -> String {
+        input.replacing(#/(^[ \t]*|[{\[,][ \t]*)("(?:[^"\\\r\n]|\\[^\r\n])*")(?=[ \t]*:)/#) { match in
+            let encoded = match.2
+            guard encoded.contains("\\") else { return String(match.0) }
+            guard encoded.utf8.prefix(1025).count <= 1024,
+                  let name = try? JSONDecoder().decode(String.self, from: Data(encoded.utf8))
+            else { return String(match.1) + "\"secret\"" }
+            let label = name + ":"
+            guard label.wholeMatch(of: patterns.secretLabelOnly) != nil
+                || label.wholeMatch(of: patterns.authorizationHeader) != nil
+                || label.wholeMatch(of: patterns.codePromptOnly) != nil
+            else { return String(match.0) }
+            // Never turn decoded control characters or quotes into new output framing.
+            let safeName = name.allSatisfy {
+                $0.isASCII && ($0.isLetter || $0.isNumber || " _-".contains($0))
+            } ? name : "secret"
+            return String(match.1) + "\"" + safeName + "\""
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -6,9 +6,12 @@ extension Redactor {
     /// Decode at most 1024 bytes and never retain decoded names or value bytes in state.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
         let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"/#)
-        return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:[^"]|"(?!\s*[:=]))*"|"(?:[^":=]|"(?!\s*[:=]))*)(?=\s*[:=]|[ \t]*$)/#) { match in
+        return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
             // A brace/comma inside a serialized value is not an outer field boundary.
-            guard !strings.contains(where: { $0.range.lowerBound < match.range.lowerBound && $0.range.contains(match.range.lowerBound) }) else { return String(match.0) }
+            guard !strings.contains(where: {
+                ($0.range.lowerBound < match.range.lowerBound && $0.range.contains(match.range.lowerBound))
+                    || ($0.range.lowerBound == match.range.lowerBound && $0.range.upperBound > match.range.upperBound)
+            }) else { return String(match.0) }
             let framing = String(match.2)
             var encoded = String(match.3)
             func key(_ name: String) -> String { String(match.1) + framing + "\"" + name + framing + "\"" }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -5,6 +5,18 @@ extension Redactor {
     /// Unknown valid names keep their spelling; malformed/oversized names fail closed.
     /// Decode at most 1024 bytes and never retain decoded names or value bytes in state.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
+        var state = StreamState()
+        return normalizingStructuredCredentialKeys(in: input, state: &state)
+    }
+
+    static func normalizingStructuredCredentialKeys(in input: String, state: inout StreamState) -> String {
+        if state.pendingEncodedCredentialKey {
+            // Discard arbitrary key fragments without retaining bytes. Once an
+            // assignment arrives, the existing secret-value scanner owns its tail.
+            guard let delimiter = input.firstIndex(where: { $0 == ":" || $0 == "=" }) else { return marker("encoded-key") }
+            state.pendingEncodedCredentialKey = false
+            return "\"secret\":" + input[input.index(after: delimiter)...]
+        }
         let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"/#)
         return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
             // A brace/comma inside a serialized value is not an outer field boundary.
@@ -16,6 +28,9 @@ extension Redactor {
             var encoded = String(match.3)
             func key(_ name: String) -> String { String(match.1) + framing + "\"" + name + framing + "\"" }
             guard encoded.contains("\\") else { return String(match.0) }
+            if encoded.last != "\"", input[match.range.upperBound...].allSatisfy(\.isWhitespace) {
+                state.pendingEncodedCredentialKey = true
+            }
             // The framing backslashes are transport quoting, not part of the JSON name.
             if !framing.isEmpty, encoded.hasSuffix(framing + "\"") {
                 encoded = String(encoded.dropLast(framing.count + 1)) + "\""

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -7,7 +7,7 @@ extension Redactor {
     /// encoded keys fail closed as a secret field, keeping decoding work bounded.
     /// A key at EOL is normalized too, so bounded label replay can accept a later colon.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
-        input.replacing(#/((?:^|[{\[,])(?:[ \t]|\r\n|\r|\n)*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?")(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
+        input.replacing(#/((?:^|[{\[,])(?:[ \t]|\r\n|\r|\n)*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?"|"(?:[^"\\:\r\n]|\\[^\r\n])*\\?)(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
             let encoded = match.2
             guard encoded.contains("\\") else { return String(match.0) }
             guard encoded.utf8.prefix(1025).count <= 1024,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -21,6 +21,10 @@ extension Redactor {
         var stringIndex = strings.startIndex
         return input.replacing(#/((?:^|[^A-Za-z0-9\\:=])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"'\\:=]|\\.))*\\*|'(?:(?!\\*'\s*[:=])(?:[^'\\]|\\.))*\\*'|'(?:(?!\\*'\s*[:=])(?:[^'"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
             guard match.3.contains("\\") else { return String(match.0) }
+            // Whitespace after an assignment introduces its value, not another key.
+            if input[..<match.range.lowerBound].last(where: { !$0.isWhitespace }).map({ ":=".contains($0) }) == true {
+                return String(match.0)
+            }
             let quote = String(match.3.prefix(1))
             let keyStart = match.3.startIndex
             let content = match.3.dropFirst().dropLast(match.3.hasSuffix(quote) ? 1 : 0)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -18,16 +18,25 @@ extension Redactor {
             return "\"secret\":" + input[input.index(after: delimiter)...]
         }
         let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"/#)
+        var stringIndex = strings.startIndex
         return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
+            guard match.3.contains("\\") else { return String(match.0) }
+            // Both scans visit monotonically increasing ranges. Advance each string
+            // at most once instead of rescanning every earlier value for every field.
+            while stringIndex < strings.endIndex, strings[stringIndex].range.upperBound <= match.range.lowerBound {
+                strings.formIndex(after: &stringIndex)
+            }
             // A brace/comma inside a serialized value is not an outer field boundary.
-            guard !strings.contains(where: {
-                ($0.range.lowerBound < match.range.lowerBound && $0.range.contains(match.range.lowerBound))
-                    || ($0.range.lowerBound == match.range.lowerBound && $0.range.upperBound > match.range.upperBound)
-            }) else { return String(match.0) }
+            if stringIndex < strings.endIndex {
+                let range = strings[stringIndex].range
+                if (range.lowerBound < match.range.lowerBound && range.contains(match.range.lowerBound))
+                    || (range.lowerBound == match.range.lowerBound && range.upperBound > match.range.upperBound) {
+                    return String(match.0)
+                }
+            }
             let framing = String(match.2)
             var encoded = String(match.3)
             func key(_ name: String) -> String { String(match.1) + framing + "\"" + name + framing + "\"" }
-            guard encoded.contains("\\") else { return String(match.0) }
             if encoded.last != "\"", input[match.range.upperBound...].allSatisfy(\.isWhitespace) {
                 state.pendingEncodedCredentialKey = true
             }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -17,32 +17,45 @@ extension Redactor {
             state.pendingEncodedCredentialKey = false
             return "\"secret\":" + input[input.index(after: delimiter)...]
         }
-        let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"/#)
+        let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/#)
         var stringIndex = strings.startIndex
-        return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
+        return input.replacing(#/((?:^|[^A-Za-z0-9\\:=])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"'\\:=]|\\.))*\\*|'(?:(?!\\*'\s*[:=])(?:[^'\\]|\\.))*\\*'|'(?:(?!\\*'\s*[:=])(?:[^'"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
             guard match.3.contains("\\") else { return String(match.0) }
+            let quote = String(match.3.prefix(1))
+            let keyStart = match.3.startIndex
+            let content = match.3.dropFirst().dropLast(match.3.hasSuffix(quote) ? 1 : 0)
+            if content.contains(#/^--[^"' \t]+\\*["'][ \t]*,/#) { return String(match.0) }
             // Both scans visit monotonically increasing ranges. Advance each string
             // at most once instead of rescanning every earlier value for every field.
-            while stringIndex < strings.endIndex, strings[stringIndex].range.upperBound <= match.range.lowerBound {
+            while stringIndex < strings.endIndex, strings[stringIndex].range.upperBound <= keyStart {
                 strings.formIndex(after: &stringIndex)
             }
             // A brace/comma inside a serialized value is not an outer field boundary.
             if stringIndex < strings.endIndex {
                 let range = strings[stringIndex].range
-                if (range.lowerBound < match.range.lowerBound && range.contains(match.range.lowerBound))
-                    || (range.lowerBound == match.range.lowerBound && range.upperBound > match.range.upperBound) {
+                if (range.lowerBound < keyStart && range.contains(keyStart))
+                    || (range.lowerBound == keyStart && range.upperBound > match.range.upperBound
+                        && content.contains(where: { "\"'".contains($0) })) {
                     return String(match.0)
                 }
             }
             let framing = String(match.2)
             var encoded = String(match.3)
-            func key(_ name: String) -> String { String(match.1) + framing + "\"" + name + framing + "\"" }
-            if encoded.last != "\"", input[match.range.upperBound...].allSatisfy(\.isWhitespace) {
+            func key(_ name: String) -> String { String(match.1) + framing + quote + name + framing + quote }
+            if !encoded.hasSuffix(quote), input[match.range.upperBound...].allSatisfy(\.isWhitespace) {
                 state.pendingEncodedCredentialKey = true
             }
             // The framing backslashes are transport quoting, not part of the JSON name.
-            if !framing.isEmpty, encoded.hasSuffix(framing + "\"") {
-                encoded = String(encoded.dropLast(framing.count + 1)) + "\""
+            if !framing.isEmpty, encoded.hasSuffix(framing + quote) {
+                encoded = String(encoded.dropLast(framing.count + 1)) + quote
+            }
+            // Single-quoted diagnostics share JSON's Unicode escapes. Normalize only
+            // the bounded name; unsupported/malformed quoting still fails closed.
+            guard encoded.utf8.prefix(1025).count <= 1024 else { return key("secret") }
+            if quote == "'" {
+                guard encoded.hasSuffix("'") else { return key("secret") }
+                encoded = "\"" + encoded.dropFirst().dropLast().replacingOccurrences(of: "\\'", with: "'")
+                    .replacingOccurrences(of: "\"", with: "\\\"") + "\""
             }
             guard encoded.utf8.prefix(1025).count <= 1024,
                   let name = try? JSONDecoder().decode(String.self, from: Data(encoded.utf8))

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -1,28 +1,34 @@
 import Foundation
 
 extension Redactor {
-    /// Canonicalize encoded JSON credential names before the existing value scanner.
-    /// Only object-key positions are considered; values are never decoded or copied into
-    /// state. Unknown valid keys retain their original spelling. Malformed or oversized
-    /// encoded keys fail closed as a secret field, keeping decoding work bounded.
-    /// A key at EOL is normalized too, so bounded label replay can accept a later colon.
+    /// Canonicalize encoded credential names only at structural field boundaries.
+    /// Unknown valid names keep their spelling; malformed/oversized names fail closed.
+    /// Decode at most 1024 bytes and never retain decoded names or value bytes in state.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
-        input.replacing(#/((?:^|[{\[,])(?:[ \t]|\r\n|\r|\n)*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?"|"(?:[^"\\:\r\n]|\\[^\r\n])*\\?)(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
-            let encoded = match.2
+        let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"/#)
+        return input.replacing(#/((?:^|[{\[,])\s*)(\\*)("(?:[^"]|"(?!\s*[:=]))*"|"(?:[^":=]|"(?!\s*[:=]))*)(?=\s*[:=]|[ \t]*$)/#) { match in
+            // A brace/comma inside a serialized value is not an outer field boundary.
+            guard !strings.contains(where: { $0.range.lowerBound < match.range.lowerBound && $0.range.contains(match.range.lowerBound) }) else { return String(match.0) }
+            let framing = String(match.2)
+            var encoded = String(match.3)
+            func key(_ name: String) -> String { String(match.1) + framing + "\"" + name + framing + "\"" }
             guard encoded.contains("\\") else { return String(match.0) }
+            // The framing backslashes are transport quoting, not part of the JSON name.
+            if !framing.isEmpty, encoded.hasSuffix(framing + "\"") {
+                encoded = String(encoded.dropLast(framing.count + 1)) + "\""
+            }
             guard encoded.utf8.prefix(1025).count <= 1024,
                   let name = try? JSONDecoder().decode(String.self, from: Data(encoded.utf8))
-            else { return String(match.1) + "\"secret\"" }
+            else { return key("secret") }
             let label = name + ":"
             guard label.wholeMatch(of: patterns.secretLabelOnly) != nil
                 || label.wholeMatch(of: patterns.authorizationHeader) != nil
                 || label.wholeMatch(of: patterns.codePromptOnly) != nil
             else { return String(match.0) }
-            // Never turn decoded control characters or quotes into new output framing.
             let safeName = name.first?.isWhitespace != true && name.last?.isWhitespace != true && name.allSatisfy {
                 $0.isASCII && ($0.isLetter || $0.isNumber || " ._-".contains($0))
             } ? name : "secret"
-            return String(match.1) + "\"" + safeName + "\""
+            return key(safeName)
         }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -5,8 +5,9 @@ extension Redactor {
     /// Only object-key positions are considered; values are never decoded or copied into
     /// state. Unknown valid keys retain their original spelling. Malformed or oversized
     /// encoded keys fail closed as a secret field, keeping decoding work bounded.
+    /// A key at EOL is normalized too, so bounded label replay can accept a later colon.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
-        input.replacing(#/(^[ \t]*|[{\[,][ \t]*)("(?:[^"\\\r\n]|\\[^\r\n])*")(?=[ \t]*:)/#) { match in
+        input.replacing(#/(^[ \t]*|[{\[,][ \t]*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?")(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
             let encoded = match.2
             guard encoded.contains("\\") else { return String(match.0) }
             guard encoded.utf8.prefix(1025).count <= 1024,
@@ -19,7 +20,7 @@ extension Redactor {
             else { return String(match.0) }
             // Never turn decoded control characters or quotes into new output framing.
             let safeName = name.first?.isWhitespace != true && name.last?.isWhitespace != true && name.allSatisfy {
-                $0.isASCII && ($0.isLetter || $0.isNumber || " _-".contains($0))
+                $0.isASCII && ($0.isLetter || $0.isNumber || " ._-".contains($0))
             } ? name : "secret"
             return String(match.1) + "\"" + safeName + "\""
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -17,12 +17,13 @@ extension Redactor {
             state.pendingEncodedCredentialKey = false
             return "\"secret\":" + input[input.index(after: delimiter)...]
         }
-        let strings = input.matches(of: #/"(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'/#)
+        let strings = closedDiagnosticStringRanges(in: input)
         var stringIndex = strings.startIndex
         return input.replacing(#/((?:^|[^A-Za-z0-9\\:=])\s*)(\\*)("(?:(?!\\*"\s*[:=])(?:[^"\\]|\\.))*\\*"|"(?:(?!\\*"\s*[:=])(?:[^"'\\:=]|\\.))*\\*|'(?:(?!\\*'\s*[:=])(?:[^'\\]|\\.))*\\*'|'(?:(?!\\*'\s*[:=])(?:[^'"\\:=]|\\.))*\\*)(?=\s*[:=]|[ \t]*$)/#) { match in
             guard match.3.contains("\\") else { return String(match.0) }
             // Whitespace after an assignment introduces its value, not another key.
-            if input[..<match.range.lowerBound].last(where: { !$0.isWhitespace }).map({ ":=".contains($0) }) == true {
+            if match.1.allSatisfy(\.isWhitespace),
+               input[..<match.range.lowerBound].last(where: { !$0.isWhitespace }).map({ ":=".contains($0) }) == true {
                 return String(match.0)
             }
             let quote = String(match.3.prefix(1))
@@ -31,12 +32,12 @@ extension Redactor {
             if content.contains(#/^--[^"' \t]+\\*["'][ \t]*,/#) { return String(match.0) }
             // Both scans visit monotonically increasing ranges. Advance each string
             // at most once instead of rescanning every earlier value for every field.
-            while stringIndex < strings.endIndex, strings[stringIndex].range.upperBound <= keyStart {
+            while stringIndex < strings.endIndex, strings[stringIndex].upperBound <= keyStart {
                 strings.formIndex(after: &stringIndex)
             }
             // A brace/comma inside a serialized value is not an outer field boundary.
             if stringIndex < strings.endIndex {
-                let range = strings[stringIndex].range
+                let range = strings[stringIndex]
                 if (range.lowerBound < keyStart && range.contains(keyStart))
                     || (range.lowerBound == keyStart && range.upperBound > match.range.upperBound
                         && content.contains(where: { "\"'".contains($0) })) {
@@ -74,5 +75,30 @@ extension Redactor {
             } ? name : "secret"
             return key(safeName)
         }
+    }
+
+    /// One pass, including when every quote is transport-escaped. A regex looking
+    /// for a closing quote would retry every unclosed opener against the whole suffix.
+    private static func closedDiagnosticStringRanges(in input: String) -> [Range<String.Index>] {
+        var ranges: [Range<String.Index>] = []
+        var opener: String.Index?
+        var delimiter: Character = "\""
+        var escaped = false
+        for index in input.indices {
+            let character = input[index]
+            if !escaped {
+                if let start = opener {
+                    if character == delimiter {
+                        ranges.append(start..<input.index(after: index))
+                        opener = nil
+                    }
+                } else if character == "\"" || character == "'" {
+                    opener = index
+                    delimiter = character
+                }
+            }
+            escaped = character == "\\" ? !escaped : false
+        }
+        return ranges
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+StructuredKeys.swift
@@ -7,7 +7,7 @@ extension Redactor {
     /// encoded keys fail closed as a secret field, keeping decoding work bounded.
     /// A key at EOL is normalized too, so bounded label replay can accept a later colon.
     static func normalizingStructuredCredentialKeys(in input: String) -> String {
-        input.replacing(#/(^[ \t]*|[{\[,][ \t]*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?")(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
+        input.replacing(#/((?:^|[{\[,])(?:[ \t]|\r\n|\r|\n)*)("(?:[^"\\\r\n]|\\[^\r\n])*\\?")(?=(?:[ \t]|\r\n|\r|\n)*:|[ \t]*$)/#) { match in
             let encoded = match.2
             guard encoded.contains("\\") else { return String(match.0) }
             guard encoded.utf8.prefix(1025).count <= 1024,

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -55,6 +55,9 @@ struct Redactor: Sendable {
         var pendingURLSlashes = 0
         /// A bounded, structural option/cookie name split across physical records.
         var pendingCredentialLabel: String?
+        /// An incomplete encoded field name owns records until its assignment arrives.
+        /// Only this bit is retained, never arbitrary key or value bytes.
+        var pendingEncodedCredentialKey = false
         /// A distinctive token prefix reached a line boundary; payload may continue after it.
         var wrappedTokenKind: String?
         /// Quoted values may wrap without indentation and remain sensitive until the quote closes.
@@ -74,6 +77,7 @@ struct Redactor: Sendable {
 
     static func mergePendingContexts(from scanned: StreamState, into state: inout StreamState) {
         state.pendingCredentialLabel = state.pendingCredentialLabel ?? scanned.pendingCredentialLabel
+        state.pendingEncodedCredentialKey = state.pendingEncodedCredentialKey || scanned.pendingEncodedCredentialKey
         state.expectingAuthorizationValue = state.expectingAuthorizationValue || scanned.expectingAuthorizationValue
         state.authorizationValueIsOnTheNextLine = state.authorizationValueIsOnTheNextLine || scanned.authorizationValueIsOnTheNextLine
         state.authorizationValueExplicitlyContinues = state.authorizationValueExplicitlyContinues || scanned.authorizationValueExplicitlyContinues

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -4,6 +4,8 @@ import Testing
 @Suite struct RedactorStructuredKeyTests {
     @Test(arguments: [
         (#"{"pass\u0077ord""#, #"{"password""#),
+        ("{\r\n  " + #""pass\u0077ord": "syntheticOpaque""# + "\r\n}", "{\r\n  " + #""password": "syntheticOpaque""# + "\r\n}"),
+        ("{\n  " + #""pass\u0077ord": "syntheticOpaque""# + "\n}", "{\n  " + #""password": "syntheticOpaque""# + "\n}"),
         (#"{"pass\u0077ord""# + "\r\n:" + #""syntheticOpaque"}"#, #"{"password""# + "\r\n:" + #""syntheticOpaque"}"#),
         (#"{"pass\u0077ord":"syntheticOpaque"}"#, #"{"password":"syntheticOpaque"}"#),
         (#"{"\u0061ccess_token":"syntheticOpaque"}"#, #"{"access_token":"syntheticOpaque"}"#),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -2,6 +2,29 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorStructuredKeyTests {
+    @Test(arguments: ["\r", "\n", "\r\n"])
+    func physicalTerminatorsInsideEncodedKeysFailClosed(_ terminator: String) {
+        let input = #"{"pass\u0077"# + terminator + #"word":"syntheticOpaque"}"#
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == #"{"secret":"syntheticOpaque"}"#)
+    }
+
+    @Test(arguments: [
+        (#""pass\u0077ord":"syntheticOpaque""#, #""password":"syntheticOpaque""#),
+        (#"\"pass\u0077ord\":\"syntheticOpaque\""#, #"\"password\":\"syntheticOpaque\""#),
+        (#"{"pass\u0077ord"="syntheticOpaque"}"#, #"{"password"="syntheticOpaque"}"#)
+    ])
+    func encodedKeyFramingSharesTheDownstreamFieldDelimiters(_ input: String, _ expected: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
+    @Test(arguments: [1, 2, 16, 256])
+    func escapedKeyFramesPreserveTheirOriginalDepth(_ depth: Int) {
+        let quote = String(repeating: "\\", count: depth) + "\""
+        let input = quote + #"pass\u0077ord"# + quote + ":" + quote + "syntheticOpaque" + quote
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input)
+            == quote + "password" + quote + ":" + quote + "syntheticOpaque" + quote)
+    }
+
     @Test(arguments: [
         (#"{"pass\u0077ord""#, #"{"password""#),
         ("{\r\n  " + #""pass\u0077ord": "syntheticOpaque""# + "\r\n}", "{\r\n  " + #""password": "syntheticOpaque""# + "\r\n}"),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -3,6 +3,8 @@ import Testing
 
 @Suite struct RedactorStructuredKeyTests {
     @Test(arguments: [
+        (#"{"pass\u0077ord""#, #"{"password""#),
+        (#"{"pass\u0077ord""# + "\r\n:" + #""syntheticOpaque"}"#, #"{"password""# + "\r\n:" + #""syntheticOpaque"}"#),
         (#"{"pass\u0077ord":"syntheticOpaque"}"#, #"{"password":"syntheticOpaque"}"#),
         (#"{"\u0061ccess_token":"syntheticOpaque"}"#, #"{"access_token":"syntheticOpaque"}"#),
         (#"{"device_\u0063ode":"abcd"}"#, #"{"device_code":"abcd"}"#),
@@ -27,6 +29,7 @@ import Testing
     }
 
     @Test(arguments: [
+        (#"{"pass\u0077ord\":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"password\u0020":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"\u0020password":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"pass\uXXXXord":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -3,6 +3,17 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorStructuredKeyTests {
+    @Test(arguments: [
+        (#""pass\u0077ord:"syntheticOpaque""#, #""secret":"syntheticOpaque""#),
+        (#"{'pass\u0077ord':'syntheticOpaque'}"#, #"{'password':'syntheticOpaque'}"#),
+        (#"INFO "pass\u0077ord":"syntheticOpaque""#, #"INFO "password":"syntheticOpaque""#),
+        (#"INFO 'pass\u0077ord'='syntheticOpaque'"#, #"INFO 'password'='syntheticOpaque'"#),
+        (#"'pass\u0077ord:'syntheticOpaque'"#, #"'secret':'syntheticOpaque'"#)
+    ])
+    func diagnosticAndMalformedKeyBoundariesNormalize(_ input: String, _ expected: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
     @Test(arguments: [1, 128, 2_048])
     func wideRecordsPreserveValuesAndNormalizeEveryEncodedKey(_ count: Int) {
         let prefix = (0..<count).map { "\"field\($0)\":\"visible\",\"pass\\u0077ord\":\"opaque\"" }.joined(separator: ",")
@@ -75,7 +86,14 @@ import Testing
         #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)
     }
 
-    @Test(arguments: [#"["--password", \"#, #"["--password", opaque\"#,
+    @Test(arguments: [#"{'na\u006de':'visible'}"#, #"{'message':'INFO "pass\\u0077ord":"visible"'}"#,
+                      #"{"message":"INFO 'pass\\u0077ord':'visible'"}"#])
+    func singleQuotedKeysAndNestedValueFramesRemainDistinct(_ input: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)
+    }
+
+    @Test(arguments: [#"[\"--password\", \"opaqueCredential\"]"#, #"[\'--password\', \'opaqueCredential\']"#,
+                      #"["--password", \"#, #"["--password", opaque\"#,
                       #"["--password", "first" \"#, #""\"{\\\"password\\\":\"""#])
     func serializedArgumentsAndEncodedValuesAreNotFieldKeys(_ input: String) {
         #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -31,6 +31,8 @@ import Testing
     }
 
     @Test(arguments: [
+        (#"{"pass\u0077ord: syntheticOpaque}"#, #"{"secret": syntheticOpaque}"#),
+        (#"{"pass\u0077ord"#, #"{"secret""#),
         (#"{"pass\u0077ord\":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"password\u0020":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"\u0020password":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -53,6 +53,12 @@ import Testing
         #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)
     }
 
+    @Test(arguments: [#"["--password", \"#, #"["--password", opaque\"#,
+                      #"["--password", "first" \"#, #""\"{\\\"password\\\":\"""#])
+    func serializedArgumentsAndEncodedValuesAreNotFieldKeys(_ input: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)
+    }
+
     @Test(arguments: [
         (#"{"pass\u0077ord: syntheticOpaque}"#, #"{"secret": syntheticOpaque}"#),
         (#"{"pass\u0077ord"#, #"{"secret""#),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -76,6 +76,8 @@ import Testing
 
     @Test(arguments: [
         #"{"na\u006de":"visible","value":"pass\u0077ord"}"#,
+        #"password: \"synthetic\", status: ready"#,
+        #"Authorization: \"synthetic\", status: ready"#,
         #"{"message":"{\"pass\\u0077ord\":\"visible\"}"}"#,
         #"{"message":"literal \"pass\\u0077ord\": visible"}"#,
         #"{"password":"already literal"}"#,

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -1,7 +1,17 @@
+import Foundation
 import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorStructuredKeyTests {
+    @Test(arguments: [1, 128, 2_048])
+    func wideRecordsPreserveValuesAndNormalizeEveryEncodedKey(_ count: Int) {
+        let prefix = (0..<count).map { "\"field\($0)\":\"visible\",\"pass\\u0077ord\":\"opaque\"" }.joined(separator: ",")
+        let input = "{" + prefix + #", "message":"{\"pass\\u0077ord\":\"visible\"}"}"#
+        let expected = "{" + prefix.replacingOccurrences(of: #""pass\u0077ord":"opaque""#, with: #""password":"opaque""#)
+            + #", "message":"{\"pass\\u0077ord\":\"visible\"}"}"#
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
     @Test func incompleteEncodedKeysRetainOnlyAnAssignmentGateAcrossRecords() {
         var state = Redactor.StreamState()
         #expect(Redactor.normalizingStructuredCredentialKeys(in: #"{"pass\u0077"#, state: &state) == #"{"secret""#)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -3,6 +3,13 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorStructuredKeyTests {
+    @Test(arguments: [1, 128, 2_048])
+    func transportEscapedRecordsNormalizeWithoutRescanningUnclosedQuotes(_ count: Int) {
+        let input = Array(repeating: #"\"pass\u0077ord\":\"opaque\""#, count: count).joined(separator: ", ")
+        let expected = Array(repeating: #"\"password\":\"opaque\""#, count: count).joined(separator: ", ")
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
     @Test(arguments: [
         (#""pass\u0077ord:"syntheticOpaque""#, #""secret":"syntheticOpaque""#),
         (#"{'pass\u0077ord':'syntheticOpaque'}"#, #"{'password':'syntheticOpaque'}"#),

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -27,6 +27,8 @@ import Testing
     }
 
     @Test(arguments: [
+        (#"{"password\u0020":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
+        (#"{"\u0020password":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"pass\uXXXXord":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"password\n":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
         (#"{"pass\uD800word":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -1,0 +1,43 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorStructuredKeyTests {
+    @Test(arguments: [
+        (#"{"pass\u0077ord":"syntheticOpaque"}"#, #"{"password":"syntheticOpaque"}"#),
+        (#"{"\u0061ccess_token":"syntheticOpaque"}"#, #"{"access_token":"syntheticOpaque"}"#),
+        (#"{"device_\u0063ode":"abcd"}"#, #"{"device_code":"abcd"}"#),
+        (#"{"\u0041uthorization":"syntheticOpaque"}"#, #"{"Authorization":"syntheticOpaque"}"#),
+        (#"{"outer":{"pass\u0077ord":"one","user_\u0063ode":"two"}}"#, #"{"outer":{"password":"one","user_code":"two"}}"#),
+        (#"  "pass\u0077ord" : "syntheticOpaque""#, #"  "password" : "syntheticOpaque""#)
+    ])
+    func encodedCredentialKeysUseTheExistingFieldGrammar(_ input: String, _ expected: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
+    @Test(arguments: [
+        #"{"na\u006de":"visible","value":"pass\u0077ord"}"#,
+        #"{"message":"{\"pass\\u0077ord\":\"visible\"}"}"#,
+        #"{"message":"literal \"pass\\u0077ord\": visible"}"#,
+        #"{"password":"already literal"}"#,
+        #"{"password\u004cength":12}"#,
+        #"{"pass\u0077ordSuffix":"visible"}"#
+    ])
+    func unknownKeysAndQuotedValuesAreNotReinterpreted(_ input: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == input)
+    }
+
+    @Test(arguments: [
+        (#"{"pass\uXXXXord":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
+        (#"{"password\n":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#),
+        (#"{"pass\uD800word":"syntheticOpaque"}"#, #"{"secret":"syntheticOpaque"}"#)
+    ])
+    func invalidEncodedKeysCannotInjectOutputFraming(_ input: String, _ expected: String) {
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == expected)
+    }
+
+    @Test func oversizedEncodedKeysDoNotReachTheJSONDecoder() {
+        let key = String(repeating: "x", count: 1024) + #"\u0077"#
+        let input = "{\"" + key + "\":\"syntheticOpaque\"}"
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: input) == #"{"secret":"syntheticOpaque"}"#)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorStructuredKeyTests.swift
@@ -2,6 +2,18 @@ import Testing
 @testable import GuesthouseCore
 
 @Suite struct RedactorStructuredKeyTests {
+    @Test func incompleteEncodedKeysRetainOnlyAnAssignmentGateAcrossRecords() {
+        var state = Redactor.StreamState()
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: #"{"pass\u0077"#, state: &state) == #"{"secret""#)
+        #expect(state.pendingEncodedCredentialKey)
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: "or", state: &state) == "[redacted:encoded-key]")
+        #expect(state.pendingEncodedCredentialKey)
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: #"d":"syntheticOpaque"}"#, state: &state)
+            == #""secret":"syntheticOpaque"}"#)
+        #expect(!state.pendingEncodedCredentialKey)
+        #expect(Redactor.normalizingStructuredCredentialKeys(in: "Finished", state: &state) == "Finished")
+    }
+
     @Test(arguments: ["\r", "\n", "\r\n"])
     func physicalTerminatorsInsideEncodedKeysFailClosed(_ terminator: String) {
         let input = #"{"pass\u0077"# + terminator + #"word":"syntheticOpaque"}"#


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope

Prerequisite for #127, implementing issue #11 and MVP-PLAN.md §§3 and 11. Normalize recognized encoded credential-key names at field boundaries before the existing value scanner. Unknown valid names keep their spelling; invalid or oversized names fail closed. JSON decoding is capped at 1,024 encoded key bytes. Values are not decoded by this helper.

Escaped quote framing and both colon/equals assignments are supported. Serialized argument arrays and complete encoded value containers are not reinterpreted as field names. An incomplete encoded key retains only an assignment-pending bit: intermediate physical key fragments are discarded, and the eventual assignment tail passes to the existing secret-value scanner. No arbitrary key/value bytes are retained in state.

## Validation and dependencies

Current exact head: 256 Core tests/19 suites with warnings-as-errors, 168 own lines. Direct tests cover CR/LF/CRLF, escape depths 1/2/16/256, malformed keys and multi-record assignment gating. #127 integrates the stateful call; #114's full physical composition passes 475/33. This is not a claim that the complete public privacy boundary is finished.

Order: #135 → #131 → #132 → this PR → #127 → #96 → #134 → #128 → #130 → #114. Fresh exact-head CI/review and parent gates apply. No new dependency, VM, signing, host setup or credential access.