### PR TITLE
Extract physical credential framing primitives for focused review

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+Encoding.swift
@@ -2,6 +2,22 @@ import Foundation
 import RegexBuilder
 
 extension Redactor {
+    /// A decoded JOSE parameter identifies an incomplete compact token at a record boundary.
+    static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
+        guard let run = text.firstMatch(of: #/(?:^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+)(?=[ \t]*$)/#) else { return nil }
+        let segments = run.1.split(separator: ".", omittingEmptySubsequences: false)
+        for index in segments.indices {
+            guard let start = joseHeaderStart(segments[index]),
+                  let header = decodedJOSEHeader(segments[index][start...]),
+                  header["alg"] != nil || header["enc"] != nil else { continue }
+            let required = header["enc"] == nil ? 3 : 5
+            let emptySignature = required == 3 && header["alg"] as? String == "none"
+            let available = segments.count - index - (segments.last?.isEmpty == true && !emptySignature ? 1 : 0)
+            if available < required { return start }
+        }
+        return nil
+    }
+
     /// Replaces all three JWS or five JWE segments inside a run of dot-separated segments. A dot is
     /// not a word boundary, so the run can begin with a label such as `session.` and can hold two
     /// adjacent tokens; every segment with at least two following it is tried as a JOSE header, and the

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PhysicalFraming.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PhysicalFraming.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+extension Redactor {
+    /// A decoded JOSE parameter identifies an incomplete compact token at a record boundary.
+    static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
+        guard let run = text.firstMatch(of: #/(?:^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+)(?=[ \t]*$)/#) else { return nil }
+        let segments = run.1.split(separator: ".", omittingEmptySubsequences: false)
+        for index in segments.indices {
+            guard let start = joseHeaderStart(segments[index]),
+                  let header = decodedJOSEHeader(segments[index][start...]),
+                  header["alg"] != nil || header["enc"] != nil else { continue }
+            let required = header["enc"] == nil ? 3 : 5
+            let emptySignature = required == 3 && header["alg"] as? String == "none"
+            let available = segments.count - index - (segments.last?.isEmpty == true && !emptySignature ? 1 : 0)
+            if available < required { return start }
+        }
+        return nil
+    }
+
+    /// Quoted and ordinary records both advance footer-to-next-opener state.
+    static func redactPEMBlocks(_ input: String, label: inout String?) -> String {
+        var text = input
+        if let active = label {
+            guard let footer = text.range(of: "-----END \(active)-----") else { return marker("private-key") }
+            label = nil
+            text = marker("private-key") + text[footer.upperBound...]
+        }
+        while let begin = text.firstMatch(of: patterns.pemBegin) {
+            let opened = String(begin.1)
+            if let end = text[begin.range.upperBound...].range(of: "-----END \(opened)-----") {
+                text.replaceSubrange(begin.range.lowerBound..<end.upperBound, with: marker("private-key"))
+            } else {
+                label = opened
+                text.replaceSubrange(begin.range.lowerBound..<text.endIndex, with: marker("private-key"))
+                break
+            }
+        }
+        return text
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PhysicalFraming.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor+PhysicalFraming.swift
@@ -1,22 +1,6 @@
 import Foundation
 
 extension Redactor {
-    /// A decoded JOSE parameter identifies an incomplete compact token at a record boundary.
-    static func incompleteJWTStartAtLineEnd(in text: String) -> String.Index? {
-        guard let run = text.firstMatch(of: #/(?:^|[^A-Za-z0-9_.-])([A-Za-z0-9_.-]+)(?=[ \t]*$)/#) else { return nil }
-        let segments = run.1.split(separator: ".", omittingEmptySubsequences: false)
-        for index in segments.indices {
-            guard let start = joseHeaderStart(segments[index]),
-                  let header = decodedJOSEHeader(segments[index][start...]),
-                  header["alg"] != nil || header["enc"] != nil else { continue }
-            let required = header["enc"] == nil ? 3 : 5
-            let emptySignature = required == 3 && header["alg"] as? String == "none"
-            let available = segments.count - index - (segments.last?.isEmpty == true && !emptySignature ? 1 : 0)
-            if available < required { return start }
-        }
-        return nil
-    }
-
     /// Quoted and ordinary records both advance footer-to-next-opener state.
     static func redactPEMBlocks(_ input: String, label: inout String?) -> String {
         var text = input

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPhysicalFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPhysicalFramingTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RedactorPhysicalFramingTests {
+    @Test(arguments: ["PRIVATE KEY", "RSA PRIVATE KEY", "ACME-PRIVATE KEY", "X9.42 DH PARAMETERS"])
+    func completePEMBlocksPreserveOnlyTheSurroundingDiagnostic(_ label: String) {
+        var pending: String?
+        let input = "before -----BEGIN " + label + "-----syntheticBody-----END " + label + "----- after"
+        #expect(Redactor.redactPEMBlocks(input, label: &pending) == "before [redacted:private-key] after")
+        #expect(pending == nil)
+    }
+
+    @Test func PEMStateCarriesTheLabelButNeverTheBody() {
+        var pending: String?
+        #expect(Redactor.redactPEMBlocks("-----BEGIN PRIVATE KEY-----syntheticFirst", label: &pending) == "[redacted:private-key]")
+        #expect(pending == "PRIVATE KEY")
+        #expect(Redactor.redactPEMBlocks("syntheticSecond", label: &pending) == "[redacted:private-key]")
+        #expect(Redactor.redactPEMBlocks("-----END RSA PRIVATE KEY-----", label: &pending) == "[redacted:private-key]")
+        #expect(pending == "PRIVATE KEY")
+        #expect(Redactor.redactPEMBlocks("-----END PRIVATE KEY----- done", label: &pending) == "[redacted:private-key] done")
+        #expect(pending == nil)
+    }
+
+    @Test func AClosedPEMBlockCanBeFollowedByAnotherOpener() {
+        var pending: String? = "PRIVATE KEY"
+        let line = "-----END PRIVATE KEY----- middle -----BEGIN RSA PRIVATE KEY-----synthetic"
+        #expect(Redactor.redactPEMBlocks(line, label: &pending) == "[redacted:private-key] middle [redacted:private-key]")
+        #expect(pending == "RSA PRIVATE KEY")
+    }
+
+    @Test(arguments: ["eyJhbGciOiJIUzI1NiJ9", "eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA", "eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA."])
+    func IncompleteJOSECandidatesKeepTheirOriginalStart(_ token: String) throws {
+        let input = "prefix " + token + " \t"
+        let start = try #require(Redactor.incompleteJWTStartAtLineEnd(in: input))
+        #expect(String(input[start...]) == token + " \t")
+    }
+
+    @Test(arguments: ["Finished", "prefix e30.payload", "eyJhbGciOiJIUzI1NiJ9.payload; status=ok"])
+    func OrdinaryOrTerminatedRecordsDoNotBecomeIncompleteJOSEHeaders(_ input: String) {
+        #expect(Redactor.incompleteJWTStartAtLineEnd(in: input) == nil)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPhysicalFramingTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Redaction/RedactorPhysicalFramingTests.swift
@@ -21,7 +21,7 @@ import Testing
         #expect(pending == nil)
     }
 
-    @Test func AClosedPEMBlockCanBeFollowedByAnotherOpener() {
+    @Test func aClosedPEMBlockCanBeFollowedByAnotherOpener() {
         var pending: String? = "PRIVATE KEY"
         let line = "-----END PRIVATE KEY----- middle -----BEGIN RSA PRIVATE KEY-----synthetic"
         #expect(Redactor.redactPEMBlocks(line, label: &pending) == "[redacted:private-key] middle [redacted:private-key]")
@@ -29,14 +29,14 @@ import Testing
     }
 
     @Test(arguments: ["eyJhbGciOiJIUzI1NiJ9", "eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA", "eyJhbGciOiJIUzI1NiJ9.cGF5bG9hZA."])
-    func IncompleteJOSECandidatesKeepTheirOriginalStart(_ token: String) throws {
+    func incompleteJOSECandidatesKeepTheirOriginalStart(_ token: String) throws {
         let input = "prefix " + token + " \t"
         let start = try #require(Redactor.incompleteJWTStartAtLineEnd(in: input))
         #expect(String(input[start...]) == token + " \t")
     }
 
     @Test(arguments: ["Finished", "prefix e30.payload", "eyJhbGciOiJIUzI1NiJ9.payload; status=ok"])
-    func OrdinaryOrTerminatedRecordsDoNotBecomeIncompleteJOSEHeaders(_ input: String) {
+    func ordinaryOrTerminatedRecordsDoNotBecomeIncompleteJOSEHeaders(_ input: String) {
         #expect(Redactor.incompleteJWTStartAtLineEnd(in: input) == nil)
     }
 }


### PR DESCRIPTION
<!-- guesthouse-current-validation -->
## Deferred: structured diagnostics replaces this MVP prerequisite

The owner approved replacing general-purpose raw-output redaction with structured diagnostics on September 8. #136 implements the replacement Core contract directly on main and records ADR 0003. This parser PR is now deferred reference, not an MVP merge prerequisite. Preserve its branch/history/tests and unresolved findings; deferral does not mean the findings are fixed or rejected. No further parser pushes or review requests are planned. Existing runtime/XPC/GUI consumers migrate through #7, #9, #21 and #30. Do not merge this old stack ahead of #136.
<!-- /guesthouse-current-validation -->

## Scope

Focused prerequisite for #128 and issue #11, implementing the review boundary required by AGENTS.md and MVP-PLAN.md §§3/11. Extracts existing PEM record framing and incomplete-JOSE boundary recognition from the oversized physical-stream integration into a separately testable component. The private JOSE decoder stays private in its original source file. No public stream API or behavior change is claimed here.

The 82-line component includes direct parameterized tests for matching/mismatched PEM footers, multiple blocks, label-only state, incomplete JOSE candidates, and ordinary/terminated diagnostics. #128 removes the duplicate implementations and remains responsible for stream orchestration. Existing nested/ambiguous framing, final-segment wrapping, PPK, and other #128 review reports stay open; extracting a helper does not solve them.

## Validation

Full GuesthouseCore suite: 309 tests in 25 suites pass with warnings-as-errors at b89c181. The first extraction build exposed a file-private access error; it was corrected by keeping the JOSE helper beside its decoder, without broadening visibility. No VM, signing, host operation, new dependency, or secrets.

Stack: #133 → #127 → #96 → this PR → #128 → #130 → #114. Await exact-head Xcode Cloud and Codex review. Related: #11, #128.