### PR TITLE
Replace MVP raw-log redaction with structured diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ bash Tests/CI/test-package-hook.sh
 - Launch processes only in the runtime service or `GuesthouseRuntimeKit`, always with an executable URL and an argument array. Never `/bin/sh -c`, never string interpolation into a command, never an inherited environment.
 - The service chooses executable paths and flags. Requests from the GUI carry environment IDs and validated options, never paths to run or provider CLI flags, including Tart or Lume flags.
 - Treat guest output, repository content, branch names, file names, and CLI text as untrusted data. Never turn any of it into a host command.
-- Never log or persist tokens, passwords, device codes, private keys, or authorization headers. Route every log line through the redaction layer once it exists (issue #11).
+- Diagnostics accept only typed `DiagnosticEvent` values (ADR 0003, issue #11). Never log raw stdout/stderr, arguments, environment variables, authentication transcripts, or arbitrary error descriptions. Keep useful error messages and recovery guidance in Guesthouse-owned templates. Runtime adapters may parse bounded temporary output; that output is not a log.
+- The general-purpose redactor is deferred reference code, not an MVP dependency. Do not extend or activate it, or restore `RedactedLine`/`SanitizedText` as a prerequisite for shared features. Preserve its history and tests; migrate pending consumers to structured events and typed errors instead.
 - Prefer environment UUIDs and relative guest paths over IP addresses as persistent identity.
 - An interrupted operation has an unknown outcome until the actual state is inspected. Never retry a mutating operation blindly.
 - Errors carry a user-facing message and at least one recovery action. "Something went wrong" is never the only information.

--- a/MVP-PLAN.md
+++ b/MVP-PLAN.md
@@ -87,7 +87,7 @@ After a crash, sleep, or unexpected disconnection, show **Checking environment**
 - Environment dashboard with one or two slots.
 - Workspace detail with repository status and separate local-integration and remote-CI results.
 - Account sheets for sign-in, expiration, wrong-account recovery, and sign-out.
-- Diagnostics and repair sheet with sanitized logs and export controls.
+- Diagnostics and repair sheet with structured operation events, actionable error messages, and export controls. Raw subprocess output is excluded.
 
 Use native controls, keyboard navigation, VoiceOver labels, selectable paths, and clear cancel/retry behavior. A read-only log disclosure is useful; an embedded terminal is not necessary.
 
@@ -152,7 +152,7 @@ Keep SwiftUI view state on the main actor and long-running host operations in th
 | `EnvironmentCoordinator` | State machine, operation ordering, cancellation, restart recovery, VM-slot accounting |
 | `RuntimeClient` / XPC contract | Authenticated, versioned messages, status streaming, reconnection, validation |
 | `TartBackend` | Runtime verification, create/start/stop, VM inventory, IP discovery, console lifecycle |
-| `ProcessRunner` | Argument-safe process execution, output streaming, timeouts, termination, redaction |
+| `ProcessRunner` | Argument-safe execution, bounded temporary output for adapters, timeouts and termination; never automatic output logging |
 | `SSHService` | Dedicated identities, trust records, managed aliases, connections, file transfer |
 | `GuestProvisioner` | Versioned, repeatable guest setup and compatibility checks |
 | `CompatibilityService` | Connect-time version/capability checks and explicit verified, unverified, or incompatible states |
@@ -175,6 +175,16 @@ Keep runtime downloads, VM data, maintenance SSH files, operation state, and dia
 Export only the development SSH connection material needed by external Codex/OpenSSH to a dedicated user-approved location such as `~/.ssh/guesthouse/`. Do not assume Codex can read a private file inside Guesthouse's protected app container. Keep maintenance connection material out of that export and out of discoverable SSH aliases. Validate external access in phase zero before freezing the layout.
 
 Store no provider token in the application metadata. Exclude private keys, tokens, device codes, authorization headers, and raw authentication logs from diagnostic exports. Prefer relative guest workspace paths and environment UUIDs over IP addresses as persistent identity.
+
+### Structured diagnostics and error messages
+
+[ADR 0003](docs/decisions/0003-structured-diagnostics.md) replaces general-purpose output redaction with structured diagnostics. Logs, OSLog entries, XPC diagnostic events, error presentation, and exports use Guesthouse-owned event/error categories and fixed message templates. Allow operation/environment UUIDs and numeric exit status; arbitrary strings, paths, URLs, command arguments, environment dumps, and underlying error descriptions are not diagnostic fields.
+
+Keep useful error messages: explain the failed operation, a known failure category, and a recovery action. When a tool's response cannot be classified, report that it failed and include its exit status, not its stderr. Do not claim a canceled or interrupted mutation completed; inspect its outcome before retrying.
+
+Runtime adapters may consume bounded temporary stdout/stderr to interpret known command responses. Drain unused output without logging it. Authentication codes use a separate temporary sign-in UI channel, never diagnostic history or exports. No raw-output debug/export fallback is included in the MVP.
+
+`DiagnosticEvent`, `DiagnosticFailure`, and `DiagnosticLog` define the Core contract and bounded session history/export. Pending runtime, XPC, error and GUI integrations must adopt this contract before merging; adding the Core types alone is not proof of those integrations. Keep the old redactor implementation, tests and PR history as deferred reference, not a prerequisite for MVP features. Cross-session diagnostic persistence remains a separate task.
 
 ### Process and trust boundaries
 
@@ -533,7 +543,7 @@ If first-boot UI, runtime ownership, secure cold-boot auth, or GUI-only pairing 
 
 Implement the proven lifecycle boundary, typed XPC client/service, process execution, durable environment state, and a fake backend for previews/tests. Put operation ownership and VM-slot reservations in the service, with observable UI adapters. Add interfaces or stubs for later maintenance, account, workspace, build, and publication services rather than implementing all services at once. Start with one environment and one in-flight lifecycle operation.
 
-Add progress, cancellation, retry, sanitized logs, and error categories such as unsupported host, insufficient disk, failed download verification, guest not reachable, and credentials locked. Never show “something went wrong” as the only recovery information.
+Add progress, cancellation, retry, structured diagnostic events, and error categories such as unsupported host, insufficient disk, failed download verification, guest not reachable, and credentials locked. Never show “something went wrong” as the only recovery information. Follow §3's diagnostic boundary; do not copy raw tool output into error messages.
 
 Implement the phase-zero window-close, viewer-close, and stop-on-Quit contracts. Reconcile process identity safely after relaunch; do not trust a reused PID, assume every crash killed Tart, or assume any surviving process can be safely restarted. Treat an interrupted XPC request as an unknown outcome until inspected.
 
@@ -641,4 +651,3 @@ Expand tested Xcode/project layouts, template and backup handling within the VM 
 Build the phase-zero Guesthouse SwiftUI/XPC harness and an app-plus-package fixture. Start with a named runtime-version request and a fake backend. Its full success condition is one recorded run from VM creation through a cold-boot Codex connection to two draft PRs, with Xcode tests and native MLX validation executing in the guest, plus the named lifecycle and recovery gates.
 
 That experiment answers the costly questions before UI polish: the signed sandbox/XPC boundary, first-boot and returning console behavior, first-use SSH trust, cold-boot Keychain access, real desktop/CLI compatibility, local Swift package resolution, import performance, maintenance/sleep recovery, and the practical resource budget. Record decisions and measured versions, then turn the proven steps into the production wizard.
-

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// The only MVP diagnostic payload (ADR 0003). No arbitrary message, path, URL, arguments,
+/// environment, stdout, stderr or underlying error can be attached to an event.
+/// IDs must come from Guesthouse's operation/environment records, not guest output.
+public struct DiagnosticEvent: Codable, Hashable, Sendable {
+    public enum Operation: String, CaseIterable, Codable, Sendable {
+        case preflight, verifyRuntime, createEnvironment, startEnvironment, stopEnvironment
+        case inspectEnvironment, connectSSH, importXcode, checkTools, codexSignIn, githubSignIn
+        case synchronizeRepositories, testWorkspace, publishChanges, exportDiagnostics
+
+        public var title: String {
+            switch self {
+            case .preflight: "Check this Mac"
+            case .verifyRuntime: "Verify runtime"
+            case .createEnvironment: "Create development Mac"
+            case .startEnvironment: "Start development Mac"
+            case .stopEnvironment: "Stop development Mac"
+            case .inspectEnvironment: "Inspect development Mac"
+            case .connectSSH: "Connect over SSH"
+            case .importXcode: "Import Xcode"
+            case .checkTools: "Check tools"
+            case .codexSignIn: "Sign in to Codex"
+            case .githubSignIn: "Sign in to GitHub"
+            case .synchronizeRepositories: "Synchronize repositories"
+            case .testWorkspace: "Test workspace"
+            case .publishChanges: "Publish changes"
+            case .exportDiagnostics: "Export diagnostics"
+            }
+        }
+    }
+
+    public enum Outcome: Codable, Hashable, Sendable {
+        case started, succeeded, cancellationRequested
+        case failed(DiagnosticFailure)
+    }
+
+    public let operation: Operation
+    public let outcome: Outcome
+    public let operationID: UUID
+    public let environmentID: EnvironmentID?
+    public let exitStatus: Int32?
+
+    public init(
+        operation: Operation, outcome: Outcome, operationID: UUID,
+        environmentID: EnvironmentID? = nil, exitStatus: Int32? = nil
+    ) {
+        self.operation = operation
+        self.outcome = outcome
+        self.operationID = operationID
+        self.environmentID = environmentID
+        self.exitStatus = exitStatus
+    }
+
+    /// Render locally from closed enums. Decoded/guest-supplied message text is never used.
+    public var message: String {
+        let detail: String
+        switch outcome {
+        case .started: detail = "Started."
+        case .succeeded: detail = "Succeeded."
+        case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
+        case .failed(let failure): detail = failure.message
+        }
+        return operation.title + ": " + detail
+            + (exitStatus.map { " Exit status: \($0)." } ?? "")
+    }
+
+    public var recoveryMessage: String? {
+        switch outcome {
+        case .failed(let failure): failure.recoveryMessage
+        case .cancellationRequested: "Wait for the operation to stop, then inspect its outcome."
+        case .started, .succeeded: nil
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -9,6 +9,9 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case inspectEnvironment, connectSSH, importXcode, checkTools, codexSignIn, githubSignIn
         case synchronizeRepositories, testWorkspace, publishChanges, exportDiagnostics
         case deleteEnvironment, exportWork, openConsole, repairEnvironment, updateGuest
+        case codexSignOut, githubSignOut
+        case openInCodex, configureWorkspace, deleteWorkspace, restoreWork, preserveEnvironment
+        case downloadRuntime, downloadGuestImage, bootstrapGuest, installTools, pairSSH
 
         public var title: String {
             switch self {
@@ -32,12 +35,25 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
             case .openConsole: "Open development Mac console"
             case .repairEnvironment: "Repair development Mac"
             case .updateGuest: "Update development Mac"
+            case .codexSignOut: "Sign out of Codex"
+            case .githubSignOut: "Sign out of GitHub"
+            case .openInCodex: "Open in Codex"
+            case .configureWorkspace: "Configure workspace"
+            case .deleteWorkspace: "Delete workspace"
+            case .restoreWork: "Restore work"
+            case .preserveEnvironment: "Preserve development Mac"
+            case .downloadRuntime: "Download runtime"
+            case .downloadGuestImage: "Download macOS image"
+            case .bootstrapGuest: "Prepare guest accounts"
+            case .installTools: "Install development tools"
+            case .pairSSH: "Pair SSH identity"
             }
         }
     }
 
     public enum Outcome: Codable, Hashable, Sendable {
         case started, succeeded, cancellationRequested
+        case pending, waitingForUserAction
         /// Emit only after cancellation/termination is confirmed, not when it is requested.
         case canceled
         case failed(DiagnosticFailure)
@@ -64,6 +80,8 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
     public var message: String {
         let detail: String
         switch outcome {
+        case .pending: detail = "Queued; not started yet."
+        case .waitingForUserAction: detail = "Waiting for user action; the operation has not failed."
         case .started: detail = "Started."
         case .succeeded: detail = "Succeeded."
         case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
@@ -76,10 +94,11 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
 
     public var recoveryMessage: String? {
         switch outcome {
+        case .waitingForUserAction: "Complete the step shown by Guesthouse, then continue."
         case .failed(let failure): recovery(for: failure)
         case .cancellationRequested: "Wait for the operation to stop, then inspect its outcome."
         case .canceled: "Inspect any partial changes before starting another operation."
-        case .started, .succeeded: nil
+        case .pending, .started, .succeeded: nil
         }
     }
 
@@ -90,15 +109,15 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         switch operation {
         case .preflight:
             return "Run Check this Mac again and review the host requirements in Settings."
-        case .verifyRuntime:
+        case .verifyRuntime, .downloadRuntime, .downloadGuestImage:
             return "Open Repair and inspect the runtime installation before trying again."
         case .exportDiagnostics:
             return "Check the selected export location and available disk space before exporting again."
-        case .codexSignIn, .githubSignIn:
+        case .codexSignIn, .githubSignIn, .codexSignOut, .githubSignOut:
             return "Open Accounts and check sign-in status before trying again."
         case .exportWork:
             return "Inspect the export destination and the development Mac before trying again."
-        case .synchronizeRepositories, .testWorkspace, .publishChanges:
+        case .synchronizeRepositories, .testWorkspace, .publishChanges, .configureWorkspace, .deleteWorkspace, .restoreWork:
             return "Inspect the workspace and any remote changes before trying the operation again."
         default:
             return failure.recoveryMessage

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -111,6 +111,9 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
     private var isDownload: Bool { operation == .downloadRuntime || operation == .downloadGuestImage }
 
     private func recovery(for failure: DiagnosticFailure) -> String {
+        if failure == .connectionFailed, isDownload {
+            return "Check Internet access and the trusted download source, then inspect the staged download in Repair before resuming. Do not bypass TLS or verification checks."
+        }
         if failure == .insufficientDiskSpace, isDownload {
             return "Free disk space, then use Repair to inspect the staged download before resuming it."
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -87,8 +87,12 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
         case .canceled: detail = "Cancellation confirmed; partial changes may remain."
         case .failed(let failure):
-            detail = failure == .verificationFailed && isDownload
-                ? "The downloaded artifact failed verification." : failure.message
+            if failure == .verificationFailed, operation == .importXcode {
+                detail = "The Xcode bundle failed verification."
+            } else {
+                detail = failure == .verificationFailed && isDownload
+                    ? "The downloaded artifact failed verification." : failure.message
+            }
         }
         return operation.title + ": " + detail
             + (exitStatus.map { " Exit status: \($0)." } ?? "")
@@ -107,6 +111,9 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
     private var isDownload: Bool { operation == .downloadRuntime || operation == .downloadGuestImage }
 
     private func recovery(for failure: DiagnosticFailure) -> String {
+        if failure == .verificationFailed, operation == .importXcode {
+            return "Use Repair to inspect the failed import, then select a trusted, stable Xcode bundle and import it again. Preserve the existing installation until verification succeeds; do not bypass signature checks."
+        }
         if failure == .verificationFailed, isDownload {
             return "Use Repair to download a verified replacement from the trusted source. Preserve the existing development Mac and do not bypass verification."
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -111,6 +111,9 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
     private var isDownload: Bool { operation == .downloadRuntime || operation == .downloadGuestImage }
 
     private func recovery(for failure: DiagnosticFailure) -> String {
+        if failure == .insufficientDiskSpace, isDownload {
+            return "Free disk space, then use Repair to inspect the staged download before resuming it."
+        }
         if failure == .verificationFailed, operation == .importXcode {
             return "Use Repair to inspect the failed import, then select a trusted, stable Xcode bundle and import it again. Preserve the existing installation until verification succeeds; do not bypass signature checks."
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -86,7 +86,9 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case .succeeded: detail = "Succeeded."
         case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
         case .canceled: detail = "Cancellation confirmed; partial changes may remain."
-        case .failed(let failure): detail = failure.message
+        case .failed(let failure):
+            detail = failure == .verificationFailed && isDownload
+                ? "The downloaded artifact failed verification." : failure.message
         }
         return operation.title + ": " + detail
             + (exitStatus.map { " Exit status: \($0)." } ?? "")
@@ -102,15 +104,22 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         }
     }
 
+    private var isDownload: Bool { operation == .downloadRuntime || operation == .downloadGuestImage }
+
     private func recovery(for failure: DiagnosticFailure) -> String {
+        if failure == .verificationFailed, isDownload {
+            return "Use Repair to download a verified replacement from the trusted source. Preserve the existing development Mac and do not bypass verification."
+        }
         guard [.timedOut, .processFailed, .outcomeUnknown].contains(failure) else {
             return failure.recoveryMessage
         }
         switch operation {
         case .preflight:
             return "Run Check this Mac again and review the host requirements in Settings."
-        case .verifyRuntime, .downloadRuntime, .downloadGuestImage:
+        case .verifyRuntime:
             return "Open Repair and inspect the runtime installation before trying again."
+        case .downloadRuntime, .downloadGuestImage:
+            return "Open Repair and inspect the download's current state before resuming it."
         case .exportDiagnostics:
             return "Check the selected export location and available disk space before exporting again."
         case .codexSignIn, .githubSignIn, .codexSignOut, .githubSignOut:

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -56,24 +56,26 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case pending, waitingForUserAction
         /// Emit only after cancellation/termination is confirmed, not when it is requested.
         case canceled
-        case failed(DiagnosticFailure)
+        /// Process status is failure context, never an attachment to a lifecycle outcome.
+        case failed(DiagnosticFailure, exitStatus: Int32? = nil)
     }
 
     public let operation: Operation
     public let outcome: Outcome
     public let operationID: UUID
     public let environmentID: EnvironmentID?
-    public let exitStatus: Int32?
+    public var exitStatus: Int32? {
+        if case .failed(_, let status) = outcome { status } else { nil }
+    }
 
     public init(
         operation: Operation, outcome: Outcome, operationID: UUID,
-        environmentID: EnvironmentID? = nil, exitStatus: Int32? = nil
+        environmentID: EnvironmentID? = nil
     ) {
         self.operation = operation
         self.outcome = outcome
         self.operationID = operationID
         self.environmentID = environmentID
-        self.exitStatus = exitStatus
     }
 
     /// Render locally from closed enums. Decoded/guest-supplied message text is never used.
@@ -86,7 +88,7 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case .succeeded: detail = "Succeeded."
         case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
         case .canceled: detail = "Cancellation confirmed; partial changes may remain."
-        case .failed(let failure):
+        case .failed(let failure, _):
             if failure == .verificationFailed, operation == .importXcode {
                 detail = "The Xcode bundle failed verification."
             } else {
@@ -101,7 +103,7 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
     public var recoveryMessage: String? {
         switch outcome {
         case .waitingForUserAction: "Complete the step shown by Guesthouse, then continue."
-        case .failed(let failure): recovery(for: failure)
+        case .failed(let failure, _): recovery(for: failure)
         case .cancellationRequested: "Wait for the operation to stop, then inspect its outcome."
         case .canceled: "Inspect any partial changes before starting another operation."
         case .pending, .started, .succeeded: nil

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -8,6 +8,7 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case preflight, verifyRuntime, createEnvironment, startEnvironment, stopEnvironment
         case inspectEnvironment, connectSSH, importXcode, checkTools, codexSignIn, githubSignIn
         case synchronizeRepositories, testWorkspace, publishChanges, exportDiagnostics
+        case deleteEnvironment, exportWork, openConsole, repairEnvironment, updateGuest
 
         public var title: String {
             switch self {
@@ -26,12 +27,19 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
             case .testWorkspace: "Test workspace"
             case .publishChanges: "Publish changes"
             case .exportDiagnostics: "Export diagnostics"
+            case .deleteEnvironment: "Delete development Mac"
+            case .exportWork: "Export work"
+            case .openConsole: "Open development Mac console"
+            case .repairEnvironment: "Repair development Mac"
+            case .updateGuest: "Update development Mac"
             }
         }
     }
 
     public enum Outcome: Codable, Hashable, Sendable {
         case started, succeeded, cancellationRequested
+        /// Emit only after cancellation/termination is confirmed, not when it is requested.
+        case canceled
         case failed(DiagnosticFailure)
     }
 
@@ -59,6 +67,7 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
         case .started: detail = "Started."
         case .succeeded: detail = "Succeeded."
         case .cancellationRequested: detail = "Cancellation requested; completion is not yet confirmed."
+        case .canceled: detail = "Cancellation confirmed; partial changes may remain."
         case .failed(let failure): detail = failure.message
         }
         return operation.title + ": " + detail
@@ -67,9 +76,32 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
 
     public var recoveryMessage: String? {
         switch outcome {
-        case .failed(let failure): failure.recoveryMessage
+        case .failed(let failure): recovery(for: failure)
         case .cancellationRequested: "Wait for the operation to stop, then inspect its outcome."
+        case .canceled: "Inspect any partial changes before starting another operation."
         case .started, .succeeded: nil
+        }
+    }
+
+    private func recovery(for failure: DiagnosticFailure) -> String {
+        guard [.timedOut, .processFailed, .outcomeUnknown].contains(failure) else {
+            return failure.recoveryMessage
+        }
+        switch operation {
+        case .preflight:
+            return "Run Check this Mac again and review the host requirements in Settings."
+        case .verifyRuntime:
+            return "Open Repair and inspect the runtime installation before trying again."
+        case .exportDiagnostics:
+            return "Check the selected export location and available disk space before exporting again."
+        case .codexSignIn, .githubSignIn:
+            return "Open Accounts and check sign-in status before trying again."
+        case .exportWork:
+            return "Inspect the export destination and the development Mac before trying again."
+        case .synchronizeRepositories, .testWorkspace, .publishChanges:
+            return "Inspect the workspace and any remote changes before trying the operation again."
+        default:
+            return failure.recoveryMessage
         }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -3,12 +3,14 @@ import Foundation
 /// Error explanations owned by Guesthouse, not copied from subprocesses or Error descriptions.
 /// Unknown errors stay actionable without attempting to recognize secrets in their text.
 public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
+    case unsupportedHost
     case timedOut, connectionFailed, authenticationRequired, credentialsLocked
     case executableUnavailable, permissionDenied, insufficientDiskSpace
     case verificationFailed, invalidResponse, processFailed, outcomeUnknown
 
     public var message: String {
         switch self {
+        case .unsupportedHost: "This Mac does not meet Guesthouse's supported host requirements."
         case .timedOut: "The operation timed out; its outcome may be unknown."
         case .connectionFailed: "Guesthouse could not connect to the development Mac."
         case .authenticationRequired: "Sign-in is required to continue."
@@ -25,6 +27,8 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
 
     public var recoveryMessage: String {
         switch self {
+        case .unsupportedHost:
+            "Open Settings and check the supported Mac architecture, macOS release and resource requirements."
         case .timedOut, .processFailed, .outcomeUnknown:
             "Inspect the development Mac's current state before trying the operation again."
         case .connectionFailed:
@@ -32,7 +36,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .authenticationRequired:
             "Open Accounts and sign in again."
         case .credentialsLocked:
-            "Unlock the guest Keychain, then check account readiness."
+            "Unlock the Keychain used by this operation, then check account readiness."
         case .executableUnavailable:
             "Open Repair and check the required tool installation."
         case .permissionDenied:

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -13,7 +13,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         switch self {
         case .unsupportedHost: "This Mac does not meet Guesthouse's supported host requirements."
         case .timedOut: "The operation timed out; its outcome may be unknown."
-        case .connectionFailed: "Guesthouse could not connect to the development Mac."
+        case .connectionFailed: "The required network connection could not be established."
         case .authenticationRequired: "Sign-in is required to continue."
         case .guestAuthenticationFailed: "The development Mac did not accept its SSH credentials."
         case .credentialsLocked: "The credentials needed for this operation are locked."
@@ -34,7 +34,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .timedOut, .processFailed, .outcomeUnknown:
             "Inspect this operation's current state before trying it again."
         case .connectionFailed:
-            "Check that the development Mac is running and its SSH connection is available."
+            "Check network access and availability of the service used by this operation, then inspect its current state before retrying."
         case .authenticationRequired:
             "Open Accounts and sign in again."
         case .guestAuthenticationFailed:

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -32,7 +32,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .unsupportedHost:
             "Open Settings and check the supported Mac architecture, macOS release and resource requirements."
         case .timedOut, .processFailed, .outcomeUnknown:
-            "Inspect the development Mac's current state before trying the operation again."
+            "Inspect this operation's current state before trying it again."
         case .connectionFailed:
             "Check that the development Mac is running and its SSH connection is available."
         case .authenticationRequired:
@@ -46,11 +46,11 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .permissionDenied:
             "Review the access requested by this operation in Settings."
         case .insufficientDiskSpace:
-            "Free disk space, then check the environment before retrying."
+            "Free disk space, then inspect this operation's current state before resuming."
         case .verificationFailed:
             "Use Repair to inspect the resource or connection used by this operation; do not bypass verification."
         case .invalidResponse:
-            "Check tool compatibility in Repair and inspect the environment before retrying."
+            "Check tool compatibility in Repair and inspect this operation's current state before retrying."
         }
     }
 }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -5,6 +5,7 @@ import Foundation
 public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
     case unsupportedHost
     case timedOut, connectionFailed, authenticationRequired, credentialsLocked
+    case guestAuthenticationFailed
     case executableUnavailable, permissionDenied, insufficientDiskSpace
     case verificationFailed, invalidResponse, processFailed, outcomeUnknown
 
@@ -14,6 +15,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .timedOut: "The operation timed out; its outcome may be unknown."
         case .connectionFailed: "Guesthouse could not connect to the development Mac."
         case .authenticationRequired: "Sign-in is required to continue."
+        case .guestAuthenticationFailed: "The development Mac did not accept its SSH credentials."
         case .credentialsLocked: "The credentials needed for this operation are locked."
         case .executableUnavailable: "A required tool is missing or could not be launched."
         case .permissionDenied: "Guesthouse does not have the required access."
@@ -35,6 +37,8 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
             "Check that the development Mac is running and its SSH connection is available."
         case .authenticationRequired:
             "Open Accounts and sign in again."
+        case .guestAuthenticationFailed:
+            "Open the development Mac console to check the guest account. Resume pairing with the correct guest-only password, or use Repair for key-based access. Keep the pinned host identity; do not bypass verification."
         case .credentialsLocked:
             "Unlock the Keychain used by this operation, then check account readiness."
         case .executableUnavailable:

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -20,7 +20,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .executableUnavailable: "A required tool is missing or could not be launched."
         case .permissionDenied: "Guesthouse does not have the required access."
         case .insufficientDiskSpace: "There is not enough disk space for this operation."
-        case .verificationFailed: "The runtime or connection failed its trust check."
+        case .verificationFailed: "A required integrity or trust check failed."
         case .invalidResponse: "A tool returned an unsupported or incomplete response."
         case .processFailed: "The tool reported a failure."
         case .outcomeUnknown: "The operation's outcome could not be confirmed."
@@ -48,7 +48,7 @@ public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
         case .insufficientDiskSpace:
             "Free disk space, then check the environment before retrying."
         case .verificationFailed:
-            "Use Repair to inspect the runtime or SSH identity; do not bypass verification."
+            "Use Repair to inspect the resource or connection used by this operation; do not bypass verification."
         case .invalidResponse:
             "Check tool compatibility in Repair and inspect the environment before retrying."
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticFailure.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Error explanations owned by Guesthouse, not copied from subprocesses or Error descriptions.
+/// Unknown errors stay actionable without attempting to recognize secrets in their text.
+public enum DiagnosticFailure: String, CaseIterable, Codable, Error, Sendable {
+    case timedOut, connectionFailed, authenticationRequired, credentialsLocked
+    case executableUnavailable, permissionDenied, insufficientDiskSpace
+    case verificationFailed, invalidResponse, processFailed, outcomeUnknown
+
+    public var message: String {
+        switch self {
+        case .timedOut: "The operation timed out; its outcome may be unknown."
+        case .connectionFailed: "Guesthouse could not connect to the development Mac."
+        case .authenticationRequired: "Sign-in is required to continue."
+        case .credentialsLocked: "The credentials needed for this operation are locked."
+        case .executableUnavailable: "A required tool is missing or could not be launched."
+        case .permissionDenied: "Guesthouse does not have the required access."
+        case .insufficientDiskSpace: "There is not enough disk space for this operation."
+        case .verificationFailed: "The runtime or connection failed its trust check."
+        case .invalidResponse: "A tool returned an unsupported or incomplete response."
+        case .processFailed: "The tool reported a failure."
+        case .outcomeUnknown: "The operation's outcome could not be confirmed."
+        }
+    }
+
+    public var recoveryMessage: String {
+        switch self {
+        case .timedOut, .processFailed, .outcomeUnknown:
+            "Inspect the development Mac's current state before trying the operation again."
+        case .connectionFailed:
+            "Check that the development Mac is running and its SSH connection is available."
+        case .authenticationRequired:
+            "Open Accounts and sign in again."
+        case .credentialsLocked:
+            "Unlock the guest Keychain, then check account readiness."
+        case .executableUnavailable:
+            "Open Repair and check the required tool installation."
+        case .permissionDenied:
+            "Review the access requested by this operation in Settings."
+        case .insufficientDiskSpace:
+            "Free disk space, then check the environment before retrying."
+        case .verificationFailed:
+            "Use Repair to inspect the runtime or SSH identity; do not bypass verification."
+        case .invalidResponse:
+            "Check tool compatibility in Repair and inspect the environment before retrying."
+        }
+    }
+}
+
+extension DiagnosticFailure: LocalizedError {
+    public var errorDescription: String? { message }
+    public var recoverySuggestion: String? { recoveryMessage }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Bounded session history, shared by the UI and export builder. Not a raw-output buffer.
+/// The owning actor serializes mutations. Cross-session persistence is deferred (#91).
+public struct DiagnosticLog: Sendable {
+    public struct Record: Encodable, Hashable, Sendable {
+        public let recordedAt: Date
+        public let event: DiagnosticEvent
+    }
+
+    public static let maximumCapacity = 2_000
+    public let capacity: Int
+    public private(set) var records: [Record] = []
+    public private(set) var discardedCount: UInt64 = 0
+
+    public init(capacity: Int = 256) {
+        self.capacity = min(max(capacity, 0), Self.maximumCapacity)
+    }
+
+    public mutating func append(_ event: DiagnosticEvent, recordedAt: Date = Date()) {
+        if records.count == capacity {
+            if discardedCount < .max { discardedCount += 1 }
+            guard capacity > 0 else { return }
+            records.removeFirst()
+        }
+        records.append(Record(recordedAt: recordedAt, event: event))
+    }
+
+    public mutating func removeAll() {
+        records.removeAll()
+        discardedCount = 0
+    }
+
+    /// Export only typed records. Never attach an error description on encoding failure.
+    public func jsonData() throws -> Data {
+        struct Export: Encodable {
+            let schemaVersion = 1
+            let discardedCount: UInt64
+            let records: [Record]
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(Export(discardedCount: discardedCount, records: records))
+    }
+
+    public var text: String {
+        let header = "Guesthouse structured diagnostics. Raw process and authentication output excluded."
+        let lines = records.map { record in
+            let event = record.event
+            return "[\(event.operationID)] "
+                + (event.environmentID.map { "environment=\($0) " } ?? "")
+                + event.message
+                + (event.recoveryMessage.map { " Recovery: " + $0 } ?? "")
+        }
+        return ([header, "Older/omitted events: \(discardedCount)."] + lines).joined(separator: "\n")
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
@@ -47,7 +47,7 @@ public struct DiagnosticLog: Sendable {
         let header = "Guesthouse structured diagnostics. Raw process and authentication output excluded."
         let lines = records.map { record in
             let event = record.event
-            return "[\(event.operationID)] "
+            return "\(record.recordedAt.ISO8601Format()) [\(event.operationID)] "
                 + (event.environmentID.map { "environment=\($0) " } ?? "")
                 + event.message
                 + (event.recoveryMessage.map { " Recovery: " + $0 } ?? "")

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticLog.swift
@@ -45,9 +45,13 @@ public struct DiagnosticLog: Sendable {
 
     public var text: String {
         let header = "Guesthouse structured diagnostics. Raw process and authentication output excluded."
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         let lines = records.map { record in
             let event = record.event
-            return "\(record.recordedAt.ISO8601Format()) [\(event.operationID)] "
+            let timestamp = formatter.string(from: record.recordedAt)
+            return "\(timestamp) [\(event.operationID)] "
                 + (event.environmentID.map { "environment=\($0) " } ?? "")
                 + event.message
                 + (event.recoveryMessage.map { " Recovery: " + $0 } ?? "")

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Redaction/Redactor.swift
@@ -1,7 +1,8 @@
 import Foundation
 import RegexBuilder
 
-/// Removes secrets from text before it can reach a log, the GUI, or a diagnostics export.
+/// Deferred redaction experiment retained with its tests. ADR 0003 replaces the MVP logging
+/// boundary with DiagnosticEvent; do not activate or extend this parser for diagnostics.
 ///
 /// MVP-PLAN.md §3 ("Local storage"): private keys, tokens, device codes, authorization
 /// headers, and raw authentication output must never be persisted or exported. The redactor

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -156,4 +156,11 @@ struct DiagnosticLogTests {
         #expect(event.recoveryMessage == "Open the development Mac console to check the guest account. Resume pairing with the correct guest-only password, or use Repair for key-based access. Keep the pinned host identity; do not bypass verification.")
         #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
     }
+
+    @Test func unverifiedXcodeImportOffersAStableVerifiedSource() throws {
+        let event = DiagnosticEvent(operation: .importXcode, outcome: .failed(.verificationFailed), operationID: Self.operationID)
+        #expect(event.message == "Import Xcode: The Xcode bundle failed verification.")
+        #expect(event.recoveryMessage == "Use Repair to inspect the failed import, then select a trusted, stable Xcode bundle and import it again. Preserve the existing installation until verification succeeds; do not bypass signature checks.")
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct DiagnosticLogTests {
+    private static let operationID = UUID(uuidString: "11111111-2222-4333-8444-555555555555")!
+    private static let timestamp = Date(timeIntervalSince1970: 0)
+
+    @Test(arguments: DiagnosticFailure.allCases)
+    func errorsRemainActionable(_ failure: DiagnosticFailure) throws {
+        let event = DiagnosticEvent(operation: .connectSSH, outcome: .failed(failure),
+                                    operationID: Self.operationID, exitStatus: 255)
+        #expect(event.message == "Connect over SSH: " + failure.message + " Exit status: 255.")
+        #expect(event.recoveryMessage == failure.recoveryMessage)
+        #expect(!failure.recoveryMessage.isEmpty)
+        #expect(failure.errorDescription == failure.message)
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
+
+    @Test(arguments: DiagnosticEvent.Operation.allCases)
+    func lifecycleMessages(_ operation: DiagnosticEvent.Operation) {
+        let event = DiagnosticEvent(operation: operation, outcome: .started, operationID: Self.operationID)
+        #expect(event.message == operation.title + ": Started.")
+        #expect(event.recoveryMessage == nil)
+    }
+
+    @Test(arguments: [
+        "syntheticOpaque", "Authorization: Bearer syntheticOpaque", "-----BEGIN PRIVATE KEY-----\nsyntheticOpaque",
+        "Your code is\nsyntheticOpaque", #"{\"pass\u0077ord\":\"syntheticOpaque\"}"#,
+        "\u{1B}[1DsyntheticOpaque"
+    ])
+    func untrustedExtraFieldsNeverReachMessagesOrExports(_ raw: String) throws {
+        let expected = DiagnosticEvent(operation: .connectSSH, outcome: .failed(.connectionFailed),
+                                       operationID: Self.operationID)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(expected)) as? [String: Any])
+        for key in ["message", "stderr", "stdout", "errorDescription", "arguments", "environment"] {
+            object[key] = raw
+        }
+        let event = try JSONDecoder().decode(DiagnosticEvent.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(event == expected)
+        var actual = DiagnosticLog()
+        var control = DiagnosticLog()
+        actual.append(event, recordedAt: Self.timestamp)
+        control.append(expected, recordedAt: Self.timestamp)
+        #expect(actual.text == control.text)
+        #expect(try actual.jsonData() == control.jsonData())
+    }
+
+    @Test(arguments: ["operation", "outcome", "operationID", "environmentID", "exitStatus"])
+    func arbitraryTextInTypedFieldsIsRejected(_ field: String) throws {
+        let event = DiagnosticEvent(operation: .checkTools, outcome: .succeeded, operationID: Self.operationID)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(event)) as? [String: Any])
+        object[field] = "syntheticOpaque"
+        let data = try JSONSerialization.data(withJSONObject: object)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(DiagnosticEvent.self, from: data) }
+    }
+
+    @Test func boundedHistoryPreservesTheNewestEvents() {
+        var log = DiagnosticLog(capacity: 2)
+        for status: Int32 in [1, 2, 3] {
+            log.append(DiagnosticEvent(operation: .checkTools, outcome: .failed(.processFailed),
+                                       operationID: Self.operationID, exitStatus: status), recordedAt: Self.timestamp)
+        }
+        #expect(log.records.map(\.event.exitStatus) == [2, 3])
+        #expect(log.discardedCount == 1)
+        log.removeAll()
+        #expect(log.records.isEmpty)
+        #expect(log.discardedCount == 0)
+    }
+
+    @Test(arguments: [-1, 0, 1, 256, Int.max])
+    func capacityIsBounded(_ capacity: Int) {
+        var log = DiagnosticLog(capacity: capacity)
+        log.append(DiagnosticEvent(operation: .checkTools, outcome: .started, operationID: Self.operationID))
+        #expect(log.capacity == min(max(capacity, 0), DiagnosticLog.maximumCapacity))
+        #expect(log.records.count == (capacity > 0 ? 1 : 0))
+        #expect(log.discardedCount == (capacity > 0 ? 0 : 1))
+    }
+
+    @Test func cancellationDoesNotClaimAStoppedProcess() {
+        let event = DiagnosticEvent(operation: .stopEnvironment, outcome: .cancellationRequested,
+                                    operationID: Self.operationID)
+        #expect(event.message == "Stop development Mac: Cancellation requested; completion is not yet confirmed.")
+        #expect(event.recoveryMessage == "Wait for the operation to stop, then inspect its outcome.")
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -163,4 +163,10 @@ struct DiagnosticLogTests {
         #expect(event.recoveryMessage == "Use Repair to inspect the failed import, then select a trusted, stable Xcode bundle and import it again. Preserve the existing installation until verification succeeds; do not bypass signature checks.")
         #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
     }
+
+    @Test(arguments: [DiagnosticEvent.Operation.downloadRuntime, .downloadGuestImage])
+    func diskExhaustedDownloadsRequireStagingInspection(_ operation: DiagnosticEvent.Operation) {
+        let event = DiagnosticEvent(operation: operation, outcome: .failed(.insufficientDiskSpace), operationID: Self.operationID)
+        #expect(event.recoveryMessage == "Free disk space, then use Repair to inspect the staged download before resuming it.")
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -8,8 +8,9 @@ struct DiagnosticLogTests {
 
     @Test(arguments: DiagnosticFailure.allCases)
     func errorsRemainActionable(_ failure: DiagnosticFailure) throws {
-        let event = DiagnosticEvent(operation: .connectSSH, outcome: .failed(failure),
-                                    operationID: Self.operationID, exitStatus: 255)
+        let event = DiagnosticEvent(operation: .connectSSH, outcome: .failed(failure, exitStatus: 255),
+                                    operationID: Self.operationID)
+        #expect(event.exitStatus == 255)
         #expect(event.message == "Connect over SSH: " + failure.message + " Exit status: 255.")
         #expect(event.recoveryMessage == failure.recoveryMessage)
         #expect(!failure.recoveryMessage.isEmpty)
@@ -46,7 +47,7 @@ struct DiagnosticLogTests {
         #expect(try actual.jsonData() == control.jsonData())
     }
 
-    @Test(arguments: ["operation", "outcome", "operationID", "environmentID", "exitStatus"])
+    @Test(arguments: ["operation", "outcome", "operationID", "environmentID"])
     func arbitraryTextInTypedFieldsIsRejected(_ field: String) throws {
         let event = DiagnosticEvent(operation: .checkTools, outcome: .succeeded, operationID: Self.operationID)
         var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(event)) as? [String: Any])
@@ -55,11 +56,36 @@ struct DiagnosticLogTests {
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(DiagnosticEvent.self, from: data) }
     }
 
+    @Test func arbitraryTextInFailureExitStatusIsRejected() throws {
+        let data = Data(#"{"failed":{"_0":"processFailed","exitStatus":"syntheticOpaque"}}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(DiagnosticEvent.Outcome.self, from: data) }
+    }
+
+    @Test(arguments: [
+        DiagnosticEvent.Outcome.started, .succeeded, .pending, .waitingForUserAction,
+        .cancellationRequested, .canceled
+    ])
+    func nonfailureOutcomesCannotCarryExitStatuses(_ outcome: DiagnosticEvent.Outcome) throws {
+        let expected = DiagnosticEvent(operation: .checkTools, outcome: outcome, operationID: Self.operationID)
+        #expect(expected.exitStatus == nil)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(expected)) as? [String: Any])
+        object["exitStatus"] = 9
+        let outcomeObject = try #require(object["outcome"] as? [String: Any])
+        object["outcome"] = outcomeObject.mapValues { _ in ["exitStatus": 9] }
+        let event = try JSONDecoder().decode(DiagnosticEvent.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(event == expected)
+        #expect(event.exitStatus == nil)
+        var log = DiagnosticLog()
+        log.append(event, recordedAt: Self.timestamp)
+        #expect(!log.text.contains("Exit status:"))
+        #expect(!String(decoding: try log.jsonData(), as: UTF8.self).contains("exitStatus"))
+    }
+
     @Test func boundedHistoryPreservesTheNewestEvents() {
         var log = DiagnosticLog(capacity: 2)
         for status: Int32 in [1, 2, 3] {
-            log.append(DiagnosticEvent(operation: .checkTools, outcome: .failed(.processFailed),
-                                       operationID: Self.operationID, exitStatus: status), recordedAt: Self.timestamp)
+            log.append(DiagnosticEvent(operation: .checkTools, outcome: .failed(.processFailed, exitStatus: status),
+                                       operationID: Self.operationID), recordedAt: Self.timestamp)
         }
         #expect(log.records.map(\.event.exitStatus) == [2, 3])
         #expect(log.discardedCount == 1)
@@ -118,12 +144,16 @@ struct DiagnosticLogTests {
         var log = DiagnosticLog()
         let event = DiagnosticEvent(operation: .githubSignOut, outcome: .succeeded, operationID: Self.operationID)
         log.append(event, recordedAt: Self.timestamp)
+        log.append(event, recordedAt: Date(timeIntervalSince1970: 0.123))
+        log.append(event, recordedAt: Date(timeIntervalSince1970: 0.999))
         log.append(event, recordedAt: Date(timeIntervalSince1970: 1))
         let expected = [
             "Guesthouse structured diagnostics. Raw process and authentication output excluded.",
             "Older/omitted events: 0.",
-            "1970-01-01T00:00:00Z [\(Self.operationID)] Sign out of GitHub: Succeeded.",
-            "1970-01-01T00:00:01Z [\(Self.operationID)] Sign out of GitHub: Succeeded."
+            "1970-01-01T00:00:00.000Z [\(Self.operationID)] Sign out of GitHub: Succeeded.",
+            "1970-01-01T00:00:00.123Z [\(Self.operationID)] Sign out of GitHub: Succeeded.",
+            "1970-01-01T00:00:00.999Z [\(Self.operationID)] Sign out of GitHub: Succeeded.",
+            "1970-01-01T00:00:01.000Z [\(Self.operationID)] Sign out of GitHub: Succeeded."
         ].joined(separator: "\n")
         #expect(log.text == expected)
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -127,4 +127,22 @@ struct DiagnosticLogTests {
         ].joined(separator: "\n")
         #expect(log.text == expected)
     }
+
+    @Test(arguments: [
+        (DiagnosticEvent.Operation.downloadGuestImage, "Download macOS image: The downloaded artifact failed verification."),
+        (.downloadRuntime, "Download runtime: The downloaded artifact failed verification.")
+    ])
+    func failedDownloadsHaveArtifactSpecificRecovery(_ example: (DiagnosticEvent.Operation, String)) throws {
+        let event = DiagnosticEvent(operation: example.0, outcome: .failed(.verificationFailed), operationID: Self.operationID)
+        #expect(event.message == example.1)
+        #expect(event.recoveryMessage == "Use Repair to download a verified replacement from the trusted source. Preserve the existing development Mac and do not bypass verification.")
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
+
+    @Test(arguments: [DiagnosticEvent.Operation.downloadGuestImage, .downloadRuntime],
+          [DiagnosticFailure.timedOut, .processFailed, .outcomeUnknown])
+    func incompleteDownloadsDoNotAssumeAnInstalledRuntime(_ operation: DiagnosticEvent.Operation, _ failure: DiagnosticFailure) {
+        let event = DiagnosticEvent(operation: operation, outcome: .failed(failure), operationID: Self.operationID)
+        #expect(event.recoveryMessage == "Open Repair and inspect the download's current state before resuming it.")
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -145,4 +145,15 @@ struct DiagnosticLogTests {
         let event = DiagnosticEvent(operation: operation, outcome: .failed(failure), operationID: Self.operationID)
         #expect(event.recoveryMessage == "Open Repair and inspect the download's current state before resuming it.")
     }
+
+    @Test(arguments: [
+        (DiagnosticEvent.Operation.pairSSH, "Pair SSH identity: The development Mac did not accept its SSH credentials."),
+        (.connectSSH, "Connect over SSH: The development Mac did not accept its SSH credentials.")
+    ])
+    func guestAuthenticationDoesNotSendUsersToProviderAccounts(_ example: (DiagnosticEvent.Operation, String)) throws {
+        let event = DiagnosticEvent(operation: example.0, outcome: .failed(.guestAuthenticationFailed), operationID: Self.operationID)
+        #expect(event.message == example.1)
+        #expect(event.recoveryMessage == "Open the development Mac console to check the guest account. Resume pairing with the correct guest-only password, or use Repair for key-based access. Keep the pinned host identity; do not bypass verification.")
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -101,4 +101,30 @@ struct DiagnosticLogTests {
         let event = DiagnosticEvent(operation: example.0, outcome: .failed(failure), operationID: Self.operationID)
         #expect(event.recoveryMessage == example.1)
     }
+
+    @Test(arguments: [
+        (DiagnosticEvent.Outcome.pending, "Queued; not started yet.", nil as String?),
+        (.waitingForUserAction, "Waiting for user action; the operation has not failed.",
+         "Complete the step shown by Guesthouse, then continue.")
+    ])
+    func nonterminalStagesHaveAnExplicitStatus(_ example: (DiagnosticEvent.Outcome, String, String?)) throws {
+        let event = DiagnosticEvent(operation: .codexSignIn, outcome: example.0, operationID: Self.operationID)
+        #expect(event.message == "Sign in to Codex: " + example.1)
+        #expect(event.recoveryMessage == example.2)
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
+
+    @Test func textExportIncludesStableUTCTimestamps() {
+        var log = DiagnosticLog()
+        let event = DiagnosticEvent(operation: .githubSignOut, outcome: .succeeded, operationID: Self.operationID)
+        log.append(event, recordedAt: Self.timestamp)
+        log.append(event, recordedAt: Date(timeIntervalSince1970: 1))
+        let expected = [
+            "Guesthouse structured diagnostics. Raw process and authentication output excluded.",
+            "Older/omitted events: 0.",
+            "1970-01-01T00:00:00Z [\(Self.operationID)] Sign out of GitHub: Succeeded.",
+            "1970-01-01T00:00:01Z [\(Self.operationID)] Sign out of GitHub: Succeeded."
+        ].joined(separator: "\n")
+        #expect(log.text == expected)
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -83,4 +83,22 @@ struct DiagnosticLogTests {
         #expect(event.message == "Stop development Mac: Cancellation requested; completion is not yet confirmed.")
         #expect(event.recoveryMessage == "Wait for the operation to stop, then inspect its outcome.")
     }
+
+    @Test func confirmedCancellationHasATerminalExplanation() throws {
+        let event = DiagnosticEvent(operation: .deleteEnvironment, outcome: .canceled, operationID: Self.operationID)
+        #expect(event.message == "Delete development Mac: Cancellation confirmed; partial changes may remain.")
+        #expect(event.recoveryMessage == "Inspect any partial changes before starting another operation.")
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
+
+    @Test(arguments: [
+        (DiagnosticEvent.Operation.preflight, "Run Check this Mac again and review the host requirements in Settings."),
+        (.verifyRuntime, "Open Repair and inspect the runtime installation before trying again."),
+        (.exportDiagnostics, "Check the selected export location and available disk space before exporting again."),
+        (.githubSignIn, "Open Accounts and check sign-in status before trying again.")
+    ], [DiagnosticFailure.timedOut, .processFailed, .outcomeUnknown])
+    func recoveryFitsTheOperation(_ example: (DiagnosticEvent.Operation, String), _ failure: DiagnosticFailure) {
+        let event = DiagnosticEvent(operation: example.0, outcome: .failed(failure), operationID: Self.operationID)
+        #expect(event.recoveryMessage == example.1)
+    }
 }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Diagnostics/DiagnosticLogTests.swift
@@ -169,4 +169,15 @@ struct DiagnosticLogTests {
         let event = DiagnosticEvent(operation: operation, outcome: .failed(.insufficientDiskSpace), operationID: Self.operationID)
         #expect(event.recoveryMessage == "Free disk space, then use Repair to inspect the staged download before resuming it.")
     }
+
+    @Test(arguments: [
+        (DiagnosticEvent.Operation.downloadRuntime, "Download runtime: The required network connection could not be established."),
+        (.downloadGuestImage, "Download macOS image: The required network connection could not be established.")
+    ])
+    func downloadConnectivityDoesNotAssumeGuestSSH(_ example: (DiagnosticEvent.Operation, String)) throws {
+        let event = DiagnosticEvent(operation: example.0, outcome: .failed(.connectionFailed), operationID: Self.operationID)
+        #expect(event.message == example.1)
+        #expect(event.recoveryMessage == "Check Internet access and the trusted download source, then inspect the staged download in Repair before resuming. Do not bypass TLS or verification checks.")
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(event)) == event)
+    }
 }

--- a/docs/decisions/0003-structured-diagnostics.md
+++ b/docs/decisions/0003-structured-diagnostics.md
@@ -1,0 +1,41 @@
+# 3. Use structured diagnostics instead of raw-output redaction
+
+Date: 2026-09-08
+
+## Status
+
+Accepted by the owner. Runtime and GUI migration remains required before those pending features merge.
+
+## Context
+
+[Issue #11](https://github.com/PicoMLX/Guesthouse/issues/11) grew from recognizable-secret filtering into a general parser for fragmented, encoded and terminal-rendered credentials. Its dependent PR stack became an MVP blocker. The owner approved excluding raw information from diagnostics while retaining useful error messages.
+
+## Decision
+
+- Diagnostic sinks accept `DiagnosticEvent`: closed operation/outcome/error enums, Guesthouse operation/environment UUIDs, and optional numeric exit status. `DiagnosticFailure` provides fixed explanations and recovery messages. No free-form message/metadata attachment exists.
+- `DiagnosticLog` keeps a bounded session history and renders/encodes only those typed records. Its JSON export reconstructs the known schema, not a received dictionary. Unknown enum values fail decoding; ignored extra fields are never forwarded or re-exported. This is not an XPC admission/size validator.
+- Raw stdout/stderr stays in bounded temporary runtime-adapter input when an operation needs it. Unused output is drained and discarded. There is no automatic output-to-log bridge and no raw-error fallback.
+- Error messages are an allowed, useful product surface, not an exception for arbitrary credential-bearing text. Known causes produce Guesthouse explanations; unknown causes produce a fixed failure message, exit status when known, and inspection/recovery guidance. Never interpolate `localizedDescription`, parser errors, paths, arguments, or raw response snippets into diagnostics.
+- Device codes may reach the dedicated temporary sign-in UI. They do not enter log events, OSLog, journals, exports or generic error payloads. Private keys and authorization headers are not diagnostic inputs.
+- Keep existing redactor history/tests as deferred reference. Do not activate its public API or make its review convergence an MVP requirement. Resume it only through a separately approved concrete use case.
+
+This supersedes only the redaction/logging direction in [ADR 0002](0002-prioritize-lume-and-shared-infrastructure.md) and `MVP-PLAN.md` §3. Named authenticated XPC, bounded input, safe process lifetime, private credential storage, strict runtime verification, Lume priority and hardware gates remain unchanged.
+
+## Consequences
+
+Unknown failures have less low-level diagnostic detail. The MVP does not export arbitrary guest text, even when requested through a debug flag. Additional diagnostic fields need a concrete use case and an explicit typed contract; do not recreate a generic string dictionary.
+
+Migration uses the existing issues and preserves shared/provider work:
+
+| Area | Required change |
+| --- | --- |
+| #11 / redactor stack ending at #59 | Structured Core contract replaces the merge prerequisite; old parser PRs are deferred, not declared fixed |
+| #7 / #121, #122, #53 | Keep error categories and recovery; replace sanitized raw-text associated values with typed facts and fixed messages |
+| #9 / #58 and later XPC envelopes | Carry `DiagnosticEvent`, not `RedactedLine`; explicitly version incompatible wire changes |
+| #21 / #69 and provider adapters | Separate bounded parser input from diagnostic events; retain pipe draining, limits, timeout and termination guarantees |
+| #27, #29, #30 / GUI and #79 | Consume typed events; show error/recovery messages; export only reconstructed structured records |
+| #91 | Cross-session persistence remains deferred and must persist structured records, never old transcripts |
+
+Main's redactor primitives are internal and have no active logging sink. This first replacement adds the public structured contract; it does not claim the unmerged runtime/XPC/GUI stack has already migrated. Each consumer must pass its own integration tests and normal CI/review gate before merging. Existing unresolved parser findings remain deferred evidence, not rejected security reports.
+
+Acceptance is finite: operation/error rendering, typed encode/decode, unknown-field non-propagation, bounded retention, and proof at each consumer that raw output and underlying errors cannot reach diagnostic sinks. Existing process-lifetime and security checks remain required. Batch locally verified changes before publishing to avoid repeated CI runs for individual parser examples.


### PR DESCRIPTION
## Summary

Implements the owner's September 8 decision for #11: structured diagnostics, no raw information, with useful error messages preserved. Updates MVP-PLAN.md §3 and records ADR 0003. This PR is based directly on main and replaces the general-purpose redactor stack as the MVP logging prerequisite.

- DiagnosticEvent accepts only closed operation/outcome/failure enums, operation/environment UUIDs and an optional numeric exit status carried only by the failed outcome. It has no arbitrary message or metadata parameter.
- DiagnosticFailure renders Guesthouse-owned explanations and recovery messages, including uncertain outcomes. No stderr or underlying Error description is copied.
- DiagnosticLog keeps bounded session history and exports only reconstructed typed records. Unknown JSON extras never reach output; unknown typed values fail decoding. This is not a replacement for XPC admission/size checks.
- Existing redactor source/tests remain internal, unchanged in behavior and deferred. No public raw-text sanitizer is activated.
- Update AGENTS.md and the MVP plan so future work does not restart parser convergence.

## Verification

- Full Core suite: **201 tests / 17 suites pass**, warnings-as-errors.
- Markdown validation: 3 files, zero errors/warnings.
- git diff --check passes. 549 changed lines, including focused review regressions kept with the same Core contract.
- Tests cover all error cases, all operation labels, exact rendering/round trips, unknown-field non-propagation, rejection of arbitrary text in typed fields, bounded history, and cancellation not claiming termination.

## Migration boundary

Domain-specific constraints are provided by stacked #137, including `GuesthouseError.vmSlotUnavailable` rendered via `DiagnosticEvent.operationFailed`. DiagnosticFailure is not a duplicate of every domain-error category. Neither Core PR activates environment creation or the unmerged runtime/GUI consumers on its own.

This implements the Core contract and history/export, not unmerged runtime/XPC/GUI integration. #11 stays open until consumer migration is verified. Existing issues #7, #9, #21 and #30 track those changes; ADR 0003 lists their existing PR coverage. Do not merge the deferred parser PRs first. Preserve process lifetime, authenticated/versioned XPC, trust checks and hardware gates.

No host/VM/signing operations, history deletion, force push or PR merge. Normal Xcode Cloud and Codex review gates remain required.

## Review corrections

922b2d4 adds explicit unsupported-host failures, delete/export/console/repair/update operations, confirmed cancellation distinct from a request, and operation-aware recovery for host checks, runtime verification, sign-in, export and workspace operations. All four initial P2 reports have targeted coverage; the full Core suite and 196-test error composition pass before publication. Fresh current-head CI and Codex review are required; the prior green check does not approve this update.

7d6fc03 completes sign-out and waiting/pending states and adds stable UTC timestamps to text exports. The remaining three P2 comments are fixed with exact/parameterized tests. Current full Core validation: 193/17; complete #137 composition: 198/18. New current-head review/CI is pending; earlier approvals are historical.

Previous publication: 47293bf fixes the two duplicate download-connectivity findings in one tested change: network-neutral connection explanation and Internet/source/staging recovery without disabling TLS or trust checks. Full root suite: 199 tests /17 suites. Fresh exact-head CI/review required. #137 is intentionally unchanged at its approved 80f323e head; final parent integration will be tested and published after this parent gate clears, minimizing duplicate child CI/review runs. Its prior 211-test composition does not yet include this parent update.

Latest publication: 28c51b5 fixes both current review findings in one locally validated batch. Text timestamps include UTC milliseconds with exact .123/.999 same-second coverage. Exit status is modeled inside `Outcome.failed(DiagnosticFailure, exitStatus:)`; other outcomes cannot retain or export it. The known numeric failure-status field still rejects arbitrary text. This changes the unmerged initial JSON shape, not an active XPC protocol; consumers must adopt the final contract. Full root suite: 201 tests /17 suites, warnings-as-errors. Current-head CI and completed Codex review with an original-message thumbs-up remain required. #137 stays unchanged at 80f323e until the root gate clears, then gets one tested final parent integration.