### PR TITLE
Migrate numeric compatibility versions onto structured Core

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/SemanticVersion.swift
@@ -1,0 +1,97 @@
+/// A dotted numeric version such as `26.5.2` or `2.36.0`, compared component by component.
+///
+/// Missing trailing components count as zero, so `26.5` equals `26.5.0`. Anything that is not
+/// a dotted sequence of integers fails to parse; callers must then treat the version as unknown
+/// rather than guess.
+public struct SemanticVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
+    public let components: [Int]
+    /// A compatibility observation is at most 256 UTF-8 bytes; this parser does not scan
+    /// arbitrary command output. Adapters extract the version before calling it.
+    public static let maximumInputLength = 256
+
+    /// Programmer-supplied components must be nonnegative and their canonical encoding must
+    /// fit maximumInputLength. Use the failable string initializer for observed input.
+    public init(_ components: [Int]) {
+        precondition(components.allSatisfy { $0 >= 0 }, "version components must be nonnegative")
+        var trimmed = components
+        while trimmed.count > 1, trimmed.last == 0 {
+            trimmed.removeLast()
+        }
+        self.components = trimmed.isEmpty ? [0] : trimmed
+        precondition(description.utf8.count <= Self.maximumInputLength, "version exceeds the supported length")
+    }
+
+    public init?(_ string: String) {
+        guard string.utf8.prefix(Self.maximumInputLength + 1).count <= Self.maximumInputLength else { return nil }
+        let parts = string.split(separator: ".", omittingEmptySubsequences: false)
+        var parsed: [Int] = []
+        for part in parts {
+            guard !part.isEmpty, part.utf8.allSatisfy({ (48...57).contains($0) }),
+                  let value = Int(part) else { return nil }
+            parsed.append(value)
+        }
+        guard !parsed.isEmpty else { return nil }
+        self.init(parsed)
+    }
+
+    public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        let count = max(lhs.components.count, rhs.components.count)
+        for index in 0..<count {
+            let l = index < lhs.components.count ? lhs.components[index] : 0
+            let r = index < rhs.components.count ? rhs.components[index] : 0
+            if l != r { return l < r }
+        }
+        return false
+    }
+
+    public var description: String {
+        components.map(String.init).joined(separator: ".")
+    }
+}
+
+extension SemanticVersion: Codable {
+    public init(from decoder: any Decoder) throws {
+        let string = try decoder.singleValueContainer().decode(String.self)
+        guard let version = SemanticVersion(string) else {
+            throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "not a supported dotted numeric version"))
+        }
+        self = version
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(description)
+    }
+}
+
+/// An inclusive version range; `maximum == nil` means open-ended.
+///
+/// The bounds are immutable: a range that could be inverted after construction would let a
+/// rule that once matched silently stop firing, without passing any of the checks below.
+public struct VersionRange: Codable, Hashable, Sendable {
+    public let minimum: SemanticVersion
+    public let maximum: SemanticVersion?
+
+    /// An inverted range would contain nothing and let a rule silently never fire.
+    public init(minimum: SemanticVersion, maximum: SemanticVersion? = nil) {
+        precondition(maximum.map { minimum <= $0 } ?? true, "inverted version range")
+        self.minimum = minimum
+        self.maximum = maximum
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let minimum = try c.decode(SemanticVersion.self, forKey: .minimum)
+        let maximum = try c.decodeIfPresent(SemanticVersion.self, forKey: .maximum)
+        if let maximum, maximum < minimum {
+            throw DecodingError.dataCorruptedError(forKey: .maximum, in: c, debugDescription: "maximum is below minimum")
+        }
+        self.init(minimum: minimum, maximum: maximum)
+    }
+
+    public func contains(_ version: SemanticVersion) -> Bool {
+        if version < minimum { return false }
+        if let maximum, maximum < version { return false }
+        return true
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/SemanticVersionTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/SemanticVersionTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct SemanticVersionTests {
+    @Test(arguments: [
+        ("26.5", [26, 5], "26.5"), ("26.5.0.0", [26, 5], "26.5"),
+        ("00026.005.2", [26, 5, 2], "26.5.2"), ("0.0.0", [0], "0")
+    ])
+    func normalization(_ input: String, _ components: [Int], _ canonical: String) throws {
+        let version = try #require(SemanticVersion(input))
+        #expect(version.components == components)
+        #expect(version.description == canonical)
+        #expect(version == SemanticVersion(components))
+        #expect(try JSONDecoder().decode(SemanticVersion.self, from: JSONEncoder().encode(version)) == version)
+    }
+
+    @Test(arguments: [
+        "", ".", "26.", ".26", "26..4", "-1", "-0", "+26", "26.+4", " 26.4",
+        "26.4 ", "26.4\n", "v26.4", "26.4-beta", "26.4+1", "２６.４", "syntheticOpaque",
+        "9999999999999999999999999999999999999999999"
+    ])
+    func unknownInputIsRejectedWithoutEchoingIt(_ input: String) throws {
+        #expect(SemanticVersion(input) == nil)
+        let data = try JSONEncoder().encode(input)
+        do {
+            _ = try JSONDecoder().decode(SemanticVersion.self, from: data)
+            Issue.record("An invalid numeric version decoded successfully")
+        } catch DecodingError.dataCorrupted(let context) {
+            #expect(context.debugDescription == "not a supported dotted numeric version")
+            #expect(context.underlyingError == nil)
+        }
+    }
+
+    @Test func observationsAreBoundedBeforeSplitting() {
+        #expect(SemanticVersion.maximumInputLength == 256)
+        let atLimit = String(repeating: "0.", count: 127) + "00"
+        #expect(SemanticVersion(atLimit) == SemanticVersion([0]))
+        #expect(SemanticVersion(atLimit + "0") == nil)
+    }
+
+    @Test(arguments: [("26.4", "26.5"), ("2.9", "2.10"), ("1", "1.0.1"), ("0", "1")])
+    func orderingIsNumeric(_ lower: String, _ higher: String) throws {
+        let lhs = try #require(SemanticVersion(lower))
+        let rhs = try #require(SemanticVersion(higher))
+        #expect(lhs < rhs)
+        #expect(!(rhs < lhs))
+    }
+
+    @Test func equalVersionsHaveTheSameHashIdentity() {
+        #expect(Set([SemanticVersion([26, 4]), SemanticVersion([26, 4, 0])]).count == 1)
+        #expect(SemanticVersion([]) == SemanticVersion([0]))
+    }
+
+    @Test(arguments: [("26.3", false), ("26.4", true), ("26.5", true), ("26.6", false)])
+    func rangesIncludeBothEndpoints(_ input: String, _ expected: Bool) throws {
+        let range = VersionRange(minimum: SemanticVersion([26, 4]), maximum: SemanticVersion([26, 5]))
+        #expect(range.contains(try #require(SemanticVersion(input))) == expected)
+        #expect(try JSONDecoder().decode(VersionRange.self, from: JSONEncoder().encode(range)) == range)
+    }
+
+    @Test func openEndedRangesAndInvalidWireBounds() throws {
+        let range = VersionRange(minimum: SemanticVersion([26, 4]))
+        #expect(range.contains(SemanticVersion([99])))
+        #expect(!range.contains(SemanticVersion([26, 3])))
+        #expect(try JSONDecoder().decode(VersionRange.self, from: JSONEncoder().encode(range)) == range)
+        let invalid = Data(#"{"minimum":"26.5","maximum":"26.4"}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(VersionRange.self, from: invalid) }
+    }
+}


### PR DESCRIPTION
## Summary

First focused migration of #55 / #14 onto current main after #136 and #137 (MVP-PLAN.md §§4–5, ADR 0003). Reuses the existing numeric version and inclusive-range implementation from #55 without its sanitizer ancestry.

- Preserve component-wise ordering, trailing-zero normalization, hashing, Codable and inclusive/open-ended ranges.
- Observed strings accept only dotted ASCII digits, bounded to 256 UTF-8 bytes; malformed, signed, suffixed and overflowing values remain unknown.
- Invalid decoding uses a fixed explanation instead of copying the rejected input into an error description.
- Programmer-supplied component construction retains explicit preconditions and now enforces the same canonical wire-length invariant.

## Validation

Full Core suite: **221 tests /19 suites pass**, warnings-as-errors. Diff check passes. **167 added lines /2 files**. Regression coverage includes normalization, numeric ordering, equal hash identity, valid round trips, rejected inputs/no echo, input-size boundary, inclusive/open ranges and inverted decoded bounds.

## Remaining migration

This PR provides numeric primitives only, not the complete compatibility evaluator. #55's tuple identity, bounded connection evidence, manifest/resource and evaluator are being migrated separately while preserving their useful code/tests. Provider identity must distinguish the Lume candidate from legacy Tart; a numeric version match does not select or verify a provider. #14 remains open until its full acceptance criteria are integrated.

No raw diagnostic fallback, dependency, process/host/VM operation, hardware evidence, PR merge or force push. Fresh Xcode Cloud and Codex review gates remain required. Do not merge old #53/#121/#122 ancestry.