### PR TITLE
Migrate provider-aware compatibility tuple identity

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityTuple.swift
@@ -1,0 +1,329 @@
+/// Identity of the runtime whose version is observed. A candidate is not a verified provider.
+/// Tart is retained for legacy identity comparisons, not active provider operations (ADR 0002).
+public enum VMProvider: String, Codable, Hashable, Sendable, CaseIterable {
+    case lume, tart
+}
+
+/// The components whose combination decides whether a Codex handoff is known to work
+/// (MVP-PLAN.md §5, "Connect-time compatibility, not only update-time checks").
+///
+/// Host macOS is tracked as both a product version and a build: a build replacement that keeps
+/// the product version is still OS drift (§4). The Codex desktop app is tracked by version,
+/// build, and the selected bundle's path, so a replaced or re-selected bundle that reports the
+/// same version is still a change (§5). The Codex CLI is tracked by version, resolved
+/// login-shell path, number of competing installations, and reported capabilities, because the
+/// same version string can belong to a different executable (§5).
+public enum CompatibilityField: String, Codable, Hashable, Sendable, CaseIterable {
+    case hostMacOSVersion
+    case hostMacOSBuild
+    case codexDesktopVersion
+    case codexDesktopBuild
+    case codexDesktopPath
+    case runtimeProtocolVersion
+    case runtimeProvider
+    case runtimeVersion
+    case guestMacOSBuild
+    case xcodeBuild
+    case codexCLIVersion
+    case codexCLIPath
+    case codexCLIInstallations
+    case codexCLICapabilities
+    case githubCLIVersion
+    case provisioningScriptVersion
+}
+
+/// A fully known combination. Values are private compatibility data, not diagnostic text.
+/// Presence is not validity or connection evidence; record validation/evaluation checks that.
+public struct CompatibilityTuple: Codable, Hashable, Sendable {
+    public var hostMacOSVersion: SemanticVersion
+    public var hostMacOSBuild: String
+    public var codexDesktopVersion: String
+    public var codexDesktopBuild: String
+    /// The selected desktop application bundle, resolved.
+    public var codexDesktopPath: String
+    public var runtimeProtocolVersion: Int
+    public var runtimeProvider: VMProvider
+    public var runtimeVersion: String
+    public var guestMacOSBuild: String
+    public var xcodeBuild: String
+    public var codexCLIVersion: String
+    /// The executable the guest login shell resolves, as reported by `which -a codex`.
+    public var codexCLIPath: String
+    /// How many `codex` executables the login shell can see. Anything but 1 is ambiguous.
+    public var codexCLIInstallations: Int
+    /// Capability identifiers the CLI reports, sorted and without duplicates. Empty when it
+    /// reports none.
+    ///
+    /// Renormalized on assignment, not only at construction: equality decides whether a
+    /// recorded connection is found again, and a tuple whose list was replaced field by field
+    /// would never match the freshly normalized observation of the same guest.
+    public var codexCLICapabilities: [String] {
+        didSet { codexCLICapabilities = Self.normalize(codexCLICapabilities) }
+    }
+    public var githubCLIVersion: String
+    public var provisioningScriptVersion: String
+
+    public init(
+        hostMacOSVersion: SemanticVersion,
+        hostMacOSBuild: String,
+        codexDesktopVersion: String,
+        codexDesktopBuild: String,
+        codexDesktopPath: String,
+        runtimeProtocolVersion: Int,
+        runtimeProvider: VMProvider,
+        runtimeVersion: String,
+        guestMacOSBuild: String,
+        xcodeBuild: String,
+        codexCLIVersion: String,
+        codexCLIPath: String,
+        codexCLIInstallations: Int,
+        codexCLICapabilities: [String],
+        githubCLIVersion: String,
+        provisioningScriptVersion: String
+    ) {
+        self.hostMacOSVersion = hostMacOSVersion
+        self.hostMacOSBuild = hostMacOSBuild
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.runtimeProvider = runtimeProvider
+        self.runtimeVersion = runtimeVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLIInstallations = codexCLIInstallations
+        self.codexCLICapabilities = Self.normalize(codexCLICapabilities)
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    /// The most capability identifiers one report may carry. A CLI names a handful, so a
+    /// longer list is noise or a hostile probe; it is refused before it is normalized, because
+    /// building a set of it and persisting it would cost CPU, memory, and state-file space in
+    /// proportion to whatever the guest chose to send.
+    public static let maximumCapabilities = 64
+
+    static let capabilityCountMessage = "a capability list may name at most \(maximumCapabilities) identifiers"
+
+    /// Decoding goes through the initializer so a document with capabilities in another
+    /// order or listed twice compares equal to the normalized form.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let capabilities = try c.decode([String].self, forKey: .codexCLICapabilities)
+        guard capabilities.count <= Self.maximumCapabilities else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: Self.capabilityCountMessage)
+        }
+        self.init(
+            hostMacOSVersion: try c.decode(SemanticVersion.self, forKey: .hostMacOSVersion),
+            hostMacOSBuild: try c.decode(String.self, forKey: .hostMacOSBuild),
+            codexDesktopVersion: try c.decode(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decode(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decode(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decode(Int.self, forKey: .runtimeProtocolVersion),
+            runtimeProvider: try c.decode(VMProvider.self, forKey: .runtimeProvider),
+            runtimeVersion: try c.decode(String.self, forKey: .runtimeVersion),
+            guestMacOSBuild: try c.decode(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decode(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
+            codexCLIInstallations: try c.decode(Int.self, forKey: .codexCLIInstallations),
+            codexCLICapabilities: capabilities,
+            githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion)
+        )
+    }
+
+    /// Sorted, without duplicates: the canonical form every comparison uses.
+    ///
+    /// A list longer than the maximum is not canonicalized. Deduplicating it first would
+    /// collapse a million repetitions of one identifier into a one-element list that
+    /// `ConnectionVerificationRecord.validate` then accepts and persists, and building a set of
+    /// whatever a guest chose to send costs CPU and memory in proportion to it. The bounded
+    /// prefix that comes back instead is still longer than the maximum, so a construction or an
+    /// assignment the decoders' own count check never saw is refused rather than repaired.
+    public static func normalize(_ capabilities: [String]) -> [String] {
+        guard capabilities.count <= maximumCapabilities else {
+            return Array(capabilities.prefix(maximumCapabilities + 1))
+        }
+        return Array(Set(capabilities)).sorted()
+    }
+
+    /// The fields whose values differ between two tuples.
+    public func differences(from other: CompatibilityTuple) -> [CompatibilityField] {
+        var changed: [CompatibilityField] = []
+        if hostMacOSVersion != other.hostMacOSVersion { changed.append(.hostMacOSVersion) }
+        if hostMacOSBuild != other.hostMacOSBuild { changed.append(.hostMacOSBuild) }
+        if codexDesktopVersion != other.codexDesktopVersion { changed.append(.codexDesktopVersion) }
+        if codexDesktopBuild != other.codexDesktopBuild { changed.append(.codexDesktopBuild) }
+        if codexDesktopPath != other.codexDesktopPath { changed.append(.codexDesktopPath) }
+        if runtimeProtocolVersion != other.runtimeProtocolVersion { changed.append(.runtimeProtocolVersion) }
+        if runtimeProvider != other.runtimeProvider { changed.append(.runtimeProvider) }
+        if runtimeVersion != other.runtimeVersion { changed.append(.runtimeVersion) }
+        if guestMacOSBuild != other.guestMacOSBuild { changed.append(.guestMacOSBuild) }
+        if xcodeBuild != other.xcodeBuild { changed.append(.xcodeBuild) }
+        if codexCLIVersion != other.codexCLIVersion { changed.append(.codexCLIVersion) }
+        if codexCLIPath != other.codexCLIPath { changed.append(.codexCLIPath) }
+        if codexCLIInstallations != other.codexCLIInstallations { changed.append(.codexCLIInstallations) }
+        if codexCLICapabilities != other.codexCLICapabilities { changed.append(.codexCLICapabilities) }
+        if githubCLIVersion != other.githubCLIVersion { changed.append(.githubCLIVersion) }
+        if provisioningScriptVersion != other.provisioningScriptVersion { changed.append(.provisioningScriptVersion) }
+        return changed
+    }
+}
+
+/// What was actually observed at connect time. `nil` means unknown, and unknown is never
+/// treated as matching anything: the plan requires reporting "unknown" rather than guessing.
+public struct ObservedTuple: Codable, Hashable, Sendable {
+    public var hostMacOSVersion: SemanticVersion?
+    public var hostMacOSBuild: String?
+    public var codexDesktopVersion: String?
+    public var codexDesktopBuild: String?
+    public var codexDesktopPath: String?
+    public var runtimeProtocolVersion: Int?
+    public var runtimeProvider: VMProvider?
+    public var runtimeVersion: String?
+    public var guestMacOSBuild: String?
+    public var xcodeBuild: String?
+    public var codexCLIVersion: String?
+    public var codexCLIPath: String?
+    public var codexCLIInstallations: Int?
+    public var codexCLICapabilities: [String]? {
+        didSet { codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize) }
+    }
+    public var githubCLIVersion: String?
+    public var provisioningScriptVersion: String?
+
+    public init(
+        hostMacOSVersion: SemanticVersion? = nil,
+        hostMacOSBuild: String? = nil,
+        codexDesktopVersion: String? = nil,
+        codexDesktopBuild: String? = nil,
+        codexDesktopPath: String? = nil,
+        runtimeProtocolVersion: Int? = nil,
+        runtimeProvider: VMProvider? = nil,
+        runtimeVersion: String? = nil,
+        guestMacOSBuild: String? = nil,
+        xcodeBuild: String? = nil,
+        codexCLIVersion: String? = nil,
+        codexCLIPath: String? = nil,
+        codexCLIInstallations: Int? = nil,
+        codexCLICapabilities: [String]? = nil,
+        githubCLIVersion: String? = nil,
+        provisioningScriptVersion: String? = nil
+    ) {
+        self.hostMacOSVersion = hostMacOSVersion
+        self.hostMacOSBuild = hostMacOSBuild
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.runtimeProvider = runtimeProvider
+        self.runtimeVersion = runtimeVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLIInstallations = codexCLIInstallations
+        self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let capabilities = try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities)
+        guard (capabilities?.count ?? 0) <= CompatibilityTuple.maximumCapabilities else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: CompatibilityTuple.capabilityCountMessage)
+        }
+        self.init(
+            hostMacOSVersion: try c.decodeIfPresent(SemanticVersion.self, forKey: .hostMacOSVersion),
+            hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
+            codexDesktopVersion: try c.decodeIfPresent(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decodeIfPresent(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decodeIfPresent(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decodeIfPresent(Int.self, forKey: .runtimeProtocolVersion),
+            runtimeProvider: try c.decodeIfPresent(VMProvider.self, forKey: .runtimeProvider),
+            runtimeVersion: try c.decodeIfPresent(String.self, forKey: .runtimeVersion),
+            guestMacOSBuild: try c.decodeIfPresent(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decodeIfPresent(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
+            codexCLIInstallations: try c.decodeIfPresent(Int.self, forKey: .codexCLIInstallations),
+            codexCLICapabilities: capabilities,
+            githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion)
+        )
+    }
+
+    public init(_ tuple: CompatibilityTuple) {
+        self.init(
+            hostMacOSVersion: tuple.hostMacOSVersion,
+            hostMacOSBuild: tuple.hostMacOSBuild,
+            codexDesktopVersion: tuple.codexDesktopVersion,
+            codexDesktopBuild: tuple.codexDesktopBuild,
+            codexDesktopPath: tuple.codexDesktopPath,
+            runtimeProtocolVersion: tuple.runtimeProtocolVersion,
+            runtimeProvider: tuple.runtimeProvider,
+            runtimeVersion: tuple.runtimeVersion,
+            guestMacOSBuild: tuple.guestMacOSBuild,
+            xcodeBuild: tuple.xcodeBuild,
+            codexCLIVersion: tuple.codexCLIVersion,
+            codexCLIPath: tuple.codexCLIPath,
+            codexCLIInstallations: tuple.codexCLIInstallations,
+            codexCLICapabilities: tuple.codexCLICapabilities,
+            githubCLIVersion: tuple.githubCLIVersion,
+            provisioningScriptVersion: tuple.provisioningScriptVersion
+        )
+    }
+
+    /// The fields that are unknown.
+    public var unknownFields: [CompatibilityField] {
+        var unknown: [CompatibilityField] = []
+        if hostMacOSVersion == nil { unknown.append(.hostMacOSVersion) }
+        if hostMacOSBuild == nil { unknown.append(.hostMacOSBuild) }
+        if codexDesktopVersion == nil { unknown.append(.codexDesktopVersion) }
+        if codexDesktopBuild == nil { unknown.append(.codexDesktopBuild) }
+        if codexDesktopPath == nil { unknown.append(.codexDesktopPath) }
+        if runtimeProtocolVersion == nil { unknown.append(.runtimeProtocolVersion) }
+        if runtimeProvider == nil { unknown.append(.runtimeProvider) }
+        if runtimeVersion == nil { unknown.append(.runtimeVersion) }
+        if guestMacOSBuild == nil { unknown.append(.guestMacOSBuild) }
+        if xcodeBuild == nil { unknown.append(.xcodeBuild) }
+        if codexCLIVersion == nil { unknown.append(.codexCLIVersion) }
+        if codexCLIPath == nil { unknown.append(.codexCLIPath) }
+        if codexCLIInstallations == nil { unknown.append(.codexCLIInstallations) }
+        if codexCLICapabilities == nil { unknown.append(.codexCLICapabilities) }
+        if githubCLIVersion == nil { unknown.append(.githubCLIVersion) }
+        if provisioningScriptVersion == nil { unknown.append(.provisioningScriptVersion) }
+        return unknown
+    }
+
+    /// The fully known tuple, or `nil` if any field is unknown.
+    public var exact: CompatibilityTuple? {
+        guard let hostMacOSVersion, let hostMacOSBuild, let codexDesktopVersion, let codexDesktopBuild,
+              let codexDesktopPath, let runtimeProtocolVersion, let runtimeProvider, let runtimeVersion, let guestMacOSBuild, let xcodeBuild,
+              let codexCLIVersion, let codexCLIPath, let codexCLIInstallations, let codexCLICapabilities,
+              let githubCLIVersion, let provisioningScriptVersion
+        else { return nil }
+        return CompatibilityTuple(
+            hostMacOSVersion: hostMacOSVersion,
+            hostMacOSBuild: hostMacOSBuild,
+            codexDesktopVersion: codexDesktopVersion,
+            codexDesktopBuild: codexDesktopBuild,
+            codexDesktopPath: codexDesktopPath,
+            runtimeProtocolVersion: runtimeProtocolVersion,
+            runtimeProvider: runtimeProvider,
+            runtimeVersion: runtimeVersion,
+            guestMacOSBuild: guestMacOSBuild,
+            xcodeBuild: xcodeBuild,
+            codexCLIVersion: codexCLIVersion,
+            codexCLIPath: codexCLIPath,
+            codexCLIInstallations: codexCLIInstallations,
+            codexCLICapabilities: codexCLICapabilities,
+            githubCLIVersion: githubCLIVersion,
+            provisioningScriptVersion: provisioningScriptVersion
+        )
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTupleTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityTupleTests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct CompatibilityTupleTests {
+    static func tuple(provider: VMProvider = .lume, capabilities: [String] = ["remote-app-server"]) -> CompatibilityTuple {
+        CompatibilityTuple(
+            hostMacOSVersion: SemanticVersion([26, 4]), hostMacOSBuild: "25E20",
+            codexDesktopVersion: "1.2.3", codexDesktopBuild: "1234", codexDesktopPath: "/Applications/Codex.app",
+            runtimeProtocolVersion: 1, runtimeProvider: provider, runtimeVersion: "0.5.3",
+            guestMacOSBuild: "25F84", xcodeBuild: "17F113", codexCLIVersion: "0.50.0",
+            codexCLIPath: "/opt/homebrew/bin/codex", codexCLIInstallations: 1, codexCLICapabilities: capabilities,
+            githubCLIVersion: "2.80.0", provisioningScriptVersion: "1"
+        )
+    }
+
+    @Test(arguments: VMProvider.allCases)
+    func fullyKnownObservationsRoundTripWithoutLosingIdentity(_ provider: VMProvider) throws {
+        let expected = Self.tuple(provider: provider)
+        let data = try JSONEncoder().encode(expected)
+        #expect(try JSONDecoder().decode(CompatibilityTuple.self, from: data) == expected)
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: data)
+        #expect(observed.exact == expected)
+        #expect(observed.unknownFields.isEmpty)
+        #expect(try JSONDecoder().decode(ObservedTuple.self, from: JSONEncoder().encode(observed)) == observed)
+    }
+
+    @Test func providerIdentityCannotBeInferredFromAVersion() {
+        let lume = Self.tuple(provider: .lume)
+        let tart = Self.tuple(provider: .tart)
+        #expect(lume != tart)
+        #expect(lume.differences(from: tart) == [.runtimeProvider])
+        var differentVersion = lume
+        differentVersion.runtimeVersion = "0.5.4"
+        #expect(lume.differences(from: differentVersion) == [.runtimeVersion])
+    }
+
+    @Test(arguments: CompatibilityField.allCases)
+    func eachMissingFieldRemainsUnknown(_ field: CompatibilityField) throws {
+        var json = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.tuple())) as? [String: Any])
+        #expect(json.removeValue(forKey: field.rawValue) != nil)
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: data)
+        #expect(observed.unknownFields == [field])
+        #expect(observed.exact == nil)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(CompatibilityTuple.self, from: data) }
+    }
+
+    @Test func legacyTartFieldDoesNotBecomeLumeEvidence() throws {
+        let data = Data(#"{"tartVersion":"2.36.0"}"#.utf8)
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: data)
+        #expect(observed.runtimeProvider == nil)
+        #expect(observed.runtimeVersion == nil)
+        #expect(observed.exact == nil)
+        #expect(observed.unknownFields == CompatibilityField.allCases)
+        #expect(!String(decoding: try JSONEncoder().encode(observed), as: UTF8.self).contains("tartVersion"))
+    }
+
+    @Test func unknownProviderDoesNotDefaultToTheCandidate() {
+        let data = Data(#"{"runtimeProvider":"syntheticOpaque"}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ObservedTuple.self, from: data) }
+    }
+
+    @Test func capabilityNormalizationSurvivesConstructionAssignmentAndDecode() throws {
+        let expected = Self.tuple(capabilities: ["a", "b"])
+        var tuple = Self.tuple(capabilities: ["b", "a", "b"])
+        #expect(tuple == expected)
+        tuple.codexCLICapabilities = ["b", "a", "b"]
+        #expect(tuple == expected)
+        var observed = ObservedTuple(tuple)
+        observed.codexCLICapabilities = ["b", "a", "b"]
+        #expect(observed.exact == expected)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(expected)) as? [String: Any])
+        object["codexCLICapabilities"] = ["b", "a", "b"]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        #expect(try JSONDecoder().decode(CompatibilityTuple.self, from: data) == expected)
+        #expect(try JSONDecoder().decode(ObservedTuple.self, from: data).exact == expected)
+    }
+
+    @Test func tooManyCapabilitiesAreNotNormalizedIntoValidEvidence() throws {
+        let excessive = Array(repeating: "same", count: 65)
+        #expect(CompatibilityTuple.maximumCapabilities == 64)
+        var tuple = Self.tuple(capabilities: excessive)
+        #expect(tuple.codexCLICapabilities.count == 65)
+        tuple.codexCLICapabilities = excessive
+        #expect(tuple.codexCLICapabilities.count == 65)
+        var observed = ObservedTuple(tuple)
+        observed.codexCLICapabilities = excessive
+        #expect(observed.codexCLICapabilities?.count == 65)
+        let data = try JSONEncoder().encode(tuple)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(CompatibilityTuple.self, from: data) }
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ObservedTuple.self, from: data) }
+    }
+
+    @Test func driftIncludesAllChangedIdentityComponents() {
+        let first = Self.tuple()
+        let second = CompatibilityTuple(
+            hostMacOSVersion: SemanticVersion([27]), hostMacOSBuild: "26A1",
+            codexDesktopVersion: "2", codexDesktopBuild: "2000", codexDesktopPath: "/Applications/Codex Beta.app",
+            runtimeProtocolVersion: 2, runtimeProvider: .tart, runtimeVersion: "2.36.0",
+            guestMacOSBuild: "26B1", xcodeBuild: "18A1", codexCLIVersion: "0.51.0",
+            codexCLIPath: "/usr/local/bin/codex", codexCLIInstallations: 2, codexCLICapabilities: ["changed"],
+            githubCLIVersion: "3", provisioningScriptVersion: "2"
+        )
+        #expect(first.differences(from: second) == CompatibilityField.allCases)
+        #expect(first.differences(from: first).isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

Second focused migration of #55 / #14, stacked on #138 (MVP-PLAN.md §§4–5, ADRs 0002/0003). Reuses the existing tuple/observation comparison code without the old sanitizer ancestry.

- Add explicit VMProvider identity and runtimeVersion; do not treat a Lume version as a Tart version or infer a provider from a string. Tart is a legacy identity value, not activated runtime work.
- Preserve every host/desktop/protocol/guest/Xcode/CLI/script identity field, exact comparison and missing-field tracking.
- Preserve bounded capability count and canonical ordering on construction, assignment and decode. Oversized duplicate lists remain invalid instead of collapsing into valid evidence.
- Legacy tartVersion extras cannot identify a provider; missing dimensions remain unknown and unknown providers fail decode.

## Validation

Full composed Core suite: **229 tests /20 suites pass**, warnings-as-errors. Diff check passes. **437 added lines /2 files**. Tests cover both providers, provider/version drift, every missing dimension, unknown/legacy-provider handling, capability construction/assignment/decode, overflow retention/rejection, full identity drift and round trips.

## Remaining boundary

These are private compatibility models, not diagnostic payloads or proof of a successful desktop connection. Presence is not validity. The next migration retains bounded observation validation, actual-connection evidence, manifest/evaluator checks and fixed diagnostics. No provider selection, hardware evidence, raw logging, process operation, PR merge or force push. #14 stays open.

#138 must pass its own gates first. This exact composition requires its own green Xcode Cloud and completed Codex review with the original-message thumbs-up before merging.