### PR TITLE
Migrate private connection evidence onto structured Core

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -57,10 +57,14 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
         let versions: [(CompatibilityField, String)] = [
             (.codexDesktopVersion, tuple.codexDesktopVersion), (.codexDesktopBuild, tuple.codexDesktopBuild),
             (.runtimeVersion, tuple.runtimeVersion), (.codexCLIVersion, tuple.codexCLIVersion),
-            (.githubCLIVersion, tuple.githubCLIVersion), (.provisioningScriptVersion, tuple.provisioningScriptVersion)
+            (.githubCLIVersion, tuple.githubCLIVersion)
         ]
         for (field, value) in versions where !isVersionIdentifier(value) {
             throw .implausibleObservation(field)
+        }
+        // Phase-0 records accept a script version or commit, which need not start with a digit.
+        guard isIdentifier(tuple.provisioningScriptVersion, punctuation: [43, 45, 46]) else {
+            throw .implausibleObservation(.provisioningScriptVersion)
         }
         for (field, value) in [
             (CompatibilityField.hostMacOSBuild, tuple.hostMacOSBuild),
@@ -89,7 +93,8 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
     /// verified one from another working directory, which is exactly the substitution
     /// MVP-PLAN.md §5 tracks the resolved path to catch.
     static func isResolvedPath(_ value: String) -> Bool {
-        guard isBoundedText(value, limit: maximumPathLength), value.hasPrefix("/") else { return false }
+        guard isBoundedText(value, limit: maximumPathLength), value.hasPrefix("/"),
+              !value.hasSuffix("/") else { return false }
         // `.` and `..` resolve against a working directory the record does not carry, so a path
         // holding either is not yet the one the probe was standing on.
         return !value.split(separator: "/").contains { $0 == "." || $0 == ".." }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -1,0 +1,263 @@
+import Foundation
+
+/// A private record of confirmation that Codex desktop opened a guest workspace with an exact combination
+/// of versions (MVP-PLAN.md §5: "Record connection verification for that exact tuple only
+/// after the real desktop flow succeeds").
+///
+/// A record can only be created from `DesktopConnectionEvidence`. Version queries such as
+/// `codex --version` are not evidence and have no way to name themselves one: the source of a
+/// machine-readable status has to be an interface on `supportedStatusInterfaces`.
+public struct ConnectionVerificationRecord: Hashable, Sendable {
+    /// Record-level schema version, so the state store can migrate history when the tuple
+    /// changes shape instead of misreading old evidence under a new schema.
+    public let schemaVersion: SchemaVersion
+
+    /// The record layout this build writes, and the only one `init(from:)` accepts.
+    ///
+    /// Its own number rather than `SchemaVersion.current`: that epoch moves whenever any
+    /// persisted record in the package changes shape, so measuring this record against it
+    /// would make every unchanged connection record unreadable after a release that only
+    /// altered an environment or VM-slot format. This number moves when this record's shape
+    /// moves, together with the migration that reads the previous one. `SchemaVersion` only
+    /// refuses a number below 1; the schema-2 literal is valid. Legacy schema 1 lacks explicit
+    /// provider identity, so it must not be accepted as Lume connection evidence.
+    public static let currentSchema = SchemaVersion(2)!
+    public let tuple: CompatibilityTuple
+    public let verifiedAt: Date
+    public let evidence: DesktopConnectionEvidence
+
+    /// - Throws: `CompatibilityRecordError.implausibleObservation` when a guest-reported string
+    ///   violates the bounded grammar of its version/build/capability/path field.
+    ///   No general-purpose secret recognition is used; these are private identity records.
+    ///   `.implausibleEvidenceSource` when the evidence names a status interface this build
+    ///   does not read.
+    public init(tuple: CompatibilityTuple, verifiedAt: Date, evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
+        try Self.validate(tuple)
+        try Self.validate(evidence)
+        schemaVersion = Self.currentSchema
+        self.tuple = tuple
+        self.verifiedAt = verifiedAt
+        self.evidence = evidence
+    }
+
+    public static let maximumObservationLength = 256
+    /// Limits are UTF-8 bytes. A full path is bounded by the file system, not by the shape of a version string: a
+    /// deeply nested but entirely valid bundle or executable must still be recordable.
+    public static let maximumPathLength = 1024
+
+    /// Every string must fit its identity field's grammar, not be a command transcript.
+    public static func validate(_ tuple: CompatibilityTuple) throws(CompatibilityRecordError) {
+        // Bounded in count as well as in length: the per-value checks below say nothing about
+        // how many values a guest may report, and the whole list is what gets persisted.
+        guard tuple.codexCLICapabilities.count <= CompatibilityTuple.maximumCapabilities else {
+            throw .implausibleObservation(.codexCLICapabilities)
+        }
+        guard tuple.runtimeProtocolVersion > 0 else { throw .implausibleObservation(.runtimeProtocolVersion) }
+        guard tuple.codexCLIInstallations == 1 else { throw .implausibleObservation(.codexCLIInstallations) }
+        let versions: [(CompatibilityField, String)] = [
+            (.codexDesktopVersion, tuple.codexDesktopVersion), (.codexDesktopBuild, tuple.codexDesktopBuild),
+            (.runtimeVersion, tuple.runtimeVersion), (.codexCLIVersion, tuple.codexCLIVersion),
+            (.githubCLIVersion, tuple.githubCLIVersion), (.provisioningScriptVersion, tuple.provisioningScriptVersion)
+        ]
+        for (field, value) in versions where !isVersionIdentifier(value) {
+            throw .implausibleObservation(field)
+        }
+        for (field, value) in [
+            (CompatibilityField.hostMacOSBuild, tuple.hostMacOSBuild),
+            (.guestMacOSBuild, tuple.guestMacOSBuild), (.xcodeBuild, tuple.xcodeBuild)
+        ] where !isBuildIdentifier(value) { throw .implausibleObservation(field) }
+        for value in tuple.codexCLICapabilities where !isIdentifier(value, punctuation: [45, 46, 58, 95]) {
+            throw .implausibleObservation(.codexCLICapabilities)
+        }
+        // The two paths are identity, not description, so they are held to more than
+        // plausibility (MVP-PLAN.md §5).
+        let paths: [(CompatibilityField, String)] = [
+            (.codexDesktopPath, tuple.codexDesktopPath),
+            (.codexCLIPath, tuple.codexCLIPath),
+        ]
+        for (field, value) in paths where !isResolvedPath(value) {
+            throw .implausibleObservation(field)
+        }
+    }
+
+    /// Checks the lexical shape of an absolute path. The probe must resolve symlinks;
+    /// this value model does not consult the filesystem or prove the executable exists.
+    ///
+    /// A login shell whose `PATH` carries a relative entry answers `which -a codex` with
+    /// `codex` or `../bin/codex`, and a compromised probe can answer with either on purpose.
+    /// Recording one as identity would let a different executable of the same name pass as the
+    /// verified one from another working directory, which is exactly the substitution
+    /// MVP-PLAN.md §5 tracks the resolved path to catch.
+    static func isResolvedPath(_ value: String) -> Bool {
+        guard isBoundedText(value, limit: maximumPathLength), value.hasPrefix("/") else { return false }
+        // `.` and `..` resolve against a working directory the record does not carry, so a path
+        // holding either is not yet the one the probe was standing on.
+        return !value.split(separator: "/").contains { $0 == "." || $0 == ".." }
+    }
+
+    /// The machine-readable connection-status interfaces this build reads.
+    ///
+    /// MVP-PLAN.md §5 records verification for a tuple only after the real desktop flow
+    /// succeeds and never equates `codex --version` with a successful desktop connection. A
+    /// caller that names its own source can do exactly that — labeling any successful probe
+    /// `.machineReadableStatus(source: "codex --version")` — so a name that merely looks like an
+    /// interface is not one; it has to be on this list. This build has no registered reader,
+    /// so the list is empty. The caller must obtain explicit GUI confirmation before using
+    /// userConfirmedWorkspaceOpened. This model cannot itself prove that a user action occurred.
+    public static let supportedStatusInterfaces: Set<String> = []
+
+    /// The evidence names where a machine-readable status came from. That name goes into
+    /// persisted history and decides whether a later handoff is allowed without asking, so it
+    /// has to be an interface this build supports rather than a plausible-looking string.
+    public static func validate(_ evidence: DesktopConnectionEvidence) throws(CompatibilityRecordError) {
+        guard case .machineReadableStatus(let source) = evidence else { return }
+        guard supportedStatusInterfaces.contains(source) else { throw .implausibleEvidenceSource }
+    }
+
+    private static func isBoundedText(_ value: String, limit: Int) -> Bool {
+        guard !value.isEmpty, value.utf8.prefix(limit + 1).count <= limit,
+              value.trimmingCharacters(in: .whitespacesAndNewlines) == value else { return false }
+        return value.unicodeScalars.allSatisfy { scalar in
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned: false
+            default: true
+            }
+        }
+    }
+
+    private static func isIdentifier(_ value: String, punctuation: Set<UInt8>) -> Bool {
+        guard isBoundedText(value, limit: maximumObservationLength) else { return false }
+        return value.utf8.allSatisfy {
+            (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0) || punctuation.contains($0)
+        }
+    }
+
+    private static func isVersionIdentifier(_ value: String) -> Bool {
+        guard let first = value.utf8.first, (48...57).contains(first) else { return false }
+        return isIdentifier(value, punctuation: [43, 45, 46])
+    }
+
+    private static func isBuildIdentifier(_ value: String) -> Bool {
+        guard let first = value.utf8.first, (48...57).contains(first) else { return false }
+        return isIdentifier(value, punctuation: [])
+    }
+}
+
+public enum CompatibilityRecordError: Error, Hashable, Sendable, LocalizedError {
+    /// A guest-reported value did not look like a version, build, or path.
+    case implausibleObservation(CompatibilityField)
+    /// The evidence named a status interface this build does not read.
+    case implausibleEvidenceSource
+    /// The stored history was written in a record layout this build does not read.
+    case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
+    /// The stored history is not connection history this build can parse.
+    case malformedHistory
+
+    public var userMessage: String {
+        switch self {
+        case .implausibleObservation(let field):
+            "The development Mac reported an unsupported \(field.title) value, so this connection was not recorded. Check the tools on the development Mac before trying again."
+        case .implausibleEvidenceSource:
+            "The Codex desktop app reported a connection status from an interface Guesthouse does not read, so this connection was not recorded. Confirm in Guesthouse that the workspace opened, or check the tools on the development Mac before trying again."
+        case .unsupportedSchema(let found, let supported):
+            "Guesthouse's record of successful Codex connections is in format \(found.rawValue), and this version reads format \(supported.rawValue). The earlier connections cannot be counted, so the next handoff asks you to confirm a connection once more."
+        case .malformedHistory:
+            "Guesthouse's record of successful Codex connections could not be read. The earlier connections cannot be counted, so the next handoff asks you to confirm a connection once more."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .implausibleObservation, .implausibleEvidenceSource:
+            [.inspectState, .repair(.tools), .cancel]
+        // Do not automatically retry or replace unreadable history. The consumer must
+        // inspect it and arrange a new explicit connection confirmation separately.
+        case .unsupportedSchema, .malformedHistory:
+            [.inspectState, .cancel]
+        }
+    }
+
+    public var errorDescription: String? { userMessage }
+}
+
+extension ConnectionVerificationRecord: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, tuple, verifiedAt, evidence
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
+        // Exactly this record's layout until an explicit migration exists: an older or newer
+        // record would otherwise be interpreted under a shape it was never written in.
+        guard version == Self.currentSchema else {
+            throw CompatibilityRecordError.unsupportedSchema(found: version, supported: Self.currentSchema)
+        }
+        schemaVersion = version
+        let tuple = try container.decode(CompatibilityTuple.self, forKey: .tuple)
+        let evidence = try container.decode(DesktopConnectionEvidence.self, forKey: .evidence)
+        // History on disk is as untrusted as the probe that first produced it: an implausible
+        // value must not become verification evidence by having survived one round trip.
+        try Self.validate(tuple)
+        try Self.validate(evidence)
+        self.tuple = tuple
+        self.evidence = evidence
+        verifiedAt = try container.decode(Date.self, forKey: .verifiedAt)
+    }
+
+    /// Reads persisted connection history. Every failure becomes something the user can act
+    /// on rather than a decoder's internal complaint: history that cannot be read decides
+    /// whether the next handoff is allowed, so the state store has to be able to say so.
+    /// The storage reader must bound input size before calling this in-memory decoder.
+    public static func decodeHistory(from data: Data, using decoder: JSONDecoder = JSONDecoder()) throws(CompatibilityRecordError) -> [ConnectionVerificationRecord] {
+        do {
+            return try decoder.decode([ConnectionVerificationRecord].self, from: data)
+        } catch let error as CompatibilityRecordError {
+            throw error
+        } catch {
+            throw .malformedHistory
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(tuple, forKey: .tuple)
+        try container.encode(verifiedAt, forKey: .verifiedAt)
+        try container.encode(evidence, forKey: .evidence)
+    }
+}
+
+/// How a real desktop connection was confirmed.
+public enum DesktopConnectionEvidence: Codable, Hashable, Sendable {
+    /// The user confirmed in the GUI that the workspace opened in Codex desktop. This is the
+    /// expected path while this build has no registered machine-readable status reader.
+    case userConfirmedWorkspaceOpened
+    /// A supported, machine-readable status from the desktop application. Its source is one of
+    /// `ConnectionVerificationRecord.supportedStatusInterfaces` and is recorded so a future
+    /// change in that interface remains part of private connection history, not diagnostics.
+    case machineReadableStatus(source: String)
+}
+
+extension CompatibilityField {
+    public var title: String {
+        switch self {
+        case .hostMacOSVersion: "host macOS version"
+        case .hostMacOSBuild: "host macOS build"
+        case .codexDesktopVersion: "Codex desktop version"
+        case .codexDesktopBuild: "Codex desktop build"
+        case .codexDesktopPath: "Codex desktop location"
+        case .runtimeProtocolVersion: "runtime protocol version"
+        case .runtimeProvider: "virtual machine provider"
+        case .runtimeVersion: "virtual machine runtime version"
+        case .guestMacOSBuild: "guest macOS build"
+        case .xcodeBuild: "Xcode build"
+        case .codexCLIVersion: "Codex CLI version"
+        case .codexCLIPath: "Codex CLI location"
+        case .codexCLIInstallations: "Codex CLI installation count"
+        case .codexCLICapabilities: "Codex CLI capabilities"
+        case .githubCLIVersion: "GitHub CLI version"
+        case .provisioningScriptVersion: "provisioning script version"
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/ConnectionVerificationRecordTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/ConnectionVerificationRecordTests.swift
@@ -73,12 +73,24 @@ struct ConnectionVerificationRecordTests {
         #expect(try Self.record(tuple).tuple == tuple)
     }
 
-    @Test(arguments: ["codex", "../bin/codex", "/opt/../bin/codex", "/opt/./bin/codex", "/bin/codex\u{202E}", "/bin/codex\n",
+    @Test(arguments: ["/", "//", "////", "/bin/codex/", "codex", "../bin/codex", "/opt/../bin/codex", "/opt/./bin/codex", "/bin/codex\u{202E}", "/bin/codex\n",
                       "/" + String(repeating: "é", count: 512)])
     func invalidPathsFailWithoutReturningThePath(_ path: String) {
         var tuple = CompatibilityTupleTests.tuple()
         tuple.codexCLIPath = path
         #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIPath)) { try Self.record(tuple) }
+        tuple = CompatibilityTupleTests.tuple()
+        tuple.codexDesktopPath = path
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexDesktopPath)) { try Self.record(tuple) }
+    }
+
+    @Test(arguments: ["abcdef0123456789abcdef0123456789abcdef0123", "b7255bd", String(repeating: "a", count: 64), "v1.2.3"])
+    func provisioningIdentityMayBeAVersionOrCommit(_ identity: String) throws {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.provisioningScriptVersion = identity
+        let record = try Self.record(tuple)
+        #expect(record.tuple.provisioningScriptVersion == identity)
+        #expect(try ConnectionVerificationRecord.decodeHistory(from: JSONEncoder().encode([record])) == [record])
     }
 
     @Test func privateIdentityPathsArePreservedNotRedacted() throws {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/ConnectionVerificationRecordTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/ConnectionVerificationRecordTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct ConnectionVerificationRecordTests {
+    static func record(_ tuple: CompatibilityTuple = CompatibilityTupleTests.tuple()) throws -> ConnectionVerificationRecord {
+        try ConnectionVerificationRecord(tuple: tuple, verifiedAt: Date(timeIntervalSince1970: 1_700_000_000),
+                                         evidence: .userConfirmedWorkspaceOpened)
+    }
+
+    static func data(changing field: CompatibilityField, to value: Any) throws -> Data {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(record())) as? [String: Any])
+        var tuple = try #require(object["tuple"] as? [String: Any])
+        tuple[field.rawValue] = value
+        object["tuple"] = tuple
+        return try JSONSerialization.data(withJSONObject: [object])
+    }
+
+    @Test(arguments: VMProvider.allCases)
+    func recordsRetainExactProviderIdentity(_ provider: VMProvider) throws {
+        let record = try Self.record(CompatibilityTupleTests.tuple(provider: provider))
+        #expect(record.schemaVersion.rawValue == 2)
+        let data = try JSONEncoder().encode([record])
+        #expect(try ConnectionVerificationRecord.decodeHistory(from: data) == [record])
+    }
+
+    @Test(arguments: [1, 3])
+    func otherSchemasDoNotBecomeCurrentEvidence(_ version: Int) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.record())) as? [String: Any])
+        object["schemaVersion"] = version
+        let data = try JSONSerialization.data(withJSONObject: [object])
+        #expect(throws: CompatibilityRecordError.unsupportedSchema(
+            found: try #require(SchemaVersion(version)), supported: ConnectionVerificationRecord.currentSchema
+        )) { try ConnectionVerificationRecord.decodeHistory(from: data) }
+    }
+
+    @Test(arguments: ["codex --version", "desktop-status", "syntheticOpaque"])
+    func callersCannotInventMachineEvidence(_ source: String) throws {
+        #expect(ConnectionVerificationRecord.supportedStatusInterfaces.isEmpty)
+        let evidence = DesktopConnectionEvidence.machineReadableStatus(source: source)
+        #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
+            try ConnectionVerificationRecord(tuple: CompatibilityTupleTests.tuple(), verifiedAt: .now, evidence: evidence)
+        }
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.record())) as? [String: Any])
+        object["evidence"] = try JSONSerialization.jsonObject(with: JSONEncoder().encode(evidence))
+        let data = try JSONSerialization.data(withJSONObject: [object])
+        #expect(throws: CompatibilityRecordError.implausibleEvidenceSource) {
+            try ConnectionVerificationRecord.decodeHistory(from: data)
+        }
+    }
+
+    @Test(arguments: [CompatibilityField.codexDesktopVersion, .codexDesktopBuild, .runtimeVersion,
+                      .codexCLIVersion, .githubCLIVersion, .provisioningScriptVersion],
+          ["", "1.2\nsyntheticOpaque", " 1.2", "1.2 ", "1.2/extra", "1.2\u{301}", String(repeating: "1", count: 257)])
+    func versionFieldsUseBoundedIdentifierGrammar(_ field: CompatibilityField, _ value: String) throws {
+        let data = try Self.data(changing: field, to: value)
+        #expect(throws: CompatibilityRecordError.implausibleObservation(field)) {
+            try ConnectionVerificationRecord.decodeHistory(from: data)
+        }
+    }
+
+    @Test(arguments: [CompatibilityField.hostMacOSBuild, .guestMacOSBuild, .xcodeBuild])
+    func buildIdentifiersCannotCarryCommandOutput(_ field: CompatibilityField) throws {
+        let data = try Self.data(changing: field, to: "25A1\rsyntheticOpaque")
+        #expect(throws: CompatibilityRecordError.implausibleObservation(field)) {
+            try ConnectionVerificationRecord.decodeHistory(from: data)
+        }
+    }
+
+    @Test func legitimateVersionSuffixesAndCapabilitiesArePreserved() throws {
+        var tuple = CompatibilityTupleTests.tuple(capabilities: ["app_server:v2", "remote-app-server"])
+        tuple.runtimeVersion = "0.5.3-rc.1+42"
+        #expect(try Self.record(tuple).tuple == tuple)
+    }
+
+    @Test(arguments: ["codex", "../bin/codex", "/opt/../bin/codex", "/opt/./bin/codex", "/bin/codex\u{202E}", "/bin/codex\n",
+                      "/" + String(repeating: "é", count: 512)])
+    func invalidPathsFailWithoutReturningThePath(_ path: String) {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLIPath = path
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIPath)) { try Self.record(tuple) }
+    }
+
+    @Test func privateIdentityPathsArePreservedNotRedacted() throws {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexDesktopPath = "/Users/De\u{301}veloper/My Apps/Codex.app"
+        tuple.codexCLIPath = "/" + String(repeating: "subdir/", count: 100) + "codex"
+        let record = try Self.record(tuple)
+        #expect(record.tuple == tuple)
+        #expect(try ConnectionVerificationRecord.decodeHistory(from: JSONEncoder().encode([record])) == [record])
+    }
+
+    @Test(arguments: [-1, 0, 2])
+    func verificationRequiresExactlyOneCLI(_ count: Int) {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLIInstallations = count
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLIInstallations)) { try Self.record(tuple) }
+    }
+
+    @Test(arguments: [-1, 0])
+    func protocolIdentityMustBePositive(_ version: Int) {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.runtimeProtocolVersion = version
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.runtimeProtocolVersion)) { try Self.record(tuple) }
+    }
+
+    @Test(arguments: [[""], ["capability\nsyntheticOpaque"], [String(repeating: "a", count: 257)], Array(repeating: "same", count: 65)])
+    func capabilitiesAreValidatedBeforeRecording(_ capabilities: [String]) {
+        let tuple = CompatibilityTupleTests.tuple(capabilities: capabilities)
+        #expect(throws: CompatibilityRecordError.implausibleObservation(.codexCLICapabilities)) { try Self.record(tuple) }
+    }
+
+    @Test(arguments: ["syntheticOpaque", "{}", "[{\"schemaVersion\":0}]", "[{\"schemaVersion\":2}]"])
+    func malformedHistoryUsesFixedErrorWithoutDecoderDetails(_ text: String) {
+        #expect(throws: CompatibilityRecordError.malformedHistory) {
+            try ConnectionVerificationRecord.decodeHistory(from: Data(text.utf8))
+        }
+        let error = CompatibilityRecordError.malformedHistory
+        #expect(!error.userMessage.contains(text))
+        #expect(error.errorDescription == error.userMessage)
+        #expect(error.recoveryActions == [.inspectState, .cancel])
+    }
+
+    @Test func rejectedValuesAndUnknownFieldsDoNotEnterErrorsOrRecords() throws {
+        let data = try Self.data(changing: .codexCLIVersion, to: "1.0\nsyntheticOpaque")
+        do { _ = try ConnectionVerificationRecord.decodeHistory(from: data); Issue.record("Expected rejection") }
+        catch {
+            #expect(error == .implausibleObservation(.codexCLIVersion))
+            #expect(!error.userMessage.contains("syntheticOpaque"))
+            #expect(error.recoveryActions.contains(.repair(.tools)))
+        }
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.record())) as? [String: Any])
+        object["rawOutput"] = "syntheticOpaque"
+        let history = try ConnectionVerificationRecord.decodeHistory(from: JSONSerialization.data(withJSONObject: [object]))
+        #expect(!String(decoding: try JSONEncoder().encode(history), as: UTF8.self).contains("syntheticOpaque"))
+    }
+}

--- a/docs/compatibility-migration.md
+++ b/docs/compatibility-migration.md
@@ -10,9 +10,10 @@ Compatibility records retain exact tool versions, resolved executable locations 
 | --- | --- |
 | Host macOS version | Bounded dotted numeric `SemanticVersion` |
 | Tool versions | Bounded ASCII identifiers starting with a digit; prerelease/build punctuation allowed |
+| Provisioning scripts | Bounded ASCII version or commit identifiers; a leading letter is valid |
 | macOS and Xcode builds | Bounded ASCII alphanumeric identifiers starting with a digit |
 | Capabilities | At most 64 bounded ASCII identifiers; canonical ordering and duplicates normalized only within that limit |
-| Executable locations | Bounded absolute paths without dot components or control/format characters; Unicode and interior spaces preserved |
+| Executable locations | Bounded absolute paths with a nonempty final component, without dot components or control/format characters; Unicode and interior spaces preserved |
 | Installation/protocol counts | Exactly one Codex CLI installation and a positive runtime protocol version |
 | Connection evidence | Explicit user confirmation, or a registered status reader; this build registers none |
 

--- a/docs/compatibility-migration.md
+++ b/docs/compatibility-migration.md
@@ -1,0 +1,35 @@
+# Compatibility migration
+
+This migrates [issue #14](https://github.com/PicoMLX/Guesthouse/issues/14) from the old [#55 stack](https://github.com/PicoMLX/Guesthouse/pull/55) onto the structured Core contract. It implements the identity and connection-evidence requirements in `MVP-PLAN.md` §5, following [ADR 0002](decisions/0002-prioritize-lume-and-shared-infrastructure.md) and [ADR 0003](decisions/0003-structured-diagnostics.md).
+
+## Private identity is not diagnostics
+
+Compatibility records retain exact tool versions, resolved executable locations and capabilities for comparison. These are private state, not sanitized messages or exportable diagnostics. A valid path can contain a private name. No general-purpose secret recognizer attempts to decide whether arbitrary text is safe.
+
+| Input | Record boundary |
+| --- | --- |
+| Host macOS version | Bounded dotted numeric `SemanticVersion` |
+| Tool versions | Bounded ASCII identifiers starting with a digit; prerelease/build punctuation allowed |
+| macOS and Xcode builds | Bounded ASCII alphanumeric identifiers starting with a digit |
+| Capabilities | At most 64 bounded ASCII identifiers; canonical ordering and duplicates normalized only within that limit |
+| Executable locations | Bounded absolute paths without dot components or control/format characters; Unicode and interior spaces preserved |
+| Installation/protocol counts | Exactly one Codex CLI installation and a positive runtime protocol version |
+| Connection evidence | Explicit user confirmation, or a registered status reader; this build registers none |
+
+The probe must actually resolve executable locations and collect the observed identity. A value model cannot prove filesystem identity, a successful connection, or a user's action. The GUI must obtain confirmation only after the actual Codex workspace flow. A successful version command never supplies that confirmation.
+
+## Provider and schema identity
+
+The exact tuple carries both `runtimeProvider` and `runtimeVersion`; equal version strings do not make Lume and Tart interchangeable. Missing fields remain unknown. Tart is retained only as legacy identity, not as a newly selected provider.
+
+Connection records use their own schema 2. Legacy schema 1 lacks explicit provider identity and is not accepted as new evidence. Unsupported or malformed history produces a fixed error with inspection/cancel actions, not automatic replacement or retry. The consumer must arrange any new confirmation separately and preserve unreadable state until it is inspected. Its storage reader must bound file input before decoding.
+
+## Error and export boundary
+
+`CompatibilityRecordError` carries a closed field identifier, schema numbers, or a fixed failure category. Its messages and recovery actions never include the rejected value or decoder description. `decodeHistory` converts decoding failures to that fixed error surface.
+
+Neither `CompatibilityTuple` nor `ConnectionVerificationRecord` is a `DiagnosticEvent` attachment. Do not serialize these private records into diagnostics, export their paths, or log underlying decoding errors. Runtime/XPC/GUI consumers still need integration tests that enforce the [structured diagnostics boundary](structured-diagnostics-migration.md).
+
+## Remaining integration
+
+The numeric-version, provider-aware tuple and connection-record changes are independently reviewed prerequisites. They do not yet replace #55's compatibility manifest and evaluator, implement probes or persistence, or certify a Lume configuration. Those components must migrate before issue #14 is complete. Preserve the old PR's remaining behavior and useful tests without importing its redactor ancestry. Hardware evidence remains a separate human gate.


### PR DESCRIPTION
## Purpose

Third focused replacement for #55 (issue #14), stacked on #139. Implements private connection evidence from MVP-PLAN.md §5 under ADR 0002/0003; it is not a runtime probe or a logging sink.

## Changes

- Retain exact provider-aware tuple identity and explicit real-workspace confirmation. Version probes cannot impersonate a registered desktop status reader; this build registers none.
- Replace the old generic redactor plausibility dependency with bounded field-specific identity grammars. Legitimate Unicode paths and interior spaces are retained privately, not declared sanitized or exported.
- Require one CLI installation and a positive runtime protocol. Revalidate decoded history; schema 2 rejects provider-less legacy evidence.
- Return closed error categories, fixed user messages and recovery actions without rejected values or underlying decoder details.
- Document private-state versus diagnostic boundaries and the remaining manifest/evaluator migration.

## Validation

- Full Core suite: **243 tests in 21 suites passed**, warnings-as-errors.
- Covers Lume/Tart identity, schema rejection, forged status sources, control-bearing/oversized identity values, Unicode/long paths, installation counts, duplicate capability limits, fixed errors and unknown-field non-propagation.
- Markdown validation and staged diff checks passed.
- Own diff: **453 added lines / 3 files**.

## Scope and merge order

#138 → #139 → this PR. Do not merge the old #55 stack or treat this as issue #14 completion: manifest/evaluator, private persistence, probes and consumer integration are still pending. No provider selected and no hardware evidence created.

Wait for this exact head's green Xcode Cloud and completed Codex review with an original-message 👍 and no unaddressed findings. The owner merges; old branches/tests/review history are preserved.

## Review follow-up

Both initial P2 findings are fixed together in 18bbefd: root/trailing-slash paths are rejected for both executable identities, and provisioning versions/commit hashes may begin with a letter. Full composed Core tests and Markdown checks pass. Fresh exact-head CI/review are required; #141 and later migrations must integrate this parent update before they are merge-ready.