### PR TITLE
Migrate exact-host compatibility manifest entries

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ManifestConnectionVerification.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ManifestConnectionVerification.swift
@@ -39,7 +39,9 @@ public struct ManifestConnectionVerification: Codable, Hashable, Sendable {
         guard text.utf8.prefix(129).count <= 128 else {
             throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not a supported ISO 8601 date")
         }
-        guard let date = (try? Self.dateStyle.parse(text)) ?? (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(text)) else {
+        // FormatStyle.parse may accept a valid prefix. Verification needs the entire value.
+        guard let date = text.wholeMatch(of: Self.dateStyle)?.output
+            ?? text.wholeMatch(of: Date.ISO8601FormatStyle(includingFractionalSeconds: true))?.output else {
             throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not an ISO 8601 date")
         }
         self.init(

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ManifestConnectionVerification.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ManifestConnectionVerification.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Evidence of a real desktop connection for one exact host, attached to a tested entry.
+public struct ManifestConnectionVerification: Codable, Hashable, Sendable {
+    /// Rounded at construction to the precision the encoded form carries, so a value and
+    /// its own decoded form compare equal and hash alike.
+    public let verifiedAt: Date
+    public let hostMacOSVersion: SemanticVersion
+    public let hostMacOSBuild: String
+    /// Where the evidence lives, for example `docs/phase0/compat.md`.
+    public let evidence: String
+
+    public init(verifiedAt: Date, hostMacOSVersion: SemanticVersion, hostMacOSBuild: String, evidence: String) {
+        self.verifiedAt = Self.encodablePrecision(verifiedAt)
+        self.hostMacOSVersion = hostMacOSVersion
+        self.hostMacOSBuild = hostMacOSBuild
+        self.evidence = evidence
+    }
+
+    /// The instant `verifiedAt` becomes once encoded. A `Date` carries far more precision
+    /// than the encoded form does, and keeping the extra digits would mean a value that
+    /// never compares equal to itself after a round trip.
+    private static func encodablePrecision(_ date: Date) -> Date {
+        Date(timeIntervalSinceReferenceDate: date.timeIntervalSinceReferenceDate.rounded())
+    }
+
+    /// `verifiedAt` has one fixed representation, an ISO 8601 string in whole seconds,
+    /// whatever encoder or decoder is used, so a manifest produced with `JSONEncoder`
+    /// reads back through `decode(from:)`. Whole seconds because `ISO8601FormatStyle`'s
+    /// fractional seconds do not survive their own round trip, and when a connection was
+    /// recorded is not a sub-second fact. A document written with fractional seconds still
+    /// decodes; it is rounded like any other input.
+    private enum CodingKeys: String, CodingKey { case verifiedAt, hostMacOSVersion, hostMacOSBuild, evidence }
+    private static let dateStyle = Date.ISO8601FormatStyle()
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let text = try c.decode(String.self, forKey: .verifiedAt)
+        guard text.utf8.prefix(129).count <= 128 else {
+            throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not a supported ISO 8601 date")
+        }
+        guard let date = (try? Self.dateStyle.parse(text)) ?? (try? Date.ISO8601FormatStyle(includingFractionalSeconds: true).parse(text)) else {
+            throw DecodingError.dataCorruptedError(forKey: .verifiedAt, in: c, debugDescription: "not an ISO 8601 date")
+        }
+        self.init(
+            verifiedAt: date,
+            hostMacOSVersion: try c.decode(SemanticVersion.self, forKey: .hostMacOSVersion),
+            hostMacOSBuild: try c.decode(String.self, forKey: .hostMacOSBuild),
+            evidence: try c.decode(String.self, forKey: .evidence)
+        )
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(Self.dateStyle.format(verifiedAt), forKey: .verifiedAt)
+        try c.encode(hostMacOSVersion, forKey: .hostMacOSVersion)
+        try c.encode(hostMacOSBuild, forKey: .hostMacOSBuild)
+        try c.encode(evidence, forKey: .evidence)
+    }
+
+    public func covers(_ tuple: CompatibilityTuple) -> Bool {
+        hostMacOSVersion == tuple.hostMacOSVersion && hostMacOSBuild == tuple.hostMacOSBuild
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/TestedCompatibilityTuple.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/TestedCompatibilityTuple.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// One tested combination. Host macOS is a range; every other field is exact.
+///
+/// Immutable throughout: `verification` names evidence for the combination the other fields
+/// spell out, so editing one field in place would leave the evidence attached to a
+/// combination it never covered. Replacing the whole entry states the pairing again.
+public struct TestedCompatibilityTuple: Codable, Hashable, Sendable {
+    public let hostMacOS: VersionRange
+    public let codexDesktopVersion: String
+    public let codexDesktopBuild: String
+    public let codexDesktopPath: String
+    public let runtimeProtocolVersion: Int
+    public let runtimeProvider: VMProvider
+    public let runtimeVersion: String
+    public let guestMacOSBuild: String
+    public let xcodeBuild: String
+    public let codexCLIVersion: String
+    public let codexCLIPath: String
+    public let codexCLICapabilities: [String]
+    public let githubCLIVersion: String
+    public let provisioningScriptVersion: String
+    /// Present only when a real desktop connection was recorded, and then only for the exact
+    /// host it names.
+    public let verification: ManifestConnectionVerification?
+
+    public init(
+        hostMacOS: VersionRange,
+        codexDesktopVersion: String,
+        codexDesktopBuild: String,
+        codexDesktopPath: String,
+        runtimeProtocolVersion: Int,
+        runtimeProvider: VMProvider,
+        runtimeVersion: String,
+        guestMacOSBuild: String,
+        xcodeBuild: String,
+        codexCLIVersion: String,
+        codexCLIPath: String,
+        codexCLICapabilities: [String] = [],
+        githubCLIVersion: String,
+        provisioningScriptVersion: String,
+        verification: ManifestConnectionVerification? = nil
+    ) {
+        self.hostMacOS = hostMacOS
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.runtimeProvider = runtimeProvider
+        self.runtimeVersion = runtimeVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLICapabilities = CompatibilityTuple.normalize(codexCLICapabilities)
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+        self.verification = verification
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let capabilities = try c.decode([String].self, forKey: .codexCLICapabilities)
+        guard capabilities.count <= CompatibilityTuple.maximumCapabilities else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: "too many capabilities")
+        }
+        self.init(
+            hostMacOS: try c.decode(VersionRange.self, forKey: .hostMacOS),
+            codexDesktopVersion: try c.decode(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decode(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decode(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decode(Int.self, forKey: .runtimeProtocolVersion),
+            runtimeProvider: try c.decode(VMProvider.self, forKey: .runtimeProvider),
+            runtimeVersion: try c.decode(String.self, forKey: .runtimeVersion),
+            guestMacOSBuild: try c.decode(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decode(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decode(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decode(String.self, forKey: .codexCLIPath),
+            // Required, never defaulted: a manifest that omits the key is stale rather than
+            // one that reports a CLI with no capabilities, and the difference decides matches.
+            codexCLICapabilities: capabilities,
+            githubCLIVersion: try c.decode(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decode(String.self, forKey: .provisioningScriptVersion),
+            verification: try c.decodeIfPresent(ManifestConnectionVerification.self, forKey: .verification)
+        )
+    }
+
+    public var isVerified: Bool { verification != nil }
+
+    /// Whether the observed combination is one this entry was tested with. A single CLI
+    /// installation is part of the tested condition.
+    public func matches(_ tuple: CompatibilityTuple) -> Bool {
+        // An invalid observation must never be approved by a similarly malformed entry.
+        guard (try? ConnectionVerificationRecord.validate(tuple)) != nil else { return false }
+        return hostMacOS.contains(tuple.hostMacOSVersion)
+            && codexDesktopVersion == tuple.codexDesktopVersion
+            && codexDesktopBuild == tuple.codexDesktopBuild
+            && codexDesktopPath == tuple.codexDesktopPath
+            && runtimeProtocolVersion == tuple.runtimeProtocolVersion
+            && runtimeProvider == tuple.runtimeProvider
+            && runtimeVersion == tuple.runtimeVersion
+            && guestMacOSBuild == tuple.guestMacOSBuild
+            && xcodeBuild == tuple.xcodeBuild
+            && codexCLIVersion == tuple.codexCLIVersion
+            && codexCLIPath == tuple.codexCLIPath
+            && tuple.codexCLIInstallations == 1
+            && codexCLICapabilities == CompatibilityTuple.normalize(tuple.codexCLICapabilities)
+            && githubCLIVersion == tuple.githubCLIVersion
+            && provisioningScriptVersion == tuple.provisioningScriptVersion
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/TestedCompatibilityTupleTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/TestedCompatibilityTupleTests.swift
@@ -1,0 +1,153 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct TestedCompatibilityTupleTests {
+    static func entry(_ tuple: CompatibilityTuple = CompatibilityTupleTests.tuple(),
+                      verification: ManifestConnectionVerification? = nil) -> TestedCompatibilityTuple {
+        TestedCompatibilityTuple(
+            hostMacOS: VersionRange(minimum: SemanticVersion([26]), maximum: SemanticVersion([27])),
+            codexDesktopVersion: tuple.codexDesktopVersion, codexDesktopBuild: tuple.codexDesktopBuild,
+            codexDesktopPath: tuple.codexDesktopPath, runtimeProtocolVersion: tuple.runtimeProtocolVersion,
+            runtimeProvider: tuple.runtimeProvider, runtimeVersion: tuple.runtimeVersion,
+            guestMacOSBuild: tuple.guestMacOSBuild, xcodeBuild: tuple.xcodeBuild,
+            codexCLIVersion: tuple.codexCLIVersion, codexCLIPath: tuple.codexCLIPath,
+            codexCLICapabilities: tuple.codexCLICapabilities, githubCLIVersion: tuple.githubCLIVersion,
+            provisioningScriptVersion: tuple.provisioningScriptVersion, verification: verification
+        )
+    }
+
+    static func verification(_ tuple: CompatibilityTuple = CompatibilityTupleTests.tuple(),
+                             at time: Double = 1_700_000_000) -> ManifestConnectionVerification {
+        ManifestConnectionVerification(verifiedAt: Date(timeIntervalSince1970: time),
+            hostMacOSVersion: tuple.hostMacOSVersion, hostMacOSBuild: tuple.hostMacOSBuild,
+            evidence: "docs/phase0/synthetic-test-only.md")
+    }
+
+    @Test(arguments: VMProvider.allCases)
+    func exactIdentitySurvivesRoundTrip(_ provider: VMProvider) throws {
+        let tuple = CompatibilityTupleTests.tuple(provider: provider)
+        let entry = Self.entry(tuple, verification: Self.verification(tuple))
+        let decoded = try JSONDecoder().decode(TestedCompatibilityTuple.self, from: JSONEncoder().encode(entry))
+        #expect(decoded == entry)
+        #expect(Set([entry, decoded]).count == 1)
+        #expect(decoded.matches(tuple))
+        #expect(decoded.isVerified)
+        #expect(decoded.verification?.covers(tuple) == true)
+    }
+
+    @Test func equalVersionsFromAnotherProviderDoNotMatch() {
+        let entry = Self.entry(CompatibilityTupleTests.tuple(provider: .tart))
+        #expect(!entry.matches(CompatibilityTupleTests.tuple(provider: .lume)))
+    }
+
+    @Test func testedHostRangeDoesNotBroadenRecordedEvidence() {
+        let original = CompatibilityTupleTests.tuple()
+        let entry = Self.entry(original, verification: Self.verification(original))
+        var observation = original
+        observation.hostMacOSBuild = "25F84"
+        #expect(entry.matches(observation))
+        #expect(entry.verification?.covers(observation) == false)
+        observation = original
+        observation.hostMacOSVersion = SemanticVersion([27])
+        #expect(entry.matches(observation))
+        #expect(entry.verification?.covers(observation) == false)
+        observation.hostMacOSVersion = SemanticVersion([28])
+        #expect(!entry.matches(observation))
+    }
+
+    @Test func unverifiedCandidateDoesNotAcquireEvidence() throws {
+        let entry = Self.entry()
+        #expect(!entry.isVerified)
+        #expect(entry.verification == nil)
+        #expect(try JSONDecoder().decode(TestedCompatibilityTuple.self, from: JSONEncoder().encode(entry)).verification == nil)
+    }
+
+    @Test(arguments: ["runtimeProvider", "runtimeVersion", "codexCLICapabilities"])
+    func requiredIdentityCannotBeDefaultedFromOldManifest(_ key: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.entry())) as? [String: Any])
+        object.removeValue(forKey: key)
+        object["tartVersion"] = "2.36.0"
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(TestedCompatibilityTuple.self, from: JSONSerialization.data(withJSONObject: object))
+        }
+    }
+
+    @Test func duplicateCapabilitiesAreCanonicalButOverLimitCannotMatch() throws {
+        let tuple = CompatibilityTupleTests.tuple(capabilities: ["b", "a", "b"])
+        let entry = Self.entry(tuple)
+        #expect(entry.codexCLICapabilities == ["a", "b"])
+        #expect(entry.matches(CompatibilityTupleTests.tuple(capabilities: ["a", "b"])))
+        let oversized = CompatibilityTupleTests.tuple(capabilities: Array(repeating: "same", count: 65))
+        #expect(!Self.entry(oversized).matches(oversized))
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(TestedCompatibilityTuple.self, from: JSONEncoder().encode(Self.entry(oversized)))
+        }
+    }
+
+    @Test(arguments: [-1, 0, 2])
+    func aTestedEntryCannotApproveAnInvalidInstallationCount(_ count: Int) {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLIInstallations = count
+        #expect(!Self.entry(tuple).matches(tuple))
+    }
+
+    @Test func matchingMalformedIdentityIsNotVerification() {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexDesktopVersion = "1.0\nsyntheticOpaque"
+        #expect(!Self.entry(tuple, verification: Self.verification(tuple)).matches(tuple))
+        tuple = CompatibilityTupleTests.tuple()
+        tuple.runtimeProtocolVersion = 0
+        #expect(!Self.entry(tuple).matches(tuple))
+    }
+
+    @Test func allNonHostIdentityChangesInvalidateEntry() throws {
+        let tuple = CompatibilityTupleTests.tuple()
+        let entry = Self.entry(tuple)
+        let replacements: [CompatibilityField: Any] = [
+            .codexDesktopVersion: "2", .codexDesktopBuild: "2000", .codexDesktopPath: "/Applications/Codex Beta.app",
+            .runtimeProtocolVersion: 2, .runtimeProvider: "tart", .runtimeVersion: "2.36.0",
+            .guestMacOSBuild: "26B1", .xcodeBuild: "18A1", .codexCLIVersion: "0.51.0",
+            .codexCLIPath: "/usr/local/bin/codex", .codexCLIInstallations: 2,
+            .codexCLICapabilities: ["changed"], .githubCLIVersion: "3", .provisioningScriptVersion: "2"
+        ]
+        let original = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(tuple)) as? [String: Any])
+        for (field, value) in replacements {
+            var object = original
+            object[field.rawValue] = value
+            let changed = try JSONDecoder().decode(CompatibilityTuple.self, from: JSONSerialization.data(withJSONObject: object))
+            #expect(!entry.matches(changed), "Changed \(field) must invalidate the entry")
+        }
+        #expect(replacements.count == CompatibilityField.allCases.count - 2)
+    }
+
+    @Test(arguments: [0.1, 0.5, 0.9])
+    func manifestTimestampHasStableWholeSecondIdentity(_ fraction: Double) throws {
+        let verification = Self.verification(at: 1_700_000_000 + fraction)
+        let data = try JSONEncoder().encode(verification)
+        let decoded = try JSONDecoder().decode(ManifestConnectionVerification.self, from: data)
+        #expect(decoded == verification)
+        #expect(Set([verification, decoded]).count == 1)
+        #expect(verification.verifiedAt.timeIntervalSince1970 == (1_700_000_000 + fraction).rounded())
+    }
+
+    @Test func fractionalWireTimestampIsNormalized() throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.verification())) as? [String: Any])
+        object["verifiedAt"] = "2023-11-14T22:13:20.900Z"
+        let decoded = try JSONDecoder().decode(ManifestConnectionVerification.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.verifiedAt == Date(timeIntervalSince1970: 1_700_000_001))
+    }
+
+    @Test(arguments: ["syntheticOpaque", String(repeating: "1", count: 129)])
+    func malformedDateErrorsDoNotQuoteInput(_ text: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.verification())) as? [String: Any])
+        object["verifiedAt"] = text
+        do {
+            _ = try JSONDecoder().decode(ManifestConnectionVerification.self, from: JSONSerialization.data(withJSONObject: object))
+            Issue.record("Expected a date decoding error")
+        } catch DecodingError.dataCorrupted(let context) {
+            #expect(!context.debugDescription.contains(text))
+            #expect(context.underlyingError == nil)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/TestedCompatibilityTupleTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/TestedCompatibilityTupleTests.swift
@@ -138,7 +138,10 @@ struct TestedCompatibilityTupleTests {
         #expect(decoded.verifiedAt == Date(timeIntervalSince1970: 1_700_000_001))
     }
 
-    @Test(arguments: ["syntheticOpaque", String(repeating: "1", count: 129)])
+    @Test(arguments: ["syntheticOpaque", String(repeating: "1", count: 129),
+                      "2023-11-14T22:13:20Zjunk", "2023-11-14T22:13:20.900Zjunk",
+                      "2023-11-14T22:13:20Z\n", "2023-11-14T22:13:20Z ",
+                      "prefix2023-11-14T22:13:20Z", "2023-11-14T23:13:20+01:00junk"])
     func malformedDateErrorsDoNotQuoteInput(_ text: String) throws {
         var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.verification())) as? [String: Any])
         object["verifiedAt"] = text
@@ -149,5 +152,13 @@ struct TestedCompatibilityTupleTests {
             #expect(!context.debugDescription.contains(text))
             #expect(context.underlyingError == nil)
         }
+    }
+
+    @Test(arguments: ["2023-11-14T22:13:20Z", "2023-11-14T22:13:20.000Z", "2023-11-14T23:13:20+01:00"])
+    func completeTimestampsRemainSupported(_ text: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.verification())) as? [String: Any])
+        object["verifiedAt"] = text
+        let decoded = try JSONDecoder().decode(ManifestConnectionVerification.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.verifiedAt == Date(timeIntervalSince1970: 1_700_000_000))
     }
 }


### PR DESCRIPTION
## Purpose
Focused #55 / issue #14 migration, stacked on #140. Implements the tested-combination and exact-host evidence rules in MVP-PLAN.md §§5 and 10 without importing the old sanitizer stack.

## Changes
- Reuse the original immutable tested-entry and ISO 8601 verification models as independently testable types.
- Match explicit runtime provider plus version; never treat equal Lume/Tart version strings as equivalent.
- Preserve all desktop/CLI path, build and capability checks. A host range does not broaden the exact host/build covered by connection evidence.
- Keep capability identity required on decode and bounded before normalization. An invalid observation cannot match an equally malformed entry as verified.
- Preserve whole-second timestamp round trips, including fractional input, with fixed date parse errors.

## Validation
**256 Core tests / 22 suites pass**, warnings-as-errors. Regression coverage includes both providers, every non-host identity dimension, host version/build drift, required fields, invalid installation/protocol/version values, oversized capabilities and timestamp precision. Staged diff checks pass. Own diff: **341 added lines / 3 files**.

## Dependencies and limits
#138 → #139 → #140 → this PR. Manifest container, typed incompatibility rules and evaluator still follow; this does not complete #14 or certify any provider/hardware combination. Types remain private compatibility data, not diagnostic attachments. Original #55/history/tests are preserved.

Wait for exact-head green Xcode Cloud and completed Codex review with an original-message 👍 and no unaddressed findings. The owner merges.

## Review follow-up

The initial timestamp P2 is fixed in 60a29220 using Foundation whole-string matching (not a custom parser). The same publication normally integrates the approved #140 corrections. All composed tests pass; this exact head requires fresh CI and Codex approval. The following manifest/evaluator migrations are tested locally but held from publication until this parent clears, to reduce repeated child CI runs.