### PR TITLE
Migrate provider-aware manifest and typed compatibility blocks

### DIFF
--- a/Packages/GuesthouseCore/Package.swift
+++ b/Packages/GuesthouseCore/Package.swift
@@ -25,6 +25,7 @@ let package = Package(
     targets: [
         .target(
             name: "GuesthouseCore",
+            resources: [.process("Resources")],
             swiftSettings: coreSwiftSettings
         ),
         .testTarget(

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityIncompatibility.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityIncompatibility.swift
@@ -1,0 +1,182 @@
+import Foundation
+
+/// Closed compatibility explanations, never text from a manifest or a process.
+public enum CompatibilityBlockReason: Codable, Hashable, Sendable {
+    case knownIncompatibleCombination
+    case incompatibleComponent(CompatibilityField)
+
+    public var userMessage: String {
+        switch self {
+        case .knownIncompatibleCombination:
+            "This combination is known not to support a Codex desktop connection. Use the offered repair path while the environment is idle before connecting again."
+        case .incompatibleComponent(let field):
+            "The current \(field.title) is incompatible with this development setup. Use the offered repair path while the environment is idle before connecting again."
+        }
+    }
+}
+
+/// A combination known not to work. Every specified field must match the observed value
+/// for the rule to apply; an unknown observed field never triggers it. A rule can single
+/// out one CLI executable, one capability set, or one desktop bundle, so a broken
+/// installation can be blocked without blocking a working one of the same version.
+///
+/// Immutable throughout: a rule blocks handoff, and the evaluator hands its `reason` and
+/// `recoveryActions` straight to the GUI, so both invariants below have to survive from
+/// construction to the moment the rule fires.
+public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
+    /// What stays available when a rule fires: a targeted repair of the tools whose
+    /// combination is blocked, the console, work export, and stopping the environment (the
+    /// persistent stop control is never an error button).
+    ///
+    /// The repair leads: a blocked combination that offered only console access and export
+    /// would refuse every new handoff with no way out of it, and MVP-PLAN.md §5 asks for a
+    /// route back rather than a dead end.
+    public static let defaultRecoveryActions: [RecoveryAction] = [.repair(.tools), .openConsole, .exportWork, .cancel]
+
+    /// A rule's own actions with everything §5 requires of a blocked state added back.
+    ///
+    /// MVP-PLAN.md §5 asks for an idle-time repair path for known-incompatible versions and
+    /// says to "preserve console access, shutdown, and work export in **every** state", so
+    /// this is not something a rule gets to choose. Expecting each rule to name the right
+    /// actions itself was enough while the manifest was written here, but the rules are data:
+    /// a `[.cancel]` in a decoded manifest, or an updated one that simply lists fewer, would
+    /// otherwise hand the GUI a blocked handoff and a single dead end.
+    ///
+    /// The rule's own actions keep their order and lead, because they were written for this
+    /// combination — except that a repair goes in front of them when the rule names none,
+    /// which is where `defaultRecoveryActions` puts it and why. A repair the rule does name
+    /// counts as the repair whatever it repairs: some incompatibilities are not fixed by the
+    /// tools flow, and offering a second button that cannot help is worse than none.
+    static func completed(_ actions: [RecoveryAction]) -> [RecoveryAction] {
+        let namesARepair = actions.contains { if case .repair = $0 { true } else { false } }
+        var completed: [RecoveryAction] = namesARepair ? [] : [.repair(.tools)]
+        completed += actions
+        for required in defaultRecoveryActions {
+            // A repair is present either way by now, its own or the default one; asking
+            // whether *this* repair is present would add the tools flow beside it.
+            if case .repair = required { continue }
+            guard !completed.contains(required) else { continue }
+            completed.append(required)
+        }
+        return completed
+    }
+
+    public let hostMacOS: VersionRange?
+    public let hostMacOSBuild: String?
+    public let codexDesktopVersion: String?
+    public let codexDesktopBuild: String?
+    public let codexDesktopPath: String?
+    public let runtimeProtocolVersion: Int?
+    public let runtimeProvider: VMProvider?
+    public let runtimeVersion: String?
+    public let guestMacOSBuild: String?
+    public let xcodeBuild: String?
+    public let codexCLIVersion: String?
+    public let codexCLIPath: String?
+    /// Matches when the observed capability list, normalized, equals this list.
+    public let codexCLICapabilities: [String]?
+    public let githubCLIVersion: String?
+    public let provisioningScriptVersion: String?
+    /// Why handoff is blocked. Closed cases provide fixed Guesthouse-owned messages.
+    public let reason: CompatibilityBlockReason
+    /// What the GUI offers when this rule fires. Never empty.
+    public let recoveryActions: [RecoveryAction]
+
+    public init(
+        hostMacOS: VersionRange? = nil,
+        hostMacOSBuild: String? = nil,
+        codexDesktopVersion: String? = nil,
+        codexDesktopBuild: String? = nil,
+        codexDesktopPath: String? = nil,
+        runtimeProtocolVersion: Int? = nil,
+        runtimeProvider: VMProvider? = nil,
+        runtimeVersion: String? = nil,
+        guestMacOSBuild: String? = nil,
+        xcodeBuild: String? = nil,
+        codexCLIVersion: String? = nil,
+        codexCLIPath: String? = nil,
+        codexCLICapabilities: [String]? = nil,
+        githubCLIVersion: String? = nil,
+        provisioningScriptVersion: String? = nil,
+        reason: CompatibilityBlockReason,
+        recoveryActions: [RecoveryAction] = CompatibilityIncompatibility.defaultRecoveryActions
+    ) {
+        self.hostMacOS = hostMacOS
+        self.hostMacOSBuild = hostMacOSBuild
+        self.codexDesktopVersion = codexDesktopVersion
+        self.codexDesktopBuild = codexDesktopBuild
+        self.codexDesktopPath = codexDesktopPath
+        self.runtimeProtocolVersion = runtimeProtocolVersion
+        self.runtimeProvider = runtimeProvider
+        self.runtimeVersion = runtimeVersion
+        self.guestMacOSBuild = guestMacOSBuild
+        self.xcodeBuild = xcodeBuild
+        self.codexCLIVersion = codexCLIVersion
+        self.codexCLIPath = codexCLIPath
+        self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
+        self.githubCLIVersion = githubCLIVersion
+        self.provisioningScriptVersion = provisioningScriptVersion
+        self.reason = reason
+        self.recoveryActions = Self.completed(recoveryActions)
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let reason = try c.decode(CompatibilityBlockReason.self, forKey: .reason)
+        let capabilities = try c.decodeIfPresent([String].self, forKey: .codexCLICapabilities)
+        guard capabilities.map({ $0.count <= CompatibilityTuple.maximumCapabilities }) ?? true else {
+            throw DecodingError.dataCorruptedError(forKey: .codexCLICapabilities, in: c, debugDescription: "too many capabilities")
+        }
+        self.init(
+            hostMacOS: try c.decodeIfPresent(VersionRange.self, forKey: .hostMacOS),
+            hostMacOSBuild: try c.decodeIfPresent(String.self, forKey: .hostMacOSBuild),
+            codexDesktopVersion: try c.decodeIfPresent(String.self, forKey: .codexDesktopVersion),
+            codexDesktopBuild: try c.decodeIfPresent(String.self, forKey: .codexDesktopBuild),
+            codexDesktopPath: try c.decodeIfPresent(String.self, forKey: .codexDesktopPath),
+            runtimeProtocolVersion: try c.decodeIfPresent(Int.self, forKey: .runtimeProtocolVersion),
+            runtimeProvider: try c.decodeIfPresent(VMProvider.self, forKey: .runtimeProvider),
+            runtimeVersion: try c.decodeIfPresent(String.self, forKey: .runtimeVersion),
+            guestMacOSBuild: try c.decodeIfPresent(String.self, forKey: .guestMacOSBuild),
+            xcodeBuild: try c.decodeIfPresent(String.self, forKey: .xcodeBuild),
+            codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
+            codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
+            codexCLICapabilities: capabilities,
+            githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
+            provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion),
+            reason: reason,
+            recoveryActions: try c.decodeIfPresent([RecoveryAction].self, forKey: .recoveryActions) ?? Self.defaultRecoveryActions
+        )
+    }
+
+    public func applies(to observed: ObservedTuple) -> Bool {
+        func check<T: Equatable>(_ rule: T?, _ value: T?) -> Bool {
+            guard let rule else { return true }
+            guard let value else { return false }
+            return rule == value
+        }
+        let hostInRange: Bool
+        if let hostMacOS {
+            guard let version = observed.hostMacOSVersion else { return false }
+            hostInRange = hostMacOS.contains(version)
+        } else {
+            hostInRange = true
+        }
+        return hostInRange
+            && check(hostMacOSBuild, observed.hostMacOSBuild)
+            && check(codexDesktopVersion, observed.codexDesktopVersion)
+            && check(codexDesktopBuild, observed.codexDesktopBuild)
+            && check(codexDesktopPath, observed.codexDesktopPath)
+            && check(runtimeProtocolVersion, observed.runtimeProtocolVersion)
+            && check(runtimeProvider, observed.runtimeProvider)
+            && check(runtimeVersion, observed.runtimeVersion)
+            && check(guestMacOSBuild, observed.guestMacOSBuild)
+            && check(xcodeBuild, observed.xcodeBuild)
+            && check(codexCLIVersion, observed.codexCLIVersion)
+            && check(codexCLIPath, observed.codexCLIPath)
+            // The rule's list is normalized at construction; an observation assembled field
+            // by field need not be, and order must never decide whether a rule fires.
+            && check(codexCLICapabilities, observed.codexCLICapabilities.map(CompatibilityTuple.normalize))
+            && check(githubCLIVersion, observed.githubCLIVersion)
+            && check(provisioningScriptVersion, observed.provisioningScriptVersion)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityIncompatibility.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityIncompatibility.swift
@@ -73,6 +73,8 @@ public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
     public let xcodeBuild: String?
     public let codexCLIVersion: String?
     public let codexCLIPath: String?
+    /// An exact installation-count selector; nil leaves this dimension unconstrained.
+    public let codexCLIInstallations: Int?
     /// Matches when the observed capability list, normalized, equals this list.
     public let codexCLICapabilities: [String]?
     public let githubCLIVersion: String?
@@ -95,6 +97,7 @@ public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
         xcodeBuild: String? = nil,
         codexCLIVersion: String? = nil,
         codexCLIPath: String? = nil,
+        codexCLIInstallations: Int? = nil,
         codexCLICapabilities: [String]? = nil,
         githubCLIVersion: String? = nil,
         provisioningScriptVersion: String? = nil,
@@ -113,6 +116,7 @@ public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
         self.xcodeBuild = xcodeBuild
         self.codexCLIVersion = codexCLIVersion
         self.codexCLIPath = codexCLIPath
+        self.codexCLIInstallations = codexCLIInstallations
         self.codexCLICapabilities = codexCLICapabilities.map(CompatibilityTuple.normalize)
         self.githubCLIVersion = githubCLIVersion
         self.provisioningScriptVersion = provisioningScriptVersion
@@ -140,6 +144,7 @@ public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
             xcodeBuild: try c.decodeIfPresent(String.self, forKey: .xcodeBuild),
             codexCLIVersion: try c.decodeIfPresent(String.self, forKey: .codexCLIVersion),
             codexCLIPath: try c.decodeIfPresent(String.self, forKey: .codexCLIPath),
+            codexCLIInstallations: try c.decodeIfPresent(Int.self, forKey: .codexCLIInstallations),
             codexCLICapabilities: capabilities,
             githubCLIVersion: try c.decodeIfPresent(String.self, forKey: .githubCLIVersion),
             provisioningScriptVersion: try c.decodeIfPresent(String.self, forKey: .provisioningScriptVersion),
@@ -173,6 +178,7 @@ public struct CompatibilityIncompatibility: Codable, Hashable, Sendable {
             && check(xcodeBuild, observed.xcodeBuild)
             && check(codexCLIVersion, observed.codexCLIVersion)
             && check(codexCLIPath, observed.codexCLIPath)
+            && check(codexCLIInstallations, observed.codexCLIInstallations)
             // The rule's list is normalized at construction; an observation assembled field
             // by field need not be, and order must never decide whether a rule fires.
             && check(codexCLICapabilities, observed.codexCLICapabilities.map(CompatibilityTuple.normalize))

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityManifest.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+/// The versioned list of combinations Guesthouse has tested, shipped with the app
+/// (MVP-PLAN.md §10, Phase 2: "Keep a versioned compatibility manifest").
+///
+/// A tested tuple is not the same as a verified one. A tested entry supports a range of host
+/// macOS versions; its `verification`, if any, names the exact host version and build on
+/// which a real Codex desktop connection was recorded, and only that exact host counts.
+public struct CompatibilityManifest: Codable, Hashable, Sendable {
+    public typealias Verification = ManifestConnectionVerification
+    public typealias TestedTuple = TestedCompatibilityTuple
+    public typealias KnownIncompatibility = CompatibilityIncompatibility
+    /// Provider-aware manifest layout, independent of other persisted model epochs.
+    public static let currentSchema = SchemaVersion(2)!
+    public let schemaVersion: SchemaVersion
+    /// Monotonic manifest revision, independent of the record schema.
+    public let manifestVersion: Int
+    public let notes: String?
+    public let tested: [TestedTuple]
+    public let incompatibilities: [KnownIncompatibility]
+
+    public init(
+        schemaVersion: SchemaVersion = Self.currentSchema,
+        manifestVersion: Int,
+        notes: String? = nil,
+        tested: [TestedTuple],
+        incompatibilities: [KnownIncompatibility] = []
+    ) throws(CompatibilityManifestError) {
+        guard schemaVersion == Self.currentSchema else {
+            throw .unsupportedSchema(found: schemaVersion, supported: Self.currentSchema)
+        }
+        guard manifestVersion > 0 else { throw .malformedManifest }
+        self.schemaVersion = schemaVersion
+        self.manifestVersion = manifestVersion
+        self.notes = notes
+        self.tested = tested
+        self.incompatibilities = incompatibilities
+    }
+
+    /// Refuses any schema this build cannot interpret: a newer document may carry a
+    /// compatibility dimension this evaluator would silently ignore. The check lives here so
+    /// that a plain `JSONDecoder().decode(CompatibilityManifest.self, from:)` enforces it too.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let schemaVersion = try c.decode(SchemaVersion.self, forKey: .schemaVersion)
+        guard schemaVersion == Self.currentSchema else {
+            throw CompatibilityManifestError.unsupportedSchema(found: schemaVersion, supported: Self.currentSchema)
+        }
+        try self.init(
+            schemaVersion: schemaVersion,
+            manifestVersion: try c.decode(Int.self, forKey: .manifestVersion),
+            notes: try c.decodeIfPresent(String.self, forKey: .notes),
+            tested: try c.decode([TestedTuple].self, forKey: .tested),
+            incompatibilities: try c.decode([KnownIncompatibility].self, forKey: .incompatibilities)
+        )
+    }
+
+    /// The manifest shipped inside this package.
+    public static func bundled() throws(CompatibilityManifestError) -> CompatibilityManifest {
+        guard let url = Bundle.module.url(forResource: "compatibility-manifest", withExtension: "json"),
+              let data = try? Data(contentsOf: url)
+        else {
+            throw CompatibilityManifestError.unreadableManifest
+        }
+        return try decode(from: data)
+    }
+
+    /// Decodes a manifest, reporting every failure as something the user can act on rather than
+    /// as a raw decoding fault: the only manifest the app reads is one it shipped with, so a
+    /// failure here means the installation, not the document, is wrong.
+    public static func decode(from data: Data) throws(CompatibilityManifestError) -> CompatibilityManifest {
+        do {
+            return try JSONDecoder().decode(CompatibilityManifest.self, from: data)
+        } catch let error as CompatibilityManifestError {
+            throw error
+        } catch {
+            throw CompatibilityManifestError.malformedManifest
+        }
+    }
+}
+
+public enum CompatibilityManifestError: Error, Hashable, Sendable, LocalizedError {
+    case unsupportedSchema(found: SchemaVersion, supported: SchemaVersion)
+    /// The shipped resource is missing from the bundle or could not be read.
+    case unreadableManifest
+    /// The document is not a compatibility manifest this build can parse. What was found is
+    /// deliberately not quoted; resource content does not belong in a user-facing message.
+    case malformedManifest
+
+    public var userMessage: String {
+        switch self {
+        case .unsupportedSchema(let found, let supported):
+            "The compatibility list shipped with this copy of Guesthouse uses format \(found.rawValue), which this version reads as \(supported.rawValue). The app and its resources do not match; reinstall Guesthouse."
+        case .unreadableManifest:
+            "The compatibility list shipped with this copy of Guesthouse is missing or cannot be read. The installation is damaged; reinstall Guesthouse."
+        case .malformedManifest:
+            "The compatibility list shipped with this copy of Guesthouse is not a list this version can read. The installation is damaged; reinstall Guesthouse."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] { [.reinstallApp, .cancel] }
+    public var errorDescription: String? { userMessage }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Resources/compatibility-manifest.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 2,
+  "manifestVersion": 1,
+  "notes": "No provider combination is approved by bundled connection evidence. Lume remains a candidate pending human validation; legacy Tart placeholders are not Lume evidence.",
+  "tested": [],
+  "incompatibilities": []
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityManifestTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityManifestTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct CompatibilityManifestTests {
+    static func manifest() throws -> CompatibilityManifest {
+        try CompatibilityManifest(manifestVersion: 1, tested: [TestedCompatibilityTupleTests.entry()],
+            incompatibilities: [.init(runtimeProvider: .tart, runtimeVersion: "2.36.0", reason: .incompatibleComponent(.runtimeVersion))])
+    }
+
+    @Test func currentManifestRoundTripsWithTypedReasons() throws {
+        let manifest = try Self.manifest()
+        #expect(try CompatibilityManifest.decode(from: JSONEncoder().encode(manifest)) == manifest)
+        #expect(manifest.schemaVersion.rawValue == 2)
+        #expect(manifest.incompatibilities.first?.reason.userMessage.contains("runtime version") == true)
+    }
+
+    @Test func bundledResourceDoesNotInventProviderEvidence() throws {
+        let manifest = try CompatibilityManifest.bundled()
+        #expect(manifest.tested.isEmpty)
+        #expect(manifest.incompatibilities.isEmpty)
+        #expect(manifest.schemaVersion == CompatibilityManifest.currentSchema)
+    }
+
+    @Test(arguments: [1, 3])
+    func wrongSchemasFailThroughEveryEntryPoint(_ version: Int) throws {
+        let schema = try #require(SchemaVersion(version))
+        let expected = CompatibilityManifestError.unsupportedSchema(found: schema, supported: .init(2)!)
+        #expect(throws: expected) { try CompatibilityManifest(schemaVersion: schema, manifestVersion: 1, tested: []) }
+        let data = Data("{\"schemaVersion\":\(version),\"manifestVersion\":1,\"tested\":[],\"incompatibilities\":[]}".utf8)
+        #expect(throws: expected) { try CompatibilityManifest.decode(from: data) }
+        #expect(throws: expected) { try JSONDecoder().decode(CompatibilityManifest.self, from: data) }
+    }
+
+    @Test(arguments: [-1, 0])
+    func revisionMustBePositive(_ revision: Int) {
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest(manifestVersion: revision, tested: [])
+        }
+    }
+
+    @Test(arguments: ["syntheticOpaque", "{}", "{\"schemaVersion\":2}"])
+    func malformedResourceUsesFixedRecovery(_ text: String) {
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: Data(text.utf8))
+        }
+        #expect(!CompatibilityManifestError.malformedManifest.userMessage.contains(text))
+        #expect(CompatibilityManifestError.malformedManifest.recoveryActions == [.reinstallApp, .cancel])
+        #expect(CompatibilityManifestError.unreadableManifest.errorDescription == CompatibilityManifestError.unreadableManifest.userMessage)
+    }
+
+    @Test func providerScopedRuleDoesNotBlockAnotherRuntime() {
+        let rule = CompatibilityIncompatibility(runtimeProvider: .tart, runtimeVersion: "0.5.3", reason: .knownIncompatibleCombination)
+        #expect(rule.applies(to: ObservedTuple(CompatibilityTupleTests.tuple(provider: .tart))))
+        #expect(!rule.applies(to: ObservedTuple(CompatibilityTupleTests.tuple(provider: .lume))))
+        var unknown = ObservedTuple(CompatibilityTupleTests.tuple(provider: .tart))
+        unknown.runtimeProvider = nil
+        #expect(!rule.applies(to: unknown))
+    }
+
+    @Test func rulesRetainIdentitySelectorsAndUnknownDoesNotMatch() {
+        let tuple = CompatibilityTupleTests.tuple(capabilities: ["a", "b"])
+        let rule = CompatibilityIncompatibility(
+            hostMacOS: VersionRange(minimum: SemanticVersion([26]), maximum: SemanticVersion([27])),
+            hostMacOSBuild: tuple.hostMacOSBuild, codexDesktopVersion: tuple.codexDesktopVersion,
+            codexDesktopBuild: tuple.codexDesktopBuild, codexDesktopPath: tuple.codexDesktopPath,
+            runtimeProtocolVersion: tuple.runtimeProtocolVersion, runtimeProvider: tuple.runtimeProvider,
+            runtimeVersion: tuple.runtimeVersion, guestMacOSBuild: tuple.guestMacOSBuild, xcodeBuild: tuple.xcodeBuild,
+            codexCLIVersion: tuple.codexCLIVersion, codexCLIPath: tuple.codexCLIPath, codexCLICapabilities: ["b", "a", "b"],
+            githubCLIVersion: tuple.githubCLIVersion, provisioningScriptVersion: tuple.provisioningScriptVersion,
+            reason: .incompatibleComponent(.codexCLIVersion)
+        )
+        var observed = ObservedTuple(tuple)
+        #expect(rule.applies(to: observed))
+        observed.codexCLICapabilities = ["b", "a", "b"]
+        #expect(rule.applies(to: observed))
+        observed.codexCLIPath = nil
+        #expect(!rule.applies(to: observed))
+        observed = ObservedTuple(tuple)
+        observed.hostMacOSVersion = SemanticVersion([28])
+        #expect(!rule.applies(to: observed))
+        observed = ObservedTuple(tuple)
+        observed.hostMacOSVersion = nil
+        #expect(!rule.applies(to: observed))
+        observed = ObservedTuple(tuple)
+        observed.codexDesktopPath = "/Applications/Codex Beta.app"
+        #expect(!rule.applies(to: observed))
+    }
+
+    @Test func recoveryCannotBeRemovedButTargetedRepairIsPreserved() throws {
+        for actions: [RecoveryAction] in [[], [.cancel], [.repair(.runtime)]] {
+            let rule = CompatibilityIncompatibility(reason: .knownIncompatibleCombination, recoveryActions: actions)
+            let decoded = try JSONDecoder().decode(CompatibilityIncompatibility.self, from: JSONEncoder().encode(rule))
+            #expect(decoded == rule)
+            #expect(decoded.recoveryActions.contains(.openConsole))
+            #expect(decoded.recoveryActions.contains(.exportWork))
+            #expect(decoded.recoveryActions.contains(.cancel))
+            #expect(decoded.recoveryActions.contains(actions.contains(.repair(.runtime)) ? .repair(.runtime) : .repair(.tools)))
+            if actions.contains(.repair(.runtime)) { #expect(!decoded.recoveryActions.contains(.repair(.tools))) }
+        }
+    }
+
+    @Test(arguments: ["", "syntheticOpaque", "knownIncompatibleCombination"])
+    func rawStringReasonsCannotEnterTheManifest(_ rawReason: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.manifest())) as? [String: Any])
+        object["incompatibilities"] = [["reason": rawReason]]
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: JSONSerialization.data(withJSONObject: object))
+        }
+    }
+
+    @Test func excessiveRuleCapabilitiesCannotNormalizeIntoAValidDocument() throws {
+        let rule = CompatibilityIncompatibility(codexCLICapabilities: Array(repeating: "same", count: 65), reason: .knownIncompatibleCombination)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(CompatibilityIncompatibility.self, from: JSONEncoder().encode(rule))
+        }
+    }
+
+    @Test func unknownTranscriptFieldsDoNotPropagate() throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.manifest())) as? [String: Any])
+        object["rawOutput"] = "syntheticOpaque"
+        let decoded = try CompatibilityManifest.decode(from: JSONSerialization.data(withJSONObject: object))
+        #expect(!String(decoding: try JSONEncoder().encode(decoded), as: UTF8.self).contains("syntheticOpaque"))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityManifestTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityManifestTests.swift
@@ -87,6 +87,43 @@ struct CompatibilityManifestTests {
         #expect(!rule.applies(to: observed))
     }
 
+    @Test(arguments: [0, 2, 3])
+    func installationCountRuleMatchesOnlyItsKnownCount(_ count: Int) throws {
+        let rule = CompatibilityIncompatibility(codexCLIInstallations: count, reason: .incompatibleComponent(.codexCLIInstallations))
+        let manifest = try CompatibilityManifest(manifestVersion: 1, tested: [], incompatibilities: [rule])
+        let decoded = try CompatibilityManifest.decode(from: JSONEncoder().encode(manifest))
+        let decodedRule = try #require(decoded.incompatibilities.first)
+        #expect(decoded == manifest)
+        #expect(decodedRule.codexCLIInstallations == count)
+        var observed = ObservedTuple(CompatibilityTupleTests.tuple())
+        observed.codexCLIInstallations = count
+        #expect(decodedRule.applies(to: observed))
+        observed.codexCLIInstallations = 1
+        #expect(!decodedRule.applies(to: observed))
+        observed.codexCLIInstallations = nil
+        #expect(!decodedRule.applies(to: observed))
+    }
+
+    @Test func omittedInstallationSelectorDoesNotAddAConstraint() throws {
+        let rule = CompatibilityIncompatibility(reason: .knownIncompatibleCombination)
+        let data = try JSONEncoder().encode(rule)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["codexCLIInstallations"] == nil)
+        let decoded = try JSONDecoder().decode(CompatibilityIncompatibility.self, from: data)
+        #expect(decoded.codexCLIInstallations == nil)
+        #expect(decoded.applies(to: ObservedTuple()))
+    }
+
+    @Test func malformedInstallationSelectorIsNotSilentlyIgnored() throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.manifest())) as? [String: Any])
+        var rules = try #require(object["incompatibilities"] as? [[String: Any]])
+        rules[0]["codexCLIInstallations"] = "syntheticOpaque"
+        object["incompatibilities"] = rules
+        #expect(throws: CompatibilityManifestError.malformedManifest) {
+            try CompatibilityManifest.decode(from: JSONSerialization.data(withJSONObject: object))
+        }
+    }
+
     @Test func recoveryCannotBeRemovedButTargetedRepairIsPreserved() throws {
         for actions: [RecoveryAction] in [[], [.cancel], [.repair(.runtime)]] {
             let rule = CompatibilityIncompatibility(reason: .knownIncompatibleCombination, recoveryActions: actions)

--- a/docs/compatibility-migration.md
+++ b/docs/compatibility-migration.md
@@ -32,4 +32,8 @@ Neither `CompatibilityTuple` nor `ConnectionVerificationRecord` is a `Diagnostic
 
 ## Remaining integration
 
-The numeric-version, provider-aware tuple and connection-record changes are independently reviewed prerequisites. They do not yet replace #55's compatibility manifest and evaluator, implement probes or persistence, or certify a Lume configuration. Those components must migrate before issue #14 is complete. Preserve the old PR's remaining behavior and useful tests without importing its redactor ancestry. Hardware evidence remains a separate human gate.
+The numeric-version, tuple, record, manifest-entry and manifest-container changes are independently reviewed prerequisites. The provider-aware manifest uses its own schema 2 and typed incompatibility reasons; unknown schemas and raw-string reasons are rejected. Its notes and evidence references are private resource data, not error messages or diagnostic attachments.
+
+The bundled manifest deliberately has no tested or verified combinations. The original Tart seed contained placeholders, not Lume evidence; it remains available in #55's preserved branch. Only actual validation should populate the active resource. This does not waive provider-selection or hardware gates.
+
+The evaluator still needs migration before issue #14 is complete. These models do not implement probes or persistence, or certify a Lume configuration. Preserve the old PR's remaining behavior and useful tests without importing its redactor ancestry. Runtime/XPC/GUI consumers require their own integration tests and review.


### PR DESCRIPTION
## Purpose

Continue the focused replacement of #55 / issue #14, stacked on the now-approved #141. Implements MVP-PLAN.md §§5 and 10 under ADR 0002/0003 without importing old sanitizer ancestry.

## Changes

- Provider-aware immutable manifest, with its own schema 2, positive revision and fixed decode/resource errors.
- Preserve all original rule selectors (host, desktop, runtime, CLI paths/capabilities, guest and provisioning identity) plus explicit runtime provider and exact Codex CLI installation count.
- Replace arbitrary blocking-reason strings with closed CompatibilityBlockReason values and Guesthouse-owned messages.
- Preserve targeted repairs and required blocked-state recovery; missing observed selectors do not match a rule.
- Retain the original nested API names as aliases to the independently tested entry types from #141.
- Bundle an explicitly unverified empty candidate manifest. Old Tart placeholders remain in the preserved #55 branch, not repurposed as Lume evidence.

## Validation

**270 Core tests / 23 suites pass**, warnings-as-errors, including the finalized #140/#141 review corrections. Tests cover schema/revision rejection, resource round trip, required identity, typed reasons, selectors, provider isolation, capability bounds, recovery completion and unknown-field non-propagation. Markdown and diff checks pass.

Own diff: **467 changed lines / 6 files**.

## Scope and merge order

#138 → #139 → #140 → #141 → this PR. The evaluator migration is committed and tested locally but will be published after this parent clears, to limit repeated downstream CI. Private manifest notes/identity/evidence references are not diagnostic attachments. No runtime probes, persistence, provider selection or hardware certification is claimed; #14 is not closed by this intermediate PR.

Wait for exact-head green Xcode Cloud and a matching completed Codex review with an original-message 👍 and no unresolved findings. The owner merges.

## Review follow-up

The missing installation-count selector (P2) is fixed in 5db4e27f with round-trip, exact-match, repaired/unknown-count, omitted-selector and malformed-input coverage. The composed evaluator also passes 284 tests locally and remains unpublished while this parent gets fresh CI and Codex approval.