### PR TITLE
Migrate compatibility evaluation to typed decisions

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/CompatibilityEvaluator.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// The three states MVP-PLAN.md §5 defines for a Codex handoff.
+public enum CompatibilityState: Codable, Hashable, Sendable {
+    /// This exact combination has a recorded real desktop connection.
+    case verified(recordedAt: Date)
+    /// Handoff is allowed only after the user performs and confirms a real desktop connection.
+    case needsValidation(NeedsValidationReason)
+    /// Handoff is blocked. Console access, shutdown, and work export stay available; the
+    /// rule names what else the user can do.
+    case incompatible(reason: CompatibilityBlockReason, recoveryActions: [RecoveryAction])
+
+    public enum NeedsValidationReason: Codable, Hashable, Sendable {
+        /// At least one component could not be identified. Never guess; ask for validation.
+        case unknownFields([CompatibilityField])
+        /// The guest login shell can see more than one Codex executable.
+        case competingInstallations(count: Int)
+        /// The guest login shell can see no Codex executable at all: a missing prerequisite,
+        /// not something a real desktop connection could validate.
+        case codexCLIMissing
+        /// A known combination, but no real connection has ever been recorded for it.
+        case neverConnected
+        /// The manifest records a connection for this combination, but on a different host
+        /// version or build than the one observed.
+        case verifiedOnDifferentHost
+        /// Something changed since the last recorded connection.
+        case changedSinceLastVerified([CompatibilityField])
+        /// This combination is not in the manifest at all.
+        case untestedCombination
+    }
+
+    public var allowsHandoff: Bool {
+        if case .verified = self { return true }
+        return false
+    }
+}
+
+/// Pure decision logic. No I/O; the caller supplies what it observed and what it remembers.
+public enum CompatibilityEvaluator: Sendable {
+    /// - Parameters:
+    ///   - observed: what was read from the host, desktop app, and guest right now.
+    ///   - manifest: the shipped list of tested combinations.
+    ///   - history: previously recorded real connections, in any order.
+    public static func evaluate(
+        observed: ObservedTuple,
+        manifest: CompatibilityManifest,
+        history: [ConnectionVerificationRecord]
+    ) -> CompatibilityState {
+        if let rule = manifest.incompatibilities.first(where: { $0.applies(to: observed) }) {
+            return .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions)
+        }
+
+        // No probe can see fewer than zero executables, so a count that says so is corrupt
+        // rather than a report of the single unambiguous installation a handoff needs.
+        if let installations = observed.codexCLIInstallations, installations < 0 {
+            return .needsValidation(.unknownFields([.codexCLIInstallations]))
+        }
+
+        // Runtime protocol epochs are positive. Invalid observations cannot become verified
+        // merely because an equally malformed value was persisted or shipped in a manifest.
+        if let protocolVersion = observed.runtimeProtocolVersion, protocolVersion <= 0 {
+            return .needsValidation(.unknownFields([.runtimeProtocolVersion]))
+        }
+
+        // A probe that found no executable is decisive on its own, whatever else is unknown.
+        if observed.codexCLIInstallations == 0 {
+            return .needsValidation(.codexCLIMissing)
+        }
+
+        // So is a probe that found several: refusing to name one of them is why the version and
+        // path are unknown, and reporting that as missing fields hides the actual problem.
+        if let installations = observed.codexCLIInstallations, installations > 1 {
+            return .needsValidation(.competingInstallations(count: installations))
+        }
+
+        let unknown = observed.unknownFields
+        guard unknown.isEmpty, let exact = observed.exact else {
+            return .needsValidation(.unknownFields(unknown))
+        }
+
+        do {
+            try ConnectionVerificationRecord.validate(exact)
+        } catch {
+            if case .implausibleObservation(let field) = error {
+                return .needsValidation(.unknownFields([field]))
+            }
+            return .needsValidation(.unknownFields(CompatibilityField.allCases))
+        }
+
+        if let record = history.filter({ $0.tuple == exact }).max(by: { $0.verifiedAt < $1.verifiedAt }) {
+            return .verified(recordedAt: record.verifiedAt)
+        }
+
+        // Official evidence for this exact combination counts regardless of what else the user
+        // connected before; only then does unrelated history mean drift. Host ranges may
+        // overlap, so every matching entry is asked, not only the first: one entry per tested
+        // host build is the natural way to record two verifications of one combination. When
+        // several cover this exact host, report its last successful connection (§5).
+        let matching = manifest.tested.filter { $0.matches(exact) }
+        if let verification = matching.compactMap(\.verification)
+            .filter({ $0.covers(exact) })
+            .max(by: { $0.verifiedAt < $1.verifiedAt }) {
+            return .verified(recordedAt: verification.verifiedAt)
+        }
+
+        if let latest = history.max(by: { $0.verifiedAt < $1.verifiedAt }) {
+            return .needsValidation(.changedSinceLastVerified(exact.differences(from: latest.tuple)))
+        }
+
+        guard !matching.isEmpty else {
+            return .needsValidation(.untestedCombination)
+        }
+        guard matching.contains(where: \.isVerified) else {
+            return .needsValidation(.neverConnected)
+        }
+        return .needsValidation(.verifiedOnDifferentHost)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityEvaluatorTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityEvaluatorTests.swift
@@ -106,6 +106,20 @@ struct CompatibilityEvaluatorTests {
         #expect(try Self.evaluate(unknown, rules: [rule]) == .needsValidation(.unknownFields([.codexCLIVersion])))
     }
 
+    @Test func repairingDuplicateInstallationsClearsOnlyTheCountSpecificBlock() throws {
+        let rule = CompatibilityIncompatibility(codexCLIInstallations: 2, reason: .incompatibleComponent(.codexCLIInstallations))
+        let manifest = try CompatibilityManifest(manifestVersion: 1, tested: [], incompatibilities: [rule])
+        let decodedRules = try CompatibilityManifest.decode(from: JSONEncoder().encode(manifest)).incompatibilities
+        let history = [try Self.record()]
+        var observed = ObservedTuple(CompatibilityTupleTests.tuple())
+        observed.codexCLIInstallations = 2
+        #expect(try Self.evaluate(observed, rules: decodedRules, history: history) == .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions))
+        observed.codexCLIInstallations = 1
+        #expect(try Self.evaluate(observed, rules: decodedRules, history: history) == .verified(recordedAt: history[0].verifiedAt))
+        observed.codexCLIInstallations = nil
+        #expect(try Self.evaluate(observed, rules: decodedRules, history: history) == .needsValidation(.unknownFields([.codexCLIInstallations])))
+    }
+
     @Test func firstMatchingRuleAndItsTargetedRecoveryArePreserved() throws {
         let first = CompatibilityIncompatibility(provisioningScriptVersion: "1", reason: .incompatibleComponent(.provisioningScriptVersion), recoveryActions: [.repair(.runtime)])
         let second = CompatibilityIncompatibility(reason: .knownIncompatibleCombination)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityEvaluatorTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Compatibility/CompatibilityEvaluatorTests.swift
@@ -1,0 +1,165 @@
+import Foundation
+import GuesthouseCore
+import Testing
+
+struct CompatibilityEvaluatorTests {
+    static func evaluate(_ observed: ObservedTuple = ObservedTuple(CompatibilityTupleTests.tuple()),
+                         entries: [TestedCompatibilityTuple] = [TestedCompatibilityTupleTests.entry()],
+                         rules: [CompatibilityIncompatibility] = [],
+                         history: [ConnectionVerificationRecord] = []) throws -> CompatibilityState {
+        let manifest = try CompatibilityManifest(manifestVersion: 1, tested: entries, incompatibilities: rules)
+        return CompatibilityEvaluator.evaluate(observed: observed, manifest: manifest, history: history)
+    }
+
+    static func record(_ tuple: CompatibilityTuple = CompatibilityTupleTests.tuple(), at time: Double = 1_700_000_000) throws -> ConnectionVerificationRecord {
+        try ConnectionVerificationRecord(tuple: tuple, verifiedAt: Date(timeIntervalSince1970: time), evidence: .userConfirmedWorkspaceOpened)
+    }
+
+    @Test func testedAndUntestedCombinationsNeedRealConnectionEvidence() throws {
+        #expect(try Self.evaluate() == .needsValidation(.neverConnected))
+        #expect(try Self.evaluate(entries: []) == .needsValidation(.untestedCombination))
+        let bundled = try CompatibilityManifest.bundled()
+        #expect(CompatibilityEvaluator.evaluate(observed: ObservedTuple(CompatibilityTupleTests.tuple()), manifest: bundled, history: []) == .needsValidation(.untestedCombination))
+    }
+
+    @Test(arguments: [false, true])
+    func newestMatchingHistoryWinsRegardlessOfUnrelatedHistoryAndOrdering(_ reversed: Bool) throws {
+        let old = try Self.record()
+        let latest = try Self.record(at: 1_700_003_600)
+        var otherTuple = old.tuple
+        otherTuple.codexCLIVersion = "0.40.0"
+        let other = try Self.record(otherTuple, at: 1_700_007_200)
+        let history = [other, old, latest]
+        let state = try Self.evaluate(history: reversed ? Array(history.reversed()) : history)
+        #expect(state == .verified(recordedAt: latest.verifiedAt))
+        #expect(state.allowsHandoff)
+    }
+
+    @Test(arguments: CompatibilityField.allCases)
+    func everyUnknownFieldPreventsVerification(_ field: CompatibilityField) throws {
+        let record = try Self.record()
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(record.tuple)) as? [String: Any])
+        object.removeValue(forKey: field.rawValue)
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(try Self.evaluate(observed, history: [record]) == .needsValidation(.unknownFields([field])))
+    }
+
+    @Test func driftIncludesProviderVersionsBuildsPathsAndCapabilities() throws {
+        let record = try Self.record()
+        let replacements: [CompatibilityField: Any] = [
+            .hostMacOSVersion: "27", .hostMacOSBuild: "26A1", .codexDesktopVersion: "2",
+            .codexDesktopBuild: "2000", .codexDesktopPath: "/Applications/Codex Beta.app",
+            .runtimeProtocolVersion: 2, .runtimeProvider: "tart", .runtimeVersion: "2.36.0",
+            .guestMacOSBuild: "26B1", .xcodeBuild: "18A1", .codexCLIVersion: "0.51.0",
+            .codexCLIPath: "/usr/local/bin/codex", .codexCLICapabilities: ["changed"],
+            .githubCLIVersion: "3", .provisioningScriptVersion: "b7255bd"
+        ]
+        let original = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(record.tuple)) as? [String: Any])
+        for (field, value) in replacements {
+            var object = original
+            object[field.rawValue] = value
+            let observed = try JSONDecoder().decode(ObservedTuple.self, from: JSONSerialization.data(withJSONObject: object))
+            #expect(try Self.evaluate(observed, history: [record]) == .needsValidation(.changedSinceLastVerified([field])))
+        }
+        #expect(replacements.count == CompatibilityField.allCases.count - 1)
+    }
+
+    @Test func missingAndCompetingInstallationsTakePriorityOverUnknownPaths() throws {
+        var observed = ObservedTuple(CompatibilityTupleTests.tuple())
+        observed.codexCLIVersion = nil
+        observed.codexCLIPath = nil
+        observed.codexCLIInstallations = 0
+        #expect(try Self.evaluate(observed, history: [Self.record()]) == .needsValidation(.codexCLIMissing))
+        observed.codexCLIInstallations = 3
+        #expect(try Self.evaluate(observed, history: [Self.record()]) == .needsValidation(.competingInstallations(count: 3)))
+        observed.codexCLIInstallations = -1
+        #expect(try Self.evaluate(observed) == .needsValidation(.unknownFields([.codexCLIInstallations])))
+    }
+
+    @Test(arguments: [-1, 0])
+    func nonpositiveProtocolCannotMatchStoredOrManifestEvidence(_ version: Int) throws {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.runtimeProtocolVersion = version
+        let entry = TestedCompatibilityTupleTests.entry(tuple, verification: TestedCompatibilityTupleTests.verification())
+        #expect(try Self.evaluate(ObservedTuple(tuple), entries: [entry], history: [Self.record()]) == .needsValidation(.unknownFields([.runtimeProtocolVersion])))
+    }
+
+    @Test func malformedKnownValuesNeedReobservationNotApproval() throws {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLIPath = "/"
+        let entry = TestedCompatibilityTupleTests.entry(tuple, verification: TestedCompatibilityTupleTests.verification())
+        #expect(try Self.evaluate(ObservedTuple(tuple), entries: [entry]) == .needsValidation(.unknownFields([.codexCLIPath])))
+        tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLICapabilities = Array(repeating: "same", count: 65)
+        #expect(try Self.evaluate(ObservedTuple(tuple)) == .needsValidation(.unknownFields([.codexCLICapabilities])))
+    }
+
+    @Test func knownBlockTakesPriorityOverBothSourcesOfSuccessfulHistory() throws {
+        let tuple = CompatibilityTupleTests.tuple()
+        let rule = CompatibilityIncompatibility(codexCLIVersion: tuple.codexCLIVersion, reason: .incompatibleComponent(.codexCLIVersion))
+        let entry = TestedCompatibilityTupleTests.entry(verification: TestedCompatibilityTupleTests.verification())
+        let state = try Self.evaluate(entries: [entry], rules: [rule], history: [Self.record()])
+        #expect(state == .incompatible(reason: rule.reason, recoveryActions: rule.recoveryActions))
+        #expect(!state.allowsHandoff)
+        var unknown = ObservedTuple(tuple)
+        unknown.codexCLIVersion = nil
+        #expect(try Self.evaluate(unknown, rules: [rule]) == .needsValidation(.unknownFields([.codexCLIVersion])))
+    }
+
+    @Test func firstMatchingRuleAndItsTargetedRecoveryArePreserved() throws {
+        let first = CompatibilityIncompatibility(provisioningScriptVersion: "1", reason: .incompatibleComponent(.provisioningScriptVersion), recoveryActions: [.repair(.runtime)])
+        let second = CompatibilityIncompatibility(reason: .knownIncompatibleCombination)
+        #expect(try Self.evaluate(rules: [first, second]) == .incompatible(reason: first.reason, recoveryActions: first.recoveryActions))
+        #expect(try Self.evaluate(rules: [second, first]) == .incompatible(reason: second.reason, recoveryActions: second.recoveryActions))
+    }
+
+    @Test(arguments: [false, true])
+    func latestCoveringManifestEvidenceWinsAndBeatsUnrelatedHistory(_ reversed: Bool) throws {
+        let tuple = CompatibilityTupleTests.tuple()
+        var otherHost = tuple
+        otherHost.hostMacOSBuild = "25F99"
+        var otherCLI = tuple
+        otherCLI.codexCLIVersion = "0.40.0"
+        let entries = [
+            TestedCompatibilityTupleTests.entry(),
+            TestedCompatibilityTupleTests.entry(verification: TestedCompatibilityTupleTests.verification(at: 1_700_000_000)),
+            TestedCompatibilityTupleTests.entry(verification: TestedCompatibilityTupleTests.verification(at: 1_700_003_600)),
+            TestedCompatibilityTupleTests.entry(verification: TestedCompatibilityTupleTests.verification(otherHost, at: 1_700_007_200)),
+            TestedCompatibilityTupleTests.entry(otherCLI, verification: TestedCompatibilityTupleTests.verification(otherCLI, at: 1_700_010_800))
+        ]
+        let state = try Self.evaluate(entries: reversed ? Array(entries.reversed()) : entries, history: [Self.record(otherCLI)])
+        #expect(state == .verified(recordedAt: Date(timeIntervalSince1970: 1_700_003_600)))
+    }
+
+    @Test func evidenceForAnotherHostBuildDoesNotVerifyButExplainsWhy() throws {
+        let entry = TestedCompatibilityTupleTests.entry(verification: TestedCompatibilityTupleTests.verification())
+        var otherHost = CompatibilityTupleTests.tuple()
+        otherHost.hostMacOSBuild = "25F99"
+        #expect(try Self.evaluate(ObservedTuple(otherHost), entries: [entry]) == .needsValidation(.verifiedOnDifferentHost))
+        #expect(try Self.evaluate(ObservedTuple(otherHost), entries: [entry], history: [Self.record()]) == .needsValidation(.changedSinceLastVerified([.hostMacOSBuild])))
+    }
+
+    @Test func canonicalCapabilitiesStillMatchSuccessfulHistory() throws {
+        var tuple = CompatibilityTupleTests.tuple(capabilities: ["a", "b"])
+        let record = try Self.record(tuple)
+        tuple.codexCLICapabilities = ["b", "a", "b"]
+        #expect(try Self.evaluate(ObservedTuple(tuple), history: [record]) == .verified(recordedAt: record.verifiedAt))
+    }
+
+    @Test func everyStateRoundTripsWithoutRawErrorPayloads() throws {
+        let states: [CompatibilityState] = [
+            .verified(recordedAt: Date(timeIntervalSince1970: 1_700_000_000)),
+            .needsValidation(.unknownFields([.runtimeProvider])), .needsValidation(.competingInstallations(count: 2)),
+            .needsValidation(.codexCLIMissing), .needsValidation(.neverConnected), .needsValidation(.verifiedOnDifferentHost),
+            .needsValidation(.changedSinceLastVerified([.codexDesktopPath])), .needsValidation(.untestedCombination),
+            .incompatible(reason: .knownIncompatibleCombination, recoveryActions: CompatibilityIncompatibility.defaultRecoveryActions)
+        ]
+        for state in states {
+            let decoded = try JSONDecoder().decode(CompatibilityState.self, from: JSONEncoder().encode(state))
+            #expect(decoded == state)
+            if case .verified = state { #expect(decoded.allowsHandoff) } else { #expect(!decoded.allowsHandoff) }
+        }
+        let raw = Data(#"{"incompatible":{"reason":"syntheticOpaque","recoveryActions":[]}}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(CompatibilityState.self, from: raw) }
+    }
+}

--- a/docs/compatibility-migration.md
+++ b/docs/compatibility-migration.md
@@ -37,4 +37,8 @@ The numeric-version, tuple, record, manifest-entry and manifest-container change
 
 The bundled manifest deliberately has no tested or verified combinations. The original Tart seed contained placeholders, not Lume evidence; it remains available in #55's preserved branch. Only actual validation should populate the active resource. This does not waive provider-selection or hardware gates.
 
-The evaluator still needs migration before issue #14 is complete. These models do not implement probes or persistence, or certify a Lume configuration. Preserve the old PR's remaining behavior and useful tests without importing its redactor ancestry. Runtime/XPC/GUI consumers require their own integration tests and review.
+The evaluator preserves the original decision order: known blocking rule; missing, ambiguous or invalid identity; matching local connection history; exact-host bundled verification; then drift or required validation. The newest matching local record wins regardless of unrelated newer records. All matching manifest entries are considered, so overlapping host ranges cannot hide newer evidence. Only `verified` permits normal handoff.
+
+`CompatibilityState.incompatible` now carries a typed reason and recovery actions, never a raw explanation from a resource or process. Consumers must render the reason's Guesthouse-owned `userMessage`; raw decoding errors and private observations remain outside diagnostics.
+
+The Core compatibility implementation is migrated, subject to each replacement PR's CI/review gate. These models do not implement probes or persistence, or certify a Lume configuration. Runtime/XPC/GUI consumers require their own integration tests and review. Original #55 behavior and useful regressions are retained across the focused replacements; its raw-string reasons, redactor recognition checks and unverified Tart placeholders are intentionally superseded, with the original source/tests preserved in that branch.


### PR DESCRIPTION
## Purpose

Final Core compatibility component in the focused replacement of #55 / issue #14, stacked on #142. Implements MVP-PLAN.md §§5 and 10 under ADR 0002/0003 without bringing back the old sanitizer ancestry.

## Changes

- Reuse the original evaluator's decision order: known incompatibility, invalid/missing/ambiguous observations, matching local connection history, exact-host manifest evidence, then drift or required validation.
- Carry CompatibilityBlockReason rather than arbitrary text in the incompatible state. Private observations and parser errors are not diagnostic payloads.
- Validate complete observed identity before it can be approved by matching history or manifest data.
- Preserve provider, host/build, desktop/CLI path, capability and provisioning drift, newest matching history, overlapping manifest entries and exact-host evidence.
- Integrate the finalized #142 installation-count selector. Its regression proves a decoded count-2 block clears after repair to the previously verified count-1 tuple, while an unknown count still cannot be verified.
- Update the migration guide to identify intentionally superseded raw reasons/redactor checks/Tart placeholders and the remaining consumer boundaries.

## Validation

The complete composed Core suite passes **284 tests / 24 suites**, warnings-as-errors. The committed branch is clean and contains approved parent 5db4e27f; no source changes occurred after the successful integration run.

Regression coverage includes every unknown identity field, drift, count precedence, malformed observations, rule priority, newest covering manifest records, unrelated history, all state round trips and raw-reason rejection. Diff and Markdown checks passed.

Own diff: **303 changed lines / 3 files**.

## Dependencies and limits

#138 → #139 → #140 → #141 → #142 → this PR. Existing #55 code and useful tests are reused across those focused replacements; original branch/history remains preserved. This finishes the Core model/evaluator migration, not probes, persistence, XPC, runner, GUI or hardware/provider certification. Consumers still require deliberate migration and their own tests.

Wait for exact-head green Xcode Cloud and a matching completed Codex review with an original-message 👍 and no unresolved findings. The owner merges; no old sanitizer stack is a prerequisite.