### PR TITLE
Migrate named XPC requests to bounded typed validation

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Pure message checks, not caller authentication, per-session admission, or file authority.
+public enum RequestValidator: Sendable {
+    public static let maximumEncodedSize = 64 * 1024
+    public static let maximumBookmarkSize = 16 * 1024
+    public static let maximumDisplayNameLength = 255
+    public static let maximumBundleIdentifierSize = 255
+    public static let maximumIPWait: Duration = .seconds(300)
+    public static let maximumGracefulStopDeadline: Duration = .seconds(600)
+
+    /// Required entry point for transport bytes: size → version → payload → option bounds.
+    /// Never forward an underlying decoder error, coding path, or input snippet to diagnostics.
+    public static func decode(_ data: Data) throws(RequestValidationError) -> RuntimeRequestEnvelope {
+        try validateEncodedSize(data)
+        do {
+            let envelope = try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data)
+            try validate(envelope)
+            return envelope
+        } catch let error as RuntimeRequestEnvelope.ProtocolMismatch {
+            throw .protocolMismatch(client: error.client, service: .current)
+        } catch let error as RequestValidationError {
+            throw error
+        } catch {
+            throw .malformed
+        }
+    }
+
+    public static func validateEncodedSize(_ data: Data) throws(RequestValidationError) {
+        guard data.count <= maximumEncodedSize else {
+            throw .oversized(bytes: data.count, limit: maximumEncodedSize)
+        }
+    }
+
+    public static func validate(_ envelope: RuntimeRequestEnvelope) throws(RequestValidationError) {
+        guard envelope.protocolVersion == .current else {
+            throw .protocolMismatch(client: envelope.protocolVersion, service: .current)
+        }
+        switch envelope.request {
+        case .runtimeVersion, .environmentStatus, .cancelOperation, .stopEnvironment(_, .force): break
+        case .startEnvironment(_, let options):
+            guard options.ipWait >= .zero, options.ipWait <= maximumIPWait else {
+                throw .optionOutOfRange(.ipWait)
+            }
+        case .stopEnvironment(_, .graceful(let deadline)):
+            guard deadline > .zero, deadline <= maximumGracefulStopDeadline else {
+                throw .optionOutOfRange(.gracefulStopDeadline)
+            }
+        case .importXcode(_, let handoff): try validate(handoff)
+        }
+    }
+
+    public static func validate(_ handoff: FileHandoff) throws(RequestValidationError) {
+        if case .securityScopedBookmark(let data) = handoff.kind {
+            guard !data.isEmpty else { throw .invalidHandoff }
+            guard data.count <= maximumBookmarkSize else {
+                throw .oversized(bytes: data.count, limit: maximumBookmarkSize)
+            }
+        }
+        let name = handoff.displayName
+        guard !name.isEmpty, name.utf8.count <= maximumDisplayNameLength * 4,
+              name.unicodeScalars.count <= maximumDisplayNameLength,
+              name != ".", name != "..", !name.contains("/"),
+              !name.unicodeScalars.contains(where: { scalar in
+                  switch scalar.properties.generalCategory {
+                  case .control, .format, .lineSeparator, .paragraphSeparator: true
+                  default: false
+                  }
+              }) else { throw .invalidDisplayName }
+        if let identifier = handoff.expectedBundleIdentifier {
+            guard !identifier.isEmpty, identifier.utf8.count <= maximumBundleIdentifierSize,
+                  identifier.utf8.allSatisfy({ (65...90).contains($0) || (97...122).contains($0)
+                      || (48...57).contains($0) || $0 == 45 || $0 == 46 }),
+                  identifier.split(separator: ".", omittingEmptySubsequences: false).allSatisfy({ !$0.isEmpty })
+            else { throw .invalidBundleIdentifier }
+        }
+    }
+}
+
+public enum RequestValidationError: Error, Hashable, Sendable {
+    public enum Option: Hashable, Sendable { case ipWait, gracefulStopDeadline }
+    case oversized(bytes: Int, limit: Int)
+    case protocolMismatch(client: RuntimeProtocolVersion, service: RuntimeProtocolVersion)
+    case optionOutOfRange(Option)
+    case invalidDisplayName, invalidBundleIdentifier, invalidHandoff, malformed
+
+    public var guesthouseError: GuesthouseError {
+        switch self {
+        case .oversized: .invalidRequest(.oversized)
+        case .protocolMismatch(let client, let service):
+            .protocolMismatch(client: client.rawValue, service: service.rawValue)
+        case .optionOutOfRange, .invalidDisplayName, .invalidBundleIdentifier, .invalidHandoff, .malformed:
+            .invalidRequest(.malformed)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -1,0 +1,25 @@
+/// Shared GUI/service wire epoch, separate from persistence and diagnostic-export schemas.
+public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStringConvertible {
+    public let rawValue: Int
+
+    public init(_ rawValue: Int) { self.rawValue = rawValue }
+
+    /// Epoch 8 reserves the incompatible structured-error/event contract (ADR 0003).
+    /// Legacy branches used 1–7, including versioned replies and admission errors in 7.
+    /// Both endpoint migrations must use this epoch; this Core model activates no transport.
+    public static let current = RuntimeProtocolVersion(8)
+
+    public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+    public var description: String { "protocol \(rawValue)" }
+}
+
+extension RuntimeProtocolVersion: Codable {
+    public init(from decoder: any Decoder) throws {
+        rawValue = try decoder.singleValueContainer().decode(Int.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -1,0 +1,93 @@
+import Foundation
+
+/// Named requests from #9 / MVP-PLAN.md §3. The service chooses executables and arguments;
+/// private selection metadata is not a command, a diagnostic attachment, or access authority.
+public enum RuntimeRequest: Codable, Hashable, Sendable {
+    case runtimeVersion
+    case environmentStatus(EnvironmentID)
+    case startEnvironment(EnvironmentID, StartOptions)
+    case stopEnvironment(EnvironmentID, StopMode)
+    case importXcode(EnvironmentID, FileHandoff)
+    case cancelOperation(OperationID)
+
+    public var caseName: String {
+        switch self {
+        case .runtimeVersion: "runtimeVersion"
+        case .environmentStatus: "environmentStatus"
+        case .startEnvironment: "startEnvironment"
+        case .stopEnvironment: "stopEnvironment"
+        case .importXcode: "importXcode"
+        case .cancelOperation: "cancelOperation"
+        }
+    }
+}
+
+/// Decode untrusted bytes through RequestValidator.decode, which bounds input first.
+/// Codable alone checks the version, not the transport's complete admission policy.
+public struct RuntimeRequestEnvelope: Codable, Hashable, Sendable {
+    public let protocolVersion: RuntimeProtocolVersion
+    public let request: RuntimeRequest
+
+    public init(protocolVersion: RuntimeProtocolVersion = .current, request: RuntimeRequest) {
+        self.protocolVersion = protocolVersion
+        self.request = request
+    }
+
+    private enum CodingKeys: String, CodingKey { case protocolVersion, request }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion)
+        guard version == .current else { throw ProtocolMismatch(client: version) }
+        protocolVersion = version
+        request = try container.decode(RuntimeRequest.self, forKey: .request)
+    }
+
+    /// A foreign header takes precedence over an unknown or absent payload.
+    public struct ProtocolMismatch: Error, Hashable, Sendable {
+        public let client: RuntimeProtocolVersion
+        public var error: GuesthouseError {
+            .protocolMismatch(client: client.rawValue, service: RuntimeProtocolVersion.current.rawValue)
+        }
+    }
+}
+
+public struct StartOptions: Codable, Hashable, Sendable {
+    /// Capability requests, not provider flags. The runtime must reject unsupported modes.
+    public enum ConsoleMode: String, Codable, Hashable, Sendable {
+        case headless, native
+    }
+    public let console: ConsoleMode
+    public let ipWait: Duration
+
+    public init(console: ConsoleMode = .headless, ipWait: Duration = .seconds(90)) {
+        self.console = console
+        self.ipWait = ipWait
+    }
+}
+
+public enum StopMode: Codable, Hashable, Sendable {
+    case graceful(deadline: Duration)
+    /// The GUI must obtain explicit confirmation; this value does not prove it did so.
+    case force
+}
+
+/// Access travels through a bookmark or an authenticated out-of-band descriptor handoff.
+/// Runtime selection/signature/containment checks remain required; hints never authorize it.
+public struct FileHandoff: Codable, Hashable, Sendable {
+    public enum Kind: Codable, Hashable, Sendable {
+        case securityScopedBookmark(Data)
+        case fileDescriptor(token: UUID)
+    }
+    public let kind: Kind
+    /// Private selection UI only. Never interpolate into error messages, logs or exports.
+    public let displayName: String
+    /// Bounded private hint. The service must independently verify the actual Xcode bundle.
+    public let expectedBundleIdentifier: String?
+
+    public init(kind: Kind, displayName: String, expectedBundleIdentifier: String? = nil) {
+        self.kind = kind
+        self.displayName = displayName
+        self.expectedBundleIdentifier = expectedBundleIdentifier
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
@@ -1,0 +1,154 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeRequestTests {
+    static let environment = EnvironmentID()
+    static let operation = OperationID()
+    static let requests: [RuntimeRequest] = [
+        .runtimeVersion, .environmentStatus(environment), .cancelOperation(operation),
+        .startEnvironment(environment, StartOptions()),
+        .startEnvironment(environment, StartOptions(console: .native, ipWait: .seconds(120))),
+        .stopEnvironment(environment, .graceful(deadline: .seconds(60))),
+        .stopEnvironment(environment, .force),
+        .importXcode(environment, FileHandoff(kind: .securityScopedBookmark(Data([1, 2, 3])),
+                                            displayName: "Xcode.app", expectedBundleIdentifier: "com.apple.dt.Xcode")),
+        .importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")),
+    ]
+
+    @Test(arguments: requests)
+    func requestsRoundTrip(request: RuntimeRequest) throws {
+        let envelope = RuntimeRequestEnvelope(request: request)
+        let data = try JSONEncoder().encode(envelope)
+        #expect(try RequestValidator.decode(data) == envelope)
+        #expect(envelope.protocolVersion.rawValue == 8)
+    }
+
+    @Test(arguments: requests, ["executable", "arguments", "command", "shell", "--", "/bin/"])
+    func requestVocabularyHasNoExecutionAPI(request: RuntimeRequest, forbidden: String) throws {
+        let data = try JSONEncoder().encode(request)
+        #expect(!String(decoding: data, as: UTF8.self).lowercased().contains(forbidden))
+    }
+
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 9, Int.max])
+    func foreignVersionPrecedesUnknownPayload(version: Int) {
+        let data = Data("{\"protocolVersion\":\(version),\"request\":{\"futureRequest\":{}}}".utf8)
+        let expected = RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(version), service: .current)
+        #expect(throws: expected) { try RequestValidator.decode(data) }
+        #expect(expected.guesthouseError == .protocolMismatch(client: version, service: 8))
+    }
+
+    @Test func directEnvelopeDecoderAlsoChecksHeaderFirst() throws {
+        let data = Data(#"{"protocolVersion":7}"#.utf8)
+        let error = try #require(throws: RuntimeRequestEnvelope.ProtocolMismatch.self) {
+            try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data)
+        }
+        #expect(error.error == .protocolMismatch(client: 7, service: 8))
+    }
+
+    @Test(arguments: ["{}", "null", #"{"request":{"runtimeVersion":{}}}"#,
+                      #"{"protocolVersion":"8","request":{}}"#, #"{"protocolVersion":8}"#,
+                      #"{"protocolVersion":8,"request":{"runCommand":{"command":"private-marker"}}}"#])
+    func malformedRequestsAreTyped(json: String) {
+        #expect(throws: RequestValidationError.malformed) { try RequestValidator.decode(Data(json.utf8)) }
+    }
+
+    @Test func encodedSizeIsCheckedBeforeParsing() throws {
+        var data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .runtimeVersion))
+        data.append(Data(repeating: 32, count: 65_536 - data.count))
+        #expect(try RequestValidator.decode(data).request == .runtimeVersion)
+        data.append(0) // Also invalid JSON: size must take precedence over parsing.
+        #expect(throws: RequestValidationError.oversized(bytes: 65_537, limit: 65_536)) {
+            try RequestValidator.decode(data)
+        }
+    }
+
+    @Test(arguments: [Duration.zero, .seconds(300)])
+    func ipWaitEndpointsAreAccepted(wait: Duration) throws {
+        try RequestValidator.validate(RuntimeRequestEnvelope(request: .startEnvironment(Self.environment, StartOptions(ipWait: wait))))
+    }
+
+    @Test(arguments: [Duration.seconds(-1), .seconds(301)])
+    func ipWaitOutsideRangeIsRejected(wait: Duration) throws {
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .startEnvironment(Self.environment, StartOptions(ipWait: wait))))
+        #expect(throws: RequestValidationError.optionOutOfRange(.ipWait)) { try RequestValidator.decode(data) }
+    }
+
+    @Test(arguments: [Duration.nanoseconds(1), .seconds(600)])
+    func gracefulDeadlineEndpointsAreAccepted(deadline: Duration) throws {
+        try RequestValidator.validate(RuntimeRequestEnvelope(request: .stopEnvironment(Self.environment, .graceful(deadline: deadline))))
+    }
+
+    @Test(arguments: [Duration.seconds(-1), .zero, .seconds(601)])
+    func gracefulDeadlineOutsideRangeIsRejected(deadline: Duration) throws {
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .stopEnvironment(Self.environment, .graceful(deadline: deadline))))
+        #expect(throws: RequestValidationError.optionOutOfRange(.gracefulStopDeadline)) { try RequestValidator.decode(data) }
+    }
+
+    @Test func programmaticEnvelopeMustAlsoMatchProtocol() {
+        #expect(throws: RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(7), service: .current)) {
+            try RequestValidator.validate(RuntimeRequestEnvelope(protocolVersion: RuntimeProtocolVersion(7), request: .runtimeVersion))
+        }
+    }
+
+    @Test(arguments: [1, 16_384])
+    func bookmarkSizeEndpointsAreAccepted(count: Int) throws {
+        try RequestValidator.validate(FileHandoff(kind: .securityScopedBookmark(Data(repeating: 1, count: count)), displayName: "Xcode.app"))
+    }
+
+    @Test func emptyAndOversizedBookmarksAreRejected() throws {
+        #expect(throws: RequestValidationError.invalidHandoff) {
+            try RequestValidator.validate(FileHandoff(kind: .securityScopedBookmark(Data()), displayName: "Xcode.app"))
+        }
+        let handoff = FileHandoff(kind: .securityScopedBookmark(Data(repeating: 1, count: 16_385)), displayName: "Xcode.app")
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .importXcode(Self.environment, handoff)))
+        #expect(throws: RequestValidationError.oversized(bytes: 16_385, limit: 16_384)) { try RequestValidator.decode(data) }
+    }
+
+    @Test(arguments: ["", ".", "..", "../Xcode.app", "Applications/Xcode.app", "Xcode\n.app",
+                      "Xcode\u{2028}.app", "Xcode\u{2029}.app", "Xcode\u{202E}.app", "Xcode\u{1B}.app",
+                      String(repeating: "x", count: 256), "👩" + String(repeating: "\u{1F3FB}", count: 5_000)])
+    func invalidDisplayNamesAreRejected(name: String) throws {
+        let handoff = FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: name)
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .importXcode(Self.environment, handoff)))
+        #expect(throws: RequestValidationError.invalidDisplayName) { try RequestValidator.decode(data) }
+    }
+
+    @Test(arguments: ["Xcode.app", "Cafe\u{301}.app", "Private-Marker.app", String(repeating: "😀", count: 255)])
+    func privateSelectionNamesArePreservedNotRedacted(name: String) throws {
+        let request = RuntimeRequest.importXcode(Self.environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: name))
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: request))
+        #expect(try RequestValidator.decode(data).request == request)
+    }
+
+    @Test(arguments: ["", "com..apple", ".com.apple", "com.apple.", "com/apple", "com.äpple", "com.\napp", String(repeating: "a", count: 256)])
+    func malformedBundleHintsAreRejected(hint: String) {
+        let handoff = FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app", expectedBundleIdentifier: hint)
+        #expect(throws: RequestValidationError.invalidBundleIdentifier) { try RequestValidator.validate(handoff) }
+    }
+
+    @Test(arguments: ["com.apple.dt.Xcode", "com.example.beta-1", String(repeating: "a", count: 255)])
+    func boundedBundleHintsRemainPrivateHints(hint: String) throws {
+        let request = RuntimeRequest.importXcode(Self.environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app", expectedBundleIdentifier: hint))
+        #expect(try RequestValidator.decode(JSONEncoder().encode(RuntimeRequestEnvelope(request: request))).request == request)
+    }
+
+    @Test func unknownMetadataIsNotForwarded() throws {
+        let data = Data(#"{"protocolVersion":8,"private":"private-marker","request":{"runtimeVersion":{}}}"#.utf8)
+        let encoded = try JSONEncoder().encode(RequestValidator.decode(data))
+        #expect(!String(decoding: encoded, as: UTF8.self).contains("private-marker"))
+    }
+
+    @Test func malformedInputCannotReachStructuredErrorsOrExports() throws {
+        let data = Data(#"{"protocolVersion":8,"request":{"private-marker":{}}}"#.utf8)
+        let rejection = try #require(throws: RequestValidationError.self) { try RequestValidator.decode(data) }
+        #expect(rejection.guesthouseError == .invalidRequest(.malformed))
+        let event = DiagnosticEvent(operation: .importXcode, outcome: .init(error: rejection.guesthouseError), operationID: UUID())
+        var log = DiagnosticLog()
+        log.append(event)
+        #expect(!event.message.contains("private-marker"))
+        #expect(!log.text.contains("private-marker"))
+        #expect(!String(decoding: try log.jsonData(), as: UTF8.self).contains("private-marker"))
+        #expect(!rejection.guesthouseError.recoveryActions.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

First focused replacement for #58 / issue #9, stacked on #143. Implements the named-message portion of MVP-PLAN.md §3 and ADR 0003; **not** an active XPC service or a complete replacement for #58.

- Retains the six original named requests, environment/operation UUIDs, console and stop options, and bookmark-versus-descriptor file handoff. No executable/argument/command API.
- Adds a single bounded request decoding entry point: 64 KiB before JSON decoding, version header before payload, then option and private metadata validation. Retains the 16 KiB bookmark bound, IP wait and graceful-stop limits, Unicode scalar/name restrictions, and adds a bounded bundle-identifier hint.
- Replaces free-form validation-error arguments and underlying decoder errors with closed facts mapped to fixed Guesthouse errors. Private selection names remain exact private UI data, never diagnostic or error text; no credential recognizer or redactor dependency is restored.
- Reserves wire epoch **8** for the structured contract. Historical descendants used epochs 1–7; do not reuse their incompatible wire versions. This model activates no endpoint, and both endpoint migrations must adopt the new contract together.

## Validation

- Full Core suite: **303 tests / 25 suites pass**, warnings-as-errors.
- Swift Testing cases retain original request round trips, foreign-header precedence, size/option/name bounds and add unknown-payload rejection, exact boundaries, private-hint bounds, metadata non-propagation and fixed-error structured-export checks.
- `git diff --check` passes. **368 added lines / 4 files**. No third-party dependency or host process/VM operation.

## Deliberately remaining

Event/status models and versioned replies, path/symlink containment helpers and regressions, actual caller authentication, session admission/correlation, descriptor/bookmark resolution, Xcode bundle/signature verification, and native transport integration remain separate migration steps. A validated hint is not access authority; a force-stop value does not prove the GUI obtained confirmation. No provider selection or hardware proof is claimed.

The original #58 branch and all old tests/findings remain preserved. Its obsolete redactor-specific expectations are superseded by the private-data/structured-diagnostics split; its non-logging safeguards must still be migrated. Do not merge the old stack or close #9 on the strength of this partial PR.

CI and automatic Codex review must approve this exact head before merge.