### PR TITLE
Migrate runtime status to private identity and typed uncertainty

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Compatibility/ConnectionVerificationRecord.swift
@@ -130,19 +130,20 @@ public struct ConnectionVerificationRecord: Hashable, Sendable {
         }
     }
 
-    private static func isIdentifier(_ value: String, punctuation: Set<UInt8>) -> Bool {
+    // Shared with private runtime-status admission; these are identity grammars, not redactors.
+    static func isIdentifier(_ value: String, punctuation: Set<UInt8>) -> Bool {
         guard isBoundedText(value, limit: maximumObservationLength) else { return false }
         return value.utf8.allSatisfy {
             (48...57).contains($0) || (65...90).contains($0) || (97...122).contains($0) || punctuation.contains($0)
         }
     }
 
-    private static func isVersionIdentifier(_ value: String) -> Bool {
+    static func isVersionIdentifier(_ value: String) -> Bool {
         guard let first = value.utf8.first, (48...57).contains(first) else { return false }
         return isIdentifier(value, punctuation: [43, 45, 46])
     }
 
-    private static func isBuildIdentifier(_ value: String) -> Bool {
+    static func isBuildIdentifier(_ value: String) -> Bool {
         guard let first = value.utf8.first, (48...57).contains(first) else { return false }
         return isIdentifier(value, punctuation: [])
     }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/EnvironmentStatus.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/EnvironmentStatus.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Private status, not diagnostics. The producer must reconcile inventory/ownership/journal;
+/// constructing or decoding this value does not prove reconciliation or authorize mutation.
+public struct EnvironmentStatus: Codable, Hashable, Sendable {
+    public enum VMState: Codable, Hashable, Sendable {
+        case notFound, stopped, running
+        /// Refuse mutation until ownership/state is inspected. No raw process reason text.
+        case uncertain(reason: UncertaintyReason)
+    }
+    public enum UncertaintyReason: String, Codable, Hashable, Sendable, CaseIterable {
+        case ownershipUnproven, processIdentityChanged, inspectionFailed, operationOutcomeUnknown
+
+        public var userMessage: String {
+            switch self {
+            case .ownershipUnproven: "Guesthouse could not confirm ownership of this development Mac."
+            case .processIdentityChanged: "The development Mac's process identity changed."
+            case .inspectionFailed: "Guesthouse could not inspect the development Mac's current state."
+            case .operationOutcomeUnknown: "The previous operation's outcome is not yet known."
+            }
+        }
+        public var recoveryActions: [RecoveryAction] { [.inspectState, .cancel] }
+    }
+    public enum Readiness: Codable, Hashable, Sendable {
+        case checking, ready
+        case needsAttention(GuesthouseError)
+    }
+
+    public let environmentID: EnvironmentID
+    public let vm: VMState
+    /// Separate from ownership and compatibility. `ready` alone is not a handoff gate.
+    public let readiness: Readiness
+    public let inFlightOperation: OperationID?
+    public let observed: ObservedTuple
+    public let reconciledAt: Date?
+
+    public init(environmentID: EnvironmentID, vm: VMState, readiness: Readiness,
+                inFlightOperation: OperationID? = nil, observed: ObservedTuple = ObservedTuple(),
+                reconciledAt: Date? = nil) {
+        self.environmentID = environmentID
+        self.vm = vm
+        self.readiness = readiness
+        self.inFlightOperation = inFlightOperation
+        self.observed = observed.admittedForWire()
+        self.reconciledAt = reconciledAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case environmentID, vm, readiness, inFlightOperation, observed, reconciledAt
+    }
+
+    /// Apply the same field admission to untrusted wire values as to local probe results.
+    /// Underlying decoding errors stay private; the event transport must map them to fixed errors.
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(environmentID: try c.decode(EnvironmentID.self, forKey: .environmentID),
+                  vm: try c.decode(VMState.self, forKey: .vm),
+                  readiness: try c.decode(Readiness.self, forKey: .readiness),
+                  inFlightOperation: try c.decodeIfPresent(OperationID.self, forKey: .inFlightOperation),
+                  observed: try c.decode(ObservedTuple.self, forKey: .observed),
+                  reconciledAt: try c.decodeIfPresent(Date.self, forKey: .reconciledAt))
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/ObservedTuple+Wire.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/ObservedTuple+Wire.swift
@@ -1,0 +1,41 @@
+extension ObservedTuple {
+    /// Preserve exact valid private identity, or mark the offending field unknown. Never
+    /// truncate, redact, hash, or manufacture replacement identity (MVP-PLAN.md §5, ADR 0003).
+    /// The transport must separately bound encoded bytes before decoding any status.
+    func admittedForWire() -> Self {
+        var result = self
+        let versions: [WritableKeyPath<Self, String?>] = [
+            \.codexDesktopVersion, \.codexDesktopBuild, \.runtimeVersion, \.codexCLIVersion, \.githubCLIVersion
+        ]
+        for key in versions {
+            if let value = result[keyPath: key], !ConnectionVerificationRecord.isVersionIdentifier(value) {
+                result[keyPath: key] = nil
+            }
+        }
+        let builds: [WritableKeyPath<Self, String?>] = [\.hostMacOSBuild, \.guestMacOSBuild, \.xcodeBuild]
+        for key in builds {
+            if let value = result[keyPath: key], !ConnectionVerificationRecord.isBuildIdentifier(value) {
+                result[keyPath: key] = nil
+            }
+        }
+        for key in [\Self.codexDesktopPath, \Self.codexCLIPath] {
+            if let value = result[keyPath: key], !ConnectionVerificationRecord.isResolvedPath(value) {
+                result[keyPath: key] = nil
+            }
+        }
+        if let value = result.provisioningScriptVersion,
+           !ConnectionVerificationRecord.isIdentifier(value, punctuation: [43, 45, 46]) {
+            result.provisioningScriptVersion = nil
+        }
+        if let values = result.codexCLICapabilities,
+           values.count > CompatibilityTuple.maximumCapabilities
+            || !values.allSatisfy({ ConnectionVerificationRecord.isIdentifier($0, punctuation: [45, 46, 58, 95]) }) {
+            result.codexCLICapabilities = nil
+        }
+        if let version = result.runtimeProtocolVersion, version <= 0 { result.runtimeProtocolVersion = nil }
+        if let count = result.codexCLIInstallations, count < 0 { result.codexCLIInstallations = nil }
+        // Zero and competing installation counts are valid adverse observations. Preserve
+        // them so the evaluator explains missing/ambiguous tools, not merely unknown fields.
+        return result
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/ProgressPhase.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/ProgressPhase.swift
@@ -1,0 +1,36 @@
+/// Named, measured runtime progress (#9, MVP-PLAN.md §2), never an output transcript.
+public struct ProgressPhase: Codable, Hashable, Sendable {
+    public enum Kind: String, Codable, Hashable, Sendable, CaseIterable {
+        case inspectingState, verifyingRuntime, startingVM, waitingForNetwork, stoppingVM
+        case forceStoppingVM, validatingSelection, copying, verifyingCopy
+    }
+    public let kind: Kind
+    /// Invalid/nonfinite measurements become indeterminate, not false completion.
+    public let fraction: Double?
+    /// The runtime still enforces safe cancellation; this is a UI presentation hint.
+    public let cancelable: Bool
+
+    public init(kind: Kind, fraction: Double? = nil, cancelable: Bool = true) {
+        self.kind = kind
+        self.fraction = Self.valid(fraction)
+        self.cancelable = cancelable
+    }
+
+    private enum CodingKeys: String, CodingKey { case kind, fraction, cancelable }
+
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(kind: try c.decode(Kind.self, forKey: .kind),
+                  fraction: try c.decodeIfPresent(Double.self, forKey: .fraction),
+                  cancelable: try c.decodeIfPresent(Bool.self, forKey: .cancelable) ?? true)
+    }
+
+    public func measured(_ fraction: Double?) -> Self {
+        Self(kind: kind, fraction: fraction, cancelable: cancelable)
+    }
+
+    private static func valid(_ fraction: Double?) -> Double? {
+        guard let fraction, fraction.isFinite, (0...1).contains(fraction) else { return nil }
+        return fraction
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeStatusTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeStatusTests.swift
@@ -1,0 +1,168 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeStatusTests {
+    static func status(_ observed: ObservedTuple = ObservedTuple(CompatibilityTupleTests.tuple())) -> EnvironmentStatus {
+        EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking, observed: observed)
+    }
+
+    /// Deliberately bypass the sender's admission to exercise an untrusted wire payload.
+    static func decodeStatus(_ observed: ObservedTuple) throws -> EnvironmentStatus {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(status())) as? [String: Any])
+        object["observed"] = try JSONSerialization.jsonObject(with: JSONEncoder().encode(observed))
+        return try JSONDecoder().decode(EnvironmentStatus.self, from: JSONSerialization.data(withJSONObject: object))
+    }
+
+    @Test(arguments: [EnvironmentStatus.VMState.notFound, .stopped, .running,
+                      .uncertain(reason: .ownershipUnproven), .uncertain(reason: .processIdentityChanged),
+                      .uncertain(reason: .inspectionFailed), .uncertain(reason: .operationOutcomeUnknown)],
+          [EnvironmentStatus.Readiness.checking, .ready, .needsAttention(.runtimeMissing)])
+    func statusRoundTripsPreserveCorrelatedState(vm: EnvironmentStatus.VMState, readiness: EnvironmentStatus.Readiness) throws {
+        let value = EnvironmentStatus(environmentID: EnvironmentID(), vm: vm, readiness: readiness,
+                                      inFlightOperation: OperationID(), observed: ObservedTuple(CompatibilityTupleTests.tuple()),
+                                      reconciledAt: Date(timeIntervalSince1970: 1_700_000_000))
+        #expect(try JSONDecoder().decode(EnvironmentStatus.self, from: JSONEncoder().encode(value)) == value)
+    }
+
+    @Test(arguments: VMProvider.allCases)
+    func exactPrivateIdentitySurvivesBothSides(provider: VMProvider) throws {
+        var tuple = CompatibilityTupleTests.tuple(provider: provider)
+        tuple.codexDesktopPath = "/Applications/Cafe\u{301} Private/Codex.app"
+        tuple.codexCLIPath = "/Users/developer/private [exact:literal]/codex"
+        tuple.provisioningScriptVersion = "abcdef123"
+        let observed = ObservedTuple(tuple)
+        #expect(Self.status(observed).observed == observed)
+        #expect(try Self.decodeStatus(observed).observed == observed)
+        #expect(try Self.decodeStatus(observed).observed.exact == tuple)
+    }
+
+    @Test(arguments: [CompatibilityField.hostMacOSBuild, .codexDesktopVersion, .codexDesktopBuild,
+                      .codexDesktopPath, .runtimeVersion, .guestMacOSBuild, .xcodeBuild,
+                      .codexCLIVersion, .codexCLIPath, .githubCLIVersion, .provisioningScriptVersion])
+    func everyMalformedStringBecomesUnknownWithoutChangingOtherIdentity(field: CompatibilityField) throws {
+        let tuple = CompatibilityTupleTests.tuple()
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(tuple)) as? [String: Any])
+        object[field.rawValue] = "private marker"
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: JSONSerialization.data(withJSONObject: object))
+        let local = Self.status(observed)
+        let remote = try Self.decodeStatus(observed)
+        #expect(local.observed == remote.observed)
+        #expect(remote.observed.unknownFields == [field])
+        #expect(remote.observed.exact == nil)
+        #expect(!String(decoding: try JSONEncoder().encode(remote), as: UTF8.self).contains("private marker"))
+        #expect(try CompatibilityEvaluatorTests.evaluate(remote.observed, history: [CompatibilityEvaluatorTests.record()])
+                == .needsValidation(.unknownFields([field])))
+    }
+
+    @Test(arguments: CompatibilityField.allCases)
+    func unknownFieldsRemainUnknown(field: CompatibilityField) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(CompatibilityTupleTests.tuple())) as? [String: Any])
+        object.removeValue(forKey: field.rawValue)
+        let observed = try JSONDecoder().decode(ObservedTuple.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(Self.status(observed).observed.unknownFields == [field])
+        #expect(try Self.decodeStatus(observed).observed.unknownFields == [field])
+    }
+
+    @Test func byteBoundsPreserveTheFullValueOrMakeItUnknown() throws {
+        let version = "1" + String(repeating: "a", count: 255)
+        let path = "/" + String(repeating: "p", count: 1023)
+        var observed = ObservedTuple(codexCLIVersion: version, codexCLIPath: path, codexCLICapabilities: [version])
+        #expect(try Self.decodeStatus(observed).observed == observed)
+        observed.codexCLIVersion = version + "a"
+        observed.codexCLIPath = path + "a"
+        observed.codexCLICapabilities = [version + "a"]
+        #expect(Self.status(observed).observed == ObservedTuple())
+        #expect(try Self.decodeStatus(observed).observed == ObservedTuple())
+    }
+
+    @Test(arguments: ["/", "//", "/opt/../bin/codex", "/opt/./codex", "/opt/codex/", "/opt/\u{1B}[31mcodex", "/opt/\u{202E}codex"])
+    func invalidPathsAreNeverNormalizedIntoEvidence(path: String) throws {
+        let observed = ObservedTuple(codexDesktopPath: path, codexCLIPath: path)
+        #expect(Self.status(observed).observed == ObservedTuple())
+        #expect(try Self.decodeStatus(observed).observed == ObservedTuple())
+    }
+
+    @Test func distinctPrivatePathsStayDistinctWhileInvalidPathsCannotVerify() throws {
+        var tuple = CompatibilityTupleTests.tuple()
+        tuple.codexCLIPath = "/opt/private-one/codex"
+        let history = [try CompatibilityEvaluatorTests.record(tuple)]
+        var other = ObservedTuple(tuple)
+        other.codexCLIPath = "/opt/private-two/codex"
+        #expect(try CompatibilityEvaluatorTests.evaluate(Self.decodeStatus(other).observed, history: history)
+                == .needsValidation(.changedSinceLastVerified([.codexCLIPath])))
+        other.codexCLIPath = "/opt/private-one/./codex"
+        #expect(try CompatibilityEvaluatorTests.evaluate(Self.decodeStatus(other).observed, history: history)
+                == .needsValidation(.unknownFields([.codexCLIPath])))
+    }
+
+    @Test(arguments: [(0, CompatibilityState.NeedsValidationReason.codexCLIMissing),
+                      (2, .competingInstallations(count: 2))])
+    func adverseInstallationCountsRemainActionable(count: Int, reason: CompatibilityState.NeedsValidationReason) throws {
+        let observed = ObservedTuple(codexCLIInstallations: count)
+        #expect(try Self.decodeStatus(observed).observed.codexCLIInstallations == count)
+        #expect(try CompatibilityEvaluatorTests.evaluate(Self.decodeStatus(observed).observed) == .needsValidation(reason))
+    }
+
+    @Test func invalidNumericObservationsBecomeUnknown() throws {
+        let observed = ObservedTuple(runtimeProtocolVersion: 0, codexCLIInstallations: -1)
+        #expect(Self.status(observed).observed == ObservedTuple())
+        #expect(try Self.decodeStatus(observed).observed == ObservedTuple())
+        #expect(try Self.decodeStatus(ObservedTuple(runtimeProtocolVersion: 8, codexCLIInstallations: 1)).observed
+                == ObservedTuple(runtimeProtocolVersion: 8, codexCLIInstallations: 1))
+    }
+
+    @Test func capabilityAdmissionDoesNotTruncateOrRewriteIdentity() throws {
+        let names = (0..<64).map { "cap\($0)" }
+        let observed = ObservedTuple(codexCLICapabilities: names.reversed())
+        #expect(try Self.decodeStatus(observed).observed == ObservedTuple(codexCLICapabilities: names))
+        let oversized = ObservedTuple(codexCLICapabilities: Array(repeating: "same", count: 65))
+        #expect(Self.status(oversized).observed.codexCLICapabilities == nil)
+        #expect(throws: DecodingError.self) { try Self.decodeStatus(oversized) }
+        #expect(try Self.decodeStatus(ObservedTuple(codexCLICapabilities: [])).observed.codexCLICapabilities == [])
+    }
+
+    @Test(arguments: ["", "has space", "cap\u{1B}[31m", "a/b", "ä"])
+    func malformedCapabilitiesMakeTheEntireSetUnknown(value: String) throws {
+        let observed = ObservedTuple(codexCLICapabilities: ["valid", value])
+        #expect(Self.status(observed).observed.codexCLICapabilities == nil)
+        #expect(try Self.decodeStatus(observed).observed.codexCLICapabilities == nil)
+    }
+
+    @Test(arguments: EnvironmentStatus.UncertaintyReason.allCases)
+    func uncertaintyUsesClosedExplanationsAndInspection(reason: EnvironmentStatus.UncertaintyReason) throws {
+        let state = EnvironmentStatus.VMState.uncertain(reason: reason)
+        #expect(try JSONDecoder().decode(EnvironmentStatus.VMState.self, from: JSONEncoder().encode(state)) == state)
+        #expect(!reason.userMessage.isEmpty)
+        #expect(reason.recoveryActions == [.inspectState, .cancel])
+    }
+
+    @Test func rawUncertaintyTextIsNotAccepted() {
+        let data = Data(#"{"uncertain":{"reason":"private process output"}}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(EnvironmentStatus.VMState.self, from: data) }
+    }
+
+    @Test(arguments: ProgressPhase.Kind.allCases, [0.0, 0.5, 1.0])
+    func measuredProgressRoundTrips(kind: ProgressPhase.Kind, fraction: Double) throws {
+        let value = ProgressPhase(kind: kind, fraction: fraction, cancelable: false)
+        #expect(try JSONDecoder().decode(ProgressPhase.self, from: JSONEncoder().encode(value)) == value)
+        #expect(value.measured(0.25) == ProgressPhase(kind: kind, fraction: 0.25, cancelable: false))
+    }
+
+    @Test(arguments: [Double.nan, .infinity, -.infinity, -0.1, 1.1])
+    func invalidMeasurementsRemainEncodableAndIndeterminate(fraction: Double) throws {
+        let phase = ProgressPhase(kind: .copying, fraction: fraction)
+        #expect(phase.fraction == nil)
+        #expect(phase.measured(fraction).fraction == nil)
+        #expect(try JSONDecoder().decode(ProgressPhase.self, from: JSONEncoder().encode(phase)) == phase)
+    }
+
+    @Test func decodedProgressPreservesBoundsAndCancellationHint() throws {
+        let value = try JSONDecoder().decode(ProgressPhase.self, from: Data(#"{"kind":"copying","fraction":7,"cancelable":false}"#.utf8))
+        #expect(value.fraction == nil)
+        #expect(!value.cancelable)
+        let absent = try JSONDecoder().decode(ProgressPhase.self, from: Data(#"{"kind":"copying"}"#.utf8))
+        #expect(absent.fraction == nil)
+        #expect(absent.cancelable)
+    }
+}


### PR DESCRIPTION
## Summary

Second focused #58 / issue #9 migration, stacked on approved #144. Implements the private status and named progress models from MVP-PLAN.md §§2, 3 and 5 under ADR 0003.

- Retains environment/operation correlation, VM state, readiness, reconciliation timestamp, and unknown compatibility observations.
- Replaces raw uncertain-state text with four closed reasons and fixed explanations plus inspect/cancel recovery. A status value is not proof of ownership, reconciliation or permission to mutate.
- Reuses the existing compatibility field grammars for private wire admission. Valid identity is preserved exactly; malformed or over-limit values become unknown, without truncation, redaction, digest suffixes or guessed provider identity. Decoding reapplies the same rules.
- Preserves missing/competing CLI installation counts as adverse observations. Invalid capability sets do not become a verified subset; the existing decoder rejects oversized wire arrays before normalization.
- Retains all nine progress phases, safe indeterminate handling of invalid/nonfinite fractions, and cancellation presentation hints.

## Validation

Full Core: **319 tests / 26 suites pass**, warnings-as-errors. Swift Testing regressions cover every private string field, all unknown dimensions/providers, identity drift through the evaluator, byte/count limits, capability admission, correlated status round trips, typed uncertainty and progress bounds. Existing compatibility validation tests still pass.

**315 changed lines / 5 files** (312 additions, 3 deletions); diff checks pass. The only modification to an existing implementation makes three grammar helpers internal for reuse, with no grammar change.

## Remaining boundaries

This is an inactive Core model layer, not completed XPC integration. Runtime version metadata, typed diagnostic events and mandatory versioned replies follow, using epoch 8. Their transport must bound response bytes before decoding and map underlying decoding errors to fixed errors. Private status values are never DiagnosticEvent attachments.

Caller authentication, session admission/correlation, containment/ownership checks, descriptor/bookmark authority, consumer migration, and unknown-mutation-outcome handling remain required in their owning layers. `ready` does not bypass those gates or verify a Codex connection. No provider selection, host mutation or hardware evidence is claimed.

Original #58 source/tests/review history are preserved. This supersedes its old observation sanitizer/digest behavior, not its non-logging safeguards. Do not close #9 or merge the old sanitizer ancestry. This PR needs its own exact-head CI/Codex gates.