### PR TITLE
Migrate runtime replies to versioned structured events

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -1,0 +1,30 @@
+/// Named service-to-GUI events (#9, MVP-PLAN.md §3). Private status is not a diagnostic.
+public enum RuntimeEvent: Codable, Hashable, Sendable {
+    case runtimeVersion(RuntimeVersionInfo)
+    /// The service must journal/register the operation before acknowledging acceptance.
+    case accepted(OperationID)
+    case progress(OperationID, ProgressPhase)
+    /// UUIDs are assigned by Guesthouse. No raw-output or arbitrary-message alternative exists.
+    case diagnostic(DiagnosticEvent)
+    case status(EnvironmentStatus)
+    case completed(OperationID)
+    case failed(OperationID, GuesthouseError)
+
+    public var caseName: String {
+        switch self {
+        case .runtimeVersion: "runtimeVersion"
+        case .accepted: "accepted"
+        case .progress: "progress"
+        case .diagnostic: "diagnostic"
+        case .status: "status"
+        case .completed: "completed"
+        case .failed: "failed"
+        }
+    }
+
+    /// Only this explicit case can enter DiagnosticLog. Consumers must not stringify other
+    /// events or infer operation completion from diagnostic presentation alone.
+    public var diagnosticEvent: DiagnosticEvent? {
+        if case .diagnostic(let event) = self { event } else { nil }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Mandatory epoch-8 reply/push envelope. No bare-event or legacy-output fallback.
+public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
+    public let protocolVersion: RuntimeProtocolVersion
+    public let event: RuntimeEvent
+
+    public init(protocolVersion: RuntimeProtocolVersion = .current, event: RuntimeEvent) {
+        self.protocolVersion = protocolVersion
+        self.event = event
+    }
+
+    private enum CodingKeys: String, CodingKey { case protocolVersion, event }
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try c.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion)
+        guard version == .current else { throw ProtocolMismatch(service: version) }
+        let decoded = try c.decode(RuntimeEvent.self, forKey: .event)
+        if case .runtimeVersion(let info) = decoded, info.protocolVersion != version {
+            throw GuesthouseError.invalidRuntimeReply(.malformed)
+        }
+        protocolVersion = version
+        event = decoded
+    }
+
+    public struct ProtocolMismatch: Error, Hashable, Sendable {
+        public let service: RuntimeProtocolVersion
+        public init(service: RuntimeProtocolVersion) { self.service = service }
+        public var error: GuesthouseError {
+            .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: service.rawValue)
+        }
+    }
+
+    public static let maximumEncodedSize = 64 * 1024
+
+    /// Transport entry point: enforce bytes before parsing, then version before event shape.
+    /// Any rejection leaves in-flight mutation outcomes unknown until the owner reconciles them.
+    public static func decode(_ data: Data) throws(GuesthouseError) -> Self {
+        guard data.count <= maximumEncodedSize else { throw .invalidRuntimeReply(.oversized) }
+        do {
+            return try JSONDecoder().decode(Self.self, from: data)
+        } catch let error as ProtocolMismatch {
+            throw error.error
+        } catch {
+            // Never export decoder descriptions, coding paths or private payload fragments.
+            throw .invalidRuntimeReply(.malformed)
+        }
+    }
+
+    /// Use for native replies and pushes. No contradictory/oversized envelope leaves this path.
+    public func encoded() throws(GuesthouseError) -> Data {
+        guard protocolVersion == .current else {
+            throw ProtocolMismatch(service: protocolVersion).error
+        }
+        if case .runtimeVersion(let info) = event, info.protocolVersion != protocolVersion {
+            throw .invalidRuntimeReply(.malformed)
+        }
+        do {
+            let data = try JSONEncoder().encode(self)
+            guard data.count <= Self.maximumEncodedSize else { throw GuesthouseError.invalidRuntimeReply(.oversized) }
+            return data
+        } catch let error as GuesthouseError {
+            throw error
+        } catch {
+            throw .invalidRuntimeReply(.malformed)
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeVersionInfo.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeVersionInfo.swift
@@ -1,0 +1,55 @@
+/// Private identity/status metadata. Never attach this value to diagnostics or export it as a log.
+public struct RuntimeVersionInfo: Codable, Hashable, Sendable {
+    public let serviceVersion: String?
+    public let serviceBuild: String?
+    public let protocolVersion: RuntimeProtocolVersion
+    /// The inspected runtime, which may be a candidate. This does not select a production provider.
+    public let runtime: RuntimeIdentityInfo?
+
+    public init(serviceVersion: String?, serviceBuild: String?,
+                protocolVersion: RuntimeProtocolVersion = .current, runtime: RuntimeIdentityInfo? = nil) {
+        self.serviceVersion = Self.admit(serviceVersion)
+        self.serviceBuild = Self.admit(serviceBuild)
+        self.protocolVersion = protocolVersion
+        self.runtime = runtime
+    }
+
+    private enum CodingKeys: String, CodingKey { case serviceVersion, serviceBuild, protocolVersion, runtime }
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(serviceVersion: try c.decodeIfPresent(String.self, forKey: .serviceVersion),
+                  serviceBuild: try c.decodeIfPresent(String.self, forKey: .serviceBuild),
+                  protocolVersion: try c.decode(RuntimeProtocolVersion.self, forKey: .protocolVersion),
+                  runtime: try c.decodeIfPresent(RuntimeIdentityInfo.self, forKey: .runtime))
+    }
+
+    static func admit(_ value: String?) -> String? {
+        value.flatMap { ConnectionVerificationRecord.isVersionIdentifier($0) ? $0 : nil }
+    }
+}
+
+/// Reported pinned bundle identity/signature/entitlement checks, not archive digest or hardware
+/// evidence. Only the runtime verifier may supply true; decoding a report is not verification.
+public struct RuntimeIdentityInfo: Codable, Hashable, Sendable {
+    public let provider: VMProvider
+    public let version: String?
+    public let verified: Bool
+    public let problem: GuesthouseError?
+
+    public init(provider: VMProvider, version: String?, verified: Bool, problem: GuesthouseError? = nil) {
+        self.provider = provider
+        self.version = RuntimeVersionInfo.admit(version)
+        // A missing/invalid identity or a reported problem cannot become a usable verification.
+        self.verified = verified && self.version != nil && problem == nil
+        self.problem = problem ?? (verified && self.version == nil ? .runtimeIncompatible : nil)
+    }
+
+    private enum CodingKeys: String, CodingKey { case provider, version, verified, problem }
+    public init(from decoder: any Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(provider: try c.decode(VMProvider.self, forKey: .provider),
+                  version: try c.decodeIfPresent(String.self, forKey: .version),
+                  verified: try c.decode(Bool.self, forKey: .verified),
+                  problem: try c.decodeIfPresent(GuesthouseError.self, forKey: .problem))
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -16,6 +16,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
     case unauthorizedCaller
     case protocolMismatch(client: Int, service: Int)
     case invalidRequest(InvalidRequestReason)
+    case invalidRuntimeReply(InvalidRuntimeReplyReason)
     case canceled
 
     public enum UnsupportedHostReason: Codable, Hashable, Sendable {
@@ -59,6 +60,9 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             }
         }
     }
+    public enum InvalidRuntimeReplyReason: String, Codable, Hashable, Sendable, CaseIterable {
+        case malformed, oversized
+    }
     public enum Category: String, Codable, Hashable, Sendable, CaseIterable {
         case host, storage, runtime, guest, credentials, tools, workflow, ipc, user
     }
@@ -73,7 +77,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .toolMismatch(.vmRuntime): .runtime
         case .toolMismatch, .xcodeComponentsIncomplete: .tools
         case .vmSlotUnavailable, .operationOutcomeUnknown: .workflow
-        case .unauthorizedCaller, .protocolMismatch, .invalidRequest: .ipc
+        case .unauthorizedCaller, .protocolMismatch, .invalidRequest, .invalidRuntimeReply: .ipc
         case .canceled: .user
         }
     }
@@ -122,6 +126,10 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             "The app (protocol \(client)) and runtime (protocol \(service)) are incompatible."
         case .invalidRequest(let reason):
             reason.message
+        case .invalidRuntimeReply(.malformed):
+            "Guesthouse received an invalid reply from its runtime service. An in-flight operation may still be running."
+        case .invalidRuntimeReply(.oversized):
+            "The runtime service's reply exceeds Guesthouse's supported size limit. An in-flight operation may still be running."
         case .canceled:
             "The operation was canceled; any partial changes must be inspected before retrying."
         }
@@ -151,6 +159,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .invalidRequest(.malformed): [.reviewRequest, .cancel]
         case .unauthorizedCaller: [.cancel]
         case .protocolMismatch: [.reinstallApp, .cancel]
+        case .invalidRuntimeReply: [.inspectState, .updateApp, .cancel]
         }
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeEventTests {
+    static let operation = OperationID()
+    static let diagnostic = DiagnosticEvent(operation: .startEnvironment, outcome: .started, operationID: operation.uuid)
+    static let events: [RuntimeEvent] = [
+        .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12")),
+        .accepted(operation), .progress(operation, ProgressPhase(kind: .copying, fraction: 0.5)),
+        .diagnostic(diagnostic), .status(RuntimeStatusTests.status()),
+        .completed(operation), .failed(operation, .operationOutcomeUnknown(operation))
+    ]
+
+    @Test(arguments: events)
+    func namedEventRoundTripsUseMandatoryEnvelope(event: RuntimeEvent) throws {
+        let envelope = RuntimeEventEnvelope(event: event)
+        let data = try envelope.encoded()
+        #expect(try RuntimeEventEnvelope.decode(data) == envelope)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(Set(object.keys) == ["protocolVersion", "event"])
+        #expect(object["protocolVersion"] as? Int == 8)
+    }
+
+    @Test(arguments: events)
+    func bareEventsHaveNoLegacyFallback(event: RuntimeEvent) throws {
+        let data = try JSONEncoder().encode(event)
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(data) }
+    }
+
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 9, Int.max])
+    func foreignHeaderPrecedesUnknownEvent(version: Int) {
+        let data = Data("{\"event\":{\"futureReply\":{}},\"protocolVersion\":\(version)}".utf8)
+        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: version)) {
+            try RuntimeEventEnvelope.decode(data)
+        }
+    }
+
+    @Test func directDecoderChecksVersionBeforeAbsentPayload() throws {
+        let data = Data(#"{"protocolVersion":7}"#.utf8)
+        let mismatch = try #require(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
+        }
+        #expect(mismatch.error == .protocolMismatch(client: 8, service: 7))
+    }
+
+    @Test func contradictoryNestedVersionIsMalformedOnBothPaths() throws {
+        let envelope = RuntimeEventEnvelope(event: .runtimeVersion(RuntimeVersionInfo(
+            serviceVersion: "0.1", serviceBuild: "12", protocolVersion: RuntimeProtocolVersion(7))))
+        let forged = try JSONEncoder().encode(envelope)
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(forged) }
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try envelope.encoded() }
+        let foreign = RuntimeEventEnvelope(protocolVersion: RuntimeProtocolVersion(7), event: Self.events[0])
+        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: 7)) { try foreign.encoded() }
+        let foreignBytes = try JSONEncoder().encode(foreign)
+        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: 7)) { try RuntimeEventEnvelope.decode(foreignBytes) }
+    }
+
+    @Test(arguments: ["{}", "null", "not-json", #"{"protocolVersion":8}"#,
+                      #"{"protocolVersion":"8","event":{}}"#,
+                      #"{"protocolVersion":8,"event":{"log":{"_0":null,"_1":"private-marker"}}}"#,
+                      #"{"protocolVersion":8,"event":{"futureReply":{}}}"#])
+    func malformedOrRawLogRepliesAreFixedErrors(json: String) {
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
+            try RuntimeEventEnvelope.decode(Data(json.utf8))
+        }
+    }
+
+    @Test func responseSizeIsAdmittedBeforeJSONParsing() throws {
+        var data = try RuntimeEventEnvelope(event: .completed(Self.operation)).encoded()
+        data.append(Data(repeating: 32, count: 65_536 - data.count))
+        #expect(try RuntimeEventEnvelope.decode(data).event == .completed(Self.operation))
+        data.append(0)
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.oversized)) { try RuntimeEventEnvelope.decode(data) }
+    }
+
+    @Test func underlyingEncoderFailureDoesNotEscape() {
+        let status = EnvironmentStatus(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking,
+                                       reconciledAt: Date(timeIntervalSince1970: .infinity))
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
+            try RuntimeEventEnvelope(event: .status(status)).encoded()
+        }
+    }
+
+    @Test func onlyExplicitDiagnosticsEnterTheLog() throws {
+        var observed = ObservedTuple(CompatibilityTupleTests.tuple())
+        observed.codexCLIPath = "/opt/private-marker/codex"
+        let status = RuntimeEvent.status(RuntimeStatusTests.status(observed))
+        let version = RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1-private-marker", serviceBuild: "12"))
+        let messages = [status, version, .diagnostic(Self.diagnostic)]
+        var log = DiagnosticLog()
+        for message in messages {
+            let decoded = try RuntimeEventEnvelope.decode(RuntimeEventEnvelope(event: message).encoded())
+            if let event = decoded.event.diagnosticEvent { log.append(event) }
+        }
+        #expect(log.records.count == 1)
+        #expect(log.records.first?.event == Self.diagnostic)
+        #expect(status.diagnosticEvent == nil)
+        #expect(version.diagnosticEvent == nil)
+        #expect(!log.text.contains("private-marker"))
+        #expect(!String(decoding: try log.jsonData(), as: UTF8.self).contains("private-marker"))
+    }
+
+    @Test func unknownDiagnosticAttachmentsAreNotReexported() throws {
+        var event = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.diagnostic)) as? [String: Any])
+        event["message"] = "private-marker"
+        event["stderr"] = "private-marker"
+        let object: [String: Any] = ["protocolVersion": 8, "event": ["diagnostic": ["_0": event]]]
+        let decoded = try RuntimeEventEnvelope.decode(JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.event.diagnosticEvent == Self.diagnostic)
+        #expect(!String(decoding: try decoded.encoded(), as: UTF8.self).contains("private-marker"))
+    }
+
+    @Test(arguments: [(GuesthouseError.InvalidRuntimeReplyReason.malformed,
+                       "Guesthouse received an invalid reply from its runtime service. An in-flight operation may still be running."),
+                      (.oversized, "The runtime service's reply exceeds Guesthouse's supported size limit. An in-flight operation may still be running.")])
+    func replyFailuresHaveSpecificSafeRecovery(reason: GuesthouseError.InvalidRuntimeReplyReason, message: String) throws {
+        let error = GuesthouseError.invalidRuntimeReply(reason)
+        #expect(error.userMessage == message)
+        #expect(error.category == .ipc)
+        #expect(error.recoveryActions == [.inspectState, .updateApp, .cancel])
+        #expect(!error.isRetryable)
+        let event = RuntimeEvent.failed(Self.operation, error)
+        #expect(try RuntimeEventEnvelope.decode(RuntimeEventEnvelope(event: event).encoded()).event == event)
+        let diagnostic = DiagnosticEvent(operation: .startEnvironment, outcome: .init(error: error), operationID: Self.operation.uuid)
+        #expect(try JSONDecoder().decode(DiagnosticEvent.self, from: JSONEncoder().encode(diagnostic)) == diagnostic)
+    }
+
+    @Test(arguments: VMProvider.allCases)
+    func providerIdentityIsExplicitAndRoundTrips(provider: VMProvider) throws {
+        let runtime = RuntimeIdentityInfo(provider: provider, version: "1.2.3", verified: true)
+        let info = RuntimeVersionInfo(serviceVersion: "0.1", serviceBuild: "12", runtime: runtime)
+        let envelope = RuntimeEventEnvelope(event: .runtimeVersion(info))
+        #expect(try RuntimeEventEnvelope.decode(envelope.encoded()) == envelope)
+        #expect(runtime.verified)
+        #expect(runtime.problem == nil)
+    }
+
+    @Test(arguments: ["", "private marker", "0.1\u{1B}[31m", String(repeating: "1", count: 257)])
+    func malformedMetadataBecomesUnknownWithoutInventingIdentity(value: String) throws {
+        let raw: [String: Any] = ["serviceVersion": value, "serviceBuild": value, "protocolVersion": 8,
+                                  "runtime": ["provider": "lume", "version": value, "verified": true]]
+        let info = try JSONDecoder().decode(RuntimeVersionInfo.self, from: JSONSerialization.data(withJSONObject: raw))
+        #expect(info.serviceVersion == nil)
+        #expect(info.serviceBuild == nil)
+        #expect(info.runtime?.version == nil)
+        #expect(info.runtime?.verified == false)
+        #expect(info.runtime?.problem == .runtimeIncompatible)
+        #expect(try JSONDecoder().decode(RuntimeVersionInfo.self, from: JSONEncoder().encode(info)) == info)
+    }
+
+    @Test func missingMetadataAndProblemsNeverImplyVerified() throws {
+        let unknown = RuntimeIdentityInfo(provider: .lume, version: nil, verified: true)
+        #expect(!unknown.verified)
+        #expect(unknown.problem == .runtimeIncompatible)
+        let failed = RuntimeIdentityInfo(provider: .lume, version: "0.5.3", verified: true, problem: .runtimeMissing)
+        #expect(!failed.verified)
+        #expect(failed.problem == .runtimeMissing)
+        let missing = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(#"{"protocolVersion":8}"#.utf8))
+        #expect(missing.runtime == nil)
+        #expect(missing.serviceVersion == nil)
+        #expect(missing.serviceBuild == nil)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(RuntimeIdentityInfo.self, from: Data(#"{"provider":"other","version":"1","verified":true}"#.utf8))
+        }
+    }
+
+    @Test func validMetadataAtTheByteLimitIsNotTruncated() throws {
+        let version = "1" + String(repeating: "a", count: 255)
+        let info = RuntimeVersionInfo(serviceVersion: version, serviceBuild: version,
+                                      runtime: RuntimeIdentityInfo(provider: .lume, version: version, verified: false))
+        #expect(info.serviceVersion == version)
+        #expect(info.runtime?.version == version)
+        #expect(try JSONDecoder().decode(RuntimeVersionInfo.self, from: JSONEncoder().encode(info)) == info)
+    }
+}


### PR DESCRIPTION
## Summary

Main-based replacement for the event/reply portion of #58 and #102 (issue #9, MVP-PLAN.md §3, ADR 0003), following merged #144/#145.

- Restores the seven original named event categories, replacing raw/redacted log lines with `diagnostic(DiagnosticEvent)`. Only that explicit case exposes a diagnostic record; private status/version data has no automatic log bridge.
- Restores mandatory versioned replies/pushes under epoch **8**. Header mismatch precedes payload interpretation, missing headers and legacy raw-log cases are rejected, and nested runtime-version contradictions fail.
- Adds bounded decode/encode entry points with a **64 KiB** reply limit and fixed error mapping. A malformed/oversized reply never supplies a raw decoder description and never implies that an in-flight mutation stopped.
- Adds a reply-specific Guesthouse error with inspect/update/cancel recovery, rather than asking users to edit a request when the service sent a broken response.
- Makes runtime identity metadata provider-aware, bounded and private. Invalid strings become unknown; a missing version or reported problem cannot yield `verified = true`. Reported bundle identity checks are not proof of archive verification, provider selection, or hardware gates.

## Validation

**334 Core tests / 27 suites pass**, warnings-as-errors. **340 changed lines / 5 files**. Diff checks pass.

Swift Testing regressions cover every event, version ordering in both directions, unknown/bare/raw-log/malformed payloads, reply size admission, encoder-failure mapping, non-propagation of unknown diagnostic attachments, typed reply recovery, exact metadata bounds, and private status exclusion from DiagnosticLog.

## Remaining integration

Inactive Core contract only. Both native XPC endpoints must adopt the bounded entry points; caller authentication, per-session admission, operation correlation, terminal event sequencing, and unknown-outcome reconciliation remain required. No request retry or host command is introduced here.

Later `environments`, `xcodeCandidate`, Lume capability/preflight metadata and their consumer-specific checks remain to migrate with their owning features; this does not certify that those descendants are integrated. Original source/tests/reviews remain preserved. Path containment and native transport are next; do not close #9 or merge the old sanitizer-dependent stack.

No host/VM/signing/hardware operations, new dependency, or provider-selection claim. Current-head Xcode Cloud and Codex review must clear before merge.