### PR TITLE
Migrate runtime path validation and symlink regressions

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator+Paths.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator+Paths.swift
@@ -1,0 +1,70 @@
+import Darwin
+import Foundation
+
+extension RequestValidator {
+    /// Shared name shape from #9: a whole lowercase UUID, never a guest-supplied display name.
+    /// Matching this shape does NOT prove Guesthouse ownership or authorize lifecycle actions.
+    public static func validateVMName(_ name: String) throws(RequestValidationError) {
+        guard name.utf8.count == 47, name.hasPrefix("guesthouse-"),
+              let uuid = UUID(uuidString: String(name.dropFirst(11))),
+              name == "guesthouse-\(uuid.uuidString.lowercased())"
+        else { throw .invalidVMName }
+    }
+
+    /// Snapshot containment sanity check retained from #58 (MVP-PLAN.md §3).
+    /// The service supplies its trusted root. This does not confer sandbox permission, prove
+    /// root ownership, or prevent filesystem races: actual access must use the runtime's
+    /// independently validated bookmark/descriptor and race-safe managed-storage operations.
+    public static func validateContainment(of candidate: URL, within root: URL) throws(RequestValidationError) -> URL {
+        guard candidate.isFileURL, root.isFileURL else { throw .invalidPath }
+        guard !candidate.pathComponents.contains("..") else { throw .pathEscapesRoot }
+        guard !containsDanglingSymbolicLink(root, below: URL(fileURLWithPath: "/")) else { throw .pathEscapesRoot }
+        let resolvedRoot = resolveThroughExistingAncestors(root)
+        let resolvedCandidate = resolveThroughExistingAncestors(candidate)
+        let rootComponents = resolvedRoot.pathComponents
+        let candidateComponents = resolvedCandidate.pathComponents
+        guard candidateComponents.count >= rootComponents.count,
+              Array(candidateComponents.prefix(rootComponents.count)) == rootComponents
+        else { throw .pathEscapesRoot }
+        // Check both spellings: the trusted root can itself be reached through an alias.
+        guard !containsDanglingSymbolicLink(candidate, below: root),
+              !containsDanglingSymbolicLink(resolvedCandidate, below: resolvedRoot)
+        else { throw .pathEscapesRoot }
+        return resolvedCandidate
+    }
+
+    /// Foundation leaves unresolved tails alone. Resolve the deepest existing ancestor so
+    /// an inside symlink to outside cannot conceal an as-yet nonexistent child.
+    private static func resolveThroughExistingAncestors(_ url: URL) -> URL {
+        let standardized = url.standardizedFileURL
+        var existing = standardized
+        var remainder: [String] = []
+        while !FileManager.default.fileExists(atPath: existing.path) {
+            let parent = existing.deletingLastPathComponent()
+            if parent.path == existing.path { break }
+            remainder.append(existing.lastPathComponent)
+            existing = parent
+        }
+        var resolved = existing.resolvingSymlinksInPath()
+        for component in remainder.reversed() { resolved.append(path: component) }
+        return resolved
+    }
+
+    /// Inspect links themselves with lstat. A dangling link can redirect a subsequent create
+    /// even though fileExists returns false; a symlink loop is likewise not a usable ancestor.
+    private static func containsDanglingSymbolicLink(_ url: URL, below root: URL) -> Bool {
+        let rootComponents = root.standardizedFileURL.pathComponents
+        let components = url.standardizedFileURL.pathComponents
+        guard components.count >= rootComponents.count,
+              Array(components.prefix(rootComponents.count)) == rootComponents
+        else { return false }
+        var current = root.standardizedFileURL
+        for component in components.dropFirst(rootComponents.count) {
+            current.append(path: component)
+            var info = stat()
+            guard lstat(current.path, &info) == 0 else { return false }
+            if (info.st_mode & S_IFMT) == S_IFLNK, stat(current.path, &info) != 0 { return true }
+        }
+        return false
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -83,13 +83,16 @@ public enum RequestValidationError: Error, Hashable, Sendable {
     case protocolMismatch(client: RuntimeProtocolVersion, service: RuntimeProtocolVersion)
     case optionOutOfRange(Option)
     case invalidDisplayName, invalidBundleIdentifier, invalidHandoff, malformed
+    case invalidVMName, invalidPath, pathEscapesRoot
 
     public var guesthouseError: GuesthouseError {
         switch self {
         case .oversized: .invalidRequest(.oversized)
         case .protocolMismatch(let client, let service):
             .protocolMismatch(client: client.rawValue, service: service.rawValue)
-        case .optionOutOfRange, .invalidDisplayName, .invalidBundleIdentifier, .invalidHandoff, .malformed:
+        case .invalidVMName: .invalidRequest(.invalidVMName)
+        case .pathEscapesRoot: .invalidRequest(.pathEscapesAllowedRoot)
+        case .optionOutOfRange, .invalidDisplayName, .invalidBundleIdentifier, .invalidHandoff, .invalidPath, .malformed:
             .invalidRequest(.malformed)
         }
     }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimePathValidationTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimePathValidationTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimePathValidationTests {
+    /// Every invocation owns its tree. No shared directories, external targets or host changes.
+    static func withTree(_ body: (URL, URL, URL) throws -> Void) throws {
+        let base = FileManager.default.temporaryDirectory.appending(path: "guesthouse-path-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: base, withIntermediateDirectories: false)
+        defer { try? FileManager.default.removeItem(at: base) }
+        let root = base.appending(path: "root")
+        let outside = base.appending(path: "outside")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: false)
+        try body(base, root, outside)
+    }
+
+    @Test func wholeUUIDNamesAreAccepted() throws {
+        let name = "guesthouse-1a2b3c4d-0000-4000-8000-000000000000"
+        try RequestValidator.validateVMName(name)
+        #expect(name == EnvironmentID(uuid: try #require(UUID(uuidString: "1a2b3c4d-0000-4000-8000-000000000000"))).tartVMName)
+    }
+
+    @Test(arguments: ["", "ubuntu", "guesthouse-1a2b3c4d", "guesthouse-1A2B3C4D-0000-4000-8000-000000000000",
+                      "GUESTHOUSE-1a2b3c4d-0000-4000-8000-000000000000",
+                      "../guesthouse-1a2b3c4d-0000-4000-8000-000000000000",
+                      "guesthouse-1a2b3c4d-0000-4000-8000-000000000000\n"])
+    func invalidNamesAreFixedRejections(name: String) {
+        #expect(throws: RequestValidationError.invalidVMName) { try RequestValidator.validateVMName(name) }
+    }
+
+    @Test func containedPathsAndInsideLinksResolve() throws {
+        try Self.withTree { _, root, _ in
+            let inside = root.appending(path: "Xcode.app")
+            try FileManager.default.createDirectory(at: inside, withIntermediateDirectories: false)
+            let link = root.appending(path: "alias")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: inside)
+            #expect(try RequestValidator.validateContainment(of: inside, within: root) == inside.resolvingSymlinksInPath())
+            #expect(try RequestValidator.validateContainment(of: link, within: root) == inside.resolvingSymlinksInPath())
+            #expect(try RequestValidator.validateContainment(of: link.appending(path: "new/file"), within: root)
+                    == inside.resolvingSymlinksInPath().appending(path: "new/file"))
+            #expect(try RequestValidator.validateContainment(of: root, within: root) == root.resolvingSymlinksInPath())
+        }
+    }
+
+    @Test(arguments: ["", "new/file"])
+    func outsideSymlinkAndItsMissingChildrenAreRejected(tail: String) throws {
+        try Self.withTree { _, root, outside in
+            let link = root.appending(path: "escape")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside)
+            #expect(throws: RequestValidationError.pathEscapesRoot) {
+                try RequestValidator.validateContainment(of: link.appending(path: tail), within: root)
+            }
+        }
+    }
+
+    @Test func traversalSiblingPrefixAndNonFileURLsAreRejected() throws {
+        try Self.withTree { base, root, _ in
+            #expect(throws: RequestValidationError.pathEscapesRoot) {
+                try RequestValidator.validateContainment(of: root.appending(path: "../outside"), within: root)
+            }
+            let sibling = base.appending(path: "root-sibling")
+            try FileManager.default.createDirectory(at: sibling, withIntermediateDirectories: false)
+            #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: sibling, within: root) }
+            let remote = try #require(URL(string: "https://example.com/private-marker"))
+            #expect(throws: RequestValidationError.invalidPath) { try RequestValidator.validateContainment(of: remote, within: root) }
+            #expect(throws: RequestValidationError.invalidPath) { try RequestValidator.validateContainment(of: root, within: remote) }
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func danglingLinksRemainRejectedThroughRootAliases(useAlias: Bool) throws {
+        try Self.withTree { base, root, outside in
+            let dangling = root.appending(path: "dangling")
+            try FileManager.default.createSymbolicLink(at: dangling, withDestinationURL: outside.appending(path: "not-created"))
+            let alias = base.appending(path: "root-alias")
+            try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: root)
+            let selectedRoot = useAlias ? alias : root
+            #expect(throws: RequestValidationError.pathEscapesRoot) {
+                try RequestValidator.validateContainment(of: selectedRoot.appending(path: "dangling"), within: selectedRoot)
+            }
+            #expect(throws: RequestValidationError.pathEscapesRoot) {
+                try RequestValidator.validateContainment(of: selectedRoot.appending(path: "dangling/child"), within: selectedRoot)
+            }
+        }
+    }
+
+    @Test(arguments: ["", "subroot"])
+    func danglingRootAndItsAncestorsAreRejected(tail: String) throws {
+        try Self.withTree { base, _, outside in
+            let link = base.appending(path: "dangling-root")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: outside.appending(path: "missing"))
+            let root = link.appending(path: tail)
+            #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root, within: root) }
+            #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: root.appending(path: "Xcode.app"), within: root) }
+        }
+    }
+
+    @Test func symlinkCyclesAreRejected() throws {
+        try Self.withTree { _, root, _ in
+            let first = root.appending(path: "first")
+            let second = root.appending(path: "second")
+            try FileManager.default.createSymbolicLink(at: first, withDestinationURL: second)
+            try FileManager.default.createSymbolicLink(at: second, withDestinationURL: first)
+            #expect(throws: RequestValidationError.pathEscapesRoot) { try RequestValidator.validateContainment(of: first.appending(path: "child"), within: root) }
+        }
+    }
+
+    @Test(arguments: [(RequestValidationError.invalidVMName, GuesthouseError.invalidRequest(.invalidVMName)),
+                      (.invalidPath, .invalidRequest(.malformed)), (.pathEscapesRoot, .invalidRequest(.pathEscapesAllowedRoot))])
+    func pathErrorsMapToFixedDomainErrors(error: RequestValidationError, expected: GuesthouseError) {
+        #expect(error.guesthouseError == expected)
+        #expect(!error.guesthouseError.recoveryActions.isEmpty)
+        #expect(!error.guesthouseError.isRetryable)
+    }
+}


### PR DESCRIPTION
## Summary

Continues the replacement of #58 for #9, under ADR 0003 and `MVP-PLAN.md` §3 (“Sandbox and XPC boundary”) and §11. This focused PR restores the shared VM-name/path checks and filesystem regressions without importing the old sanitizer ancestry.

- Validate the complete lowercase `guesthouse-<uuid>` name, never a display name.
- Preserve canonical containment checks through existing ancestors, including missing children, outside symlinks, sibling-prefix tricks, dangling links through root aliases, and dangling root ancestors.
- Map failures to the existing fixed `GuesthouseError` cases. No raw paths or arbitrary error descriptions enter diagnostics.
- Each test owns a unique temporary tree; both name and filesystem cases use the existing Swift Testing conventions.

## Boundaries

This is a snapshot sanity check, **not** proof of VM/root ownership, sandbox access, or race-safe authorization for a later write. The runtime must still independently validate bookmark/descriptor authority and use race-safe managed-storage operations. No host process, provider CLI, endpoint, import, or VM operation is activated here. Lume remains a candidate; no new Tart feature is introduced.

This PR branches directly from merged main at `c24b5308b62a37f4c07ea8be1401d94cbd54259a` and is independent of event/reply PR #146. Original #58 remains a migration reference: native event-envelope adoption, caller authentication, admission, operation correlation and unknown-outcome handling still need their owning transport changes. This PR does not declare those findings fixed.

## Validation

- Full `GuesthouseCore` suite: **328 tests / 27 suites passed**, warnings treated as errors.
- `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`
- `git diff --check` passed.
- 191 changed lines across three files; no dependencies added.
- Xcode Cloud and the automatic Codex review must pass on the published head before merge.
