### PR TITLE
Migrate bounded request admission and atomic session registration

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Shared #20 admission decisions (MVP-PLAN.md §3), not an authenticated transport.
+/// A dispatch decision still needs atomic session registration and operation-specific authority.
+public enum RuntimeDispatcher: Sendable {
+    public enum Decision: Hashable, Sendable {
+        case reply(RuntimeEvent)
+        /// Record refusal, hand over every owed reply, then close through SessionLifetime.
+        case replyAndClose(RuntimeEvent)
+        case dispatch(RuntimeRequest)
+    }
+
+    /// Reply obligations, not running operations. The transport balances every successful
+    /// began() with exactly one finished(), AFTER handing its reply (if any) to XPC.
+    public struct SessionLifetime: Sendable {
+        public private(set) var inFlight = 0
+        public private(set) var refusal: RuntimeEvent?
+        public private(set) var isClosing = false
+
+        public init() {}
+
+        /// Returns the number of other replies owed. Refused sessions still answer pipelined
+        /// messages until one caller claims the close; nothing is admitted after that claim.
+        public mutating func began() -> Int? {
+            guard !isClosing else { return nil }
+            inFlight += 1
+            return inFlight - 1
+        }
+
+        /// The first refusal remains authoritative; later failures cannot rewrite its cause.
+        public mutating func refuse(_ rejection: RuntimeEvent) {
+            if refusal == nil { refusal = rejection }
+        }
+
+        /// The caller getting true owns cancellation. Never call for an uncounted message.
+        public mutating func finished() -> Bool {
+            precondition(inFlight > 0, "Unbalanced runtime reply accounting")
+            inFlight -= 1
+            guard refusal != nil, inFlight == 0, !isClosing else { return false }
+            isClosing = true
+            return true
+        }
+    }
+
+    public static let maximumInFlightRequestsPerSession = 8
+
+    public static func undecodable() -> Decision {
+        .reply(.failed(OperationID(), .invalidRequest(.malformed)))
+    }
+
+    /// Only reads the bounded header at the cap, never the request payload. The eventual
+    /// native frame must independently enforce actual key/type/byte bounds before copying.
+    public static func admit(inFlight: Int, clientVersion: () -> RuntimeProtocolVersion?) -> Decision? {
+        guard inFlight >= 0 else { return undecodable() }
+        guard inFlight >= maximumInFlightRequestsPerSession else { return nil }
+        guard let version = clientVersion() else { return undecodable() }
+        guard version == .current else {
+            return mismatch(.protocolMismatch(client: version.rawValue, service: RuntimeProtocolVersion.current.rawValue))
+        }
+        return .reply(.failed(OperationID(), .invalidRequest(.tooManyInFlight)))
+    }
+
+    public static func mismatch(_ error: GuesthouseError) -> Decision {
+        .replyAndClose(.failed(OperationID(), error))
+    }
+
+    public static func refused(_ rejection: RuntimeEvent) -> Decision { .reply(rejection) }
+
+    /// Pure early-rejection convenience, NOT authorization based on a refusal snapshot.
+    /// RuntimeSessionGate.commit must recheck refusal and register under the same lock.
+    public static func honoring(_ refusal: RuntimeEvent?, _ decision: Decision) -> Decision {
+        guard let refusal, case .dispatch = decision else { return decision }
+        return refused(refusal)
+    }
+
+    /// Accept only the original JSON payload bytes. Measuring a decoded/re-encoded envelope
+    /// loses ignored fields (#112); there is deliberately no decoded-envelope overload.
+    /// The size check bounds JSON work here, not native XPC's receive/copy allocation.
+    public static func decide(_ data: Data, inFlight: Int) -> Decision {
+        do {
+            try RequestValidator.validateEncodedSize(data)
+            if let refusal = admit(inFlight: inFlight, clientVersion: {
+                try? JSONDecoder().decode(Header.self, from: data).protocolVersion
+            }) { return refusal }
+            return .dispatch(try RequestValidator.decode(data).request)
+        } catch {
+            let event = RuntimeEvent.failed(OperationID(), error.guesthouseError)
+            if case .protocolMismatch = error { return .replyAndClose(event) }
+            return .reply(event)
+        }
+    }
+
+    private struct Header: Decodable {
+        let protocolVersion: RuntimeProtocolVersion
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeDispatcher.swift
@@ -19,10 +19,10 @@ public enum RuntimeDispatcher: Sendable {
 
         public init() {}
 
-        /// Returns the number of other replies owed. Refused sessions still answer pipelined
-        /// messages until one caller claims the close; nothing is admitted after that claim.
+        /// Returns the number of other replies owed. Refusal immediately stops new admission;
+        /// only messages already counted may drain, so continued traffic cannot delay closure.
         public mutating func began() -> Int? {
-            guard !isClosing else { return nil }
+            guard refusal == nil, !isClosing else { return nil }
             inFlight += 1
             return inFlight - 1
         }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
@@ -1,0 +1,36 @@
+import Synchronization
+
+/// Serializes one session's reply accounting, refusal, and synchronous operation registration.
+/// This is not an executor or command interface. Only authenticated, admitted, validated
+/// requests may reach commit. Registration is bounded, synchronous and in-memory: no I/O,
+/// suspension or reentry. Register identity/cancellation here; perform work outside the gate.
+/// Mutex fits the native synchronous callback boundary without unchecked Sendable or actors.
+public final class RuntimeSessionGate: Sendable {
+    // Internal so tests can nonblockingly verify registration shares the refusal lock.
+    let state = Mutex(RuntimeDispatcher.SessionLifetime())
+
+    public init() {}
+
+    public func began() -> Int? { state.withLock { $0.began() } }
+
+    /// Early rejection only; a snapshot cannot authorize later dispatch.
+    public var refusal: RuntimeEvent? { state.withLock { $0.refusal } }
+
+    public func refuse(_ event: RuntimeEvent) { state.withLock { $0.refuse(event) } }
+
+    /// A prior refusal prevents registration. A later refusal cannot undo registered work.
+    /// Refusal or a thrown registration still owes this message's reply: hand over its answer,
+    /// including a typed failure after a throw, then call finished exactly once.
+    public func commit(
+        _ request: RuntimeRequest,
+        register: (RuntimeRequest) throws -> RuntimeEvent
+    ) rethrows -> RuntimeEvent {
+        try state.withLock { lifetime in
+            if let refusal = lifetime.refusal { return refusal }
+            return try register(request)
+        }
+    }
+
+    /// After reply handoff, returns whether this caller owns the refused session's cancel.
+    public func finished() -> Bool { state.withLock { $0.finished() } }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
@@ -11,6 +11,8 @@ public final class RuntimeSessionGate: Sendable {
 
     public init() {}
 
+    /// Refusal and admission share this lock. A nil result incurs no reply obligation:
+    /// the adapter must not decode, dispatch, or call finished for that later callback.
     public func began() -> Int? { state.withLock { $0.began() } }
 
     /// Early rejection only; a snapshot cannot authorize later dispatch.

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Errors/GuesthouseError.swift
@@ -48,7 +48,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         }
     }
     public enum InvalidRequestReason: String, Codable, Hashable, Sendable, CaseIterable {
-        case oversized, pathEscapesAllowedRoot, invalidVMName, unsupportedOperation, malformed
+        case oversized, pathEscapesAllowedRoot, invalidVMName, unsupportedOperation, malformed, tooManyInFlight
 
         fileprivate var message: String {
             switch self {
@@ -57,6 +57,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
             case .invalidVMName: "The request contains an invalid development Mac name."
             case .unsupportedOperation: "This version of Guesthouse does not support the requested operation."
             case .malformed: "The request is incomplete or has an invalid format."
+            case .tooManyInFlight: "Guesthouse's runtime service is already handling too many requests."
             }
         }
     }
@@ -157,6 +158,7 @@ public enum GuesthouseError: Error, Codable, Hashable, Sendable {
         case .invalidRequest(.oversized): [.reduceRequestSize, .cancel]
         case .invalidRequest(.unsupportedOperation): [.updateApp, .cancel]
         case .invalidRequest(.malformed): [.reviewRequest, .cancel]
+        case .invalidRequest(.tooManyInFlight): [.inspectState, .cancel]
         case .unauthorizedCaller: [.cancel]
         case .protocolMismatch: [.reinstallApp, .cancel]
         case .invalidRuntimeReply: [.inspectState, .updateApp, .cancel]

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeDispatcherTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeDispatcherTests.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeDispatcherTests {
+    /// Migrated #110 scenarios now pass original bytes, never a re-encoded decoded object.
+    @Test func validRequestIsDispatchedAtTheLastAvailableSlot() throws {
+        let data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .runtimeVersion))
+        #expect(RuntimeDispatcher.decide(data, inFlight: 7) == .dispatch(.runtimeVersion))
+    }
+
+    @Test(arguments: [0, 8])
+    func foreignVersionWinsOverAnUnknownPayload(inFlight: Int) throws {
+        let version = RuntimeProtocolVersion.current.rawValue + 1
+        let data = Data("{\"protocolVersion\":\(version),\"request\":{\"futureOperation\":{}}}".utf8)
+        guard case .replyAndClose(.failed(_, let error)) = RuntimeDispatcher.decide(data, inFlight: inFlight) else {
+            Issue.record("expected mismatch and close"); return
+        }
+        #expect(error == .protocolMismatch(client: version, service: RuntimeProtocolVersion.current.rawValue))
+    }
+
+    @Test func invalidOptionsAreRejectedWithoutClosing() throws {
+        let envelope = RuntimeRequestEnvelope(request: .startEnvironment(EnvironmentID(), StartOptions(ipWait: .seconds(10_000))))
+        let data = try JSONEncoder().encode(envelope)
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(data, inFlight: 0) else {
+            Issue.record("expected request rejection"); return
+        }
+        #expect(error == .invalidRequest(.malformed))
+    }
+
+    @Test(arguments: [8, 9, Int.max])
+    func theCapRejectsBeforeInterpretingPayload(inFlight: Int) {
+        let data = Data("{\"protocolVersion\":\(RuntimeProtocolVersion.current.rawValue),\"request\":\"not-a-request\"}".utf8)
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(data, inFlight: inFlight) else {
+            Issue.record("expected over-cap rejection"); return
+        }
+        #expect(error == .invalidRequest(.tooManyInFlight))
+        #expect(error.recoveryActions == [.inspectState, .cancel])
+        #expect(!error.isRetryable)
+    }
+
+    @Test func theHeaderIsReadOnlyAtTheCap() {
+        var reads = 0
+        #expect(RuntimeDispatcher.admit(inFlight: 7, clientVersion: { reads += 1; return .current }) == nil)
+        #expect(reads == 0)
+        _ = RuntimeDispatcher.admit(inFlight: 8, clientVersion: { reads += 1; return .current })
+        #expect(reads == 1)
+    }
+
+    @Test func anUnreadableHeaderAndInvalidAccountingAreMalformed() {
+        guard case .reply(.failed(_, let missing))? = RuntimeDispatcher.admit(inFlight: 8, clientVersion: { nil }) else {
+            Issue.record("expected malformed header rejection"); return
+        }
+        #expect(missing == .invalidRequest(.malformed))
+        var reads = 0
+        guard case .reply(.failed(_, let invalid))? = RuntimeDispatcher.admit(inFlight: -1, clientVersion: { reads += 1; return .current }) else {
+            Issue.record("expected invalid accounting rejection"); return
+        }
+        #expect(invalid == .invalidRequest(.malformed))
+        #expect(reads == 0)
+    }
+
+    @Test(arguments: ["", "{}", "{\"protocolVersion\":\"private-marker\"}"])
+    func malformedInputHasOnlyFixedErrors(input: String) {
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(Data(input.utf8), inFlight: 0) else {
+            Issue.record("expected malformed request"); return
+        }
+        #expect(error == .invalidRequest(.malformed))
+        #expect(error.userMessage == "The request is incomplete or has an invalid format.")
+    }
+
+    @Test func ignoredFieldsCannotDisappearBeforeTheSizeCheck() throws {
+        let payload = "{\"protocolVersion\":\(RuntimeProtocolVersion.current.rawValue),\"request\":{\"runtimeVersion\":{}},\"ignored\":\"\(String(repeating: "x", count: 65_537))\"}"
+        let data = Data(payload.utf8)
+        // Reproduces the old loss: bare decoding/reencoding removes the oversized extra field.
+        let decoded = try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data)
+        #expect(try JSONEncoder().encode(decoded).count < RequestValidator.maximumEncodedSize)
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(data, inFlight: 0) else {
+            Issue.record("expected original-byte size rejection"); return
+        }
+        #expect(error == .invalidRequest(.oversized))
+    }
+
+    @Test func exactByteBoundaryAndOversizeBeforeHeaderParsing() throws {
+        var data = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .runtimeVersion))
+        data.append(Data(repeating: 32, count: RequestValidator.maximumEncodedSize - data.count))
+        #expect(RuntimeDispatcher.decide(data, inFlight: 0) == .dispatch(.runtimeVersion))
+        data.append(32)
+        guard case .reply(.failed(_, let error)) = RuntimeDispatcher.decide(data, inFlight: 8) else {
+            Issue.record("expected size rejection before header parsing"); return
+        }
+        #expect(error == .invalidRequest(.oversized))
+    }
+
+    @Test func refusalOverridesOnlyDispatch() {
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        let dispatch = RuntimeDispatcher.Decision.dispatch(.runtimeVersion)
+        let answer = RuntimeDispatcher.undecodable()
+        #expect(RuntimeDispatcher.refused(refusal) == .reply(refusal))
+        #expect(RuntimeDispatcher.honoring(refusal, dispatch) == .reply(refusal))
+        #expect(RuntimeDispatcher.honoring(nil, dispatch) == dispatch)
+        #expect(RuntimeDispatcher.honoring(refusal, answer) == answer)
+    }
+
+    @Test func unrefusedSessionNeverClosesAndSingleRefusedReplyDoes() {
+        var lifetime = RuntimeDispatcher.SessionLifetime()
+        let firstCount = lifetime.began()
+        let firstCloses = lifetime.finished()
+        #expect(firstCount == 0)
+        #expect(!firstCloses)
+        #expect(lifetime.refusal == nil)
+        let secondCount = lifetime.began()
+        #expect(secondCount == 0)
+        lifetime.refuse(.failed(OperationID(), .unauthorizedCaller))
+        let secondCloses = lifetime.finished()
+        #expect(secondCloses)
+        #expect(lifetime.isClosing)
+        let afterClose = lifetime.began()
+        #expect(afterClose == nil)
+        #expect(lifetime.inFlight == 0)
+    }
+
+    @Test func capErrorRoundTripsWithoutRawMetadata() throws {
+        let event = RuntimeEvent.failed(OperationID(), .invalidRequest(.tooManyInFlight))
+        let envelope = RuntimeEventEnvelope(event: event)
+        #expect(try RuntimeEventEnvelope.decode(envelope.encoded()) == envelope)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
@@ -1,4 +1,5 @@
 import Dispatch
+import Foundation
 import Synchronization
 import Testing
 @testable import GuesthouseCore
@@ -44,19 +45,50 @@ import Testing
         let gate = RuntimeSessionGate()
         let expected = RuntimeEvent.completed(OperationID())
         #expect(gate.began() == 0)
-        var lockWasHeld = false
+        let lockWasHeld = Mutex<Bool?>(nil)
+        let observed = DispatchSemaphore(value: 0)
         var registeredRequest: RuntimeRequest?
         let reply = gate.commit(.runtimeVersion) { request in
-            // Unlike a scheduling sleep, this fails deterministically if commit reads a
-            // snapshot, unlocks, and only then calls registration. It never blocks/reenters.
-            lockWasHeld = gate.state.withLockIfAvailable { _ in true } == nil
+            // A distinct native thread avoids recursively trying the nonrecursive mutex.
+            // This synchronous test holds the callback open only until the nonblocking probe
+            // completes (bounded wait, no scheduling sleeps or async-executor blocking).
+            Thread.detachNewThread {
+                let unavailable = gate.state.withLockIfAvailable { _ in true } == nil
+                lockWasHeld.withLock { $0 = unavailable }
+                observed.signal()
+            }
+            #expect(observed.wait(timeout: .now() + 5) == .success)
             registeredRequest = request
             return expected
         }
-        #expect(lockWasHeld)
+        #expect(lockWasHeld.withLock { $0 } == true)
         #expect(registeredRequest == .runtimeVersion)
         #expect(reply == expected)
         #expect(!gate.finished(), "an unrefused session stays open")
+    }
+
+    @Test func trafficAfterRefusalCannotExtendTheDrain() {
+        let gate = RuntimeSessionGate()
+        let first = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        #expect(gate.began() == 0)
+        #expect(gate.began() == 1)
+        gate.refuse(first)
+        let unexpectedAdmissions = Mutex(0)
+        DispatchQueue.concurrentPerform(iterations: 64) { _ in
+            if gate.began() != nil { unexpectedAdmissions.withLock { $0 += 1 } }
+        }
+        #expect(unexpectedAdmissions.withLock { $0 } == 0)
+        #expect(gate.state.withLock { $0.inFlight } == 2)
+        #expect(!gate.state.withLock { $0.isClosing }, "already counted replies must be handed over")
+        var registrations = 0
+        #expect(gate.commit(.runtimeVersion) { _ in registrations += 1; return .completed(OperationID()) } == first)
+        #expect(registrations == 0)
+        #expect(!gate.finished())
+        #expect(gate.began() == nil, "the remaining reply cannot be kept alive by new traffic")
+        #expect(gate.finished())
+        #expect(gate.state.withLock { $0.inFlight } == 0)
+        #expect(gate.state.withLock { $0.isClosing })
+        #expect(gate.began() == nil)
     }
 
     @Test func laterRefusalPreservesTheAlreadyRegisteredAnswerAndFirstRejection() {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionGateTests.swift
@@ -1,0 +1,93 @@
+import Dispatch
+import Synchronization
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct RuntimeSessionGateTests {
+    @Test func concurrentRepliesClaimExactlyOneClose() {
+        let gate = RuntimeSessionGate()
+        let closes = Mutex(0)
+        for index in 0..<32 { #expect(gate.began() == index) }
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            if gate.finished() { closes.withLock { $0 += 1 } }
+        }
+        #expect(closes.withLock { $0 } == 1)
+        #expect(gate.state.withLock { $0.inFlight } == 0)
+        #expect(gate.began() == nil)
+    }
+
+    @Test(arguments: [GuesthouseError.unauthorizedCaller, .protocolMismatch(client: 99, service: 7)])
+    func refusalBeforeCommitPreventsRegistrationDespiteAnEarlierOpenSnapshot(error: GuesthouseError) {
+        let gate = RuntimeSessionGate()
+        let refusal = RuntimeEvent.failed(OperationID(), error)
+        #expect(gate.began() == 0)
+        #expect(gate.began() == 1)
+        let earlierSnapshot = gate.refusal
+        #expect(earlierSnapshot == nil)
+        gate.refuse(refusal)
+
+        var registrations = 0
+        let reply = gate.commit(.runtimeVersion) { _ in
+            registrations += 1
+            return .completed(OperationID())
+        }
+        #expect(reply == refusal)
+        #expect(registrations == 0)
+        #expect(gate.state.withLock { $0.inFlight } == 2, "rejection still owes both replies")
+        #expect(!gate.finished(), "the first reply must not discard the second")
+        #expect(gate.finished(), "only the last reply claims cancellation")
+        #expect(gate.began() == nil, "nothing is admitted once cancellation is claimed")
+    }
+
+    @Test func registrationRunsUnderTheSameLockAsRefusal() {
+        let gate = RuntimeSessionGate()
+        let expected = RuntimeEvent.completed(OperationID())
+        #expect(gate.began() == 0)
+        var lockWasHeld = false
+        var registeredRequest: RuntimeRequest?
+        let reply = gate.commit(.runtimeVersion) { request in
+            // Unlike a scheduling sleep, this fails deterministically if commit reads a
+            // snapshot, unlocks, and only then calls registration. It never blocks/reenters.
+            lockWasHeld = gate.state.withLockIfAvailable { _ in true } == nil
+            registeredRequest = request
+            return expected
+        }
+        #expect(lockWasHeld)
+        #expect(registeredRequest == .runtimeVersion)
+        #expect(reply == expected)
+        #expect(!gate.finished(), "an unrefused session stays open")
+    }
+
+    @Test func laterRefusalPreservesTheAlreadyRegisteredAnswerAndFirstRejection() {
+        let gate = RuntimeSessionGate()
+        let expected = RuntimeEvent.completed(OperationID())
+        let first = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        #expect(gate.began() == 0)
+        let reply = gate.commit(.runtimeVersion) { _ in expected }
+        gate.refuse(first)
+        gate.refuse(.failed(OperationID(), .protocolMismatch(client: 99, service: 7)))
+        #expect(reply == expected)
+        #expect(gate.refusal == first)
+        #expect(gate.state.withLock { $0.inFlight } == 1)
+        #expect(gate.finished())
+        #expect(gate.began() == nil)
+    }
+
+    @Test func thrownRegistrationUnlocksWithoutReleasingItsReplyObligation() {
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        #expect(throws: CancellationError.self) {
+            try gate.commit(.runtimeVersion) { _ in throw CancellationError() }
+        }
+        #expect(gate.state.withLockIfAvailable { $0.inFlight } == 1)
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        #expect(gate.finished(), "the caller still owns sending its failure then finishing")
+        #expect(gate.began() == nil)
+    }
+
+    @Test func gateHasCheckedSendableConformance() {
+        func requireSendable<T: Sendable>(_: T.Type) {}
+        requireSendable(RuntimeSessionGate.self)
+    }
+}


### PR DESCRIPTION
## Scope

Focused replacement of the shared admission/registration portion of #110/#68 for #20, following ADR 0003 and `MVP-PLAN.md` §3 (sandbox/XPC boundary) and §11. Stacked on #146 at `8a3b749a1be2b8884e81ba0822d4809133aa5b66`; independent of #147. No old sanitizer ancestry is imported.

- Restore the eight-request admission cap, version-mismatch versus malformed/over-cap decisions, first-refusal preservation, reply accounting, and exactly-one close ownership.
- Restore checked-Sendable `RuntimeSessionGate` with the original atomic refusal/registration invariant. Registration remains a short synchronous in-memory callback, never an executor or arbitrary command interface.
- Add the closed `tooManyInFlight` error with a fixed Guesthouse message and inspect/cancel recovery, never automatic retry.
- Accept **original JSON payload bytes** in `RuntimeDispatcher.decide`. Check their actual length before parsing the header/request. There is no decoded-envelope overload, re-encode measurement, or encoder-error-to-empty-data fallback.

## Tests and reuse

All five original #110 gate scenarios are retained, including deterministic same-lock checking, refusal before commit despite an earlier open snapshot, registration before later refusal, first-cause preservation, throws retaining reply obligations, and checked Sendable conformance. A distinct-thread probe checks the registration lock without recursive acquisition. Additional concurrent tests prove exactly one close claim and that continued traffic cannot extend a refused session's drain; there are no scheduling sleeps.

Dispatcher scenarios are migrated to original-byte inputs: cap boundary, malformed headers/options, foreign version before unknown payload, cheap header reads only at the cap, refusal decisions and lifecycle. A regression explicitly demonstrates that a 65,537-byte ignored field disappears through bare Codable decode/re-encode, but is rejected by the new original-byte decision path. Exact 64 KiB is accepted, one extra byte rejected. That is a **Core JSON regression**, not the native-XPC reproduction or its completed fix.

Full `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: **353 tests / 29 suites passed**, exit 0. Diff checks pass; 391 changed lines across five files. No dependencies or warnings added.

## Remaining boundaries — not claimed complete

- This PR activates no endpoint and authenticates no caller. Only an independently authenticated, admitted and validated request may reach the gate.
- #112 remains required: native fixed-schema framing must check actual keys/types/XPCData length before copying into Swift Data. This PR bounds JSON decode work, not libxpc receive allocation. Do not feed it a re-encoded object or keep an unbounded native Codable fallback.
- Native integration must preserve same-team/exact-identifier and per-message authentication, one-way refusal handling, explicit reply-before-finish/cancel, generation retirement, correlation, preaccept/accepted unknown outcomes, and no automatic replay.
- The gate counts reply obligations, not running operations. Its caller must balance each successful `began` with exactly one `finished` after handing over a reply, including failures. A refusal never cancels or proves the outcome of previously registered work.
- Current Core wire 8 remains inactive. The actual #112 transport activation needs a fresh epoch beyond the historical 8–11 reservations and a reviewed consumer migration map; this PR does not settle that activation.
- Original #110/#68 and their remaining native-boundary findings stay open/reference. No issue closure, provider activation, signing or hardware proof is claimed.

Fresh exact-head Xcode Cloud and automatic Codex review must pass before merge.

## Review follow-up — 2026-09-09

Both reported findings are addressed together in `780a95949cc02602e739b5ec497dabd0e987cc0a`: stop new admission immediately on refusal while draining counted replies, and probe lock ownership from a separate native test thread. Temporary local mutants reproduced failure of the drain and same-lock regressions; fixes were restored before the successful full 353-test run. Existing green CI belonged to the preceding head and does not approve this update. Fresh exact-head CI/review remain required.
