### PR TITLE
Validate native XPC frames before copying payloads

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RawRuntimeFrame.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RawRuntimeFrame.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XPC
+
+/// Fixed-schema native XPC frame validation for #112 / MVP-PLAN.md §3.
+/// No endpoint is activated here. The transport must authenticate the received message FIRST,
+/// choose its agreed wire epoch, and validate nested request/event versions after framing.
+public enum RawRuntimeFrame: Sendable {
+    public static let maximumPayloadBytes = 64 * 1024
+
+    public enum Failure: Error, Hashable, Sendable {
+        case malformed, oversized
+        case protocolMismatch(received: Int64)
+    }
+
+    /// Returns an owned, bounded copy. Native type/count/length checks happen before copying
+    /// or JSON decoding. This does NOT bound libxpc's initial receive allocation or authenticate
+    /// the caller. Do not concurrently mutate the dictionary while validating it.
+    public static func payload(_ message: XPCDictionary, expectedVersion: Int64) throws(Failure) -> Data {
+        try withPayloadBytes(message, expectedVersion: expectedVersion) { Data($0) }
+    }
+
+    /// Internal test seam: the pointer stays inside the retained dictionary's scope. Only
+    /// payload() exposes this publicly, as owned Data; no borrowed pointer escapes that API.
+    static func withPayloadBytes<ResultValue>(
+        _ message: XPCDictionary,
+        expectedVersion: Int64,
+        _ body: (UnsafeRawBufferPointer) -> ResultValue
+    ) throws(Failure) -> ResultValue {
+        let result: Result<ResultValue, Failure> = message.withUnsafeUnderlyingDictionary { dictionary in
+            guard let header = xpc_dictionary_get_value(dictionary, "protocolVersion"),
+                  xpc_get_type(header) == XPC_TYPE_INT64 else { return .failure(.malformed) }
+            let received = xpc_int64_get_value(header)
+            guard received == expectedVersion else { return .failure(.protocolMismatch(received: received)) }
+            // Two fixed keys plus the exact count reject unknown fields without copying
+            // attacker-controlled keys/values into Swift strings or collections.
+            guard xpc_dictionary_get_count(dictionary) == 2,
+                  let payload = xpc_dictionary_get_value(dictionary, "payload"),
+                  xpc_get_type(payload) == XPC_TYPE_DATA else { return .failure(.malformed) }
+            let length = xpc_data_get_length(payload)
+            guard length <= maximumPayloadBytes else { return .failure(.oversized) }
+            guard length > 0, let pointer = xpc_data_get_bytes_ptr(payload) else { return .failure(.malformed) }
+            return .success(body(UnsafeRawBufferPointer(start: pointer, count: length)))
+        }
+        return try result.get()
+    }
+
+    /// Frames already encoded bytes, not arbitrary Codable objects or a command interface.
+    /// The caller owns bounded encoding, version consistency and typed error presentation.
+    public static func encode(_ payload: Data, protocolVersion: Int64) throws(Failure) -> XPCDictionary {
+        guard payload.count <= maximumPayloadBytes else { throw .oversized }
+        guard !payload.isEmpty else { throw .malformed }
+        var result = XPCDictionary()
+        result["protocolVersion"] = protocolVersion
+        result["payload"] = payload.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+        return result
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/NativeRawRuntimeFrameTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/NativeRawRuntimeFrameTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+import XPC
+@testable import GuesthouseCore
+
+/// Anonymous endpoints test real native delivery, not signing identity, app activation,
+/// explicit reply-context ownership, one-way authentication or production epoch selection.
+@Suite(.timeLimit(.minutes(1))) struct NativeRawRuntimeFrameTests {
+    enum Fixture: Sendable { case bounded, exactBoundary, empty, oversizedData, unknownOuterField, oversizedIgnoredJSON, foreignHeader, wrongPayload }
+
+    @Test(arguments: [
+        (Fixture.bounded, true, Int64(0)), (.exactBoundary, true, 0), (.empty, false, 1), (.oversizedData, false, 2),
+        (.unknownOuterField, false, 1), (.oversizedIgnoredJSON, false, 2),
+        (.foreignHeader, false, 3), (.wrongPayload, false, 1)
+    ])
+    func nativeDeliveryChecksFrameBeforePayloadDecode(fixture: Fixture, expectedDecode: Bool, expectedFailure: Int64) async throws {
+        let listener = XPCListener { request in
+            request.accept { (received: XPCDictionary) -> XPCDictionary? in
+                var answer = XPCDictionary()
+                var decoded = false
+                var failure: Int64 = 0
+                do {
+                    let bytes = try RawRuntimeFrame.payload(received, expectedVersion: 12)
+                    decoded = true
+                    _ = try JSONDecoder().decode([String: String].self, from: bytes)
+                } catch let error as RawRuntimeFrame.Failure {
+                    switch error {
+                    case .malformed: failure = 1
+                    case .oversized: failure = 2
+                    case .protocolMismatch: failure = 3
+                    }
+                } catch { failure = 4 }
+                answer["failure"] = failure
+                answer["decoded"] = decoded
+                return answer
+            }
+        }
+        defer { listener.cancel() }
+        let session = try XPCSession(endpoint: listener.endpoint)
+        defer { session.cancel(reason: "native frame test completed") }
+        var message = XPCDictionary()
+        message["protocolVersion"] = Int64(12)
+        var json = try JSONEncoder().encode(["known": "value"])
+        switch fixture {
+        case .bounded, .foreignHeader, .wrongPayload: break
+        case .exactBoundary: json.append(Data(repeating: 32, count: RawRuntimeFrame.maximumPayloadBytes - json.count))
+        case .empty: json = Data()
+        case .oversizedData: json = Data(repeating: 0x78, count: 65_537)
+        case .unknownOuterField: message["ignored"] = String(repeating: "x", count: 65_537)
+        case .oversizedIgnoredJSON:
+            json = try JSONEncoder().encode(["known": "value", "ignored": String(repeating: "x", count: 65_537)])
+        }
+        message["payload"] = json.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+        if fixture == .foreignHeader { message["protocolVersion"] = Int64(99) }
+        if fixture == .wrongPayload { message["payload"] = "not bytes" }
+        let result: Delivery = try await withCheckedThrowingContinuation { continuation in
+            session.send(message: message) { response in
+                switch response {
+                case .success(let reply):
+                    continuation.resume(returning: Delivery(
+                        decoded: reply["decoded", as: Bool.self],
+                        failure: reply["failure", as: Int64.self]
+                    ))
+                case .failure(let error): continuation.resume(throwing: error)
+                }
+            }
+        }
+        #expect(result.decoded == expectedDecode)
+        #expect(result.failure == expectedFailure)
+    }
+
+    private struct Delivery: Sendable {
+        let decoded: Bool?
+        let failure: Int64?
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RawRuntimeFrameTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RawRuntimeFrameTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import Testing
+import XPC
+@testable import GuesthouseCore
+
+@Suite struct RawRuntimeFrameTests {
+    // Fixture-only frame epoch. This codec does not activate or select production wire 12.
+    let version: Int64 = 12
+
+    @Test(arguments: [1, RawRuntimeFrame.maximumPayloadBytes])
+    func acceptedBoundaryDeliversOnlyBoundedBytes(length: Int) throws {
+        let expected = Data(repeating: 0x78, count: length)
+        let message = try RawRuntimeFrame.encode(expected, protocolVersion: version)
+        let actual = try RawRuntimeFrame.withPayloadBytes(message, expectedVersion: version) { Data($0) }
+        #expect(actual == expected)
+    }
+
+    @Test func oversizedDataNeverReachesCopyOrDecoder() {
+        let message = dataFrame(length: RawRuntimeFrame.maximumPayloadBytes + 1)
+        var copies = 0
+        #expect(throws: RawRuntimeFrame.Failure.oversized) {
+            try RawRuntimeFrame.withPayloadBytes(message, expectedVersion: version) { bytes in
+                copies += 1
+                return Data(bytes)
+            }
+        }
+        #expect(copies == 0)
+    }
+
+    @Test func unknownOuterFieldIsRejectedWithoutReadingItsValue() {
+        var message = dataFrame(length: 1)
+        message["ignored"] = String(repeating: "x", count: RawRuntimeFrame.maximumPayloadBytes + 1)
+        expectMalformedBeforeCallback(message)
+    }
+
+    @Test func missingKeyIsNotReplacedByAnUnknownKey() {
+        var message = XPCDictionary()
+        message["protocolVersion"] = version
+        message["ignored"] = xpc_data_create(nil, 0)
+        expectMalformedBeforeCallback(message)
+    }
+
+    @Test func payloadAndVersionMustHaveExactWireTypes() {
+        var stringPayload = XPCDictionary()
+        stringPayload["protocolVersion"] = version
+        stringPayload["payload"] = "not bytes"
+        expectMalformedBeforeCallback(stringPayload)
+        var unsignedVersion = dataFrame(length: 1)
+        unsignedVersion["protocolVersion"] = UInt64(version)
+        expectMalformedBeforeCallback(unsignedVersion)
+        var stringVersion = dataFrame(length: 1)
+        stringVersion["protocolVersion"] = "12"
+        expectMalformedBeforeCallback(stringVersion)
+    }
+
+    @Test func emptyPayloadAndMissingVersionAreMalformed() {
+        expectMalformedBeforeCallback(dataFrame(length: 0))
+        var noVersion = XPCDictionary()
+        noVersion["payload"] = xpc_data_create(nil, 0)
+        expectMalformedBeforeCallback(noVersion)
+    }
+
+    @Test func foreignVersionIsReportedBeforeAnUnknownPayloadIsInspected() {
+        var message = XPCDictionary()
+        message["protocolVersion"] = Int64(99)
+        message["payload"] = "future wire representation"
+        var calls = 0
+        #expect(throws: RawRuntimeFrame.Failure.protocolMismatch(received: 99)) {
+            try RawRuntimeFrame.withPayloadBytes(message, expectedVersion: version) { _ in calls += 1 }
+        }
+        #expect(calls == 0)
+    }
+
+    @Test func unknownJSONFieldsStillCountAgainstTheReceivedByteBudget() throws {
+        let json = try JSONEncoder().encode(["known": "value", "ignored": String(repeating: "x", count: RawRuntimeFrame.maximumPayloadBytes)])
+        var message = XPCDictionary()
+        message["protocolVersion"] = version
+        message["payload"] = json.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+        var copied = false
+        #expect(throws: RawRuntimeFrame.Failure.oversized) {
+            try RawRuntimeFrame.withPayloadBytes(message, expectedVersion: version) { bytes in
+                copied = true
+                return Data(bytes)
+            }
+        }
+        #expect(!copied)
+    }
+
+    @Test func publicPayloadIsAnOwnedCopy() throws {
+        var message = dataFrame(length: 4)
+        let owned = try RawRuntimeFrame.payload(message, expectedVersion: version)
+        message["payload"] = xpc_data_create(nil, 0)
+        #expect(owned == Data(repeating: 0x78, count: 4))
+    }
+
+    @Test func outgoingBoundsFailWithClosedErrors() {
+        #expect(throws: RawRuntimeFrame.Failure.malformed) {
+            try RawRuntimeFrame.encode(Data(), protocolVersion: version)
+        }
+        #expect(throws: RawRuntimeFrame.Failure.oversized) {
+            try RawRuntimeFrame.encode(Data(repeating: 1, count: 65_537), protocolVersion: version)
+        }
+    }
+
+    private func dataFrame(length: Int) -> XPCDictionary {
+        var message = XPCDictionary()
+        message["protocolVersion"] = version
+        let data = Data(repeating: 0x78, count: length)
+        message["payload"] = data.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+        return message
+    }
+
+    private func expectMalformedBeforeCallback(_ message: XPCDictionary) {
+        var calls = 0
+        #expect(throws: RawRuntimeFrame.Failure.malformed) {
+            try RawRuntimeFrame.withPayloadBytes(message, expectedVersion: version) { _ in calls += 1 }
+        }
+        #expect(calls == 0)
+    }
+}


### PR DESCRIPTION
## Scope

First native-framing implementation slice for #112, related to #9/#19/#20 and `MVP-PLAN.md` §3 and §11. Stacked on approved #148 at `780a95949cc02602e739b5ec497dabd0e987cc0a`. Reuses the retained local RawFrame prototype and its regressions; the original prototype files remain untouched.

- `RawRuntimeFrame` validates an exact two-key native `XPCDictionary`: signed Int64 protocol header plus XPCData payload.
- Validate the header type/version first, then exact key count, payload type, actual `xpc_data_get_length`, nonempty data and pointer availability **before copying bytes into Swift Data**.
- Unknown keys are rejected by fixed-key presence plus count, without copying attacker-controlled keys or reading their values.
- The public API returns owned bounded Data, not an escaping borrowed pointer. The internal borrowed-byte seam proves malformed/oversized inputs never invoke the copy callback.
- Encoding accepts already encoded bytes and enforces the same nonempty 64 KiB bound. Closed malformed/oversized/version-mismatch failures carry no raw text.

## Verification

Full `swift test --package-path Packages/GuesthouseCore -Xswiftc -warnings-as-errors`: **364 tests / 31 suites passed**, exit 0. `git diff --check` passes. **253 added lines / 3 files**, no dependency or build-setting changes.

Unit coverage retains native boundary sizes, missing/unknown keys, exact native types, wrong and absent headers, foreign-version precedence, ignored JSON bytes counting toward the original size, plus owned-copy lifetime and outgoing rejection.

**Eight actual anonymous native-XPC delivery cases pass**: ordinary payload, exactly 64 KiB, empty payload, 65,537-byte data, oversized unknown outer field, oversized ignored JSON field, foreign header, and non-data payload. The receiver uses the new public payload API before attempting JSON decode. Results are returned as fixed fixture booleans/numeric codes; no production operation runs. Each invocation owns and cancels its listener/session.

Public API declarations and ownership behavior were checked against the installed macOS SDK's XPC.swiftinterface and xpc/xpc.h (`XPCDictionary.withUnsafeUnderlyingDictionary`, dictionary count/value access, data length/bytes/copying, anonymous listener/session APIs). No private API or introspection is used.

## Explicit remaining work

This does **not close #112** or resolve #110's actual production-boundary finding by itself:

- No app/service endpoint, authentication path or production wire epoch is activated. Test frame epoch 12 is fixture-only; current Core epoch 8 is unchanged. Actual activation must allocate/reconcile a fresh epoch beyond historical 8–11 and enforce nested envelope consistency.
- The byte bound covers application copying/decoding, **not libxpc's initial receive allocation**.
- Callers must authenticate before framing and must not concurrently mutate a received dictionary. Framing does not confer file/operation authority or validate request options.
- The anonymous tests use ordinary implicit fixture replies; explicit one-owner reply contexts, reply-before-finish/cancel, one-way authentication/refusal, pushed events, and all service/client consumers still need separate native integration.
- Preserve same-team/exact-identifier and per-message authentication, the #148 refusal-stops-admission fix, atomic registration, generation retirement, correlation, unknown mutation outcomes, terminal reserves and no automatic replay.
- Production transport must use original raw dictionary/data input, with no unbounded Codable fallback. Do not pass re-encoded decoded messages to simulate the raw-byte check.

Fresh exact-head Xcode Cloud and automatic Codex review remain required before the user merges.
