### PR TITLE
Retain native XPC replies for single-owner explicit handoff

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RawRuntimeReplyContext.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RawRuntimeReplyContext.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Synchronization
+import XPC
+
+/// Owns the single native reply context of one received dictionary (#112 / MVP-PLAN.md §3).
+/// This is framing/ownership only: no session, process, authentication policy or send API.
+public final class RawRuntimeReplyContext: Sendable {
+    private let pending: Mutex<NativeReply?>
+
+    // The C factory is XPC_MALLOC: this is a NEW retained dictionary, never the received
+    // message or an externally supplied dictionary. Swift cannot infer that independence.
+    // The wrapper is private, created only below, and accessed only while claiming pending
+    // under its mutex. Clearing pending transfers the only reachable dictionary to the winner.
+    // Remove this FFI bridge when the importer models independent native-result ownership.
+    private struct NativeReply: @unchecked Sendable {
+        let dictionary: XPCDictionary
+    }
+
+    /// The transport must authenticate the ORIGINAL message before calling this initializer.
+    /// Call once per received message. Nil means no available native reply context (including
+    /// one-way messages), not authentication or permission to dispatch. Successful creation
+    /// consumes XPC's context; the handler must return nil, never request an implicit reply.
+    /// Do not concurrently access the original dictionary while consuming its reply context.
+    public init?(receivedMessage: XPCDictionary) {
+        guard let reply = receivedMessage.withUnsafeUnderlyingDictionary({ xpc_dictionary_create_reply($0) }) else {
+            return nil
+        }
+        pending = Mutex(NativeReply(dictionary: XPCDictionary(reply)))
+    }
+
+    /// Transfers a bounded framed reply to at most one caller, even under concurrent attempts.
+    /// Invalid bytes do not consume the retained reply, so a typed encoding failure can still
+    /// be answered. Nil means another caller already claimed it; do not send or finish twice.
+    /// The winner must explicitly send through its active XPCSession before finishing the
+    /// counted callback or canceling the session. A send error never authorizes reclaim/retry.
+    /// Handoff to XPC is not proof of delivery or of a mutating operation's outcome.
+    public func takeReply(
+        payload: Data, protocolVersion: Int64
+    ) throws(RawRuntimeFrame.Failure) -> XPCDictionary? {
+        guard payload.count <= RawRuntimeFrame.maximumPayloadBytes else { throw .oversized }
+        guard !payload.isEmpty else { throw .malformed }
+        return pending.withLock { pending in
+            guard let native = pending else { return nil }
+            pending = nil
+            var reply = native.dictionary
+            reply["protocolVersion"] = protocolVersion
+            reply["payload"] = payload.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+            return reply
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/NativeReplyContextTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/NativeReplyContextTests.swift
@@ -1,0 +1,222 @@
+import Dispatch
+import Foundation
+import Synchronization
+import Testing
+import XPC
+@testable import GuesthouseCore
+
+private let fixtureVersion = Int64(RuntimeProtocolVersion.current.rawValue)
+
+/// Actual anonymous transport, not signed-caller proof or production endpoint activation.
+/// Authentication is outside this primitive; no fixture decision authorizes a real caller.
+@Suite(.timeLimit(.minutes(1))) struct NativeReplyContextTests {
+    @Test func unreceivedDictionaryHasNoReplyContext() {
+        #expect(RawRuntimeReplyContext(receivedMessage: XPCDictionary()) == nil)
+    }
+
+    @Test func retainedRepliesCanBeSentInReverseOrderAndRemainCorrelated() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let first = fixture.request()
+        let firstIncoming = try await next(fixture.incoming)
+        let second = fixture.request()
+        let secondIncoming = try await next(fixture.incoming)
+        let firstContext = try #require(firstIncoming.context)
+        let secondContext = try #require(secondIncoming.context)
+        #expect(firstIncoming.secondCreationRejected)
+        #expect(secondIncoming.secondCreationRejected)
+        // Receiving the second message lets the first handler return without an implicit
+        // reply. Neither the test nor the context retains the original received dictionary.
+        try fixture.send(secondContext, bytes: Data([2]))
+        try fixture.send(firstContext, bytes: Data([1]))
+        #expect(try await next(first) == Data([1]))
+        #expect(try await next(second) == Data([2]))
+        #expect(try firstContext.takeReply(payload: Data([3]), protocolVersion: fixtureVersion) == nil)
+        #expect(try secondContext.takeReply(payload: Data([3]), protocolVersion: fixtureVersion) == nil)
+    }
+
+    @Test func oneWayMessageDoesNotConsumeTheNextRequestsReplyContext() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        try fixture.client.send(message: XPCDictionary())
+        let oneWay = try await next(fixture.incoming)
+        #expect(oneWay.context == nil)
+        #expect(oneWay.secondCreationRejected)
+        let reply = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        try fixture.send(context, bytes: Data([7]))
+        #expect(try await next(reply) == Data([7]))
+    }
+
+    @Test(arguments: [0, RawRuntimeFrame.maximumPayloadBytes + 1])
+    func invalidEncodingPreservesTheContextForATypedFailure(_ count: Int) async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let reply = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        let expected: RawRuntimeFrame.Failure = count == 0 ? .malformed : .oversized
+        #expect(throws: expected) {
+            try context.takeReply(payload: Data(repeating: 0, count: count), protocolVersion: fixtureVersion)
+        }
+        let failure = try RuntimeEventEnvelope(event: .failed(OperationID(), .invalidRuntimeReply(.malformed))).encoded()
+        try fixture.send(context, bytes: failure)
+        let data = try await next(reply)
+        let decoded = try RuntimeEventEnvelope.decode(data)
+        guard case .failed(_, .invalidRuntimeReply(.malformed)) = decoded.event else {
+            Issue.record("Expected the fixed typed encoding-failure response")
+            return
+        }
+    }
+
+    @Test func exactPayloadBoundarySurvivesExplicitReplyHandoff() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let reply = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        let bytes = Data(repeating: 32, count: RawRuntimeFrame.maximumPayloadBytes)
+        try fixture.send(context, bytes: bytes)
+        #expect(try await next(reply) == bytes)
+    }
+
+    @Test func aClaimedReplyCannotBeReclaimedWithoutSuccessfulDelivery() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        _ = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        // Deliberately discard the claimed frame without sending it. A caller whose send
+        // failed or whose session disappeared likewise cannot acquire a second context.
+        let claimed = try context.takeReply(payload: Data([6]), protocolVersion: fixtureVersion)
+        #expect(claimed != nil)
+        #expect(try context.takeReply(payload: Data([6]), protocolVersion: fixtureVersion) == nil)
+    }
+
+    @Test func concurrentClaimsHaveExactlyOneReplyOwner() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let reply = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        let claims = Mutex(0)
+        let failures = Mutex(0)
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            do {
+                if let message = try context.takeReply(payload: Data([9]), protocolVersion: fixtureVersion) {
+                    claims.withLock { $0 += 1 }
+                    try fixture.server().send(message: message)
+                }
+            } catch { failures.withLock { $0 += 1 } }
+        }
+        #expect(claims.withLock { $0 } == 1)
+        #expect(failures.withLock { $0 } == 0)
+        #expect(try await next(reply) == Data([9]))
+    }
+
+    @Test func explicitHandoffPrecedesFinishingAndCancelingARefusedSession() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let reply = fixture.request()
+        let context = try #require(try await next(fixture.incoming).context)
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        // This is injected lifetime state, not a signed authentication test. Production must
+        // balance its own admission and explicitly hand off before finished/cancel, as here.
+        try fixture.send(context, bytes: Data([4]))
+        #expect(gate.finished())
+        try fixture.server().cancel(reason: "reply context fixture refused")
+        #expect(try await next(reply) == Data([4]))
+        #expect(gate.began() == nil)
+        #expect(try context.takeReply(payload: Data([5]), protocolVersion: fixtureVersion) == nil)
+    }
+}
+
+private struct Incoming: Sendable {
+    let context: RawRuntimeReplyContext?
+    let secondCreationRejected: Bool
+}
+
+private final class Fixture: Sendable {
+    let listener: XPCListener
+    let client: XPCSession
+    let incoming: AsyncThrowingStream<Incoming, any Error>
+    private let holder: SessionHolder
+
+    init() throws {
+        let (stream, events) = AsyncThrowingStream<Incoming, any Error>.makeStream()
+        incoming = stream
+        // The listener owns its session; this separate holder allows deterministic fixture
+        // cleanup without global state. XPCSession is SDK-declared Sendable.
+        let holder = SessionHolder()
+        let listener = XPCListener { request in
+            request.accept { session in
+                holder.session.withLock { $0 = session }
+                return Handler(events: events)
+            }
+        }
+        do { client = try XPCSession(endpoint: listener.endpoint) }
+        catch { listener.cancel(); throw error }
+        self.listener = listener
+        self.holder = holder
+    }
+
+    func server() throws -> XPCSession {
+        try #require(holder.session.withLock { $0 })
+    }
+
+    func request() -> AsyncThrowingStream<Data, any Error> {
+        let (stream, answers) = AsyncThrowingStream<Data, any Error>.makeStream()
+        client.send(message: XPCDictionary()) { result in
+            switch result {
+            case .success(let message):
+                do {
+                    answers.yield(try RawRuntimeFrame.payload(message, expectedVersion: fixtureVersion))
+                    answers.finish()
+                } catch { answers.finish(throwing: error) }
+            case .failure: answers.finish(throwing: FixtureFailure.transport)
+            }
+        }
+        return stream
+    }
+
+    func send(_ context: RawRuntimeReplyContext, bytes: Data) throws {
+        let reply = try #require(try context.takeReply(payload: bytes, protocolVersion: fixtureVersion))
+        try server().send(message: reply)
+    }
+
+    func cancel() {
+        client.cancel(reason: "reply context fixture completed")
+        holder.session.withLock { $0 }?.cancel(reason: "reply context fixture completed")
+        listener.cancel()
+    }
+}
+
+private final class SessionHolder: Sendable {
+    let session = Mutex<XPCSession?>(nil)
+}
+
+private struct Handler: XPCPeerHandler {
+    let events: AsyncThrowingStream<Incoming, any Error>.Continuation
+
+    func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
+        let context = RawRuntimeReplyContext(receivedMessage: message)
+        let second = RawRuntimeReplyContext(receivedMessage: message)
+        events.yield(Incoming(context: context, secondCreationRejected: second == nil))
+        return nil // Context was consumed: never let the native API create a second reply.
+    }
+}
+
+private enum FixtureFailure: Error { case timeout, transport }
+
+private func next<T: Sendable>(_ stream: AsyncThrowingStream<T, any Error>) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            var iterator = stream.makeAsyncIterator()
+            return try #require(await iterator.next())
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(5))
+            throw FixtureFailure.timeout
+        }
+        defer { group.cancelAll() }
+        return try #require(await group.next())
+    }
+}


### PR DESCRIPTION
## Summary

Refs #112, #19 and #20; implements the native reply-ownership portion of MVP-PLAN.md §3. Based directly on main after #146–#149; no old sanitizer/Tart ancestry is restored.

- `RawRuntimeReplyContext` consumes the original dictionary's native reply context exactly once and retains the newly created reply. A one-way/unreceived/already-consumed message has no available context.
- Valid bounded bytes can be claimed by only one caller under a mutex. Empty/oversized encoding attempts leave the context available for a fixed typed failure. Once claimed, unsuccessful delivery cannot authorize reclaim/retry.
- Core does not send messages or own sessions. The runtime must authenticate the original message first, explicitly send the claimed dictionary through its active session before finishing/canceling, and return nil from the native handler instead of creating a second implicit reply.
- Anonymous native regressions reuse the retained #112 prototype's explicit send route: delayed/out-of-order correlated replies, one-way followed by normal request, failed encoding then typed failure, exact 64 KiB, no reclaim without delivery, 32 competing claims, and reply handoff before refused-session finish/cancel.

## Ownership and proof limits

The private `NativeReply` FFI wrapper alone is `@unchecked Sendable`: the public SDK marks `xpc_dictionary_create_reply` as XPC_MALLOC / retained, but Swift's import cannot prove the returned dictionary is independent of the received object. Only that factory's new result may enter the wrapper; it never exposes arbitrary supplied dictionaries. The enclosing class is checked-Sendable, all pending access is mutex-confined, and claiming clears the sole retained reference before returning the frame. The source documents removing the bridge when the importer expresses independent-result ownership. No blanket MainActor, preconcurrency import, global mutable state or public unchecked conformance is added.

Actual anonymous endpoint delivery tests validate this route, not production authentication. The refusal test injects lifetime state; it does not prove signed caller identity. XPC handoff is not guaranteed delivery and does not establish a mutating operation's outcome.

This does **not** activate a production endpoint, choose a new production wire epoch, implement authenticated one-way rejection, or complete all #112 service/client/push/correlation/retirement consumers. Fixture outer/inner versions agree with current Core; a fresh incompatible epoch beyond historical reservations remains required before production framing activation. #9 and #112 remain open. No provider, VM, signing, credentials or hardware setup.

## Validation

- Full Core: **381 tests / 33 suites passed**, warnings-as-errors.
- Focused native reply suite: **five consecutive passing runs**, 8 test functions per run (including parameterized boundary cases).
- Two new files, **273 added lines**; no package/project/dependency settings changed.
- Exact head: `64342ca559223475aa2d1b97882cb9deb84b73fd`.
- Fresh Xcode Cloud and Codex review required; local success is not merge approval.

Current migration dashboard: #48. All 40 legacy open PRs are draft references with preserved code, descriptions and review evidence.
