### PR TITLE
Add fixed native runtime caller authentication

### DIFF
--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CD1501510000000000000004 /* GuesthouseRuntimeKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseRuntimeKit; path = Packages/GuesthouseRuntimeKit; sourceTree = "<group>"; };
 		F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Guesthouse Codex VM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8976E97304933D30071C234 /* GuesthouseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuesthouseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuesthouseUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -84,6 +85,7 @@
 			children = (
 				F8ACD8A93049406300550943 /* MVP-PLAN.md */,
 				921BF84465C14B2296CA65E2 /* GuesthouseCore */,
+				CD1501510000000000000004 /* GuesthouseRuntimeKit */,
 				F8976E8C304933D10071C234 /* Guesthouse */,
 				F8976E9A304933D30071C234 /* GuesthouseTests */,
 				F8976EA4304933D30071C234 /* GuesthouseUITests */,
@@ -207,6 +209,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				F8ACD8A630493E2C00550943 /* XCLocalSwiftPackageReference "Packages/GuesthouseCore" */,
+				CD1501510000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseRuntimeKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F8976E8B304933D10071C234 /* Products */;
@@ -630,6 +633,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		CD1501510000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseRuntimeKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/GuesthouseRuntimeKit;
+		};
 		F8ACD8A630493E2C00550943 /* XCLocalSwiftPackageReference "Packages/GuesthouseCore" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/GuesthouseCore;

--- a/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
+++ b/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:Packages/GuesthouseCore">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GuesthouseRuntimeKitTests"
+               BuildableName = "GuesthouseRuntimeKitTests"
+               BlueprintName = "GuesthouseRuntimeKitTests"
+               ReferencedContainer = "container:Packages/GuesthouseRuntimeKit">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -44,6 +58,16 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GuesthouseRuntimeKitTests"
+               BuildableName = "GuesthouseRuntimeKitTests"
+               BlueprintName = "GuesthouseRuntimeKitTests"
+               ReferencedContainer = "container:Packages/GuesthouseRuntimeKit">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference

--- a/Packages/GuesthouseRuntimeKit/Package.swift
+++ b/Packages/GuesthouseRuntimeKit/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.3
+import PackageDescription
+
+let runtimeSwiftSettings: [SwiftSetting] = [
+    .defaultIsolation(nil),
+    .enableUpcomingFeature("MemberImportVisibility"),
+]
+
+// Runtime-only code. The GUI must not import or link this product (MVP-PLAN.md §3).
+let package = Package(
+    name: "GuesthouseRuntimeKit",
+    platforms: [.macOS(.v26)],
+    products: [.library(name: "GuesthouseRuntimeKit", targets: ["GuesthouseRuntimeKit"])],
+    dependencies: [.package(path: "../GuesthouseCore")],
+    targets: [
+        // Pure C owns the retained native requirement for process lifetime; no ARC/unsafe
+        // compiler flags are needed when this product is consumed by the Xcode project.
+        .target(name: "GuesthouseRuntimeAuthentication"),
+        .target(
+            name: "GuesthouseRuntimeKit",
+            dependencies: ["GuesthouseRuntimeAuthentication"],
+            swiftSettings: runtimeSwiftSettings
+        ),
+        .testTarget(
+            name: "GuesthouseRuntimeKitTests",
+            dependencies: [
+                "GuesthouseRuntimeKit", "GuesthouseRuntimeAuthentication",
+                .product(name: "GuesthouseCore", package: "GuesthouseCore"),
+            ],
+            swiftSettings: runtimeSwiftSettings
+        ),
+    ],
+    swiftLanguageModes: [.v6]
+)

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeAuthentication/GHRCallerAuthentication.c
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeAuthentication/GHRCallerAuthentication.c
@@ -1,0 +1,24 @@
+#include "GHRCallerAuthentication.h"
+#include <pthread.h>
+
+static xpc_peer_requirement_t requirement = NULL;
+static pthread_once_t once = PTHREAD_ONCE_INIT;
+
+static void initializeRequirement(void) {
+    // The factory returns a retained, concurrency-safe native object. This C cache owns
+    // that creation reference until process exit. No per-call release, reset or mutation.
+    // NULL is error_out, not a Team ID override: Apple checks this process's actual team.
+    requirement = xpc_peer_requirement_create_team_identity(GHRGuesthouseSigningIdentifier, NULL);
+}
+
+bool GHRMessageSenderIsGuesthouse(xpc_object_t message) {
+    if (message == NULL || xpc_get_type(message) != XPC_TYPE_DICTIONARY) {
+        return false;
+    }
+    // pthread_once publishes the immutable requirement before every read. Initialization
+    // or matching failure always refuses; neither raw native errors nor input gets logged.
+    if (pthread_once(&once, initializeRequirement) != 0 || requirement == NULL) {
+        return false;
+    }
+    return xpc_peer_requirement_match_received_message(requirement, message, NULL);
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeAuthentication/include/GHRCallerAuthentication.h
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeAuthentication/include/GHRCallerAuthentication.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <xpc/xpc.h>
+
+// One fixed identity for both listener and per-message requirements. This matches the
+// GUI's PRODUCT_BUNDLE_IDENTIFIER; no caller-supplied identity or team is accepted.
+#define GHRGuesthouseSigningIdentifier "com.starlingprotocol.Guesthouse"
+
+API_AVAILABLE(macos(26.0))
+bool GHRMessageSenderIsGuesthouse(xpc_object_t _Nullable message);

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeCallerAuthentication.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeCallerAuthentication.swift
@@ -1,0 +1,18 @@
+import GuesthouseRuntimeAuthentication
+import XPC
+
+/// Fixed host-app identity policy for #20/#112 and MVP-PLAN.md §3. No endpoint is activated.
+public enum RuntimeCallerAuthentication: Sendable {
+    /// Apply when creating the service listener. Per-message checks below remain mandatory.
+    public static var listenerRequirement: XPCPeerRequirement {
+        .isFromSameTeam(andMatchesSigningIdentifier: GHRGuesthouseSigningIdentifier)
+    }
+
+    /// Check the ORIGINAL received dictionary before framing, decoding or reply-context
+    /// consumption, including one-way messages. Do not reconstruct it from client fields.
+    /// The service still owns refusal, bounded admission, registration and reply accounting;
+    /// true does not authorize arbitrary operations or prove their eventual outcomes.
+    public static func allows(_ receivedMessage: XPCDictionary) -> Bool {
+        receivedMessage.withUnsafeUnderlyingDictionary(GHRMessageSenderIsGuesthouse)
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeCallerAuthenticationTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeCallerAuthenticationTests.swift
@@ -1,0 +1,168 @@
+import Dispatch
+import Foundation
+import GuesthouseCore
+import GuesthouseRuntimeAuthentication
+import GuesthouseRuntimeKit
+import Synchronization
+import Testing
+import XPC
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeCallerAuthenticationTests {
+    @Test func nullWrongTypeAndUnreceivedDictionariesAreRefused() {
+        #expect(!GHRMessageSenderIsGuesthouse(nil))
+        #expect(!GHRMessageSenderIsGuesthouse(xpc_int64_create(1)))
+        #expect(!RuntimeCallerAuthentication.allows(XPCDictionary()))
+        #expect(GHRGuesthouseSigningIdentifier == "com.starlingprotocol.Guesthouse")
+    }
+
+    @Test func concurrentChecksShareOnlyAnImmutableRequirement() {
+        let allowed = Mutex(0)
+        DispatchQueue.concurrentPerform(iterations: 64) { _ in
+            if RuntimeCallerAuthentication.allows(XPCDictionary()) {
+                allowed.withLock { $0 += 1 }
+            }
+        }
+        #expect(allowed.withLock { $0 } == 0)
+    }
+
+    // Standalone package test runners are not the signed Guesthouse GUI. Rejection may
+    // mean requirement creation failed OR the sender did not match; this is not positive
+    // signed-app proof. No fixture injects an authenticated decision or executes an operation.
+    @Test(arguments: [false, true], [false, true])
+    func nonGuesthouseMessagesAreRefused(replyBearing: Bool, spoofedFields: Bool) async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let message = Self.message(spoofedFields: spoofedFields)
+        if replyBearing {
+            let reply = fixture.request(message)
+            let observation = try await next(fixture.observations)
+            #expect(!observation.allowed)
+            #expect(observation.expectsReply)
+            #expect(try await next(reply) == Data([0]))
+        } else {
+            try fixture.client.send(message: message)
+            let observation = try await next(fixture.observations)
+            #expect(!observation.allowed)
+            #expect(!observation.expectsReply)
+        }
+    }
+
+    @Test func checkerRunsForBothOneWayAndFollowingReplyBearingMessage() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        try fixture.client.send(message: Self.message(spoofedFields: true))
+        let first = try await next(fixture.observations)
+        let reply = fixture.request(Self.message(spoofedFields: false))
+        let second = try await next(fixture.observations)
+        #expect(!first.allowed && !first.expectsReply)
+        #expect(!second.allowed && second.expectsReply)
+        #expect(try await next(reply) == Data([0]))
+    }
+
+    private static func message(spoofedFields: Bool) -> XPCDictionary {
+        var message = XPCDictionary()
+        if spoofedFields {
+            message["signingIdentifier"] = GHRGuesthouseSigningIdentifier
+            message["teamIdentifier"] = "claimed-team"
+            message["authorized"] = true
+            message["pid"] = Int64(1)
+            message["payload"] = "not an authorization credential"
+        }
+        return message
+    }
+}
+
+private struct Observation: Sendable {
+    let allowed: Bool
+    let expectsReply: Bool
+}
+
+private final class AcceptedSession: Sendable {
+    let value = Mutex<XPCSession?>(nil)
+}
+
+private final class Fixture: Sendable {
+    let listener: XPCListener
+    let client: XPCSession
+    let observations: AsyncThrowingStream<Observation, any Error>
+    private let accepted: AcceptedSession
+
+    init() throws {
+        let (stream, events) = AsyncThrowingStream<Observation, any Error>.makeStream()
+        observations = stream
+        let accepted = AcceptedSession()
+        self.accepted = accepted
+        // Deliberately no listener requirement here: the anonymous fixture must reach the
+        // REAL per-message check. Production must apply BOTH requirements, not this fixture.
+        let listener = XPCListener { request in
+            request.accept { session in
+                accepted.value.withLock { $0 = session }
+                return Handler(session: session, observations: events)
+            }
+        }
+        do { client = try XPCSession(endpoint: listener.endpoint) }
+        catch { listener.cancel(); throw error }
+        self.listener = listener
+    }
+
+    func request(_ message: XPCDictionary) -> AsyncThrowingStream<Data, any Error> {
+        let (stream, answers) = AsyncThrowingStream<Data, any Error>.makeStream()
+        client.send(message: message) { result in
+            switch result {
+            case .success(let reply):
+                do {
+                    answers.yield(try RawRuntimeFrame.payload(reply, expectedVersion: Int64(RuntimeProtocolVersion.current.rawValue)))
+                    answers.finish()
+                } catch { answers.finish(throwing: error) }
+            case .failure: answers.finish(throwing: FixtureFailure.transport)
+            }
+        }
+        return stream
+    }
+
+    func cancel() {
+        client.cancel(reason: "caller authentication fixture completed")
+        accepted.value.withLock { $0 }?.cancel(reason: "caller authentication fixture completed")
+        listener.cancel()
+    }
+}
+
+private struct Handler: XPCPeerHandler {
+    let session: XPCSession
+    let observations: AsyncThrowingStream<Observation, any Error>.Continuation
+
+    func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
+        // Authenticate the original native message before consuming its reply context.
+        let allowed = RuntimeCallerAuthentication.allows(message)
+        let context = RawRuntimeReplyContext(receivedMessage: message)
+        if let context {
+            do {
+                guard let reply = try context.takeReply(
+                    payload: Data([allowed ? 1 : 0]), protocolVersion: Int64(RuntimeProtocolVersion.current.rawValue)
+                ) else { observations.finish(throwing: FixtureFailure.missingReply); return nil }
+                try session.send(message: reply)
+            } catch { observations.finish(throwing: FixtureFailure.transport); return nil }
+        }
+        // Report checker observations only. This fixture does NOT implement production
+        // session refusal, admission or operation dispatch; those require their own adapter.
+        observations.yield(Observation(allowed: allowed, expectsReply: context != nil))
+        return nil
+    }
+}
+
+private enum FixtureFailure: Error { case timeout, transport, missingReply }
+
+private func next<T: Sendable>(_ stream: AsyncThrowingStream<T, any Error>) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            var iterator = stream.makeAsyncIterator()
+            return try #require(await iterator.next())
+        }
+        group.addTask {
+            try await Task.sleep(for: .seconds(5))
+            throw FixtureFailure.timeout
+        }
+        defer { group.cancelAll() }
+        return try #require(await group.next())
+    }
+}

--- a/Tests/CI/Fixtures/swift
+++ b/Tests/CI/Fixtures/swift
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
-[[ $# == 5 && "$1" == test && "$2" == --package-path &&
-    "$4" == -Xswiftc && "$5" == -warnings-as-errors ]] || exit 91
+[[ $# == 11 && "$1" == test && "$2" == --package-path &&
+    "$4" == -Xswiftc && "$5" == -warnings-as-errors &&
+    "$6" == -Xcc && "$7" == -Wall && "$8" == -Xcc && "$9" == -Wextra &&
+    "${10}" == -Xcc && "${11}" == -Werror ]] || exit 91
 [[ "$(pwd -P)" == "${CI_HOOK_EXPECTED_ROOT}" ]] || exit 92
 printf '%s\n' "$3" >> "${CI_HOOK_INVOCATIONS}"
 if [[ "$3" == "${CI_HOOK_FAIL_PACKAGE:-}" ]]; then

--- a/ci_scripts/ci_pre_xcodebuild.sh
+++ b/ci_scripts/ci_pre_xcodebuild.sh
@@ -25,5 +25,6 @@ fi
 for manifest in "${package_manifests[@]}"; do
     package_directory="${manifest%/Package.swift}"
     printf 'Testing %s with warnings treated as errors\n' "${package_directory}"
-    swift test --package-path "${package_directory}" -Xswiftc -warnings-as-errors
+    swift test --package-path "${package_directory}" -Xswiftc -warnings-as-errors \
+        -Xcc -Wall -Xcc -Wextra -Xcc -Werror
 done


### PR DESCRIPTION
## Scope and stack

Stacked on #150 (`mvp/native-reply-context`, parent `64342ca559223475aa2d1b97882cb9deb84b73fd`). Merge #150 first, then settle this PR's base on main and recheck the final head before merging this one. The parent has current-head green Xcode Cloud and the original-message Codex thumbs-up.

Refs #20, #112, #19, #21 and dashboard #48. Implements the fixed caller-identity primitive and runtime-only package boundary from **MVP-PLAN.md §3 (Sandbox and XPC boundary)**, with test integration under **§11**. This does not close those integration issues.

## Migration

- Introduce `GuesthouseRuntimeKit`, without importing or linking it in the GUI or GUI test bundle. Both package test targets are explicitly in the shared scheme.
- One fixed signing identifier, `com.starlingprotocol.Guesthouse`, is shared by the Swift listener requirement and the native per-message requirement. Both require the current process's actual signing team; client fields cannot select the identity or team.
- Adapt the retained caller-authentication prototype into a small pure-C bridge to Apple's macOS 26 XPC peer-requirement API (not exported directly to Swift). `pthread_once` publishes an immutable, concurrency-safe native requirement. The cache owns the factory's retained creation reference until process exit; no ARC/unsafe package flags, per-call release or reset.
- Check the **original received dictionary**, including one-way messages, before framing, decoding or consuming reply context. Null, wrong-type, requirement-creation and matching failures refuse. No raw native errors or client data are logged.
- Extend the existing CI package hook's warning policy to C compilation as well as Swift, with its command-contract fixture updated.

## Validation

- Final CI package hook: **Core 381 tests / 33 suites and RuntimeKit 4 tests / 1 suite passed**, with Swift warnings-as-errors and C `-Wall -Wextra -Werror`.
- Runtime tests cover null/wrong-type/unreceived dictionaries, 64 concurrent checks, four reply-bearing/one-way × spoofed-field combinations over real anonymous XPC endpoints, and a one-way message followed by a reply-bearing request. The strict runtime suite also passed three consecutive repetitions.
- CI hook fixture: **7 scenarios passed**.
- Unsigned shared-scheme `xcodebuild build-for-testing CODE_SIGNING_ALLOWED=NO` passed. Verified the actual build graph and generated `.xctestrun` include RuntimeKitTests with Apple's standalone XCTest host, not the GUI. A package-container project reference is necessary; listing a package scheme alone was insufficient. Verified no authentication symbols in the GUI binary.
- Project/scheme syntax and diff checks passed. No Swift/C compiler warnings. Xcode emits its existing optional App Intents metadata-extraction notice; no unrelated framework was added to suppress it.

## Deliberate limits / next slice

These are **negative authentication tests**, not positive signed-Guesthouse proof. An unsigned/ad-hoc test runner can be refused because requirement creation fails or because the sender mismatches. The fixture omits listener requirements deliberately so that the real per-message check runs; it is not a production listener or refusal/operation-dispatch implementation.

No endpoint is activated, no signing settings or credentials are changed, and no wire epoch is selected here. Production integration must still apply both listener and per-message checks, preserve refusal/admission/registration and explicit reply-before-close, migrate reply/push/client correlation and generation retirement together, and retain unknown outcomes without replay. #112 remains open. Do not close the preserved native-XPC drafts based on this primitive alone.