### PR TITLE
Migrate bounded native runtime request handling

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Diagnostics/DiagnosticEvent.swift
@@ -5,6 +5,7 @@ import Foundation
 /// IDs must come from Guesthouse's operation/environment records, not guest output.
 public struct DiagnosticEvent: Codable, Hashable, Sendable {
     public enum Operation: String, CaseIterable, Codable, Sendable {
+        case runtimeRequest
         case preflight, verifyRuntime, createEnvironment, startEnvironment, stopEnvironment
         case inspectEnvironment, connectSSH, importXcode, checkTools, codexSignIn, githubSignIn
         case synchronizeRepositories, testWorkspace, publishChanges, exportDiagnostics
@@ -15,6 +16,7 @@ public struct DiagnosticEvent: Codable, Hashable, Sendable {
 
         public var title: String {
             switch self {
+            case .runtimeRequest: "Contact runtime service"
             case .preflight: "Check this Mac"
             case .verifyRuntime: "Verify runtime"
             case .createEnvironment: "Create development Mac"

--- a/Packages/GuesthouseRuntimeKit/Package.swift
+++ b/Packages/GuesthouseRuntimeKit/Package.swift
@@ -18,7 +18,10 @@ let package = Package(
         .target(name: "GuesthouseRuntimeAuthentication"),
         .target(
             name: "GuesthouseRuntimeKit",
-            dependencies: ["GuesthouseRuntimeAuthentication"],
+            dependencies: [
+                "GuesthouseRuntimeAuthentication",
+                .product(name: "GuesthouseCore", package: "GuesthouseCore"),
+            ],
             swiftSettings: runtimeSwiftSettings
         ),
         .testTarget(

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
@@ -1,0 +1,152 @@
+import Foundation
+import GuesthouseCore
+import XPC
+
+/// Native service ingress for #19/#20/#112 (MVP-PLAN.md §3). No listener is activated here.
+/// Only runtimeVersion is implemented: mutations stay unavailable until client retirement,
+/// streaming and unknown-outcome handling migrate together with the activation wire epoch.
+public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
+    private let gate: RuntimeSessionGate
+    private let authenticate: @Sendable (XPCDictionary) -> Bool
+    private let decode: @Sendable (Data, Int) -> RuntimeDispatcher.Decision
+    private let register: @Sendable (RuntimeRequest) -> RuntimeEvent
+    private let send: @Sendable (XPCDictionary) throws -> Void
+    private let cancel: @Sendable () -> Void
+    private let diagnostic: @Sendable (DiagnosticEvent) -> Void
+    private static var epoch: Int64 { Int64(RuntimeProtocolVersion.current.rawValue) }
+
+    /// The listener must also apply RuntimeCallerAuthentication.listenerRequirement.
+    /// Bundle inspection is done by the owner, outside registration's synchronous gate.
+    public convenience init(
+        session: XPCSession, version: RuntimeVersionInfo,
+        diagnostic: @escaping @Sendable (DiagnosticEvent) -> Void
+    ) {
+        self.init(
+            authenticate: RuntimeCallerAuthentication.allows,
+            register: { Self.queryReply($0, version: version) },
+            send: { try session.send(message: $0) },
+            cancel: { session.cancel(reason: "runtime session refused") },
+            diagnostic: diagnostic
+        )
+    }
+
+    static func queryReply(_ request: RuntimeRequest, version: RuntimeVersionInfo) -> RuntimeEvent {
+        if case .runtimeVersion = request { return .runtimeVersion(version) }
+        return .failed(OperationID(), .invalidRequest(.unsupportedOperation))
+    }
+
+    // Internal test seam only. Public construction never permits replacement authentication
+    // or operation dispatch. Registration must stay bounded/in-memory with no I/O or reentry.
+    init(
+        gate: RuntimeSessionGate = RuntimeSessionGate(),
+        authenticate: @escaping @Sendable (XPCDictionary) -> Bool,
+        decode: @escaping @Sendable (Data, Int) -> RuntimeDispatcher.Decision = RuntimeDispatcher.decide,
+        register: @escaping @Sendable (RuntimeRequest) -> RuntimeEvent,
+        send: @escaping @Sendable (XPCDictionary) throws -> Void,
+        cancel: @escaping @Sendable () -> Void,
+        diagnostic: @escaping @Sendable (DiagnosticEvent) -> Void
+    ) {
+        self.gate = gate; self.authenticate = authenticate; self.decode = decode
+        self.register = register; self.send = send; self.cancel = cancel; self.diagnostic = diagnostic
+    }
+
+    public func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
+        guard let others = gate.began() else { return nil }
+        // Finish every counted callback once, AFTER explicit reply handoff (or send failure).
+        // Refusal stops new admission immediately; only already counted callbacks may drain.
+        defer { if gate.finished() { cancel() } }
+        let authorized = authenticate(message) // ORIGINAL, before context/header/payload access.
+        let context = RawRuntimeReplyContext(receivedMessage: message)
+        guard authorized else {
+            answer(refusing(.unauthorizedCaller), context: context)
+            return nil
+        }
+        // One-way messages never decode/register: no acceptance could be observed or canceled.
+        guard let context else {
+            record(.failed(OperationID(), .invalidRequest(.malformed)))
+            return nil
+        }
+        if let refusal = gate.refusal { answer(refusal, context: context); return nil }
+        let decision: RuntimeDispatcher.Decision
+        if let capped = RuntimeDispatcher.admit(inFlight: others, clientVersion: {
+            message.withUnsafeUnderlyingDictionary { dictionary in
+                guard let value = xpc_dictionary_get_value(dictionary, "protocolVersion"),
+                      xpc_get_type(value) == XPC_TYPE_INT64,
+                      let version = Int(exactly: xpc_int64_get_value(value)) else { return nil }
+                return RuntimeProtocolVersion(version)
+            }
+        }) { decision = capped }
+        else {
+            do {
+                let bytes = try RawRuntimeFrame.payload(message, expectedVersion: Self.epoch)
+                let decoded = decode(bytes, others)
+                // The authoritative outer epoch was current: a foreign nested version is a
+                // contradictory frame, not a handshake from that foreign client version.
+                if case .replyAndClose(.failed(_, .protocolMismatch)) = decoded {
+                    decision = .replyAndClose(.failed(OperationID(), .invalidRequest(.malformed)))
+                } else { decision = decoded }
+            } catch {
+                switch error {
+                case .protocolMismatch(let version):
+                    decision = .replyAndClose(.failed(OperationID(), .protocolMismatch(
+                        client: Int(version), service: RuntimeProtocolVersion.current.rawValue)))
+                case .oversized: decision = .reply(.failed(OperationID(), .invalidRequest(.oversized)))
+                case .malformed: decision = .reply(.failed(OperationID(), .invalidRequest(.malformed)))
+                }
+            }
+        }
+        let event: RuntimeEvent
+        switch decision {
+        case .reply(let reply): event = reply
+        case .replyAndClose(let refusal):
+            gate.refuse(refusal)
+            event = gate.refusal ?? refusal
+        case .dispatch(let request): event = gate.commit(request, register: register)
+        }
+        answer(event, context: context)
+        return nil // No implicit second reply/context creation.
+    }
+
+    private func refusing(_ error: GuesthouseError) -> RuntimeEvent {
+        let refusal = RuntimeEvent.failed(OperationID(), error)
+        gate.refuse(refusal)
+        return gate.refusal ?? refusal
+    }
+
+    private func answer(_ event: RuntimeEvent, context: RawRuntimeReplyContext?) {
+        record(event)
+        guard let context else { return }
+        let payload: Data
+        do { payload = try RuntimeEventEnvelope(event: event).encoded() }
+        catch {
+            // No mutation can run through the public handler. This is a transport failure,
+            // not success/operation completion. A future mutating adapter must preserve its
+            // registered ID and unknown outcome instead of reusing this query-only fallback.
+            let failure = refusing(error)
+            record(failure)
+            guard let bytes = try? RuntimeEventEnvelope(event: failure).encoded() else { return }
+            payload = bytes
+        }
+        do {
+            guard let reply = try context.takeReply(payload: payload, protocolVersion: Self.epoch) else {
+                record(refusing(.invalidRuntimeReply(.malformed)))
+                return
+            }
+            try send(reply)
+        } catch {
+            // Context ownership is already consumed. Never reclaim/retry a failed send.
+            record(refusing(.invalidRuntimeReply(.malformed)))
+        }
+    }
+
+    private func record(_ event: RuntimeEvent) {
+        guard case .failed(let id, let error) = event else { return }
+        diagnostic(DiagnosticEvent(operation: .runtimeRequest, outcome: .init(error: error), operationID: id.uuid))
+    }
+
+    public func handleCancellation(error: XPCRichError) {
+        // Opaque native error text is not a diagnostic input. Stop new registration now;
+        // counted callbacks still finish themselves, without inventing operation outcomes.
+        _ = refusing(.invalidRuntimeReply(.malformed))
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
@@ -1,0 +1,284 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+import XPC
+@testable import GuesthouseRuntimeKit
+
+/// Actual anonymous delivery, with explicitly injected authentication for positive ingress
+/// cases. This is not signed-GUI, production activation, streaming or host-mutation proof.
+@Suite(.timeLimit(.minutes(1))) struct NativeRuntimeRequestHandlerTests {
+    enum Shape: Sendable, CaseIterable {
+        case current, exactBoundary, empty, oversized, ignoredJSON, unknownOuter, missingPayload, missingHeader
+        case wrongPayload, wrongHeader, foreignHeader, contradictoryInner, malformedJSON
+    }
+
+    @Test(arguments: Shape.allCases)
+    func validatesOriginalFrameBeforePayloadDecoder(shape: Shape) async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        let reply = try await next(fixture.request(try message(shape)))
+        _ = try await next(fixture.processed)
+        let trace = fixture.trace.steps.withLock { $0 }
+        #expect(trace.first == .authenticated)
+        switch shape {
+        case .current, .exactBoundary:
+            #expect(reply == .runtimeVersion(version))
+            #expect(trace == [.authenticated, .decoded, .registered, .sendAttempt, .sent])
+        case .malformedJSON, .contradictoryInner:
+            #expect(failure(reply) == .invalidRequest(.malformed))
+            #expect(trace.contains(.decoded) && !trace.contains(.registered))
+        case .foreignHeader:
+            #expect(failure(reply) == .protocolMismatch(client: 99, service: RuntimeProtocolVersion.current.rawValue))
+            #expect(!trace.contains(.decoded) && trace.suffix(2) == [.sent, .canceled])
+        default:
+            let expected: GuesthouseError = [.oversized, .ignoredJSON].contains(shape)
+                ? .invalidRequest(.oversized) : .invalidRequest(.malformed)
+            #expect(failure(reply) == expected)
+            #expect(!trace.contains(.decoded) && !trace.contains(.registered))
+        }
+        // Only Guesthouse-built closed records leave the boundary, never ignored raw fields.
+        for diagnostic in fixture.trace.diagnostics.withLock({ $0 }) {
+            #expect(diagnostic.operation == .runtimeRequest)
+            #expect(!diagnostic.message.contains("private-fixture-marker"))
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func unauthorizedTrafficRefusesBeforeDecodeAndHandsReplyBeforeCancel(oneWay: Bool) async throws {
+        let fixture = try Fixture(authorized: false)
+        defer { fixture.cancel() }
+        if oneWay { try fixture.client.send(message: try message(.unknownOuter)) }
+        else { #expect(failure(try await next(fixture.request(try message(.unknownOuter)))) == .unauthorizedCaller) }
+        _ = try await next(fixture.processed)
+        let trace = fixture.trace.steps.withLock { $0 }
+        #expect(!trace.contains(.decoded) && !trace.contains(.registered))
+        #expect(trace == (oneWay ? [.authenticated, .diagnostic, .canceled]
+            : [.authenticated, .diagnostic, .sendAttempt, .sent, .canceled]))
+    }
+
+    @Test func publicInitializerUsesRealAuthentication() async throws {
+        let fixture = try Fixture(usePublicPolicy: true)
+        defer { fixture.cancel() }
+        let event = try await next(fixture.request(try message(.current)))
+        #expect(failure(event) == .unauthorizedCaller)
+        // The standalone runner is not the GUI. A rejection is not positive signing proof.
+    }
+
+    @Test func productionRegistrationSupportsOnlyTheReadOnlyVersionQuery() {
+        let environment = EnvironmentID()
+        let requests: [RuntimeRequest] = [
+            .environmentStatus(environment), .startEnvironment(environment, StartOptions()),
+            .stopEnvironment(environment, .force), .cancelOperation(OperationID()),
+            .importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")),
+        ]
+        for request in requests {
+            #expect(failure(NativeRuntimeRequestHandler.queryReply(request, version: version)) == .invalidRequest(.unsupportedOperation))
+        }
+        #expect(NativeRuntimeRequestHandler.queryReply(.runtimeVersion, version: version) == .runtimeVersion(version))
+    }
+
+    @Test func oneWayDoesNotDecodeOrStealFollowingReply() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        try fixture.client.send(message: try message(.ignoredJSON))
+        _ = try await next(fixture.processed)
+        #expect(fixture.trace.steps.withLock { $0 } == [.authenticated, .diagnostic])
+        #expect(try await next(fixture.request(try message(.current))) == .runtimeVersion(version))
+    }
+
+    @Test func simultaneousNativeRepliesStayWithTheirRequests() async throws {
+        let fixture = try Fixture()
+        defer { fixture.cancel() }
+        try await withThrowingTaskGroup(of: (Bool, RuntimeEvent).self) { group in
+            for index in 0..<4 {
+                group.addTask {
+                    let query = index.isMultiple(of: 2)
+                    let request: RuntimeRequest = query ? .runtimeVersion : .environmentStatus(EnvironmentID())
+                    let bytes = try JSONEncoder().encode(RuntimeRequestEnvelope(request: request))
+                    let frame = try RawRuntimeFrame.encode(bytes, protocolVersion: Int64(RuntimeProtocolVersion.current.rawValue))
+                    return (query, try await next(fixture.request(frame)))
+                }
+            }
+            for try await (query, event) in group {
+                if query { #expect(event == .runtimeVersion(version)) }
+                else { #expect(failure(event) == .invalidRequest(.unsupportedOperation)) }
+            }
+        }
+    }
+
+    @Test func capChecksNativeHeaderWithoutCopyingOrDecodingPayload() async throws {
+        let gate = RuntimeSessionGate()
+        for _ in 0..<RuntimeDispatcher.maximumInFlightRequestsPerSession { _ = try #require(gate.began()) }
+        let fixture = try Fixture(gate: gate)
+        defer { fixture.cancel() }
+        #expect(failure(try await next(fixture.request(try message(.ignoredJSON)))) == .invalidRequest(.tooManyInFlight))
+        _ = try await next(fixture.processed)
+        #expect(!fixture.trace.steps.withLock { $0.contains(.decoded) || $0.contains(.registered) })
+        // Release the synthetic already-counted callbacks; native tests above cover real replies.
+        for _ in 0..<RuntimeDispatcher.maximumInFlightRequestsPerSession { #expect(!gate.finished()) }
+    }
+
+    @Test func refusalBetweenDecodeAndCommitPreventsRegistration() async throws {
+        let fixture = try Fixture(refuseDuringDecode: true)
+        defer { fixture.cancel() }
+        #expect(failure(try await next(fixture.request(try message(.current)))) == .unauthorizedCaller)
+        _ = try await next(fixture.processed)
+        #expect(!fixture.trace.steps.withLock { $0.contains(.registered) })
+        #expect(fixture.trace.steps.withLock { Array($0.suffix(2)) } == [.sent, .canceled])
+    }
+
+    @Test func replyEncodingFailureKeepsContextForTypedQueryFailure() async throws {
+        let fixture = try Fixture(badVersion: true)
+        defer { fixture.cancel() }
+        let reply = try await next(fixture.request(try message(.current)))
+        #expect(failure(reply) == .invalidRuntimeReply(.malformed))
+        _ = try await next(fixture.processed)
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .sendAttempt }.count } == 1)
+        #expect(fixture.trace.steps.withLock { Array($0.suffix(2)) } == [.sent, .canceled])
+    }
+
+    @Test func sendFailureRetiresWithoutRetryingOrReclaimingReply() async throws {
+        let fixture = try Fixture(failSend: true)
+        defer { fixture.cancel() }
+        await #expect(throws: FixtureFailure.transport) { try await next(fixture.request(try message(.current))) }
+        _ = try await next(fixture.processed)
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .sendAttempt }.count } == 1)
+        #expect(fixture.trace.steps.withLock { $0.last } == .canceled)
+        // Once refused, even a further direct callback cannot decode, register or cancel twice.
+        let before = fixture.trace.steps.withLock { $0 }
+        _ = fixture.state.handler.withLock { $0 }?.handleIncomingRequest(try message(.current))
+        #expect(fixture.trace.steps.withLock { $0 } == before)
+    }
+
+    private func message(_ shape: Shape) throws -> XPCDictionary {
+        var result = XPCDictionary()
+        result["protocolVersion"] = Int64(RuntimeProtocolVersion.current.rawValue)
+        var bytes = try JSONEncoder().encode(RuntimeRequestEnvelope(request: .runtimeVersion))
+        switch shape {
+        case .exactBoundary: bytes.append(Data(repeating: 32, count: 65_536 - bytes.count))
+        case .empty: bytes = Data()
+        case .oversized: bytes = Data(repeating: 32, count: 65_537)
+        case .ignoredJSON:
+            var object = try #require(JSONSerialization.jsonObject(with: bytes) as? [String: Any])
+            object["ignored"] = String(repeating: "x", count: 65_537)
+            bytes = try JSONSerialization.data(withJSONObject: object)
+        case .contradictoryInner: bytes = try JSONEncoder().encode(RuntimeRequestEnvelope(protocolVersion: .init(99), request: .runtimeVersion))
+        case .malformedJSON: bytes = Data("{".utf8)
+        default: break
+        }
+        if shape != .missingPayload { result["payload"] = bytes.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) } }
+        if shape == .unknownOuter { result["ignored"] = "private-fixture-marker" + String(repeating: "x", count: 65_537) }
+        if shape == .wrongPayload { result["payload"] = "not bytes" }
+        if shape == .wrongHeader { result["protocolVersion"] = "not an integer" }
+        if shape == .missingHeader { result.withUnsafeUnderlyingDictionary { xpc_dictionary_set_value($0, "protocolVersion", nil) } }
+        if shape == .foreignHeader { result["protocolVersion"] = Int64(99); result["payload"] = "unknown future format" }
+        return result
+    }
+
+    private func failure(_ event: RuntimeEvent) -> GuesthouseError? {
+        if case .failed(_, let error) = event { error } else { nil }
+    }
+}
+
+private let version = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
+private enum Step { case authenticated, decoded, registered, diagnostic, sendAttempt, sent, canceled }
+private final class Trace: Sendable {
+    let steps = Mutex<[Step]>([])
+    let diagnostics = Mutex<[DiagnosticEvent]>([])
+    func record(_ step: Step) { steps.withLock { $0.append(step) } }
+}
+
+private final class Fixture: Sendable {
+    let trace = Trace()
+    let state = SessionState()
+    let listener: XPCListener
+    let client: XPCSession
+    let processed: AsyncThrowingStream<Bool, any Error>
+
+    init(authorized: Bool = true, usePublicPolicy: Bool = false, gate: RuntimeSessionGate = RuntimeSessionGate(),
+         refuseDuringDecode: Bool = false, badVersion: Bool = false, failSend: Bool = false) throws {
+        let (stream, completion) = AsyncThrowingStream<Bool, any Error>.makeStream()
+        processed = stream
+        let trace = trace, state = state
+        let listener = XPCListener { request in
+            request.accept { session in
+                state.accepted.withLock { $0 = session }
+                let log: @Sendable (DiagnosticEvent) -> Void = { event in
+                    trace.record(.diagnostic); trace.diagnostics.withLock { $0.append(event) }
+                }
+                let native: NativeRuntimeRequestHandler
+                if usePublicPolicy { native = NativeRuntimeRequestHandler(session: session, version: version, diagnostic: log) }
+                else {
+                    native = NativeRuntimeRequestHandler(gate: gate,
+                        authenticate: { _ in trace.record(.authenticated); return authorized },
+                        decode: { bytes, count in
+                            trace.record(.decoded)
+                            if refuseDuringDecode { gate.refuse(.failed(OperationID(), .unauthorizedCaller)) }
+                            return RuntimeDispatcher.decide(bytes, inFlight: count)
+                        },
+                        register: { request in
+                            trace.record(.registered)
+                            return NativeRuntimeRequestHandler.queryReply(request, version: badVersion
+                                ? RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(99)) : version)
+                        },
+                        send: { reply in
+                            trace.record(.sendAttempt)
+                            if failSend { throw FixtureFailure.transport }
+                            try session.send(message: reply); trace.record(.sent)
+                        },
+                        cancel: { trace.record(.canceled); session.cancel(reason: "test refusal") }, diagnostic: log)
+                }
+                state.handler.withLock { $0 = native }
+                return ObservingHandler(native: native, completion: completion)
+            }
+        }
+        do { client = try XPCSession(endpoint: listener.endpoint) }
+        catch { listener.cancel(); throw error }
+        self.listener = listener
+    }
+
+    func request(_ message: XPCDictionary) -> AsyncThrowingStream<RuntimeEvent, any Error> {
+        let (stream, replies) = AsyncThrowingStream<RuntimeEvent, any Error>.makeStream()
+        client.send(message: message) { response in
+            do {
+                let native = try response.get()
+                let bytes = try RawRuntimeFrame.payload(native, expectedVersion: Int64(RuntimeProtocolVersion.current.rawValue))
+                replies.yield(try RuntimeEventEnvelope.decode(bytes).event); replies.finish()
+            } catch { replies.finish(throwing: FixtureFailure.transport) }
+        }
+        return stream
+    }
+
+    func cancel() {
+        client.cancel(reason: "test completed")
+        state.accepted.withLock { $0 }?.cancel(reason: "test completed")
+        listener.cancel()
+    }
+}
+
+private final class SessionState: Sendable {
+    let handler = Mutex<NativeRuntimeRequestHandler?>(nil)
+    let accepted = Mutex<XPCSession?>(nil)
+}
+
+private struct ObservingHandler: XPCPeerHandler {
+    let native: NativeRuntimeRequestHandler
+    let completion: AsyncThrowingStream<Bool, any Error>.Continuation
+    func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
+        let result = native.handleIncomingRequest(message)
+        #expect(result == nil)
+        completion.yield(true)
+        return nil
+    }
+    func handleCancellation(error: XPCRichError) { native.handleCancellation(error: error) }
+}
+private enum FixtureFailure: Error { case transport, timeout }
+private func next<T: Sendable>(_ stream: AsyncThrowingStream<T, any Error>) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask { var iterator = stream.makeAsyncIterator(); return try #require(await iterator.next()) }
+        group.addTask { try await Task.sleep(for: .seconds(5)); throw FixtureFailure.timeout }
+        defer { group.cancelAll() }
+        return try #require(await group.next())
+    }
+}


### PR DESCRIPTION
## Scope and stack

Stacked on #151 (`mvp/runtime-caller-authentication`, parent `42781589562dbd6c3d57bcae4795aa3138560fc9`). Intended order: #150 → #151 → this PR, **into main after each base is settled**, never into a feature parent. #151 has exact-head green Xcode Cloud and a matching completed Codex review with original-message thumbs-up; it still awaits #150's merge/base settlement.

Refs #19, #20, #112, #11 and dashboard #48. Migrates the request-ingress portion of retained #68 against the merged/approved primitives, under **MVP-PLAN.md §3 (Sandbox and XPC boundary), §11, ADR 0003**. Does not close the aggregate issues or superseded drafts.

## What changes

- Add the actual `XPCDictionary` request handler to runtime-only RuntimeKit. Its public initializer fixes original-message authentication to #151 and implements **runtimeVersion only**; all other named requests return unsupported. No listener, GUI connection, mutation or provider operation is activated.
- Count each admitted callback with #148's gate. Authenticate the original message before touching header/payload/reply context, including one-way messages. Refusal immediately stops new admission; already-counted replies drain.
- Use #150's single-owner native context, reject authenticated one-way requests before decoding/registration, and explicitly send each answer before `finished`/cancel. Always return nil; no second implicit reply.
- At the admission cap, inspect only the native integer header. Otherwise #149 validates actual fixed keys/types/data length before copying or invoking the decoder. Unknown native fields and the original 65,537-byte ignored-field reproducer cannot disappear through decode/re-encode.
- Preserve outer-version-first mismatch. A current outer frame with a foreign nested epoch is contradictory/malformed, not a foreign handshake. Registration rechecks refusal under the same lock, outside payload decoding.
- Encoding failure preserves the context for a fixed typed **query** failure; send failure consumes the context, refuses the session and never retries. Public construction cannot register mutations, so this fallback cannot fabricate their terminal outcomes. Future mutating adapters must preserve registered IDs and unknown outcomes explicitly.
- Emit only Guesthouse-built `DiagnosticEvent` rejection records using the new closed `runtimeRequest` operation case. No raw-output/redactor, arbitrary error description, message or metadata channel. Diagnostic callbacks run outside registration's lock.

## Verification

- Final strict CI package hook passed: **Core 381 tests / 33 suites; RuntimeKit 14 tests / 2 suites**. Swift warnings-as-errors and C `-Wall -Wextra -Werror`.
- RuntimeKit suite passed **five consecutive repetitions**.
- New native tests: 13 original-frame shapes (including exact 64 KiB, empty/oversized/ignored payload, unknown/missing keys, wrong types, outer mismatch, contradictory inner version and malformed JSON); authorized one-way followed by normal request; unauthorized one-way/reply-bearing refusal; native reply-before-cancel; cap before payload decoder; controlled refusal between decode and registration; encoding failure; send failure/no reclaim/retry; post-refusal callback drop; simultaneous differently typed replies; only version query supported.
- Positive ingress tests deliberately inject an authentication verdict through an **internal-only test seam**. A separate anonymous test uses the real public initializer and confirms refusal of the non-GUI runner. Neither is positive signed-Guesthouse evidence.
- Shared-scheme unsigned `build-for-testing CODE_SIGNING_ALLOWED=NO` passed on final content. RuntimeKitTests is included with standalone XCTest hosting; the GUI binary has no native-handler/authentication symbols. Existing optional App Intents metadata-extraction notices remain; no Swift/C compiler warnings.
- Seven CI-hook fixture scenarios and diff checks pass. No project, signing or entitlement changes in this PR.

## Still required

The embedded service target/listener and GUI native transport/client are not yet connected on main. Migrate their generation retirement, event correlation, bounded push/reply paths and unknown outcomes, then activate all native consumers with a fresh incompatible epoch **newer than historical 8–11**. This test-only traffic uses the current Core epoch consistently and does not select a production epoch.

Keep #112 open for the complete boundary and descendant responder/sink migration. Signed Finder-launched behavior and host/VM hardware gates remain human evidence, not unit-test claims. Preserve the old draft implementations/reviews until their entire retained scope lands.