### PR TITLE
Preserve client session retirement and unknown outcomes

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionFailure.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionFailure.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Client-local transport cause plus request-specific uncertainty (#19/#112, MVP-PLAN.md §3).
+/// Not a wire event, diagnostic attachment, or an operation's terminal result.
+public struct RuntimeSessionFailure: Error, Hashable, Sendable, LocalizedError {
+    public enum Cause: Hashable, Sendable {
+        case connectionLost, malformedResponse, oversizedResponse
+        case protocolMismatch(service: Int)
+    }
+
+    public let cause: Cause
+    public let operationID: OperationID?
+    public let mayHaveMutated: Bool
+    public var outcomeUnknown: Bool { operationID != nil || mayHaveMutated }
+
+    public init(cause: Cause, operationID: OperationID? = nil, mayHaveMutated: Bool = false) {
+        self.cause = cause; self.operationID = operationID; self.mayHaveMutated = mayHaveMutated
+    }
+
+    /// Adds context for the SAME request without erasing a learned ID or weakening uncertainty.
+    /// The registry stores only cause, never one request's identity on the whole generation.
+    public func contextualized(operationID: OperationID? = nil, mayHaveMutated: Bool = false) -> Self {
+        Self(cause: cause, operationID: self.operationID ?? operationID,
+             mayHaveMutated: self.mayHaveMutated || mayHaveMutated)
+    }
+
+    public static func frameFailure(_ failure: RawRuntimeFrame.Failure) -> Self {
+        switch failure {
+        case .malformed: Self(cause: .malformedResponse)
+        case .oversized: Self(cause: .oversizedResponse)
+        case .protocolMismatch(let received): Self(cause: .protocolMismatch(service: Int(received)))
+        }
+    }
+
+    /// For RuntimeEventEnvelope.decode failures only, not arbitrary domain/operation errors.
+    public static func decodingFailure(_ error: GuesthouseError) -> Self {
+        switch error {
+        case .protocolMismatch(_, let service): Self(cause: .protocolMismatch(service: service))
+        case .invalidRuntimeReply(.oversized): Self(cause: .oversizedResponse)
+        default: Self(cause: .malformedResponse)
+        }
+    }
+
+    public var userMessage: String {
+        let message: String
+        switch cause {
+        case .connectionLost: message = "Guesthouse lost contact with its runtime service before it answered."
+        case .malformedResponse: message = "Guesthouse's runtime service sent an invalid response."
+        case .oversizedResponse: message = "Guesthouse's runtime service sent a response exceeding the supported size limit."
+        case .protocolMismatch(let service):
+            message = GuesthouseError.protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: service).userMessage
+        }
+        return outcomeUnknown ? message + " The operation may or may not have completed. Inspect its current state before continuing." : message
+    }
+
+    /// A read-only connection loss may offer a USER retry; this type never schedules replay.
+    public var recoveryActions: [RecoveryAction] {
+        if cause == .connectionLost { return outcomeUnknown ? [.inspectState, .cancel] : [.retry, .cancel] }
+        return outcomeUnknown ? [.inspectState, .reinstallApp, .cancel] : [.reinstallApp, .cancel]
+    }
+    public var errorDescription: String? { userMessage }
+    public var recoverySuggestion: String? { recoveryActions.map(\.title).joined(separator: "; ") }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionRegistry.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionRegistry.swift
@@ -1,0 +1,116 @@
+import Synchronization
+
+/// Callbacks retain their own generation, not an ever-growing history of retired sessions.
+public final class RuntimeSessionGeneration: Sendable {
+    fileprivate let retirement = Mutex<RuntimeSessionFailure.Cause?>(nil)
+    fileprivate init() {}
+}
+
+/// In-memory client session ownership and ordered delivery (#19/#112, MVP-PLAN.md §3).
+/// No session creation/activation/cancellation, native I/O, tasks or operation dispatch here.
+/// Delivery callbacks MUST only enqueue bounded work: no blocking, I/O or registry reentry.
+/// Their synchronous handoff shares the retirement lock so an interruption cannot overtake
+/// a live reply or trail the replacement's events. Cancellation always happens outside it.
+public final class RuntimeSessionRegistry<Session: Sendable>: Sendable {
+    public struct Lease: Sendable {
+        public let session: Session
+        public let generation: RuntimeSessionGeneration
+    }
+    struct State: Sendable {
+        var generation: RuntimeSessionGeneration?
+        var session: Session?
+        var ready = false
+    }
+    // Internal for nonblocking lock-ownership tests; not an authorization snapshot.
+    let state = Mutex(State())
+    private let incoming: @Sendable (RuntimeEvent) -> Void
+    private let interrupted: @Sendable (RuntimeSessionFailure) -> Void
+
+    public init(incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+                interrupted: @escaping @Sendable (RuntimeSessionFailure) -> Void) {
+        self.incoming = incoming; self.interrupted = interrupted
+    }
+
+    public var current: Lease? {
+        state.withLock { state in
+            guard state.ready, let session = state.session, let generation = state.generation else { return nil }
+            return Lease(session: session, generation: generation)
+        }
+    }
+
+    /// Reserve before creating an INACTIVE native session outside this lock. Nil means a
+    /// session is already live/connecting, not permission to create a competing connection.
+    /// The transport serializes its setup callers; it must not hold this delivery lock.
+    public func reserve() -> RuntimeSessionGeneration? {
+        state.withLock { state in
+            guard state.generation == nil else { return nil }
+            let generation = RuntimeSessionGeneration()
+            state.generation = generation
+            return generation
+        }
+    }
+
+    /// Transfer cleanup ownership before activation. Call once per newly created candidate;
+    /// never resubmit a handle whose ownership was already transferred. On false the creator
+    /// still owns that candidate and must cancel it; on true ONLY retire's winner cancels it.
+    public func install(_ session: Session, for generation: RuntimeSessionGeneration) -> Bool {
+        state.withLock { state in
+            guard state.generation === generation, state.session == nil else { return false }
+            state.session = session
+            return true
+        }
+    }
+
+    /// Call after successful activation, outside this lock. A retirement during setup wins:
+    /// false never restores the session and does not transfer cleanup ownership back.
+    public func activated(_ generation: RuntimeSessionGeneration) -> Bool {
+        state.withLock { state in
+            guard state.generation === generation, state.session != nil else { return false }
+            state.ready = true
+            return true
+        }
+    }
+
+    /// Transport failures must retire first, then deliver their request-specific reply error.
+    /// Even a late acceptance retains its ID as UNKNOWN outcome, never a new live operation.
+    public func deliverReply(_ result: Result<RuntimeEvent, RuntimeSessionFailure>,
+                             from generation: RuntimeSessionGeneration,
+                             to reply: @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) {
+        state.withLock { state in
+            if state.generation === generation, state.session != nil { reply(result); return }
+            let cause = generation.retirement.withLock { $0 } ?? .connectionLost
+            var failure = RuntimeSessionFailure(cause: cause)
+            switch result {
+            case .success(.accepted(let id)): failure = failure.contextualized(operationID: id)
+            case .failure(let received):
+                // Ordinary cancellation may have preceded the decoder's more specific cause.
+                // Preserve that cause for this reply only, never for a replacement/other request.
+                failure = cause == .connectionLost ? received : failure.contextualized(
+                    operationID: received.operationID, mayHaveMutated: received.mayHaveMutated)
+            case .success: break
+            }
+            reply(.failure(failure))
+        }
+    }
+
+    public func deliverIncoming(_ event: RuntimeEvent, from generation: RuntimeSessionGeneration) {
+        state.withLock { state in
+            guard state.generation === generation, state.session != nil else { return }
+            incoming(event)
+        }
+    }
+
+    /// Notify exactly once, even if failure arrives before installation. Returned session is
+    /// the sole cancellation handoff; no synthetic success/terminal operation event is sent.
+    public func retire(_ generation: RuntimeSessionGeneration,
+                       failure: RuntimeSessionFailure = .init(cause: .connectionLost)) -> Session? {
+        state.withLock { state in
+            guard state.generation === generation else { return nil }
+            generation.retirement.withLock { $0 = failure.cause }
+            let doomed = state.session
+            state = State()
+            interrupted(RuntimeSessionFailure(cause: failure.cause))
+            return doomed
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionFailureTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionFailureTests.swift
@@ -1,0 +1,37 @@
+import Testing
+@testable import GuesthouseCore
+
+struct RuntimeSessionFailureTests {
+    @Test(arguments: [RuntimeSessionFailure.Cause.connectionLost, .malformedResponse, .oversizedResponse, .protocolMismatch(service: 99)],
+          [(false, false), (true, false), (false, true), (true, true)])
+    func causeAndOutcomeAreIndependent(cause: RuntimeSessionFailure.Cause, context: (Bool, Bool)) {
+        let (accepted, preacceptMutation) = context
+        let id = accepted ? OperationID() : nil
+        let failure = RuntimeSessionFailure(cause: cause, operationID: id, mayHaveMutated: preacceptMutation)
+        #expect(failure.outcomeUnknown == (accepted || preacceptMutation))
+        #expect(failure.recoveryActions.contains(.inspectState) == failure.outcomeUnknown)
+        #expect(failure.recoveryActions.contains(.retry) == (cause == .connectionLost && !failure.outcomeUnknown))
+        #expect(failure.userMessage.contains("may or may not have completed") == failure.outcomeUnknown)
+        #expect(failure.contextualized().operationID == id)
+        #expect(failure.contextualized().mayHaveMutated == preacceptMutation)
+        #expect(failure.errorDescription == failure.userMessage)
+        #expect(failure.recoverySuggestion?.isEmpty == false)
+    }
+
+    @Test func addingContextCannotEraseOrReplaceLearnedIdentity() {
+        let id = OperationID()
+        let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: id, mayHaveMutated: true)
+        let preserved = failure.contextualized(operationID: OperationID(), mayHaveMutated: false)
+        #expect(preserved == failure)
+        #expect(RuntimeSessionFailure(cause: .oversizedResponse).contextualized(operationID: id).operationID == id)
+    }
+
+    @Test func nativeAndNestedFailuresRetainOnlyClosedCauses() {
+        #expect(RuntimeSessionFailure.frameFailure(.malformed).cause == .malformedResponse)
+        #expect(RuntimeSessionFailure.frameFailure(.oversized).cause == .oversizedResponse)
+        #expect(RuntimeSessionFailure.frameFailure(.protocolMismatch(received: 99)).cause == .protocolMismatch(service: 99))
+        #expect(RuntimeSessionFailure.decodingFailure(.invalidRuntimeReply(.malformed)).cause == .malformedResponse)
+        #expect(RuntimeSessionFailure.decodingFailure(.invalidRuntimeReply(.oversized)).cause == .oversizedResponse)
+        #expect(RuntimeSessionFailure.decodingFailure(.protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: 99)).cause == .protocolMismatch(service: 99))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionRegistryTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeSessionRegistryTests.swift
@@ -1,0 +1,169 @@
+import Dispatch
+import Foundation
+import Synchronization
+import Testing
+@testable import GuesthouseCore
+
+/// Migrated retirement/order regressions from retained #68, using inert Sendable handles.
+/// No native session, actor inbox, connection activation, automatic replay or signing proof.
+struct RuntimeSessionRegistryTests {
+    @Test func installationAndActivationAreSeparateFromReservation() throws {
+        let registry = makeRegistry()
+        let generation = try #require(registry.reserve())
+        #expect(registry.current == nil)
+        #expect(registry.reserve() == nil)
+        #expect(!registry.activated(generation))
+        #expect(registry.install(1, for: generation))
+        #expect(!registry.install(2, for: generation))
+        #expect(registry.current == nil)
+        #expect(registry.activated(generation))
+        #expect(registry.current?.session == 1)
+        #expect(registry.current?.generation === generation)
+        #expect(registry.retire(generation) == 1)
+        #expect(registry.current == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func retirementDuringSetupCannotResurrectCandidate(installed: Bool) throws {
+        let records = Records()
+        let registry = makeRegistry(records)
+        let old = try #require(registry.reserve())
+        if installed { #expect(registry.install(1, for: old)) }
+        #expect(registry.retire(old) == (installed ? 1 : nil))
+        #expect(!registry.activated(old))
+        #expect(!registry.install(1, for: old))
+        #expect(registry.retire(old) == nil)
+        #expect(records.failures.withLock { $0.count } == 1)
+        let replacement = try connected(registry, handle: 2)
+        #expect(replacement !== old)
+        #expect(registry.current?.session == 2)
+    }
+
+    @Test func lateAcceptanceKeepsItsIDAsUnknownWithoutReachingReplacement() throws {
+        let records = Records()
+        let registry = makeRegistry(records)
+        let old = try connected(registry)
+        let acceptedID = OperationID()
+        let originalFailure = RuntimeSessionFailure(cause: .protocolMismatch(service: 99), operationID: OperationID(), mayHaveMutated: true)
+        #expect(registry.retire(old, failure: originalFailure) == 1)
+        let replacement = try connected(registry, handle: 2)
+        let late = delivered(registry, .success(.accepted(acceptedID)), from: old)
+        guard case .failure(let error) = late else { Issue.record("Stale acceptance became live"); return }
+        #expect(error.cause == originalFailure.cause)
+        #expect(error.operationID == acceptedID)
+        #expect(error.outcomeUnknown && !error.recoveryActions.contains(.retry))
+        #expect(error.contextualized().operationID == acceptedID)
+        // Generation-wide reports must not blame unrelated requests on the triggering ID.
+        #expect(records.failures.withLock { $0 } == [RuntimeSessionFailure(cause: originalFailure.cause)])
+        #expect(registry.retire(old, failure: .init(cause: .malformedResponse)) == nil)
+        let current = RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1"))
+        #expect(try delivered(registry, .success(current), from: replacement).get() == current)
+        registry.deliverIncoming(.completed(acceptedID), from: old)
+        registry.deliverIncoming(current, from: replacement)
+        #expect(records.events.withLock { $0 } == [current])
+    }
+
+    @Test(arguments: [RuntimeSessionFailure.Cause.malformedResponse, .oversizedResponse, .protocolMismatch(service: 99)])
+    func ordinaryRetirementPreservesLateRepliesSpecificCauseOnlyForThatRequest(cause: RuntimeSessionFailure.Cause) throws {
+        let registry = makeRegistry()
+        let old = try connected(registry)
+        _ = registry.retire(old)
+        let current = try connected(registry, handle: 2)
+        let specific = RuntimeSessionFailure(cause: cause, mayHaveMutated: true)
+        #expect(delivered(registry, .failure(specific), from: old) == .failure(specific))
+        // The late decoder cannot rewrite retirement cause or poison the replacement.
+        #expect(delivered(registry, .success(.completed(OperationID())), from: old) == .failure(.init(cause: .connectionLost)))
+        #expect(registry.current?.generation === current)
+    }
+
+    @Test func storedRetirementCauseWinsWithoutLosingPerReplyUncertainty() throws {
+        let registry = makeRegistry()
+        let old = try connected(registry)
+        _ = registry.retire(old, failure: .init(cause: .oversizedResponse))
+        let id = OperationID()
+        let later = RuntimeSessionFailure(cause: .connectionLost, operationID: id, mayHaveMutated: true)
+        #expect(delivered(registry, .failure(later), from: old) == .failure(
+            .init(cause: .oversizedResponse, operationID: id, mayHaveMutated: true)))
+    }
+
+    @Test func deliveryAndInterruptionShareTheReservationLockWithoutTimingAssumptions() throws {
+        let probe = RegistryProbe()
+        let registry = RuntimeSessionRegistry<Int>(incoming: { _ in
+            #expect(probe.isDeliveryLocked())
+        }, interrupted: { _ in
+            // A replacement reserve() uses this same lock, so it cannot overtake this enqueue.
+            #expect(probe.isDeliveryLocked())
+        })
+        probe.registry.withLock { $0 = registry }
+        defer { probe.registry.withLock { $0 = nil } }
+        let generation = try connected(registry)
+        let event = RuntimeEvent.completed(OperationID())
+        registry.deliverReply(.success(event), from: generation) { _ in
+            #expect(registry.state.withLockIfAvailable { _ in true } == nil)
+        }
+        registry.deliverIncoming(event, from: generation)
+        #expect(registry.retire(generation) == 1)
+        #expect(registry.state.withLockIfAvailable { _ in true } == true)
+    }
+
+    @Test func concurrentReservationsAndRetirementsHaveOneOwner() throws {
+        let records = Records()
+        let registry = makeRegistry(records)
+        let reservations = Mutex<[RuntimeSessionGeneration]>([])
+        DispatchQueue.concurrentPerform(iterations: 64) { _ in
+            if let generation = registry.reserve() { reservations.withLock { $0.append(generation) } }
+        }
+        #expect(reservations.withLock { $0.count } == 1)
+        let generation = try #require(reservations.withLock { $0.first })
+        #expect(registry.install(1, for: generation))
+        #expect(registry.activated(generation))
+        let cancellationOwners = Mutex(0)
+        DispatchQueue.concurrentPerform(iterations: 64) { _ in
+            if registry.retire(generation) != nil { cancellationOwners.withLock { $0 += 1 } }
+        }
+        #expect(cancellationOwners.withLock { $0 } == 1)
+        #expect(records.failures.withLock { $0.count } == 1)
+    }
+
+    @Test func registryDoesNotKeepRetiredGenerationHistoryAlive() throws {
+        let registry = makeRegistry()
+        weak var old: RuntimeSessionGeneration?
+        do {
+            let generation = try connected(registry)
+            old = generation
+            _ = registry.retire(generation)
+        }
+        #expect(old == nil)
+    }
+
+    private func makeRegistry(_ records: Records = Records()) -> RuntimeSessionRegistry<Int> {
+        RuntimeSessionRegistry(incoming: { event in records.events.withLock { $0.append(event) } },
+                               interrupted: { failure in records.failures.withLock { $0.append(failure) } })
+    }
+    private func connected(_ registry: RuntimeSessionRegistry<Int>, handle: Int = 1) throws -> RuntimeSessionGeneration {
+        let generation = try #require(registry.reserve())
+        #expect(registry.install(handle, for: generation))
+        #expect(registry.activated(generation))
+        return generation
+    }
+    private func delivered(_ registry: RuntimeSessionRegistry<Int>, _ result: Result<RuntimeEvent, RuntimeSessionFailure>,
+                           from generation: RuntimeSessionGeneration) -> Result<RuntimeEvent, RuntimeSessionFailure> {
+        let replies = Mutex<[Result<RuntimeEvent, RuntimeSessionFailure>]>([])
+        registry.deliverReply(result, from: generation) { result in replies.withLock { $0.append(result) } }
+        let delivered = replies.withLock { $0 }
+        #expect(delivered.count == 1)
+        return delivered.first ?? .failure(.init(cause: .connectionLost))
+    }
+}
+
+private final class Records: Sendable {
+    let events = Mutex<[RuntimeEvent]>([])
+    let failures = Mutex<[RuntimeSessionFailure]>([])
+}
+private final class RegistryProbe: Sendable {
+    let registry = Mutex<RuntimeSessionRegistry<Int>?>(nil)
+    func isDeliveryLocked() -> Bool {
+        guard let value = registry.withLock({ $0 }) else { return false }
+        return value.state.withLockIfAvailable { _ in true } == nil
+    }
+}


### PR DESCRIPTION
## Scope and stack

Stacked on #152 (`mvp/native-request-handler`, parent `6dd735cf62c249417f61fce7d0bfd69a65509488`). Intended main integration order: **#150 → #151 → #152 → this PR**. Settle each child's base on main and recheck composition after its parent merges; do not merge children into feature parents.

Refs #19, #9 and #112; **MVP-PLAN.md §3 (interruption/unknown outcomes), §11; ADR 0003**. This is the client session-state portion of the retained #68 migration, not endpoint activation or completion of the whole client.

## Migration

- Move typed client-local failure context and session-generation retirement into Core with checked `Sendable` and `Mutex`. No NSLock/unchecked escape hatch, native I/O, actor task, factory, activation or cancellation is hidden in Core.
- Keep connection loss, malformed/oversized response and protocol mismatch separate from whether a request may have changed the host. Adding request context never erases a learned ID or weakens uncertainty. An uncertain operation never offers retry; a known read-only connection loss may offer a **user** retry, never automatic replay.
- Preserve a late `accepted(id)` as an **unknown outcome carrying that ID**, not as a live operation on a dead session. Store only the cause on a retired generation, so one request's ID does not contaminate other requests.
- Preserve a late decoder's more specific cause after ordinary cancellation for that reply only. A previously recorded contract cause wins, while retaining per-reply uncertainty; neither path poisons the replacement.
- Reserve a generation before constructing an inactive native session **outside the delivery lock**. Install transfers cleanup ownership; only successful activation publishes the current lease. Retirement during either setup interval wins and cannot resurrect the candidate. The transport must serialize its setup callers, activate outside the registry and honor the documented cleanup handoff.
- Retire/report once and return the sole session-to-cancel outside the lock. Reply, push and interruption enqueues share the retirement lock, so old callbacks cannot overtake retirement or affect a replacement. Enqueue callbacks must be bounded, nonblocking and non-reentrant.
- Retain only each callback's own generation, not an ever-growing retirement history. No raw error descriptions, payload snippets, logging attachment or new wire format.

## Verification

- Full strict package hook passed: **Core 392 tests / 35 suites; RuntimeKit 14 tests / 2 suites** (406 test functions, plus parameterized cases).
- Eleven new Core tests include 16 cause/context combinations, pending/installed setup retirement, late acceptance identity, cause isolation, stale push refusal, single reply delivery, cleanup ownership, contextualization that cannot weaken uncertainty, and retired-token release.
- **64 concurrent reservations and 64 competing retirements** produce one owner/report. The old timing/semaphore lock tests are replaced by direct nonblocking lock-ownership assertions, including the shared lock that orders replacement reservation after interruption enqueue.
- The two focused suites passed **five consecutive repetitions**.
- Final unsigned shared-scheme `build-for-testing CODE_SIGNING_ALLOWED=NO` and seven CI-hook fixture scenarios passed. No Swift/C compiler warnings; existing optional App Intents metadata notices remain. No app/project, signing, entitlement or dependency changes.

## Remaining integration

Tests use inert Sendable handles, not native sessions. The actual GUI native transport must now use reserve → create inactive → install → activate → publish, perform bounded original-frame decoding, retire failed reply/push generations, and preserve this context into the client/UI. Reuse the retained client correlation/backpressure/terminal-reserve regressions; this state model alone does not prove them.

The embedded listener/query client and eventual push/mutation consumers still need coherent migration and a fresh activation epoch newer than historical8–11. Signed Finder behavior and hardware gates remain separate. #9/#19/#20/#112 and the preserved native-XPC reference PRs stay open until their entire retained scope lands.