### PR TITLE
Migrate bounded native client transport and session cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Prioritize Lume candidate validation and shared infrastructure under [ADR 0002](
 | `Guesthouse/` | The SwiftUI app. App Sandbox and Hardened Runtime on. Product name is "Guesthouse Codex VM". | UI state is `@MainActor` (the target sets MainActor default isolation). Never launches processes. |
 | `GuesthouseRuntime/` | Embedded XPC service, non-sandboxed, Hardened Runtime on (added by issue #19). | The only place host operations run. Exposes named operations, never a generic "run a command" API. |
 | `Packages/GuesthouseCore` | Shared models, typed XPC contract, state machines, parsers, validation. | Nonisolated by default; every public type is `Sendable`. No process execution, no host mutations. |
+| `Packages/GuesthouseClientKit` | GUI-safe native XPC transport, independently testable without launching the app. | Depends only on Core/system frameworks. No RuntimeKit, process execution, provider adapters or host mutations. |
 | `Packages/GuesthouseRuntimeKit` | Process execution and provider adapters (added by issue #21); shared infrastructure and Lume candidate work are active, Tart adapters are retained. | Linked only by `GuesthouseRuntime`. The app target must never import it. |
 | `Fixtures/` | Sample app and package repositories used inside the guest VM by the phase-0 gates. | Not part of the product. Excluded from CI. |
 | `docs/phase0/` | Recorded results of the phase-0 hardware experiments. | Only filled in from a real run. Never from reasoning. |

--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		CD1501540000000000000004 /* GuesthouseClientKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseClientKit; path = Packages/GuesthouseClientKit; sourceTree = "<group>"; };
 		CD1501510000000000000004 /* GuesthouseRuntimeKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseRuntimeKit; path = Packages/GuesthouseRuntimeKit; sourceTree = "<group>"; };
 		F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Guesthouse Codex VM.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8976E97304933D30071C234 /* GuesthouseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuesthouseTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -86,6 +87,7 @@
 				F8ACD8A93049406300550943 /* MVP-PLAN.md */,
 				921BF84465C14B2296CA65E2 /* GuesthouseCore */,
 				CD1501510000000000000004 /* GuesthouseRuntimeKit */,
+				CD1501540000000000000004 /* GuesthouseClientKit */,
 				F8976E8C304933D10071C234 /* Guesthouse */,
 				F8976E9A304933D30071C234 /* GuesthouseTests */,
 				F8976EA4304933D30071C234 /* GuesthouseUITests */,
@@ -210,6 +212,7 @@
 			packageReferences = (
 				F8ACD8A630493E2C00550943 /* XCLocalSwiftPackageReference "Packages/GuesthouseCore" */,
 				CD1501510000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseRuntimeKit" */,
+				CD1501540000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseClientKit" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = F8976E8B304933D10071C234 /* Products */;
@@ -633,6 +636,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
+		CD1501540000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseClientKit" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/GuesthouseClientKit;
+		};
 		CD1501510000000000000001 /* XCLocalSwiftPackageReference "Packages/GuesthouseRuntimeKit" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/GuesthouseRuntimeKit;

--- a/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
+++ b/Guesthouse.xcodeproj/xcshareddata/xcschemes/Guesthouse.xcscheme
@@ -49,6 +49,20 @@
                ReferencedContainer = "container:Packages/GuesthouseRuntimeKit">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GuesthouseClientKitTests"
+               BuildableName = "GuesthouseClientKitTests"
+               BlueprintName = "GuesthouseClientKitTests"
+               ReferencedContainer = "container:Packages/GuesthouseClientKit">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -58,6 +72,16 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       shouldAutocreateTestPlan = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "GuesthouseClientKitTests"
+               BuildableName = "GuesthouseClientKitTests"
+               BlueprintName = "GuesthouseClientKitTests"
+               ReferencedContainer = "container:Packages/GuesthouseClientKit">
+            </BuildableReference>
+         </TestableReference>
          <TestableReference
             skipped = "NO">
             <BuildableReference

--- a/Packages/GuesthouseClientKit/Package.swift
+++ b/Packages/GuesthouseClientKit/Package.swift
@@ -1,0 +1,15 @@
+// swift-tools-version: 6.3
+import PackageDescription
+
+// GUI-safe native transport, separately testable without launching the app. No RuntimeKit,
+// process execution, provider adapters, credentials or host mutations (MVP-PLAN.md §3).
+let settings: [SwiftSetting] = [.defaultIsolation(nil), .enableUpcomingFeature("MemberImportVisibility")]
+let package = Package(
+    name: "GuesthouseClientKit", platforms: [.macOS(.v26)],
+    products: [.library(name: "GuesthouseClientKit", targets: ["GuesthouseClientKit"])],
+    dependencies: [.package(path: "../GuesthouseCore")],
+    targets: [
+        .target(name: "GuesthouseClientKit", dependencies: [.product(name: "GuesthouseCore", package: "GuesthouseCore")], swiftSettings: settings),
+        .testTarget(name: "GuesthouseClientKitTests", dependencies: ["GuesthouseClientKit", .product(name: "GuesthouseCore", package: "GuesthouseCore")], swiftSettings: settings),
+    ], swiftLanguageModes: [.v6]
+)

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/NativeRuntimeSession.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/NativeRuntimeSession.swift
@@ -1,0 +1,73 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import XPC
+
+protocol RuntimeClientSession: AnyObject, Sendable {
+    func activate() throws
+    func send(_ payload: Data, reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void)
+    /// Must safely dispose of an inactive candidate as well as an active session.
+    func cancel()
+}
+
+/// Owns exactly one initially inactive XPC session. Never expose the native handle.
+/// SDK session.h requires activation before cancellation/release, and forbids sends after
+/// cancellation. The lifecycle lock serializes our activate/send/cancel calls. Native XPC
+/// callbacks are asynchronous/non-preemptive; they never run inline under this lock.
+final class NativeRuntimeSession: RuntimeClientSession {
+    private enum Phase { case inactive, active, closed }
+    private let phase = Mutex(Phase.inactive)
+    private let native: XPCSession
+
+    init(_ inactiveSession: XPCSession) { native = inactiveSession }
+    deinit { cancel() }
+
+    func activate() throws(RuntimeSessionFailure) {
+        try phase.withLock { (phase: inout Phase) throws(RuntimeSessionFailure) in
+            guard phase == .inactive else { throw RuntimeSessionFailure(cause: .connectionLost) }
+            do { try native.activate(); phase = .active }
+            catch { phase = .closed; throw RuntimeSessionFailure(cause: .connectionLost) }
+        }
+    }
+
+    func cancel() {
+        phase.withLock { phase in
+            guard phase != .closed else { return }
+            let wasInactive = phase == .inactive
+            phase = .closed
+            // An uninstalled candidate still needs legal disposal. Failed activation already
+            // cancels it. No request is sent, even if cancellation wins before installation.
+            if wasInactive { do { try native.activate() } catch { return } }
+            native.cancel(reason: "Guesthouse client session retired")
+        }
+    }
+
+    func send(_ payload: Data, reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) {
+        let sent = phase.withLock { phase in
+            guard phase == .active, let frame = try? RawRuntimeFrame.encode(
+                payload, protocolVersion: Int64(RuntimeProtocolVersion.current.rawValue)) else { return false }
+            native.send(message: frame) { result in
+                switch result {
+                case .success(let message): reply(Self.decode(message))
+                case .failure: reply(.failure(RuntimeSessionFailure(cause: .connectionLost)))
+                }
+            }
+            return true
+        }
+        if !sent { reply(.failure(RuntimeSessionFailure(cause: .connectionLost))) }
+    }
+
+    /// Reply and push share the ORIGINAL native frame checks before any JSON decoder.
+    static func decode(_ message: XPCDictionary) -> Result<RuntimeEvent, RuntimeSessionFailure> {
+        let payload: Data
+        do { payload = try RawRuntimeFrame.payload(message, expectedVersion: Int64(RuntimeProtocolVersion.current.rawValue)) }
+        catch { return .failure(.frameFailure(error)) }
+        do { return .success(try RuntimeEventEnvelope.decode(payload).event) }
+        catch {
+            // The outer version is current: a foreign inner version is a contradiction,
+            // not a compatible handshake with an older service. Never forward decoder text.
+            if case .protocolMismatch = error { return .failure(.init(cause: .malformedResponse)) }
+            return .failure(.decodingFailure(error))
+        }
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
@@ -1,0 +1,119 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import XPC
+
+/// GUI-side native client migrated from #67/#68/#103 (#19/#112, MVP-PLAN.md §3).
+/// The app does not instantiate this yet. Embedding/activation must choose a fresh shared
+/// wire epoch; the current epoch remains a fixture contract, not a production handshake.
+/// All callbacks MUST only enqueue bounded, nonblocking work and must not reenter transport.
+/// There is no replay, background reconnect, process execution or raw diagnostic output.
+public final class XPCRuntimeTransport: Sendable {
+    static let serviceName = "com.starlingprotocol.Guesthouse.Runtime"
+    typealias Connect = @Sendable (
+        @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+        @escaping @Sendable () -> Void
+    ) throws -> any RuntimeClientSession
+    private let registry: RuntimeSessionRegistry<any RuntimeClientSession>
+    private let setup = Mutex(())
+    private let connect: Connect
+
+    public convenience init(incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+                            interrupted: @escaping @Sendable (RuntimeSessionFailure) -> Void) {
+        self.init(incoming: incoming, interrupted: interrupted, connect: Self.connectToService)
+    }
+
+    init(incoming: @escaping @Sendable (RuntimeEvent) -> Void,
+         interrupted: @escaping @Sendable (RuntimeSessionFailure) -> Void,
+         connect: @escaping Connect) {
+        registry = RuntimeSessionRegistry(incoming: incoming, interrupted: interrupted)
+        self.connect = connect
+    }
+
+    deinit {
+        if let lease = registry.current { Self.retire(lease.generation, in: registry) }
+    }
+
+    /// Only the read-only query is public until the streaming client/outcome routing migrates.
+    public func queryRuntimeVersion(reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) throws {
+        try send(RuntimeRequestEnvelope(request: .runtimeVersion), reply: reply)
+    }
+
+    func send(_ envelope: RuntimeRequestEnvelope,
+              reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) throws {
+        let bytes: Data
+        do {
+            try RequestValidator.validate(envelope)
+            bytes = try JSONEncoder().encode(envelope)
+            try RequestValidator.validateEncodedSize(bytes)
+        } catch let error as RequestValidationError { throw error.guesthouseError }
+        catch { throw GuesthouseError.invalidRequest(.malformed) }
+        let lease = try activeSession()
+        let mayMutate: Bool
+        switch envelope.request {
+        case .runtimeVersion, .environmentStatus: mayMutate = false
+        case .startEnvironment, .stopEnvironment, .importXcode, .cancelOperation: mayMutate = true
+        }
+        // Retain the registry, not self: deinit can cancel pending work, while late callbacks
+        // still preserve learned operation IDs. Native sessions capture the registry weakly.
+        lease.session.send(bytes) { [registry] result in
+            if case .failure(let failure) = result { Self.retire(lease.generation, in: registry, failure: failure) }
+            registry.deliverReply(result, from: lease.generation) { delivered in
+                reply(delivered.mapError { $0.contextualized(mayHaveMutated: mayMutate) })
+            }
+        }
+    }
+
+    private func activeSession() throws -> RuntimeSessionRegistry<any RuntimeClientSession>.Lease {
+        // Setup is serialized separately: native callbacks/retirement never need this lock.
+        try setup.withLock { _ in
+            if let current = registry.current { return current }
+            guard let generation = registry.reserve() else { throw RuntimeSessionFailure(cause: .connectionLost) }
+            do {
+                let candidate = try connect(
+                    { [weak registry] result in
+                        guard let registry else { return }
+                        switch result {
+                        case .success(let event): registry.deliverIncoming(event, from: generation)
+                        case .failure(let failure): Self.retire(generation, in: registry, failure: failure)
+                        }
+                    },
+                    { [weak registry] in
+                        if let registry { Self.retire(generation, in: registry) }
+                    }
+                )
+                guard registry.install(candidate, for: generation) else {
+                    candidate.cancel() // Creator still owns this uninstalled candidate.
+                    throw RuntimeSessionFailure(cause: .connectionLost)
+                }
+                try candidate.activate()
+                guard registry.activated(generation), let lease = registry.current,
+                      lease.generation === generation else { throw RuntimeSessionFailure(cause: .connectionLost) }
+                return lease
+            } catch {
+                Self.retire(generation, in: registry)
+                throw generation.retirementFailure ?? RuntimeSessionFailure(cause: .connectionLost)
+            }
+        }
+    }
+
+    private static func retire(_ generation: RuntimeSessionGeneration,
+                               in registry: RuntimeSessionRegistry<any RuntimeClientSession>,
+                               failure: RuntimeSessionFailure = .init(cause: .connectionLost)) {
+        registry.retire(generation, failure: failure)?.cancel() // Outside delivery lock; sole cleanup owner.
+    }
+
+    private static func connectToService(
+        incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+        dropped: @escaping @Sendable () -> Void
+    ) throws -> any RuntimeClientSession {
+        let native = try XPCSession(
+            xpcService: serviceName, options: .inactive,
+            requirement: .isFromSameTeam(andMatchesSigningIdentifier: serviceName),
+            incomingMessageHandler: { (message: XPCDictionary) -> XPCDictionary? in
+                incoming(NativeRuntimeSession.decode(message)); return nil
+            }, cancellationHandler: { _ in dropped() }
+        )
+        return NativeRuntimeSession(native)
+    }
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/NativeRuntimeSessionTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/NativeRuntimeSessionTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+import XPC
+@testable import GuesthouseClientKit
+
+/// Anonymous native I/O, never a signed-app identity, embedding, provider or hardware proof.
+@Suite(.timeLimit(.minutes(1))) struct NativeRuntimeSessionTests {
+    enum Shape: Sendable, CaseIterable {
+        case current, exactBoundary, oversized, foreignOuter, contradictoryInner, unknownEvent, bareEvent, wrongHeader, wrongPayload, extraKey
+    }
+    @Test(arguments: Shape.allCases, [false, true])
+    func boundedNativeRepliesAndPushes(shape: Shape, push: Bool) async throws {
+        let result = try await exchange(shape, push: push)
+        switch shape {
+        case .current, .exactBoundary: #expect(try result.get() == event)
+        case .oversized: #expect(throws: RuntimeSessionFailure(cause: .oversizedResponse)) { try result.get() }
+        case .foreignOuter: #expect(throws: RuntimeSessionFailure(cause: .protocolMismatch(service: 99))) { try result.get() }
+        default: #expect(throws: RuntimeSessionFailure(cause: .malformedResponse)) { try result.get() }
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func cancellationSafelyDisposesOfInactiveOrActiveSessions(active: Bool) throws {
+        let listener = XPCListener { request in request.reject(reason: "Test cleanup only") }
+        defer { listener.cancel() }
+        let session = NativeRuntimeSession(try XPCSession(endpoint: listener.endpoint, options: .inactive))
+        if active { try session.activate() }
+        session.cancel(); session.cancel()
+        #expect(throws: RuntimeSessionFailure(cause: .connectionLost)) { try session.activate() }
+        let received = Results()
+        session.send(Data([1])) { result in received.values.withLock { $0.append(result) } }
+        let results = received.values.withLock { $0 }
+        try #require(results.count == 1)
+        #expect(throws: RuntimeSessionFailure(cause: .connectionLost)) { try results[0].get() }
+    }
+
+    @Test func releasingAnUnusedNativeCandidateDoesNotViolateXPCLifecycle() throws {
+        let listener = XPCListener { request in request.reject(reason: "Test cleanup only") }
+        defer { listener.cancel() }
+        var session: NativeRuntimeSession? = NativeRuntimeSession(try XPCSession(endpoint: listener.endpoint, options: .inactive))
+        weak let released = session
+        session = nil
+        #expect(released == nil)
+    }
+
+    private func exchange(_ shape: Shape, push: Bool) async throws -> Result<RuntimeEvent, RuntimeSessionFailure> {
+        let delivery = AsyncStream<Result<RuntimeEvent, RuntimeSessionFailure>>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        let holder = Server()
+        let listener = XPCListener { request in
+            let (decision, server) = request.accept(incomingMessageHandler: { (message: XPCDictionary) -> XPCDictionary? in
+                do {
+                    let bytes = try RawRuntimeFrame.payload(message, expectedVersion: epoch)
+                    #expect(try RequestValidator.decode(bytes).request == .runtimeVersion)
+                    let context = try #require(RawRuntimeReplyContext(receivedMessage: message))
+                    let reply = try #require(try context.takeReply(payload: RuntimeEventEnvelope(event: event).encoded(), protocolVersion: epoch))
+                    let peer = try #require(holder.session.withLock { $0 })
+                    if push { try peer.send(message: shaped(shape, frame: XPCDictionary())) }
+                    try peer.send(message: push ? reply : shaped(shape, frame: reply))
+                    return nil // Context was consumed explicitly; never request a second implicit reply.
+                } catch {
+                    Issue.record("Native response fixture failed")
+                    delivery.continuation.yield(.failure(.init(cause: .connectionLost)))
+                    delivery.continuation.finish()
+                    return nil
+                }
+            })
+            holder.session.withLock { $0 = server }
+            return decision
+        }
+        let client = XPCRuntimeTransport(
+            incoming: { delivery.continuation.yield(.success($0)); delivery.continuation.finish() },
+            interrupted: { if push { delivery.continuation.yield(.failure($0)); delivery.continuation.finish() } },
+            connect: { incoming, dropped in
+                NativeRuntimeSession(try XPCSession(
+                    endpoint: listener.endpoint, options: .inactive,
+                    incomingMessageHandler: { (message: XPCDictionary) -> XPCDictionary? in
+                        incoming(NativeRuntimeSession.decode(message)); return nil
+                    }, cancellationHandler: { _ in dropped() }
+                ))
+            }
+        )
+        defer {
+            withExtendedLifetime(client) {}
+            holder.session.withLock { $0 }?.cancel(reason: "Native response fixture finished")
+            listener.cancel()
+        }
+        try client.queryRuntimeVersion { result in
+            if !push { delivery.continuation.yield(result); delivery.continuation.finish() }
+        }
+        var iterator = delivery.stream.makeAsyncIterator()
+        return try #require(await iterator.next())
+    }
+}
+
+private let epoch = Int64(RuntimeProtocolVersion.current.rawValue)
+private let event = RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1"))
+private final class Server: Sendable { let session = Mutex<XPCSession?>(nil) }
+private final class Results: Sendable { let values = Mutex<[Result<RuntimeEvent, RuntimeSessionFailure>]>([]) }
+
+private func shaped(_ shape: NativeRuntimeSessionTests.Shape, frame: XPCDictionary) throws -> XPCDictionary {
+    var frame = frame
+    var payload = try RuntimeEventEnvelope(event: event).encoded()
+    if shape == .exactBoundary { payload.append(Data(repeating: 32, count: RawRuntimeFrame.maximumPayloadBytes - payload.count)) }
+    if shape == .oversized { payload = Data(repeating: 32, count: RawRuntimeFrame.maximumPayloadBytes + 1) }
+    if shape == .foreignOuter || shape == .unknownEvent { payload = Data("{\"protocolVersion\":\(epoch),\"event\":{\"unknown\":{}}}".utf8) }
+    if shape == .contradictoryInner { payload = Data("{\"protocolVersion\":99,\"event\":{}}".utf8) }
+    if shape == .bareEvent { payload = try JSONEncoder().encode(event) }
+    frame["protocolVersion"] = shape == .foreignOuter ? Int64(99) : epoch
+    frame["payload"] = payload.withUnsafeBytes { xpc_data_create($0.baseAddress, $0.count) }
+    if shape == .wrongHeader { frame["protocolVersion"] = "private-fixture-marker" }
+    if shape == .wrongPayload { frame["payload"] = "private-fixture-marker" }
+    if shape == .extraKey { frame["private-fixture-marker"] = true }
+    return frame
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeTransportTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeTransportTests.swift
@@ -1,0 +1,147 @@
+import Dispatch
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite struct RuntimeTransportTests {
+    @Test func invalidOutgoingOptionsNeverConnect() {
+        let fixture = TransportFixture()
+        defer { fixture.releaseCallbacks() }
+        #expect(throws: GuesthouseError.invalidRequest(.malformed)) {
+            try fixture.client().send(.init(request: .startEnvironment(EnvironmentID(), .init(ipWait: .seconds(-1))))) { _ in }
+        }
+        #expect(fixture.sessions.withLock { $0.isEmpty })
+    }
+
+    @Test(arguments: [Mode.connectFails, .activationFails, .retireBeforeInstall, .retireDuringActivation, .contractFailureDuringActivation, .replyFails])
+    func failuresRetireOnceAndOnlyTheNextRequestReconnects(mode: Mode) throws {
+        let fixture = TransportFixture(mode)
+        defer { fixture.releaseCallbacks() }
+        let client = fixture.client()
+        for _ in 0..<2 {
+            if mode == .replyFails { try client.queryRuntimeVersion { result in fixture.replies.withLock { $0.append(result) } } }
+            else {
+                let cause: RuntimeSessionFailure.Cause = mode == .contractFailureDuringActivation ? .malformedResponse : .connectionLost
+                #expect(throws: RuntimeSessionFailure(cause: cause)) { try client.queryRuntimeVersion { _ in } }
+            }
+        }
+        let sessions = fixture.sessions.withLock { $0 }
+        #expect(sessions.count == 2)
+        #expect(fixture.interruptions.withLock { $0.count } == 2)
+        let results = fixture.replies.withLock { $0 }
+        #expect(results.count == (mode == .replyFails ? 2 : 0))
+        for result in results { #expect(throws: RuntimeSessionFailure(cause: .malformedResponse)) { try result.get() } }
+        for session in sessions {
+            #expect(session.cancellations.withLock { $0 } == (mode == .connectFails ? 0 : 1))
+            #expect(session.sends.withLock { $0.count } == (mode == .replyFails ? 1 : 0))
+        }
+    }
+
+    @Test func lateAcceptanceKeepsItsIdentityWithoutContaminatingReplacement() throws {
+        let fixture = TransportFixture(.held)
+        defer { fixture.releaseCallbacks() }
+        let client = fixture.client()
+        try client.send(.init(request: .startEnvironment(EnvironmentID(), .init()))) { result in
+            fixture.replies.withLock { $0.append(result) }
+        }
+        let old = try #require(fixture.sessions.withLock { $0.first })
+        old.incoming(.failure(.init(cause: .oversizedResponse)))
+        try client.queryRuntimeVersion { result in fixture.replies.withLock { $0.append(result) } }
+        let replacement = try #require(fixture.sessions.withLock { $0.last })
+        let id = OperationID()
+        let lateReply = try #require(old.sends.withLock { $0.first })
+        lateReply(.success(.accepted(id)))
+        old.incoming(.success(.completed(id)))
+        old.dropped()
+        let liveReply = try #require(replacement.sends.withLock { $0.first })
+        liveReply(.success(versionEvent))
+        let results = fixture.replies.withLock { $0 }
+        try #require(results.count == 2)
+        #expect(throws: RuntimeSessionFailure(cause: .oversizedResponse, operationID: id, mayHaveMutated: true)) { try results[0].get() }
+        #expect(try results[1].get() == versionEvent)
+        #expect(fixture.incoming.withLock { $0.isEmpty })
+        #expect(fixture.interruptions.withLock { $0 } == [.init(cause: .oversizedResponse)])
+        #expect(replacement.cancellations.withLock { $0 } == 0)
+    }
+
+    @Test func simultaneousQueriesShareOneActivatedConnection() throws {
+        let fixture = TransportFixture()
+        defer { fixture.releaseCallbacks() }
+        let client = fixture.client()
+        DispatchQueue.concurrentPerform(iterations: 32) { _ in
+            #expect(throws: Never.self) {
+                try client.queryRuntimeVersion { result in fixture.replies.withLock { $0.append(result) } }
+            }
+        }
+        let sessions = fixture.sessions.withLock { $0 }
+        try #require(sessions.count == 1)
+        #expect(sessions[0].activations.withLock { $0 } == 1)
+        #expect(sessions[0].sends.withLock { $0.count } == 32)
+        #expect(fixture.replies.withLock { $0.count } == 32)
+    }
+
+    @Test func releasingClientCancelsTheConnectionDespitePendingReply() throws {
+        let fixture = TransportFixture(.held)
+        defer { fixture.releaseCallbacks() }
+        var client: XPCRuntimeTransport? = fixture.client()
+        weak let weakClient = client
+        try client?.queryRuntimeVersion { _ in }
+        client = nil
+        #expect(weakClient == nil)
+        #expect(try #require(fixture.sessions.withLock { $0.first }).cancellations.withLock { $0 } == 1)
+        #expect(fixture.interruptions.withLock { $0.count } == 1)
+    }
+}
+
+private let versionEvent = RuntimeEvent.runtimeVersion(RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1"))
+enum Mode: Sendable { case success, connectFails, activationFails, retireBeforeInstall, retireDuringActivation, contractFailureDuringActivation, replyFails, held }
+private final class TransportFixture: Sendable {
+    let mode: Mode
+    let sessions = Mutex<[TestSession]>([])
+    let interruptions = Mutex<[RuntimeSessionFailure]>([])
+    let incoming = Mutex<[RuntimeEvent]>([])
+    let replies = Mutex<[Result<RuntimeEvent, RuntimeSessionFailure>]>([])
+    init(_ mode: Mode = .success) { self.mode = mode }
+    func releaseCallbacks() {
+        for session in sessions.withLock({ $0 }) { session.sends.withLock { $0.removeAll() } }
+    }
+    func client() -> XPCRuntimeTransport {
+        XPCRuntimeTransport(
+            incoming: { event in self.incoming.withLock { $0.append(event) } },
+            interrupted: { failure in self.interruptions.withLock { $0.append(failure) } },
+            connect: { incoming, dropped in
+                let session = TestSession(mode: self.mode, incoming: incoming, dropped: dropped)
+                self.sessions.withLock { $0.append(session) }
+                if self.mode == .connectFails { throw CocoaError(.fileReadCorruptFile) }
+                if self.mode == .retireBeforeInstall { dropped() }
+                return session
+            }
+        )
+    }
+}
+
+private final class TestSession: RuntimeClientSession {
+    let mode: Mode
+    let incoming: @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
+    let dropped: @Sendable () -> Void
+    let activations = Mutex(0), cancellations = Mutex(0)
+    let sends = Mutex<[@Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void]>([])
+    init(mode: Mode, incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+         dropped: @escaping @Sendable () -> Void) {
+        self.mode = mode; self.incoming = incoming; self.dropped = dropped
+    }
+    func activate() throws {
+        activations.withLock { $0 += 1 }
+        if mode == .activationFails { throw CocoaError(.fileReadCorruptFile) }
+        if mode == .retireDuringActivation { dropped() }
+        if mode == .contractFailureDuringActivation { incoming(.failure(.init(cause: .malformedResponse))) }
+    }
+    func cancel() { cancellations.withLock { $0 += 1 }; dropped() } // Synchronous reentry must not deadlock.
+    func send(_ payload: Data, reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) {
+        sends.withLock { $0.append(reply) }
+        if mode == .held { return }
+        reply(mode == .replyFails ? .failure(.init(cause: .malformedResponse)) : .success(versionEvent))
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionRegistry.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionRegistry.swift
@@ -4,6 +4,11 @@ import Synchronization
 public final class RuntimeSessionGeneration: Sendable {
     fileprivate let retirement = Mutex<RuntimeSessionFailure.Cause?>(nil)
     fileprivate init() {}
+    /// Diagnostic after retirement, never a connection-authority snapshot. Setup can fail
+    /// before a request exists; preserve its known contract cause without inventing an ID.
+    public var retirementFailure: RuntimeSessionFailure? {
+        retirement.withLock { $0.map { RuntimeSessionFailure(cause: $0) } }
+    }
 }
 
 /// In-memory client session ownership and ordered delivery (#19/#112, MVP-PLAN.md §3).


### PR DESCRIPTION
## Stack and scope

Stacked on #153 (`c328be6d0aada34927731d08ffb14769b14dc052`). Current intended integration order: #150 → #151 → #152 → #153 → this PR, **into main one at a time after each parent/base settles and the exact-head CI/review gates are rechecked**. The owner merges; do not merge this into the feature parent.

Partial migration of retained #67/#68/#103 for #19/#20/#112; implements MVP-PLAN.md §3 and §11 under ADR 0003. This does **not** close their remaining acceptance. Original draft branches, findings and tests remain reference material.

## What changes

- Add GUI-safe `GuesthouseClientKit`, depending only on Core/system frameworks. This keeps native client I/O out of Core and avoids linking RuntimeKit into the GUI; its actual transport can be tested without launching/signing the app. Shared Xcode scheme explicitly includes its standalone tests.
- Migrate lazy connection, failure retirement and generation-fenced delivery onto #153's registry. Serialize setup separately from reply/event handoff; install inactive candidates before activation, prevent resurrection, and assign one cleanup owner. Failed connections are replaced **only for the next request**, never by replaying an interrupted one.
- Native session wrapper follows Apple's `xpc/session.h` lifecycle: activation before cancellation/release, no local send after cancellation, idempotent cleanup, and legal disposal of uninstalled/inactive candidates. Native callbacks are asynchronous; cancellation is outside the registry's delivery lock.
- Validate original native reply/push dictionaries through RawRuntimeFrame before bounded copying/JSON decoding. Foreign outer versions retain their mismatch; a conflicting inner version is malformed. No automatic native Codable fallback or arbitrary error descriptions.
- Preserve late acceptance IDs, per-request uncertainty, generation-specific causes and causes arriving during activation. A five-line read-only Core diagnostic exposes a retired generation's cause; it is not a connection-authority snapshot.
- The only public request entry point is the read-only runtimeVersion query. Its production factory fixes the embedded service name and same-team/exact-service signing-identifier requirement. No provider or host operation runs here.

Callbacks must only enqueue bounded, nonblocking work and must not reenter the transport. Full streaming/outcome routing and backpressure remain a separate retained migration, not an implied unbounded inbox.

## Validation

- Strict CI package hook passes: **Core 392 tests / 35 suites, RuntimeKit 14 / 2, ClientKit 8 / 2** (414 test functions; parameterized cases additional).
- Client tests include actual anonymous native transport composition for 10 frame shapes × reply/push, exact 64 KiB and over-limit frames, six setup/refusal modes, concurrent queries sharing one activation, late acceptance after retirement, stale push suppression, deinit with a pending reply, and inactive/active native cleanup.
- All client tests passed **five consecutive repetitions**.
- Seven CI-hook discovery/path/phase/failure scenarios passed.
- Final unsigned shared-scheme build-for-testing passes; generated xctestrun explicitly contains ClientKitTests hosted by Apple's standalone xctest agent. GUI still links Core only. No new Swift/C warnings; existing optional AppIntents metadata-extraction notices remain.
- Diff: 507 added lines across nine files; no third-party dependency.

## Deliberately not claimed

The app does not instantiate this transport yet. Service embedding plus GUI query activation must choose **one fresh incompatible wire epoch newer than historical 8–11** consistently on both sides; current epoch 8 is fixture-only. Positive signed-client authentication/Finder behavior, live provider/VM operation, full streaming/operation routing and remaining #112 responders are not proven by anonymous tests. No credentials, signing, entitlements, hardware records or provider-selection policy changed.

Next: integrate the embedded query listener and GUI connection using this native client, then finish retained streaming/client and runtime consumer migrations. Dashboard: #48.
