### PR TITLE
Embed authenticated query-only runtime with fresh wire epoch

### DIFF
--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -7,7 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD1501550000000000000003 /* GuesthouseRuntimeKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD1501550000000000000004 /* GuesthouseRuntimeKit */; };
 		F8ACD8A830493E2C00550943 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = F8ACD8A730493E2C00550943 /* GuesthouseCore */; };
+		4DF3B7691BA84C0992A05F43 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9668531454184F48A8F15863 /* GuesthouseCore */; };
+		24C65336F28345A5ACC4C24E /* GuesthouseRuntime.xpc in Embed XPC Services */ = {isa = PBXBuildFile; fileRef = A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -25,7 +28,28 @@
 			remoteGlobalIDString = F8976E89304933D10071C234;
 			remoteInfo = Guesthouse;
 		};
+		B736EBAA2A7A4CC5975E5B05 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8976E82304933D10071C234 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 16255D1DB7F34BFAB6C65BC8;
+			remoteInfo = GuesthouseRuntime;
+		};
 /* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		7B059FE13FBE429E9CE0FDD6 /* Embed XPC Services */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/XPCServices";
+			dstSubfolderSpec = 16;
+			files = (
+				24C65336F28345A5ACC4C24E /* GuesthouseRuntime.xpc in Embed XPC Services */,
+			);
+			name = "Embed XPC Services";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		CD1501540000000000000004 /* GuesthouseClientKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseClientKit; path = Packages/GuesthouseClientKit; sourceTree = "<group>"; };
@@ -35,6 +59,7 @@
 		F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = GuesthouseUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8ACD8A93049406300550943 /* MVP-PLAN.md */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MVP-PLAN.md"; sourceTree = "<group>"; };
 		921BF84465C14B2296CA65E2 /* GuesthouseCore */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = GuesthouseCore; path = Packages/GuesthouseCore; sourceTree = "<group>"; };
+		A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = GuesthouseRuntime.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -51,6 +76,12 @@
 		F8976EA4304933D30071C234 /* GuesthouseUITests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = GuesthouseUITests;
+			sourceTree = "<group>";
+		};
+		3EAD2573296645A68021C352 /* GuesthouseRuntime */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			name = GuesthouseRuntime;
+			path = GuesthouseRuntime/Sources;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -78,6 +109,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		739B23D1D5D0418FA13E75FD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DF3B7691BA84C0992A05F43 /* GuesthouseCore in Frameworks */,
+				CD1501550000000000000003 /* GuesthouseRuntimeKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -91,6 +131,7 @@
 				F8976E8C304933D10071C234 /* Guesthouse */,
 				F8976E9A304933D30071C234 /* GuesthouseTests */,
 				F8976EA4304933D30071C234 /* GuesthouseUITests */,
+				3EAD2573296645A68021C352 /* GuesthouseRuntime */,
 				F8976E8B304933D10071C234 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -101,6 +142,7 @@
 				F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */,
 				F8976E97304933D30071C234 /* GuesthouseTests.xctest */,
 				F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */,
+				A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -115,10 +157,12 @@
 				F8976E86304933D10071C234 /* Sources */,
 				F8976E87304933D10071C234 /* Frameworks */,
 				F8976E88304933D10071C234 /* Resources */,
+				7B059FE13FBE429E9CE0FDD6 /* Embed XPC Services */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4A465B87B26A476B8A414EE2 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F8976E8C304933D10071C234 /* Guesthouse */,
@@ -177,6 +221,30 @@
 			productReference = F8976EA1304933D30071C234 /* GuesthouseUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0F136BAB2D67436C81229C09 /* Build configuration list for PBXNativeTarget "GuesthouseRuntime" */;
+			buildPhases = (
+				3F90A9E53755462D9CEF9426 /* Sources */,
+				739B23D1D5D0418FA13E75FD /* Frameworks */,
+				A599CC66E8FD406CA0FDA6CA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				3EAD2573296645A68021C352 /* GuesthouseRuntime */,
+			);
+			name = GuesthouseRuntime;
+			packageProductDependencies = (
+				9668531454184F48A8F15863 /* GuesthouseCore */,
+				CD1501550000000000000004 /* GuesthouseRuntimeKit */,
+			);
+			productName = GuesthouseRuntime;
+			productReference = A7BC2A0FC7FD4B87A4B65300 /* GuesthouseRuntime.xpc */;
+			productType = "com.apple.product-type.xpc-service";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -197,6 +265,9 @@
 					F8976EA0304933D30071C234 = {
 						CreatedOnToolsVersion = 26.6;
 						TestTargetID = F8976E89304933D10071C234;
+					};
+					16255D1DB7F34BFAB6C65BC8 = {
+						CreatedOnToolsVersion = 26.6;
 					};
 				};
 			};
@@ -222,6 +293,7 @@
 				F8976E89304933D10071C234 /* Guesthouse */,
 				F8976E96304933D30071C234 /* GuesthouseTests */,
 				F8976EA0304933D30071C234 /* GuesthouseUITests */,
+				16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */,
 			);
 		};
 /* End PBXProject section */
@@ -242,6 +314,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		F8976E9F304933D30071C234 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A599CC66E8FD406CA0FDA6CA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -272,6 +351,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		3F90A9E53755462D9CEF9426 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -284,6 +370,11 @@
 			isa = PBXTargetDependency;
 			target = F8976E89304933D10071C234 /* Guesthouse */;
 			targetProxy = F8976EA2304933D30071C234 /* PBXContainerItemProxy */;
+		};
+		4A465B87B26A476B8A414EE2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 16255D1DB7F34BFAB6C65BC8 /* GuesthouseRuntime */;
+			targetProxy = B736EBAA2A7A4CC5975E5B05 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -433,6 +524,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse;
+				PRODUCT_MODULE_NAME = Guesthouse;
 				PRODUCT_NAME = "Guesthouse Codex VM";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -477,6 +569,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 26.4;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse;
+				PRODUCT_MODULE_NAME = Guesthouse;
 				PRODUCT_NAME = "Guesthouse Codex VM";
 				REGISTER_APP_GROUPS = YES;
 				SDKROOT = auto;
@@ -594,6 +687,64 @@
 			};
 			name = Release;
 		};
+		B25ED7FAA0094EE18B8FCB75 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TPKP4XK352;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = GuesthouseRuntime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse.Runtime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Debug;
+		};
+		B8F0C7A4BF3B43648D2AE322 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = TPKP4XK352;
+				ENABLE_APP_SANDBOX = NO;
+				ENABLE_HARDENED_RUNTIME = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = GuesthouseRuntime/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../../../../Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.starlingprotocol.Guesthouse.Runtime;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = auto;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = macosx;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -633,6 +784,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		0F136BAB2D67436C81229C09 /* Build configuration list for PBXNativeTarget "GuesthouseRuntime" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B25ED7FAA0094EE18B8FCB75 /* Debug */,
+				B8F0C7A4BF3B43648D2AE322 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
@@ -651,7 +811,15 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD1501550000000000000004 /* GuesthouseRuntimeKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GuesthouseRuntimeKit;
+		};
 		F8ACD8A730493E2C00550943 /* GuesthouseCore */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GuesthouseCore;
+		};
+		9668531454184F48A8F15863 /* GuesthouseCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GuesthouseCore;
 		};

--- a/GuesthouseRuntime/Info.plist
+++ b/GuesthouseRuntime/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key><string>$(DEVELOPMENT_LANGUAGE)</string>
+    <key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+    <key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+    <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+    <key>CFBundleName</key><string>$(PRODUCT_NAME)</string>
+    <key>CFBundlePackageType</key><string>XPC!</string>
+    <key>CFBundleShortVersionString</key><string>$(MARKETING_VERSION)</string>
+    <key>CFBundleVersion</key><string>$(CURRENT_PROJECT_VERSION)</string>
+    <key>XPCService</key>
+    <dict>
+        <key>ServiceType</key><string>Application</string>
+        <!-- Gate #34 must verify actual UI/Keychain behavior; this flag is not that proof. -->
+        <key>JoinExistingSession</key><true/>
+    </dict>
+</dict>
+</plist>

--- a/GuesthouseRuntime/Sources/main.swift
+++ b/GuesthouseRuntime/Sources/main.swift
@@ -1,0 +1,34 @@
+import Darwin
+import Dispatch
+import Foundation
+import GuesthouseCore
+import GuesthouseRuntimeKit
+import OSLog
+import XPC
+
+// Embedded, ordinary-user service (#19/#20, MVP-PLAN.md §3). No VM/provider is activated.
+private func record(_ event: DiagnosticEvent) {
+    Logger(subsystem: "com.starlingprotocol.Guesthouse.Runtime", category: "runtime")
+        .notice("\(event.message, privacy: .public)")
+}
+
+do {
+    let version = RuntimeVersionInfo(
+        serviceVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+        serviceBuild: Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+    )
+    let listener = try XPCListener(
+        service: "com.starlingprotocol.Guesthouse.Runtime",
+        requirement: RuntimeCallerAuthentication.listenerRequirement
+    ) { request in
+        request.accept { session in
+            NativeRuntimeRequestHandler(session: session, version: version, diagnostic: record)
+        }
+    }
+    // Default initialization already activates the listener. Never activate it a second time.
+    withExtendedLifetime(listener) { dispatchMain() }
+} catch {
+    record(DiagnosticEvent(operation: .runtimeRequest,
+                           outcome: .failed(.executableUnavailable), operationID: UUID()))
+    exit(EXIT_FAILURE)
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
@@ -4,8 +4,7 @@ import Synchronization
 import XPC
 
 /// GUI-side native client migrated from #67/#68/#103 (#19/#112, MVP-PLAN.md §3).
-/// The app does not instantiate this yet. Embedding/activation must choose a fresh shared
-/// wire epoch; the current epoch remains a fixture contract, not a production handshake.
+/// Matches the embedded service's activation wire epoch. GUI query presentation is separate.
 /// All callbacks MUST only enqueue bounded, nonblocking work and must not reenter transport.
 /// There is no replay, background reconnect, process execution or raw diagnostic output.
 public final class XPCRuntimeTransport: Sendable {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Mandatory epoch-8 reply/push envelope. No bare-event or legacy-output fallback.
+/// Mandatory versioned reply/push envelope. No bare-event or legacy-output fallback.
 public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
     public let protocolVersion: RuntimeProtocolVersion
     public let event: RuntimeEvent

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -4,10 +4,9 @@ public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStri
 
     public init(_ rawValue: Int) { self.rawValue = rawValue }
 
-    /// Epoch 8 reserves the incompatible structured-error/event contract (ADR 0003).
-    /// Legacy branches used 1–7, including versioned replies and admission errors in 7.
-    /// Both endpoint migrations must use this epoch; this Core model activates no transport.
-    public static let current = RuntimeProtocolVersion(8)
+    /// Epoch 12 activates bounded native frames and structured diagnostics on both endpoints.
+    /// Historical prototypes used 1–11. None is a compatible production fallback (ADR 0003).
+    public static let current = RuntimeProtocolVersion(12)
 
     public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
     public var description: String { "protocol \(rawValue)" }

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
@@ -19,7 +19,7 @@ import Testing
         #expect(try RuntimeEventEnvelope.decode(data) == envelope)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(Set(object.keys) == ["protocolVersion", "event"])
-        #expect(object["protocolVersion"] as? Int == 8)
+        #expect(object["protocolVersion"] as? Int == 12)
     }
 
     @Test(arguments: events)
@@ -28,10 +28,10 @@ import Testing
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(data) }
     }
 
-    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 9, Int.max])
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, Int.max])
     func foreignHeaderPrecedesUnknownEvent(version: Int) {
         let data = Data("{\"event\":{\"futureReply\":{}},\"protocolVersion\":\(version)}".utf8)
-        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: version)) {
+        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: version)) {
             try RuntimeEventEnvelope.decode(data)
         }
     }
@@ -41,7 +41,7 @@ import Testing
         let mismatch = try #require(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
             try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
         }
-        #expect(mismatch.error == .protocolMismatch(client: 8, service: 7))
+        #expect(mismatch.error == .protocolMismatch(client: 12, service: 7))
     }
 
     @Test func contradictoryNestedVersionIsMalformedOnBothPaths() throws {
@@ -51,15 +51,15 @@ import Testing
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(forged) }
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try envelope.encoded() }
         let foreign = RuntimeEventEnvelope(protocolVersion: RuntimeProtocolVersion(7), event: Self.events[0])
-        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: 7)) { try foreign.encoded() }
+        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: 7)) { try foreign.encoded() }
         let foreignBytes = try JSONEncoder().encode(foreign)
-        #expect(throws: GuesthouseError.protocolMismatch(client: 8, service: 7)) { try RuntimeEventEnvelope.decode(foreignBytes) }
+        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: 7)) { try RuntimeEventEnvelope.decode(foreignBytes) }
     }
 
-    @Test(arguments: ["{}", "null", "not-json", #"{"protocolVersion":8}"#,
-                      #"{"protocolVersion":"8","event":{}}"#,
-                      #"{"protocolVersion":8,"event":{"log":{"_0":null,"_1":"private-marker"}}}"#,
-                      #"{"protocolVersion":8,"event":{"futureReply":{}}}"#])
+    @Test(arguments: ["{}", "null", "not-json", #"{"protocolVersion":12}"#,
+                      #"{"protocolVersion":"12","event":{}}"#,
+                      #"{"protocolVersion":12,"event":{"log":{"_0":null,"_1":"private-marker"}}}"#,
+                      #"{"protocolVersion":12,"event":{"futureReply":{}}}"#])
     func malformedOrRawLogRepliesAreFixedErrors(json: String) {
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
             try RuntimeEventEnvelope.decode(Data(json.utf8))
@@ -105,7 +105,7 @@ import Testing
         var event = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.diagnostic)) as? [String: Any])
         event["message"] = "private-marker"
         event["stderr"] = "private-marker"
-        let object: [String: Any] = ["protocolVersion": 8, "event": ["diagnostic": ["_0": event]]]
+        let object: [String: Any] = ["protocolVersion": 12, "event": ["diagnostic": ["_0": event]]]
         let decoded = try RuntimeEventEnvelope.decode(JSONSerialization.data(withJSONObject: object))
         #expect(decoded.event.diagnosticEvent == Self.diagnostic)
         #expect(!String(decoding: try decoded.encoded(), as: UTF8.self).contains("private-marker"))
@@ -138,7 +138,7 @@ import Testing
 
     @Test(arguments: ["", "private marker", "0.1\u{1B}[31m", String(repeating: "1", count: 257)])
     func malformedMetadataBecomesUnknownWithoutInventingIdentity(value: String) throws {
-        let raw: [String: Any] = ["serviceVersion": value, "serviceBuild": value, "protocolVersion": 8,
+        let raw: [String: Any] = ["serviceVersion": value, "serviceBuild": value, "protocolVersion": 12,
                                   "runtime": ["provider": "lume", "version": value, "verified": true]]
         let info = try JSONDecoder().decode(RuntimeVersionInfo.self, from: JSONSerialization.data(withJSONObject: raw))
         #expect(info.serviceVersion == nil)
@@ -156,7 +156,7 @@ import Testing
         let failed = RuntimeIdentityInfo(provider: .lume, version: "0.5.3", verified: true, problem: .runtimeMissing)
         #expect(!failed.verified)
         #expect(failed.problem == .runtimeMissing)
-        let missing = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(#"{"protocolVersion":8}"#.utf8))
+        let missing = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(#"{"protocolVersion":12}"#.utf8))
         #expect(missing.runtime == nil)
         #expect(missing.serviceVersion == nil)
         #expect(missing.serviceBuild == nil)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
@@ -21,7 +21,7 @@ import Testing
         let envelope = RuntimeRequestEnvelope(request: request)
         let data = try JSONEncoder().encode(envelope)
         #expect(try RequestValidator.decode(data) == envelope)
-        #expect(envelope.protocolVersion.rawValue == 8)
+        #expect(envelope.protocolVersion.rawValue == 12)
     }
 
     @Test(arguments: requests, ["executable", "arguments", "command", "shell", "--", "/bin/"])
@@ -30,12 +30,12 @@ import Testing
         #expect(!String(decoding: data, as: UTF8.self).lowercased().contains(forbidden))
     }
 
-    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 9, Int.max])
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, Int.max])
     func foreignVersionPrecedesUnknownPayload(version: Int) {
         let data = Data("{\"protocolVersion\":\(version),\"request\":{\"futureRequest\":{}}}".utf8)
         let expected = RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(version), service: .current)
         #expect(throws: expected) { try RequestValidator.decode(data) }
-        #expect(expected.guesthouseError == .protocolMismatch(client: version, service: 8))
+        #expect(expected.guesthouseError == .protocolMismatch(client: version, service: 12))
     }
 
     @Test func directEnvelopeDecoderAlsoChecksHeaderFirst() throws {
@@ -43,12 +43,12 @@ import Testing
         let error = try #require(throws: RuntimeRequestEnvelope.ProtocolMismatch.self) {
             try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data)
         }
-        #expect(error.error == .protocolMismatch(client: 7, service: 8))
+        #expect(error.error == .protocolMismatch(client: 7, service: 12))
     }
 
     @Test(arguments: ["{}", "null", #"{"request":{"runtimeVersion":{}}}"#,
-                      #"{"protocolVersion":"8","request":{}}"#, #"{"protocolVersion":8}"#,
-                      #"{"protocolVersion":8,"request":{"runCommand":{"command":"private-marker"}}}"#])
+                      #"{"protocolVersion":"12","request":{}}"#, #"{"protocolVersion":12}"#,
+                      #"{"protocolVersion":12,"request":{"runCommand":{"command":"private-marker"}}}"#])
     func malformedRequestsAreTyped(json: String) {
         #expect(throws: RequestValidationError.malformed) { try RequestValidator.decode(Data(json.utf8)) }
     }
@@ -134,13 +134,13 @@ import Testing
     }
 
     @Test func unknownMetadataIsNotForwarded() throws {
-        let data = Data(#"{"protocolVersion":8,"private":"private-marker","request":{"runtimeVersion":{}}}"#.utf8)
+        let data = Data(#"{"protocolVersion":12,"private":"private-marker","request":{"runtimeVersion":{}}}"#.utf8)
         let encoded = try JSONEncoder().encode(RequestValidator.decode(data))
         #expect(!String(decoding: encoded, as: UTF8.self).contains("private-marker"))
     }
 
     @Test func malformedInputCannotReachStructuredErrorsOrExports() throws {
-        let data = Data(#"{"protocolVersion":8,"request":{"private-marker":{}}}"#.utf8)
+        let data = Data(#"{"protocolVersion":12,"request":{"private-marker":{}}}"#.utf8)
         let rejection = try #require(throws: RequestValidationError.self) { try RequestValidator.decode(data) }
         #expect(rejection.guesthouseError == .invalidRequest(.malformed))
         let event = DiagnosticEvent(operation: .importXcode, outcome: .init(error: rejection.guesthouseError), operationID: UUID())

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
@@ -3,8 +3,8 @@ import GuesthouseCore
 import XPC
 
 /// Native service ingress for #19/#20/#112 (MVP-PLAN.md §3). No listener is activated here.
-/// Only runtimeVersion is implemented: mutations stay unavailable until client retirement,
-/// streaming and unknown-outcome handling migrate together with the activation wire epoch.
+/// Only runtimeVersion is implemented: mutations stay unavailable until streaming and
+/// operation correlation/unknown-outcome handling migrate across all native consumers.
 public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
     private let gate: RuntimeSessionGate
     private let authenticate: @Sendable (XPCDictionary) -> Bool


### PR DESCRIPTION
## Summary

Migrate the retained #67 embedded-target definition onto the approved native service/client chain. Implements the query-only portion of #19/#20/#112 and MVP-PLAN.md §§3, 10 and 11, following ADR 0002/0003. Stacked on #154; merge parents into main first and settle this base before merging.

- Embed GuesthouseRuntime.xpc with ordinary-user, non-sandboxed/hardened settings. Preserve the sandboxed/hardened GUI, existing team and product identities; link RuntimeKit only to the service, never the GUI.
- Use the fixed same-team/exact-GUI-identifier listener requirement and NativeRuntimeRequestHandler's original-message authentication, bounded native frames, atomic refusal/registration and single-owner explicit replies.
- The listener uses the SDK's default active initialization exactly once. It retains its lifetime through dispatchMain; no second activate() call.
- Serve bundle version/build and protocol metadata only. All other named operations remain unsupported; no provider, process, credentials or VM operation is activated.
- Allocate shared wire epoch 12, newer than historical prototypes 1–11, coherently across the current native client/service. Extend request/reply mismatch fixtures to reject epochs 8–11; no legacy fallback.
- Runtime diagnostics accept DiagnosticEvent only. Bundle identity is private status, never a diagnostic attachment; startup/underlying errors cannot escape as raw text.

## Validation

- Strict CI package hook: Core392 tests/35 suites, RuntimeKit14/2, ClientKit8/2 (414 test functions; parameterized cases additional).
- Seven package-hook discovery/failure scenarios pass.
- Shared-scheme unsigned Debug build-for-testing and Release build pass.
- Inspected the built app: correct embedded XPC path and bundle identity, Application service type, JoinExistingSession=true. Native authentication symbols are in the service, not the GUI executable. All three package test targets remain in the generated xctestrun.
- Project/Info.plist parsing and diff checks pass. No Swift/C warnings; Xcode's optional AppIntents metadata notices remain.

No app was launched or signed, and no signing identity, certificate, provisioning or host/VM configuration was changed. Unsigned builds and anonymous negative/injected native tests are not positive signed-GUI proof.

## Remaining acceptance

GUI query presentation is the next focused slice, split from this 280-line project/service migration to keep reviews small. The current GUI does not start this query automatically. Full RuntimeBackend/streaming correlation/backpressure and unknown-outcome consumers remain before mutations or closing #112. Gate #34 must prove signed Finder-launched behavior, actual caller acceptance/rejection and UI/Keychain session behavior. #9/#19/#20/#112 and original draft references remain open; this PR does not select/prove Lume or complete phase zero.
