### PR TITLE
Add a cancellable runtime connection check to the GUI

### DIFF
--- a/Guesthouse.xcodeproj/project.pbxproj
+++ b/Guesthouse.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		CD1501560000000000000001 /* GuesthouseClientKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD1501560000000000000002 /* GuesthouseClientKit */; };
 		CD1501550000000000000003 /* GuesthouseRuntimeKit in Frameworks */ = {isa = PBXBuildFile; productRef = CD1501550000000000000004 /* GuesthouseRuntimeKit */; };
 		F8ACD8A830493E2C00550943 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = F8ACD8A730493E2C00550943 /* GuesthouseCore */; };
 		4DF3B7691BA84C0992A05F43 /* GuesthouseCore in Frameworks */ = {isa = PBXBuildFile; productRef = 9668531454184F48A8F15863 /* GuesthouseCore */; };
@@ -92,6 +93,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F8ACD8A830493E2C00550943 /* GuesthouseCore in Frameworks */,
+				CD1501560000000000000001 /* GuesthouseClientKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -170,6 +172,7 @@
 			name = Guesthouse;
 			packageProductDependencies = (
 				F8ACD8A730493E2C00550943 /* GuesthouseCore */,
+				CD1501560000000000000002 /* GuesthouseClientKit */,
 			);
 			productName = Guesthouse;
 			productReference = F8976E8A304933D10071C234 /* Guesthouse Codex VM.app */;
@@ -811,6 +814,10 @@
 /* End XCLocalSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		CD1501560000000000000002 /* GuesthouseClientKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = GuesthouseClientKit;
+		};
 		CD1501550000000000000004 /* GuesthouseRuntimeKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = GuesthouseRuntimeKit;

--- a/Guesthouse/ContentView.swift
+++ b/Guesthouse/ContentView.swift
@@ -6,16 +6,65 @@
 //
 
 import SwiftUI
+import GuesthouseClientKit
+import GuesthouseCore
 
 struct ContentView: View {
+    @State private var check: Task<Void, Never>?
+    @State private var outcome: RuntimeVersionQuery.Outcome?
+
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        VStack(alignment: .leading, spacing: 16) {
+            Text("Guesthouse").font(.title)
+            Text("Check the connection to Guesthouse’s embedded runtime service. This does not create or start a development Mac.")
+                .foregroundStyle(.secondary)
+            HStack {
+                Button("Check runtime connection", action: startCheck)
+                    .disabled(check != nil)
+                    .accessibilityIdentifier("checkRuntimeConnection")
+                if check != nil {
+                    ProgressView().controlSize(.small).accessibilityLabel("Checking runtime connection")
+                    Button("Cancel", action: cancelCheck).disabled(check?.isCancelled == true)
+                }
+            }
+            if let outcome {
+                VStack(alignment: .leading, spacing: 8) {
+                    switch outcome {
+                    case .success(let info):
+                        Text("Runtime service responded.").font(.headline)
+                        Text("Version \(info.serviceVersion ?? "unknown"), build \(info.serviceBuild ?? "unknown"), protocol \(info.protocolVersion.rawValue).")
+                        Text("VM, provider and Xcode readiness have not been checked.")
+                            .foregroundStyle(.secondary)
+                    case .failure(let error):
+                        Text(error.userMessage)
+                        Text(error.recoveryMessage).foregroundStyle(.secondary)
+                    }
+                }
+                .textSelection(.enabled)
+                .accessibilityIdentifier("runtimeConnectionResult")
+            }
         }
-        .padding()
+        .padding(24)
+        .frame(minWidth: 420, idealWidth: 520, minHeight: 260, alignment: .topLeading)
+        .onDisappear(perform: cancelCheck)
+    }
+
+    private func startCheck() {
+        guard check == nil else { return }
+        outcome = nil
+        check = Task {
+            let result = await RuntimeVersionQuery.run()
+            outcome = Task.isCancelled ? .failure(.canceled) : result
+            check = nil
+        }
+    }
+
+    private func cancelCheck() {
+        guard let check else { return }
+        check.cancel()
+        // Keep the check occupied until its structured children and connection have finished.
+        // A late result cannot race a new check, and repeated cancel/start cannot stack sessions.
+        outcome = .failure(.canceled)
     }
 }
 

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
@@ -1,0 +1,78 @@
+import GuesthouseCore
+
+/// One user-requested, read-only connection check. Not RuntimeBackend or a streaming inbox.
+/// Native callbacks only enqueue one bounded result; connection disposal is outside them.
+public enum RuntimeVersionQuery {
+    public enum Failure: Error, Hashable, Sendable {
+        case runtime(GuesthouseError), connection(RuntimeSessionFailure), timedOut, canceled
+
+        public var userMessage: String {
+            switch self {
+            case .runtime(let error): error.userMessage
+            case .connection(let error): error.userMessage
+            case .timedOut: "The runtime service did not answer the connection check within 10 seconds."
+            case .canceled: "The connection check was canceled."
+            }
+        }
+        public var recoveryMessage: String {
+            switch self {
+            case .runtime(let error): error.recoveryMessage
+            case .connection(let error): error.recoveryActions.map(\.title).joined(separator: "; ")
+            case .timedOut: "Try this read-only check again. If it keeps timing out, quit and reopen Guesthouse."
+            case .canceled: "You can run another read-only connection check when ready."
+            }
+        }
+    }
+    public typealias Outcome = Result<RuntimeVersionInfo, Failure>
+
+    @concurrent public static func run() async -> Outcome {
+        let deadline = ContinuousClock.now + .seconds(10)
+        return await perform(connect: nil, deadline: { try await ContinuousClock().sleep(until: deadline) })
+    }
+
+    // Inject native-session creation/deadline only in package tests, never from GUI requests.
+    static func perform(connect: XPCRuntimeTransport.Connect?,
+                        deadline: @escaping @Sendable () async throws -> Void) async -> Outcome {
+        guard !Task.isCancelled else { return .failure(.canceled) }
+        let (stream, continuation) = AsyncStream<Outcome>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        let client: XPCRuntimeTransport
+        // A query consumes its correlated reply, never unsolicited pushes. Native failures
+        // retire the session and reach the pending reply; a missing reply hits the deadline.
+        if let connect { client = XPCRuntimeTransport(incoming: { _ in }, interrupted: { _ in }, connect: connect) }
+        else { client = XPCRuntimeTransport(incoming: { _ in }, interrupted: { _ in }) }
+        defer { continuation.finish(); withExtendedLifetime(client) {} }
+        do {
+            try client.queryRuntimeVersion { reply in
+                continuation.yield(result(reply))
+                continuation.finish()
+            }
+        } catch let error as GuesthouseError { return .failure(.runtime(error)) }
+        catch let error as RuntimeSessionFailure { return .failure(.connection(error)) }
+        catch { return .failure(.connection(.init(cause: .connectionLost))) }
+
+        return await withTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                for await value in stream { return value }
+                return .failure(.canceled)
+            }
+            group.addTask {
+                do { try await deadline(); return .failure(.timedOut) }
+                catch { return .failure(.canceled) }
+            }
+            defer { group.cancelAll() }
+            let value = await group.next() ?? .failure(.canceled)
+            return Task.isCancelled ? .failure(.canceled) : value
+        }
+    }
+
+    private static func result(_ reply: Result<RuntimeEvent, RuntimeSessionFailure>) -> Outcome {
+        switch reply {
+        case .failure(let error): return .failure(.connection(error))
+        case .success(.runtimeVersion(let info)) where info.protocolVersion == .current: return .success(info)
+        case .success(.failed(_, let error)): return .failure(.runtime(error))
+        case .success(.accepted(let id)), .success(.completed(let id)), .success(.progress(let id, _)):
+            return .failure(.connection(.init(cause: .malformedResponse, operationID: id)))
+        default: return .failure(.connection(.init(cause: .malformedResponse)))
+        }
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
@@ -4,7 +4,7 @@ import Synchronization
 import XPC
 
 /// GUI-side native client migrated from #67/#68/#103 (#19/#112, MVP-PLAN.md §3).
-/// Matches the embedded service's activation wire epoch. GUI query presentation is separate.
+/// Used by the GUI's read-only connection check with the embedded service's shared wire epoch.
 /// All callbacks MUST only enqueue bounded, nonblocking work and must not reenter transport.
 /// There is no replay, background reconnect, process execution or raw diagnostic output.
 public final class XPCRuntimeTransport: Sendable {

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeVersionQueryTests {
+    static let info = RuntimeVersionInfo(serviceVersion: "1.0", serviceBuild: "1")
+    static let id = OperationID()
+    static let cases: [(RuntimeEvent, RuntimeVersionQuery.Outcome)] = [
+        (.runtimeVersion(info), .success(info)),
+        (.runtimeVersion(.init(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(11))),
+         .failure(.connection(.init(cause: .malformedResponse)))),
+        (.failed(id, .unauthorizedCaller), .failure(.runtime(.unauthorizedCaller))),
+        (.accepted(id), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
+        (.completed(id), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
+        (.progress(id, .init(kind: .copying)), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
+        (.diagnostic(.init(operation: .runtimeRequest, outcome: .started, operationID: id.uuid)),
+         .failure(.connection(.init(cause: .malformedResponse)))),
+        (.status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)),
+         .failure(.connection(.init(cause: .malformedResponse)))),
+    ]
+
+    @Test(arguments: cases)
+    func onlyTheExpectedResponseIsSuccess(event: RuntimeEvent, expected: RuntimeVersionQuery.Outcome) async {
+        let session = QuerySession([.success(event)])
+        defer { session.releaseReply() }
+        #expect(await run(session) == expected)
+        #expect(session.cancellations.withLock { $0 } == 1)
+        if case .failure(let failure) = expected { #expect(!failure.recoveryMessage.isEmpty) }
+    }
+
+    @Test(arguments: [RuntimeSessionFailure.Cause.connectionLost, .malformedResponse,
+                       .oversizedResponse, .protocolMismatch(service: 11)])
+    func nativeFailureKeepsItsCause(cause: RuntimeSessionFailure.Cause) async {
+        let session = QuerySession([.failure(.init(cause: cause))])
+        defer { session.releaseReply() }
+        #expect(await run(session) == .failure(.connection(.init(cause: cause))))
+        #expect(session.cancellations.withLock { $0 } == 1)
+    }
+
+    @Test func setupFailureNeverExposesTheUnderlyingError() async {
+        let value = await RuntimeVersionQuery.perform(connect: { _, _ in
+            throw NSError(domain: "private-marker", code: 1)
+        }, deadline: waitForCancellation)
+        #expect(value == .failure(.connection(.init(cause: .connectionLost))))
+        if case .failure(let error) = value {
+            #expect(!(error.userMessage + error.recoveryMessage).contains("private-marker"))
+        }
+    }
+
+    @Test func oneReplyFinishesAndCancelsTheDeadline() async {
+        let canceled = Mutex(false)
+        let session = QuerySession([.success(.runtimeVersion(Self.info)), .success(.accepted(Self.id))])
+        defer { session.releaseReply() }
+        let value = await run(session, deadline: {
+            try await withTaskCancellationHandler {
+                try await waitForCancellation()
+            } onCancel: { canceled.withLock { $0 = true } }
+        })
+        #expect(value == .success(Self.info))
+        #expect(canceled.withLock { $0 })
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test func timeoutDisposesTheConnectionAndDoesNotReplay() async {
+        let session = QuerySession([])
+        defer { session.releaseReply() }
+        #expect(await run(session, deadline: {}) == .failure(.timedOut))
+        #expect(session.cancellations.withLock { $0 } == 1)
+        session.answerLate(.success(.runtimeVersion(Self.info)))
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test func cancelingAPendingCheckDisposesItWithoutWaitingForTheTimeout() async {
+        let (started, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        let session = QuerySession([], didSend: { signal.yield(()); signal.finish() })
+        defer { session.releaseReply(); signal.finish() }
+        let task = Task { await run(session) }
+        for await _ in started { break }
+        task.cancel()
+        #expect(await task.value == .failure(.canceled))
+        #expect(session.cancellations.withLock { $0 } == 1)
+        session.answerLate(.success(.accepted(Self.id)))
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test func anAlreadyCanceledCheckNeverConnects() async {
+        let (gate, finish) = AsyncStream<Void>.makeStream()
+        let connections = Mutex(0)
+        let session = QuerySession([])
+        let task = Task {
+            for await _ in gate { break }
+            return await RuntimeVersionQuery.perform(connect: { _, _ in
+                connections.withLock { $0 += 1 }; return session
+            }, deadline: waitForCancellation)
+        }
+        task.cancel()
+        #expect(await task.value == .failure(.canceled))
+        finish.finish()
+        #expect(connections.withLock { $0 } == 0)
+    }
+}
+
+private func waitForCancellation() async throws { try await ContinuousClock().sleep(for: .seconds(60)) }
+private func run(_ session: QuerySession,
+                 deadline: @escaping @Sendable () async throws -> Void = waitForCancellation) async -> RuntimeVersionQuery.Outcome {
+    await RuntimeVersionQuery.perform(connect: { _, _ in session }, deadline: deadline)
+}
+
+private final class QuerySession: RuntimeClientSession {
+    typealias Reply = @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
+    let responses: [Result<RuntimeEvent, RuntimeSessionFailure>]
+    let didSend: @Sendable () -> Void
+    let cancellations = Mutex(0), sends = Mutex(0), reply = Mutex<Reply?>(nil)
+    init(_ responses: [Result<RuntimeEvent, RuntimeSessionFailure>], didSend: @escaping @Sendable () -> Void = {}) {
+        self.responses = responses; self.didSend = didSend
+    }
+    func activate() throws {}
+    func cancel() { cancellations.withLock { $0 += 1 } }
+    func send(_ payload: Data, reply: @escaping Reply) {
+        do { let request = try RequestValidator.decode(payload); #expect(request.request == .runtimeVersion) }
+        catch { Issue.record("The connection check must send a valid read-only version request.") }
+        sends.withLock { $0 += 1 }
+        self.reply.withLock { $0 = reply }
+        didSend()
+        for response in responses { reply(response) }
+    }
+    func answerLate(_ value: Result<RuntimeEvent, RuntimeSessionFailure>) { reply.withLock { $0 }?(value) }
+    func releaseReply() { reply.withLock { $0 = nil } }
+}


### PR DESCRIPTION
## Summary

Give developers a visible, read-only connection check using the migrated native transport and embedded service (#19/#20/#112; MVP-PLAN.md §§2, 3, 10 and 11; ADR 0002/0003). Stacked on #155 at 41921bce; parents must merge into main and bases settle before this PR merges.

- Replace Hello World with a native **Check runtime connection** button, progress, Cancel, and selectable version/build/protocol or typed error/recovery text. This accessible window action replaces the retained prototype's Debug-only query menu; it does not introduce the future provisioning shell.
- No automatic connection on launch or preview, no VM command and no provider/readiness claim. Success explicitly says VM, provider and Xcode readiness have not been checked.
- Link GUI-safe ClientKit to the app; RuntimeKit remains linked only to the embedded service. Native setup runs off the main actor.
- RuntimeVersionQuery owns one ephemeral read-only transport. Callbacks enqueue at most one result in a bounded stream; structured child tasks race the reply against a monotonic ten-second deadline. Cancellation/timeout finishes the wait and releases the connection outside native callback locks. No background reconnect or replay.
- Accept only a current-version runtimeVersion response. Preserve typed native/domain failures; unexpected accepted/progress/completed replies retain their operation identity and unknown-outcome warning. No raw error, transcript, diagnostic string attachment or generic command API.
- The window stays single-flight through cancellation cleanup, so a late old completion cannot overwrite a new check or rapid cancel/start accumulate live sessions.

## Validation

- Strict full CI package hook: Core392/35 suites, RuntimeKit14/2, ClientKit15/3 = **421 test functions** (parameterized cases additional).
- New query suite: eight response shapes, four native failure causes, opaque setup failure, first-reply-only delivery and deadline cancellation, timeout cleanup/no replay, pending cancellation/late reply, already-canceled no-connect. Seven functions pass in **five consecutive repetitions**.
- Seven CI-hook scenarios pass.
- Final shared-scheme unsigned Debug build-for-testing and Release build pass. Generated xctestrun contains the new ClientKit tests.
- Project parsing/diff checks pass; no Swift/C warnings. Existing optional AppIntents extraction notices remain.

The SwiftUI/concurrency/testing guidance shaped the native controls, view-owned single-flight task, bounded result bridge and deterministic async fixtures. No actual app launch, signing/credential change or host/VM setup was performed. GUI interaction/accessibility and positive signed-GUI authentication must still be exercised by a person; this is not gate #34 evidence.

## Remaining work

This is a **query-only adapter**, not the complete RuntimeClient/RuntimeBackend streaming consumer. Bounded multi-operation inboxes, backpressure, correlation, unknown-outcome routing and descendant responders remain before mutation activation or closing #112. Keep #9/#19/#20/#112 and retained draft references open until their full acceptance has landed. Lume selection, provisioning, real credentials, native MLX and the phase-zero complete path remain unproven.
