### PR TITLE
Migrate bounded runtime event delivery and consumer cleanup

### DIFF
--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
@@ -1,0 +1,172 @@
+import GuesthouseCore
+import Synchronization
+
+/// Bounded consumer delivery migrated from #67/#103 RuntimeClient (MVP-PLAN.md §3).
+/// No native calls, request dispatch, or pre-acceptance routing. The client owns those.
+/// One consumer only. End callbacks must enqueue bounded work, never reenter a transport.
+final class RuntimeEventStream: Sendable {
+    enum Termination: Equatable, Sendable { case finished, abandoned }
+    private enum End: Sendable { case finished, failed(RuntimeSessionFailure), rejected(GuesthouseError), abandoned }
+    private enum Delivery: Sendable { case value(RuntimeEvent), end(End), wait }
+    private struct State {
+        var queue: [RuntimeEvent] = []
+        var operation: OperationID?
+        var receivedReply = false
+        var end: End?
+        var dropped: UInt64 = 0
+        var terminated: (@Sendable (Termination) -> Void)?
+    }
+    private let state: Mutex<State>
+    private let capacity: Int
+    private let mayHaveMutated: Bool
+    private let wakeups: AsyncStream<Void>
+    private let signal: AsyncStream<Void>.Continuation
+
+    /// The producer must not retain the returned stream: dropping it notifies abandonment.
+    /// The unfolding stream adds no second payload buffer; reads release actual queue slots.
+    /// Cancellation may throw or end iteration (SDK behavior); only a terminal event proves
+    /// an operation finished. Abandonment always notifies the owner, including before a read.
+    static func make(capacity: Int = 64, mayHaveMutated: Bool,
+                     terminated: @escaping @Sendable (Termination) -> Void)
+        -> (producer: RuntimeEventStream, stream: AsyncThrowingStream<RuntimeEvent, any Error>) {
+        let producer = RuntimeEventStream(capacity: capacity, mayHaveMutated: mayHaveMutated, terminated: terminated)
+        let lifetime = ConsumerLifetime(producer)
+        return (producer, AsyncThrowingStream(unfolding: { try await lifetime.producer.next() }))
+    }
+
+    private init(capacity: Int, mayHaveMutated: Bool, terminated: @escaping @Sendable (Termination) -> Void) {
+        self.capacity = min(max(capacity, 2), 1_024)
+        self.mayHaveMutated = mayHaveMutated
+        state = Mutex(State(terminated: terminated))
+        (wakeups, signal) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1))
+    }
+    var bufferedCount: Int { state.withLock { $0.queue.count } }
+    var droppedCount: UInt64 { state.withLock { $0.dropped } }
+
+    /// Called once with the correlated reply. Acceptance always precedes pushed events.
+    /// The surrounding client validates the reply against the request's expected shape.
+    func reply(_ event: RuntimeEvent) {
+        let ending = state.withLock { state -> Bool in
+            guard state.end == nil else { return false }
+            guard !state.receivedReply else {
+                state.end = .failed(failure(.malformedResponse, state: state)); return true
+            }
+            state.receivedReply = true
+            switch event {
+            case .accepted(let id): state.operation = id; state.queue.append(event); return false
+            case .runtimeVersion, .status, .completed, .failed:
+                state.queue.append(event); state.end = .finished; return true
+            case .progress, .diagnostic:
+                state.end = .failed(failure(.malformedResponse, state: state)); return true
+            }
+        }
+        publish(ending: ending)
+    }
+
+    /// Pre-acceptance events belong in the client's separately bounded pending-event map.
+    /// Wrong-operation events cannot enter this consumer, even if its caller misroutes them.
+    func push(_ event: RuntimeEvent) {
+        let ending = state.withLock { state -> Bool in
+            guard state.end == nil, let id = state.operation else { return false }
+            let terminal: Bool
+            switch event {
+            case .completed(let owner), .failed(let owner, _):
+                guard owner == id else { return false }; terminal = true
+            case .progress(let owner, _):
+                guard owner == id else { return false }; terminal = false
+            case .diagnostic(let diagnostic):
+                guard diagnostic.operationID == id.uuid else { return false }; terminal = false
+            case .status(let status):
+                guard status.inFlightOperation == nil || status.inFlightOperation == id else { return false }
+                terminal = false // Unscoped environment snapshots must be filtered by the client.
+            case .runtimeVersion, .accepted:
+                state.end = .failed(failure(.malformedResponse, state: state)); return true
+            }
+            // Nonterminal traffic can never consume the last terminal slot.
+            if terminal {
+                state.queue.append(event); state.end = .finished; return true
+            }
+            guard state.queue.count < capacity - 1 else {
+                if state.dropped < .max { state.dropped += 1 }
+                return false
+            }
+            state.queue.append(event); return false
+        }
+        publish(ending: ending)
+    }
+
+    func interrupt(_ error: RuntimeSessionFailure) {
+        let ending = state.withLock { state -> Bool in
+            guard state.end == nil else { return false }
+            state.end = .failed(error.contextualized(operationID: state.operation, mayHaveMutated: mayHaveMutated))
+            return true
+        }
+        publish(ending: ending)
+    }
+
+    /// Only for a known local rejection before sending, never an uncertain native send.
+    /// Once accepted, even a mistaken caller cannot replace uncertainty with an unsent error.
+    func rejectBeforeSend(_ error: GuesthouseError) {
+        let ending = state.withLock { state -> Bool in
+            guard state.end == nil else { return false }
+            state.end = state.receivedReply
+                ? .failed(failure(.malformedResponse, state: state)) : .rejected(error)
+            return true
+        }
+        publish(ending: ending)
+    }
+
+    private func failure(_ cause: RuntimeSessionFailure.Cause, state: State) -> RuntimeSessionFailure {
+        .init(cause: cause, operationID: state.operation, mayHaveMutated: mayHaveMutated)
+    }
+    private func publish(ending: Bool) {
+        // Wake/finish and the client callback are outside the state lock.
+        if ending { signal.finish(); notify(.finished) }
+        else { signal.yield(()) }
+    }
+    private func abandon() {
+        let notify = state.withLock { state -> Bool in
+            state.queue.removeAll()
+            guard state.end == nil else { return false }
+            state.end = .abandoned; return true
+        }
+        signal.finish()
+        if notify { self.notify(.abandoned) }
+    }
+    private func notify(_ reason: Termination) {
+        let callback = state.withLock { state in
+            let callback = state.terminated
+            state.terminated = nil // A finished stream must not retain its client owner.
+            return callback
+        }
+        callback?(reason)
+    }
+    private func take() -> Delivery {
+        state.withLock { state in
+            if !state.queue.isEmpty { return .value(state.queue.removeFirst()) }
+            return state.end.map(Delivery.end) ?? .wait
+        }
+    }
+    private func next() async throws -> RuntimeEvent? {
+        try await withTaskCancellationHandler {
+            var iterator = wakeups.makeAsyncIterator()
+            while true {
+                if Task.isCancelled { throw GuesthouseError.canceled }
+                switch take() {
+                case .value(let event): return event
+                case .end(.finished): return nil
+                case .end(.failed(let error)): throw error
+                case .end(.rejected(let error)): throw error
+                case .end(.abandoned): throw GuesthouseError.canceled
+                case .wait: _ = await iterator.next()
+                }
+            }
+        } onCancel: { self.abandon() }
+    }
+
+    private final class ConsumerLifetime: Sendable {
+        let producer: RuntimeEventStream
+        init(_ producer: RuntimeEventStream) { self.producer = producer }
+        deinit { producer.abandon() }
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
@@ -13,6 +13,7 @@ final class RuntimeEventStream: Sendable {
         var operation: OperationID?
         var receivedReply = false
         var end: End?
+        var failureObserved = false
         var dropped: UInt64 = 0
         var terminated: (@Sendable (Termination) -> Void)?
     }
@@ -26,6 +27,8 @@ final class RuntimeEventStream: Sendable {
     /// The unfolding stream adds no second payload buffer; reads release actual queue slots.
     /// Cancellation may throw or end iteration (SDK behavior); only a terminal event proves
     /// an operation finished. Abandonment always notifies the owner, including before a read.
+    /// The SDK clears its unfolding closure on cancellation, releasing ConsumerLifetime even
+    /// if it skips next() and the stream itself remains retained (covered by an SDK regression).
     static func make(capacity: Int = 64, mayHaveMutated: Bool,
                      terminated: @escaping @Sendable (Termination) -> Void)
         -> (producer: RuntimeEventStream, stream: AsyncThrowingStream<RuntimeEvent, any Error>) {
@@ -95,8 +98,20 @@ final class RuntimeEventStream: Sendable {
         publish(ending: ending)
     }
 
+    /// A late owning reply can enrich an unread failure, never replace an observed outcome.
+    /// The router must retain request context for replies arriving after failure observation.
     func interrupt(_ error: RuntimeSessionFailure) {
         let ending = state.withLock { state -> Bool in
+            if case .failed(let existing) = state.end, !state.failureObserved {
+                guard existing.operationID == nil || error.operationID == nil
+                    || existing.operationID == error.operationID else { return false }
+                // Match registry semantics: ordinary cancellation can precede a precise cause.
+                let cause = existing.cause == .connectionLost ? error.cause : existing.cause
+                state.end = .failed(.init(cause: cause,
+                    operationID: existing.operationID ?? error.operationID,
+                    mayHaveMutated: existing.mayHaveMutated || error.mayHaveMutated))
+                return false // Preserve a known ID/specific cause and the single end callback.
+            }
             guard state.end == nil else { return false }
             state.end = .failed(error.contextualized(operationID: state.operation, mayHaveMutated: mayHaveMutated))
             return true
@@ -144,6 +159,7 @@ final class RuntimeEventStream: Sendable {
     private func take() -> Delivery {
         state.withLock { state in
             if !state.queue.isEmpty { return .value(state.queue.removeFirst()) }
+            if case .failed = state.end { state.failureObserved = true }
             return state.end.map(Delivery.end) ?? .wait
         }
     }

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
@@ -1,0 +1,250 @@
+import Dispatch
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeEventStreamTests {
+    static let id = OperationID()
+    static let info = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
+    static var progress: RuntimeEvent { .progress(id, .init(kind: .copying)) }
+    static let traffic: [RuntimeEvent] = [
+        progress, .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: id.uuid)),
+        .status(.init(environmentID: EnvironmentID(), vm: .running, readiness: .checking, inFlightOperation: id)),
+        .status(.init(environmentID: EnvironmentID(), vm: .running, readiness: .checking)),
+    ]
+
+    @Test(arguments: traffic, [RuntimeEvent.completed(id), .failed(id, .runtimeMissing)])
+    func floodRetainsAcceptanceAndTerminal(traffic: RuntimeEvent, terminal: RuntimeEvent) async throws {
+        let notices = Mutex<[RuntimeEventStream.Termination]>([])
+        let pair = RuntimeEventStream.make(capacity: 4, mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+        pair.producer.reply(.accepted(Self.id))
+        for _ in 0..<10_000 { pair.producer.push(traffic) }
+        #expect(pair.producer.bufferedCount == 3)
+        #expect(pair.producer.droppedCount == 9_998)
+        pair.producer.push(terminal)
+        #expect(pair.producer.bufferedCount == 4)
+        pair.producer.push(.completed(Self.id)) // Neither duplicate terminal nor late failure wins.
+        pair.producer.interrupt(.init(cause: .connectionLost))
+        let values = try await collect(pair.stream)
+        #expect(values == [.accepted(Self.id), traffic, traffic, terminal])
+        #expect(notices.withLock { $0 } == [.finished])
+        #expect(pair.producer.bufferedCount == 0)
+    }
+
+    @Test func aReaderThatCatchesUpResumesTrafficImmediately() async throws {
+        let pair = RuntimeEventStream.make(capacity: 3, mayHaveMutated: true) { _ in }
+        pair.producer.reply(.accepted(Self.id))
+        for _ in 0..<100 { pair.producer.push(Self.progress) }
+        var iterator = pair.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        #expect(try await iterator.next() == Self.progress)
+        #expect(pair.producer.bufferedCount == 0)
+        for _ in 0..<100 {
+            pair.producer.push(Self.progress)
+            #expect(try await iterator.next() == Self.progress)
+        }
+        pair.producer.push(.completed(Self.id))
+        #expect(try await iterator.next() == .completed(Self.id))
+        #expect(try await iterator.next() == nil)
+    }
+
+    @Test(arguments: [Int.min, 2, 64, 1_024, Int.max])
+    func capacitiesAreClampedAndAlwaysReserveATerminalSlot(requested: Int) async throws {
+        let pair = RuntimeEventStream.make(capacity: requested, mayHaveMutated: true) { _ in }
+        let capacity = min(max(requested, 2), 1_024)
+        pair.producer.reply(.accepted(Self.id))
+        for _ in 0..<2_000 { pair.producer.push(Self.progress) }
+        pair.producer.push(.completed(Self.id))
+        #expect(pair.producer.bufferedCount == capacity)
+        #expect(try await collect(pair.stream).count == capacity)
+    }
+
+    @Test(arguments: [RuntimeEvent.runtimeVersion(info),
+                       .status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)),
+                       .completed(id), .failed(id, .unauthorizedCaller)])
+    func queryReplyFinishesOnce(event: RuntimeEvent) async throws {
+        let pair = RuntimeEventStream.make(mayHaveMutated: false) { _ in }
+        pair.producer.reply(event)
+        pair.producer.reply(.accepted(Self.id))
+        #expect(try await collect(pair.stream) == [event])
+    }
+
+    @Test(arguments: [false, true])
+    func interruptionsRetainAcceptedAndPreacceptUncertainty(accepted: Bool) async throws {
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        if accepted { pair.producer.reply(.accepted(Self.id)) }
+        pair.producer.interrupt(.init(cause: .protocolMismatch(service: 11)))
+        let expected = RuntimeSessionFailure(cause: .protocolMismatch(service: 11),
+                                            operationID: accepted ? Self.id : nil, mayHaveMutated: true)
+        var iterator = pair.stream.makeAsyncIterator()
+        if accepted { #expect(try await iterator.next() == .accepted(Self.id)) }
+        await #expect(throws: expected) { try await iterator.next() }
+        #expect(!expected.recoveryActions.contains(.retry))
+    }
+
+    @Test func misroutedTrafficAndPrematurePushesAreNotDelivered() async throws {
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        let other = OperationID()
+        pair.producer.push(Self.progress) // Pending traffic is the router's separate responsibility.
+        pair.producer.reply(.accepted(Self.id))
+        for event in [RuntimeEvent.progress(other, .init(kind: .copying)),
+                      .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: other.uuid)),
+                      .status(.init(environmentID: EnvironmentID(), vm: .running, readiness: .checking, inFlightOperation: other)),
+                      .completed(other), .failed(other, .runtimeMissing)] { pair.producer.push(event) }
+        pair.producer.push(.completed(Self.id))
+        #expect(try await collect(pair.stream) == [.accepted(Self.id), .completed(Self.id)])
+    }
+
+    @Test(arguments: [false, true])
+    func invalidControlEndsWithTypedUnknownOutcome(duplicateReply: Bool) async throws {
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        pair.producer.reply(.accepted(Self.id))
+        if duplicateReply { pair.producer.reply(.accepted(OperationID())) }
+        else { pair.producer.push(.runtimeVersion(Self.info)) }
+        var iterator = pair.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        await #expect(throws: RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id, mayHaveMutated: true)) {
+            try await iterator.next()
+        }
+    }
+
+    @Test func droppingAnUnreadStreamNotifiesAbandonmentOnce() {
+        let notices = Mutex<[RuntimeEventStream.Termination]>([])
+        var stream: AsyncThrowingStream<RuntimeEvent, any Error>?
+        let producer: RuntimeEventStream
+        (producer, stream) = RuntimeEventStream.make(mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+        withExtendedLifetime(stream) {}
+        stream = nil
+        producer.reply(.accepted(Self.id))
+        #expect(notices.withLock { $0 } == [.abandoned])
+        #expect(producer.bufferedCount == 0)
+    }
+
+    @Test func canceledBeforeFirstReadStillNotifiesTheOwner() async throws {
+        let notices = Mutex<[RuntimeEventStream.Termination]>([])
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+        let (gate, finish) = AsyncStream<Void>.makeStream()
+        let task = Task {
+            for await _ in gate { break }
+            var iterator = pair.stream.makeAsyncIterator()
+            return try await iterator.next()
+        }
+        task.cancel()
+        // The SDK can end an already-canceled unfolding iterator before invoking next().
+        // No successful event is allowed, and cleanup must occur even while stream is retained.
+        do { #expect(try await task.value == nil) }
+        catch let error as GuesthouseError { #expect(error == .canceled) }
+        finish.finish()
+        #expect(notices.withLock { $0 } == [.abandoned])
+        withExtendedLifetime(pair.stream) {}
+    }
+
+    @Test func concurrentProducersDoNotOverfillOrFinishTwice() async throws {
+        let notices = Mutex<[RuntimeEventStream.Termination]>([])
+        let pair = RuntimeEventStream.make(capacity: 8, mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+        pair.producer.reply(.accepted(Self.id))
+        DispatchQueue.concurrentPerform(iterations: 64) { index in
+            if index % 7 == 0 { pair.producer.push(.completed(Self.id)) }
+            else { pair.producer.push(Self.progress) }
+        }
+        #expect(pair.producer.bufferedCount <= 8)
+        let values = try await collect(pair.stream)
+        #expect(values.first == .accepted(Self.id))
+        #expect(values.last == .completed(Self.id))
+        #expect(values.filter { $0 == .completed(Self.id) }.count == 1)
+        #expect(notices.withLock { $0 } == [.finished])
+    }
+
+    @Test func lateAcceptanceIdentitySurvivesAPreacceptTransportFailure() async {
+        let pair = RuntimeEventStream.make(mayHaveMutated: false) { _ in }
+        let error = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id)
+        pair.producer.interrupt(error)
+        await #expect(throws: error) { try await collect(pair.stream) }
+        #expect(!error.recoveryActions.contains(.retry))
+    }
+
+    @Test func localRejectionDoesNotInventAnOperationOrEraseAnAcceptedOne() async throws {
+        let rejected = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        rejected.producer.rejectBeforeSend(.invalidRequest(.malformed))
+        await #expect(throws: GuesthouseError.invalidRequest(.malformed)) { try await collect(rejected.stream) }
+        #expect(rejected.producer.bufferedCount == 0)
+        let accepted = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        accepted.producer.reply(.accepted(Self.id))
+        accepted.producer.rejectBeforeSend(.invalidRequest(.malformed))
+        var iterator = accepted.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        await #expect(throws: RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id, mayHaveMutated: true)) {
+            try await iterator.next()
+        }
+    }
+
+    @Test(arguments: [progress, traffic[1]], [false, true])
+    func invalidInitialRepliesDoNotPretendToComplete(event: RuntimeEvent, mutating: Bool) async {
+        let pair = RuntimeEventStream.make(mayHaveMutated: mutating) { _ in }
+        pair.producer.reply(event)
+        await #expect(throws: RuntimeSessionFailure(cause: .malformedResponse, mayHaveMutated: mutating)) {
+            try await collect(pair.stream)
+        }
+    }
+
+    @Test func completionReleasesTheOwnersCallbackBeforeTheStreamIsReleased() {
+        var retainedStream: AsyncThrowingStream<RuntimeEvent, any Error>?
+        weak var scopedOwner: Owner?
+        do {
+            let owner = Owner()
+            scopedOwner = owner
+            let pair = makeCapturing(owner)
+            retainedStream = pair.stream
+            pair.producer.reply(.runtimeVersion(Self.info))
+        }
+        #expect(scopedOwner == nil)
+        withExtendedLifetime(retainedStream) {}
+    }
+
+    @Test func cancellationWhileReadingReleasesTheBufferAndNotifiesOnce() async throws {
+        let notices = Mutex<[RuntimeEventStream.Termination]>([])
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+        let (started, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        pair.producer.reply(.accepted(Self.id))
+        let task = Task {
+            var iterator = pair.stream.makeAsyncIterator()
+            #expect(try await iterator.next() == .accepted(Self.id))
+            signal.yield(()); signal.finish()
+            return try await iterator.next()
+        }
+        for await _ in started { break }
+        task.cancel()
+        // Cancellation can win before the unfolding closure starts its second read.
+        do { #expect(try await task.value == nil) }
+        catch let error as GuesthouseError { #expect(error == .canceled) }
+        pair.producer.push(.completed(Self.id))
+        #expect(pair.producer.bufferedCount == 0)
+        #expect(notices.withLock { $0 } == [.abandoned])
+    }
+
+    @Test func terminationCallbackCanReadProducerStateWithoutLockReentry() {
+        let holder = Mutex<RuntimeEventStream?>(nil)
+        let observed = Mutex<[Int]>([])
+        let pair = RuntimeEventStream.make(mayHaveMutated: false) { _ in
+            let count = holder.withLock { $0 }?.bufferedCount ?? -1
+            observed.withLock { $0.append(count) }
+        }
+        holder.withLock { $0 = pair.producer }
+        defer { holder.withLock { $0 = nil } }
+        pair.producer.reply(.runtimeVersion(Self.info))
+        #expect(observed.withLock { $0 } == [1])
+        withExtendedLifetime(pair.stream) {}
+    }
+}
+
+private final class Owner: Sendable {}
+private func makeCapturing(_ owner: Owner)
+    -> (producer: RuntimeEventStream, stream: AsyncThrowingStream<RuntimeEvent, any Error>) {
+    RuntimeEventStream.make(mayHaveMutated: false) { _ in withExtendedLifetime(owner) {} }
+}
+private func collect(_ stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> [RuntimeEvent] {
+    var result: [RuntimeEvent] = []
+    for try await event in stream { result.append(event) }
+    return result
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
@@ -124,20 +124,41 @@ import Testing
     @Test func canceledBeforeFirstReadStillNotifiesTheOwner() async throws {
         let notices = Mutex<[RuntimeEventStream.Termination]>([])
         let pair = RuntimeEventStream.make(mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
-        let (gate, finish) = AsyncStream<Void>.makeStream()
         let task = Task {
-            for await _ in gate { break }
+            withUnsafeCurrentTask { $0?.cancel() }
+            #expect(Task.isCancelled)
             var iterator = pair.stream.makeAsyncIterator()
             return try await iterator.next()
         }
-        task.cancel()
         // The SDK can end an already-canceled unfolding iterator before invoking next().
         // No successful event is allowed, and cleanup must occur even while stream is retained.
         do { #expect(try await task.value == nil) }
         catch let error as GuesthouseError { #expect(error == .canceled) }
-        finish.finish()
         #expect(notices.withLock { $0 } == [.abandoned])
         withExtendedLifetime(pair.stream) {}
+    }
+
+    @Test func sdkCancellationReleasesTheSkippedProducerWhileStreamIsRetained() async throws {
+        let calls = Mutex(0), releases = Mutex(0)
+        let stream: AsyncThrowingStream<Int, any Error>
+        do {
+            let capture = CancellationCapture { releases.withLock { $0 += 1 } }
+            stream = AsyncThrowingStream(unfolding: {
+                calls.withLock { $0 += 1 }
+                return withExtendedLifetime(capture) { 1 }
+            })
+        }
+        #expect(releases.withLock { $0 } == 0)
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            #expect(Task.isCancelled)
+            var iterator = stream.makeAsyncIterator()
+            return try await iterator.next()
+        }
+        #expect(try await task.value == nil)
+        #expect(calls.withLock { $0 } == 0)
+        #expect(releases.withLock { $0 } == 1)
+        withExtendedLifetime(stream) {}
     }
 
     @Test func concurrentProducersDoNotOverfillOrFinishTwice() async throws {
@@ -162,6 +183,28 @@ import Testing
         pair.producer.interrupt(error)
         await #expect(throws: error) { try await collect(pair.stream) }
         #expect(!error.recoveryActions.contains(.retry))
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func lateInterruptionEnrichesOnlyUnreadFailure(accepted: Bool, observed: Bool) async throws {
+        for cause in [RuntimeSessionFailure.Cause.connectionLost, .protocolMismatch(service: 11)] {
+            let notices = Mutex<[RuntimeEventStream.Termination]>([])
+            let pair = RuntimeEventStream.make(mayHaveMutated: true) { reason in notices.withLock { $0.append(reason) } }
+            if accepted { pair.producer.reply(.accepted(Self.id)) }
+            pair.producer.interrupt(.init(cause: cause))
+            var iterator = pair.stream.makeAsyncIterator()
+            if accepted { #expect(try await iterator.next() == .accepted(Self.id)) }
+            let first = RuntimeSessionFailure(cause: cause,
+                                              operationID: accepted ? Self.id : nil, mayHaveMutated: true)
+            if observed { await #expect(throws: first) { try await iterator.next() } }
+            pair.producer.interrupt(.init(cause: .protocolMismatch(service: 11), operationID: Self.id))
+            pair.producer.interrupt(.init(cause: .oversizedResponse, operationID: OperationID()))
+            let expected = observed ? first : RuntimeSessionFailure(
+                cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true)
+            await #expect(throws: expected) { try await iterator.next() }
+            #expect(!expected.recoveryActions.contains(.retry))
+            #expect(notices.withLock { $0 } == [.finished])
+        }
     }
 
     @Test func localRejectionDoesNotInventAnOperationOrEraseAnAcceptedOne() async throws {
@@ -239,6 +282,11 @@ import Testing
 }
 
 private final class Owner: Sendable {}
+private final class CancellationCapture: Sendable {
+    let released: @Sendable () -> Void
+    init(_ released: @escaping @Sendable () -> Void) { self.released = released }
+    deinit { released() }
+}
 private func makeCapturing(_ owner: Owner)
     -> (producer: RuntimeEventStream, stream: AsyncThrowingStream<RuntimeEvent, any Error>) {
     RuntimeEventStream.make(mayHaveMutated: false) { _ in withExtendedLifetime(owner) {} }


### PR DESCRIPTION
## Summary

Migrate the bounded **consumer-delivery** portion of the retained #67/#103 RuntimeClient into GUI-safe ClientKit. This is the next focused piece of #19/#112, implementing MVP-PLAN.md §3 and §11 under ADR 0003. It is **not yet** the full RuntimeBackend, request router or native mutation path.

Stacked on #156 (`mvp/runtime-connection-ui`). Merge the approved parents into main in order, then settle this base and recheck. The owner merges. Existing draft references remain preserved until all retained scope has migrated and merged.

## Behavior

- One read-driven payload queue, bounded to 2–1,024 events (default 64); a payload-free wakeup stream is bounded separately to one signal. No task per event or second unbounded payload queue.
- Acceptance is delivered first and a terminal slot is reserved. Progress/status/typed diagnostics may be dropped under pressure, with a saturating counter; acceptance and the first matching completion/failure survive a flood.
- Reading frees actual slots immediately. This replaces the retained client's cached `yield.remaining` estimate, which could stop admitting traffic after the consumer caught up.
- Operation IDs fence pushed events; malformed control traffic ends with typed uncertainty. Transport failures preserve accepted or late-learned IDs, the cause and mutation uncertainty. A known pre-send local rejection stays a Guesthouse-owned error.
- Consumer cancellation/drop clears the queue and notifies abandonment once. Finish releases the owner's callback even while the stream is retained. Notifications run outside the state lock and must only enqueue bounded client work.
- Cancellation can throw or end iteration depending on the SDK's unfolding-stream path. Only an actual terminal event proves operation completion; cancellation never proves the VM stopped.

## Explicit remaining integration

The owning client still needs expected-reply validation, a bounded ordered inbox, request/event correlation, bounded pre-acceptance routing, environment filtering for unscoped snapshots, generation retirement, and abandoned-operation cleanup. Premature pushes are deliberately not buffered by this delivery object. Do not invoke native transport cleanup directly from its callback.

The component is internal and is not wired into public mutation requests. The current GUI/runtime remain query-only. No epoch bump (current 12), backend/provider activation, raw diagnostic output, host/VM/signing setup or positive signed-boundary claim.

## Review follow-up

- P1: unread interruptions now preserve late owning-reply IDs and stronger uncertainty, without replacing a known ID, losing a specific cause, repeating the end callback or rewriting an observed failure. Eight preaccept/accepted × unread/observed × initial-cause cases are covered. The router must still retain context for late replies after the failure has already been observed.
- P2: skipped-producer cancellation was rejected after verifying the Swift implementation and adding a deterministic SDK regression. Cancellation clears the stored producer closure, releasing its captured lifetime even when the stream remains retained; the test proves zero producer calls and exactly one release. The production abandonment test is now deterministic too.

## Validation

- Full strict package hook: **439 test functions** — Core 392/35 suites, RuntimeKit 14/2, ClientKit 33/4; warnings as errors.
- **18 new stream tests**, including parameterized 10,000-event floods, exact acceptance/terminal retention, catch-up recovery, capacity extremes, wrong IDs, malformed/duplicate control, known/unknown failures, concurrent producers, cancellation before/while reading, unread-stream drop and owner release.
- Stream suite passed **five consecutive Debug runs** and **Release**.
- Seven CI-hook scenarios passed.
- Unsigned shared-scheme `build-for-testing` passed; no app launched. No new Swift/C warnings; the existing optional AppIntents metadata-extraction notice remains.
- 486 additions in two files; staged diff check passed.

Remote Xcode Cloud and a matching completed Codex review with original-message 👍 are still required. No old finding is deemed resolved merely because its PR is a draft.
