### PR TITLE
Migrate bounded runtime event routing and reconciliation effects

### DIFF
--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -15,9 +15,17 @@ struct RuntimeEventRouter: Sendable {
     enum Effect: Equatable, Sendable {
         case cancel(OperationID), retireConnection
         /// The owner retains bounded reconciliation state even if the stream already ended.
-        case unknownOutcome(RuntimeSessionFailure)
+        case unknownOutcome(UncertainRequest)
+    }
+    /// Client-local reconciliation identity, not a raw request, wire payload or diagnostic.
+    struct UncertainRequest: Equatable, Sendable {
+        let key: RuntimeRequestKey
+        let environmentID: EnvironmentID?
+        let cancellationTarget: OperationID?
+        let failure: RuntimeSessionFailure
     }
     private struct Request: Sendable {
+        let key: RuntimeRequestKey
         let request: RuntimeRequest
         let producer: RuntimeEventStream
         var operation: OperationID?
@@ -48,7 +56,7 @@ struct RuntimeEventRouter: Sendable {
         guard !requiresRetirement else { return .retiring }
         guard admitted < Self.lifetimeLimit else { return .rotationRequired }
         guard requests.count < Self.requestLimit, requests[key] == nil else { return .full }
-        requests[key] = Request(request: request, producer: producer)
+        requests[key] = Request(key: key, request: request, producer: producer)
         admitted += 1 // Bounds retired IDs for the whole connection, not only active requests.
         return .admitted
     }
@@ -66,7 +74,15 @@ struct RuntimeEventRouter: Sendable {
     mutating func reply(_ result: Result<RuntimeEvent, RuntimeSessionFailure>,
                         to key: RuntimeRequestKey) -> [Effect] {
         guard var entry = requests[key] else { return [] }
-        guard entry.awaiting else { return fault(.malformedResponse) }
+        guard entry.awaiting else {
+            // Preserve a second possible mutation without assigning its ID to the first consumer.
+            var effects: [Effect] = []
+            if case .success(.accepted(let id)) = result, id != entry.operation {
+                effects = uncertainty(entry, .init(cause: .malformedResponse, operationID: id,
+                                                   mayHaveMutated: entry.request.mayMutate))
+            }
+            return effects + fault(.malformedResponse)
+        }
         requests.removeValue(forKey: key)
         defer { discardUnjustifiedPending() }
         switch result {
@@ -169,7 +185,11 @@ struct RuntimeEventRouter: Sendable {
     private func fail(_ entry: Request, with failure: RuntimeSessionFailure) -> [Effect] {
         let scoped = failure.contextualized(operationID: entry.operation, mayHaveMutated: entry.request.mayMutate)
         entry.producer.interrupt(scoped)
-        return scoped.outcomeUnknown ? [.unknownOutcome(scoped)] : []
+        return uncertainty(entry, scoped)
+    }
+    private func uncertainty(_ entry: Request, _ failure: RuntimeSessionFailure) -> [Effect] {
+        failure.outcomeUnknown ? [.unknownOutcome(.init(key: entry.key, environmentID: entry.request.environment,
+            cancellationTarget: entry.request.cancellationTarget, failure: failure))] : []
     }
     private mutating func fault(_ cause: RuntimeSessionFailure.Cause) -> [Effect] {
         guard !requiresRetirement else { return [] }
@@ -200,6 +220,9 @@ private extension RuntimeRequest {
         case .startEnvironment, .stopEnvironment, .importXcode: true
         case .runtimeVersion, .environmentStatus, .cancelOperation: false
         }
+    }
+    var cancellationTarget: OperationID? {
+        if case .cancelOperation(let id) = self { id } else { nil }
     }
     func acceptsReply(_ event: RuntimeEvent) -> Bool {
         if case .failed = event { return true } // Correlated service rejection, not a live registration.

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -1,0 +1,234 @@
+import GuesthouseCore
+
+/// Identity is retained until its owning reply arrives, even if the consumer has left.
+final class RuntimeRequestKey: Hashable, Sendable {
+    static func == (lhs: RuntimeRequestKey, rhs: RuntimeRequestKey) -> Bool { lhs === rhs }
+    func hash(into hasher: inout Hasher) { hasher.combine(ObjectIdentifier(self)) }
+}
+
+/// Serial-owner routing state migrated from #67/#103 (MVP-PLAN.md §3). No native calls.
+/// The owner must feed validated callbacks through ONE bounded ordered inbox, execute effects
+/// outside native callback locks, and process retirement before replacement-session traffic.
+/// This is not the inbox, transport lifecycle or public RuntimeBackend implementation.
+struct RuntimeEventRouter: Sendable {
+    enum Admission: Equatable, Sendable { case admitted, full, retiring, rotationRequired }
+    enum Effect: Equatable, Sendable {
+        case cancel(OperationID), retireConnection
+        /// The owner retains bounded reconciliation state even if the stream already ended.
+        case unknownOutcome(RuntimeSessionFailure)
+    }
+    private struct Request: Sendable {
+        let request: RuntimeRequest
+        let producer: RuntimeEventStream
+        var operation: OperationID?
+        var awaiting = true
+        var abandoned = false
+        var invalidated: RuntimeSessionFailure.Cause?
+    }
+    static let requestLimit = 64
+    static let lifetimeLimit = 1_024
+    static let pendingIDLimit = 64
+    static let pendingEventLimit = 16
+    private var requests: [RuntimeRequestKey: Request] = [:]
+    private var operations: [OperationID: RuntimeRequestKey] = [:]
+    private var pending: [OperationID: [RuntimeEvent]] = [:]
+    private var retired: Set<OperationID> = []
+    private var admitted = 0
+    private var requiresRetirement = false
+    var requestCount: Int { requests.count }
+    var pendingIDCount: Int { pending.count }
+    var retiredCount: Int { retired.count }
+    var isIdle: Bool { requests.isEmpty }
+
+    /// The owner validates requests, then calls in send order BEFORE native send. On refusal
+    /// it still owns the producer and must reject the unsent request. Planned budget rotation
+    /// waits for idle; fault retirement is immediate. Neither permits replaying a sent mutation.
+    mutating func register(_ key: RuntimeRequestKey, request: RuntimeRequest,
+                           producer: RuntimeEventStream) -> Admission {
+        guard !requiresRetirement else { return .retiring }
+        guard admitted < Self.lifetimeLimit else { return .rotationRequired }
+        guard requests.count < Self.requestLimit, requests[key] == nil else { return .full }
+        requests[key] = Request(request: request, producer: producer)
+        admitted += 1 // Bounds retired IDs for the whole connection, not only active requests.
+        return .admitted
+    }
+
+    /// Only a verified pre-send local rejection, never an ambiguous native failure.
+    mutating func rejected(_ key: RuntimeRequestKey, error: GuesthouseError) -> [Effect] {
+        guard let entry = requests[key] else { return [] }
+        guard entry.awaiting else { return fault(.malformedResponse) }
+        requests.removeValue(forKey: key)
+        entry.producer.rejectBeforeSend(error)
+        discardUnjustifiedPending()
+        return []
+    }
+
+    mutating func reply(_ result: Result<RuntimeEvent, RuntimeSessionFailure>,
+                        to key: RuntimeRequestKey) -> [Effect] {
+        guard var entry = requests[key] else { return [] }
+        guard entry.awaiting else { return fault(.malformedResponse) }
+        requests.removeValue(forKey: key)
+        defer { discardUnjustifiedPending() }
+        switch result {
+        case .failure(let failure):
+            return fail(entry, with: failure)
+        case .success(let event):
+            if let cause = entry.invalidated {
+                // The requested retirement, not a late acceptance, owns cleanup.
+                return fail(entry, with: .init(cause: cause, operationID: event.routingID))
+            }
+            guard entry.request.acceptsReply(event) else {
+                let cause: RuntimeSessionFailure.Cause
+                if case .runtimeVersion(let info) = event, info.protocolVersion != .current {
+                    cause = .protocolMismatch(service: info.protocolVersion.rawValue)
+                } else { cause = .malformedResponse }
+                return fail(entry, with: .init(cause: cause, operationID: event.routingID)) + fault(cause)
+            }
+            guard case .accepted(let id) = event else { entry.producer.reply(event); return [] }
+            guard operations[id] == nil, !retired.contains(id) else {
+                return fail(entry, with: .init(cause: .malformedResponse, operationID: id)) + fault(.malformedResponse)
+            }
+            if entry.abandoned {
+                pending.removeValue(forKey: id); retired.insert(id)
+                return [.cancel(id)] // A live acceptance, not a replay of the original request.
+            }
+            entry.awaiting = false; entry.operation = id
+            requests[key] = entry; operations[id] = key
+            entry.producer.reply(event)
+            for buffered in pending.removeValue(forKey: id) ?? [] { _ = route(buffered) }
+            return []
+        }
+    }
+
+    /// End callbacks enqueue this message; they must not reenter this mutable state directly.
+    mutating func consumerEnded(_ key: RuntimeRequestKey, reason: RuntimeEventStream.Termination) -> [Effect] {
+        guard reason == .abandoned, var entry = requests[key] else { return [] }
+        guard let id = entry.operation else {
+            entry.abandoned = true; requests[key] = entry; return []
+        }
+        remove(key, operation: id)
+        return [.cancel(id)]
+    }
+
+    mutating func incoming(_ event: RuntimeEvent) -> [Effect] {
+        guard !requiresRetirement else { return [] }
+        switch event {
+        case .accepted, .runtimeVersion: return fault(.malformedResponse)
+        case .status(let status) where status.inFlightOperation == nil:
+            for entry in requests.values where entry.operation != nil && entry.request.environment == status.environmentID {
+                entry.producer.push(event)
+            }
+            return []
+        default: return route(event)
+        }
+    }
+
+    /// The registry fences stale pushes before this ordered notification. Pending owning
+    /// replies remain: they carry late IDs/causes, and some may belong to a new generation
+    /// whose send was queued before this notification. Never fail them indiscriminately.
+    mutating func interrupted(_ failure: RuntimeSessionFailure) -> [Effect] {
+        var effects: [Effect] = []
+        for key in operations.values {
+            // A generation-wide signal carries only cause, never another request's identity.
+            if let entry = requests.removeValue(forKey: key) { effects += fail(entry, with: .init(cause: failure.cause)) }
+        }
+        operations.removeAll(); pending.removeAll(); retired.removeAll()
+        admitted = requests.count; requiresRetirement = false
+        return effects
+    }
+
+    private mutating func route(_ event: RuntimeEvent) -> [Effect] {
+        guard let id = event.routingID else { return [] }
+        if let key = operations[id], let entry = requests[key] {
+            guard event.matchesEnvironment(entry.request.environment) else { return [] }
+            if event.isTerminal { remove(key, operation: id) }
+            entry.producer.push(event)
+            return []
+        }
+        guard !retired.contains(id), requests.values.contains(where: {
+            $0.awaiting && $0.invalidated == nil && $0.request.acceptsOperation && event.matchesEnvironment($0.request.environment)
+        }) else { return [] }
+        if pending[id] == nil, pending.count == Self.pendingIDLimit {
+            return fault(.oversizedResponse) // Never silently lose a legitimate terminal/ID.
+        }
+        var events = pending[id] ?? []
+        guard events.last?.isTerminal != true else { return [] }
+        if event.isTerminal { events.append(event) }
+        else if events.count < Self.pendingEventLimit - 1 { events.append(event) }
+        pending[id] = events // One terminal slot is always free; duplicate terminals are dropped.
+        return []
+    }
+
+    private mutating func remove(_ key: RuntimeRequestKey, operation: OperationID) {
+        requests.removeValue(forKey: key); operations.removeValue(forKey: operation)
+        pending.removeValue(forKey: operation); retired.insert(operation)
+    }
+    private mutating func discardUnjustifiedPending() {
+        if !requests.values.contains(where: { $0.awaiting && $0.invalidated == nil && $0.request.acceptsOperation }) { pending.removeAll() }
+    }
+    private func fail(_ entry: Request, with failure: RuntimeSessionFailure) -> [Effect] {
+        let scoped = failure.contextualized(operationID: entry.operation, mayHaveMutated: entry.request.mayMutate)
+        entry.producer.interrupt(scoped)
+        return scoped.outcomeUnknown ? [.unknownOutcome(scoped)] : []
+    }
+    private mutating func fault(_ cause: RuntimeSessionFailure.Cause) -> [Effect] {
+        guard !requiresRetirement else { return [] }
+        requiresRetirement = true; pending.removeAll()
+        var effects: [Effect] = [.retireConnection]
+        for key in Array(requests.keys) {
+            guard var entry = requests[key] else { continue }
+            if let id = entry.operation { remove(key, operation: id) }
+            else { entry.invalidated = cause; requests[key] = entry }
+            effects += fail(entry, with: .init(cause: cause))
+        }
+        return effects
+    }
+}
+
+private extension RuntimeRequest {
+    var mayMutate: Bool {
+        switch self { case .runtimeVersion, .environmentStatus: false; default: true }
+    }
+    var environment: EnvironmentID? {
+        switch self {
+        case .environmentStatus(let id), .startEnvironment(let id, _), .stopEnvironment(let id, _), .importXcode(let id, _): id
+        case .runtimeVersion, .cancelOperation: nil
+        }
+    }
+    var acceptsOperation: Bool {
+        switch self {
+        case .startEnvironment, .stopEnvironment, .importXcode: true
+        case .runtimeVersion, .environmentStatus, .cancelOperation: false
+        }
+    }
+    func acceptsReply(_ event: RuntimeEvent) -> Bool {
+        if case .failed = event { return true } // Correlated service rejection, not a live registration.
+        switch (self, event) {
+        case (.runtimeVersion, .runtimeVersion(let info)): return info.protocolVersion == .current
+        case (.environmentStatus(let id), .status(let status)): return status.environmentID == id
+        case (.cancelOperation, .completed): return true // Cancel-request acknowledgement, not proof its target stopped.
+        case (_, .accepted): return acceptsOperation
+        default: return false
+        }
+    }
+}
+private extension RuntimeEvent {
+    var routingID: OperationID? {
+        switch self {
+        case .accepted(let id), .progress(let id, _), .completed(let id), .failed(let id, _): id
+        case .diagnostic(let event): OperationID(uuid: event.operationID)
+        case .status(let status): status.inFlightOperation
+        case .runtimeVersion: nil
+        }
+    }
+    var isTerminal: Bool {
+        switch self { case .completed, .failed: true; default: false }
+    }
+    func matchesEnvironment(_ expected: EnvironmentID?) -> Bool {
+        switch self {
+        case .status(let status): status.environmentID == expected
+        case .diagnostic(let event): event.environmentID == nil || event.environmentID == expected
+        default: true
+        }
+    }
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
@@ -74,7 +74,7 @@ import Testing
         let fixture = try start(&router, request: .runtimeVersion)
         let event: RuntimeEvent = accepted ? .accepted(Self.id) : .progress(Self.id, .init(kind: .copying))
         let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id)
-        #expect(router.reply(.success(event), to: fixture.key) == [.unknownOutcome(failure), .retireConnection])
+        #expect(router.reply(.success(event), to: fixture.key) == [unknown(fixture, failure, environment: nil), .retireConnection])
         await #expect(throws: failure) { try await collectRouting(fixture.stream) }
         #expect(router.isIdle)
     }
@@ -109,7 +109,7 @@ import Testing
         for _ in 0..<RuntimeEventRouter.pendingIDLimit { _ = router.incoming(.completed(OperationID())) }
         #expect(router.pendingIDCount == RuntimeEventRouter.pendingIDLimit)
         let failure = RuntimeSessionFailure(cause: .oversizedResponse, mayHaveMutated: true)
-        #expect(router.incoming(.completed(Self.id)) == [.retireConnection, .unknownOutcome(failure)])
+        #expect(router.incoming(.completed(Self.id)) == [.retireConnection, unknown(fixture, failure)])
         #expect(router.pendingIDCount == 0)
         #expect(router.requestCount == 1)
         let refused = Fixture()
@@ -118,7 +118,7 @@ import Testing
         #expect(router.consumerEnded(fixture.key, reason: .finished).isEmpty)
         // Even after the consumer observed failure, reconciliation learns the late identity.
         #expect(router.reply(.success(.accepted(Self.id)), to: fixture.key) == [
-            .unknownOutcome(failure.contextualized(operationID: Self.id)),
+            unknown(fixture, failure.contextualized(operationID: Self.id)),
         ])
         #expect(router.isIdle)
         #expect(router.incoming(.completed(OperationID())).isEmpty)
@@ -131,7 +131,7 @@ import Testing
         let newID = OperationID()
         _ = router.incoming(.progress(newID, .init(kind: .copying)))
         let failure = RuntimeSessionFailure(cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true)
-        #expect(router.interrupted(.init(cause: .protocolMismatch(service: 11), operationID: OperationID())) == [.unknownOutcome(failure)])
+        #expect(router.interrupted(.init(cause: .protocolMismatch(service: 11), operationID: OperationID())) == [unknown(old, failure)])
         #expect(router.pendingIDCount == 0)
         #expect(router.requestCount == 1)
         await #expect(throws: failure) { try await collectRouting(old.stream) }
@@ -146,7 +146,7 @@ import Testing
         let fixture = try start(&router)
         #expect(router.interrupted(.init(cause: .connectionLost)).isEmpty)
         let failure = RuntimeSessionFailure(cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true)
-        #expect(router.reply(.failure(failure), to: fixture.key) == [.unknownOutcome(failure)])
+        #expect(router.reply(.failure(failure), to: fixture.key) == [unknown(fixture, failure)])
         await #expect(throws: failure) { try await collectRouting(fixture.stream) }
         #expect(router.isIdle)
     }
@@ -177,6 +177,37 @@ import Testing
         let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id, mayHaveMutated: true)
         await #expect(throws: failure) { try await collectRouting(a.stream) }
         #expect(router.incoming(.completed(Self.id)).isEmpty)
+    }
+
+    @Test func duplicateAcceptanceRetainsBothIDsWithTheOriginalRequestContext() async throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router), secondID = OperationID()
+        _ = router.reply(.success(.accepted(Self.id)), to: fixture.key)
+        let first = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id, mayHaveMutated: true)
+        let second = RuntimeSessionFailure(cause: .malformedResponse, operationID: secondID, mayHaveMutated: true)
+        #expect(router.reply(.success(.accepted(secondID)), to: fixture.key) == [
+            unknown(fixture, second), .retireConnection, unknown(fixture, first),
+        ])
+        await #expect(throws: first) { try await collectRouting(fixture.stream) }
+        #expect(router.isIdle)
+    }
+
+    @Test func preAcceptanceFaultRetainsDistinctEnvironmentsAndCancellationTarget() async throws {
+        var router = RuntimeEventRouter()
+        let other = EnvironmentID()
+        let a = try start(&router), b = try start(&router, request: .stopEnvironment(other, .force))
+        let cancel = try start(&router, request: .cancelOperation(Self.id))
+        let failure = RuntimeSessionFailure(cause: .malformedResponse, mayHaveMutated: true)
+        let effects = router.incoming(.runtimeVersion(Self.info))
+        #expect(effects.count == 4)
+        #expect(effects.contains(.retireConnection))
+        #expect(effects.contains(unknown(a, failure)))
+        #expect(effects.contains(unknown(b, failure, environment: other)))
+        #expect(effects.contains(unknown(cancel, failure, environment: nil, cancellationTarget: Self.id)))
+        for fixture in [a, b, cancel] {
+            await #expect(throws: failure) { try await collectRouting(fixture.stream) }
+        }
+        #expect(router.requestCount == 3) // Owning replies can still supply late IDs.
     }
 
     @Test func requestAndLifetimeBudgetsAreBounded() throws {
@@ -220,4 +251,9 @@ private func collectRouting(_ stream: AsyncThrowingStream<RuntimeEvent, any Erro
     var values: [RuntimeEvent] = []
     for try await value in stream { values.append(value) }
     return values
+}
+private func unknown(_ fixture: Fixture, _ failure: RuntimeSessionFailure,
+                     environment: EnvironmentID? = RuntimeEventRouterTests.environment,
+                     cancellationTarget: OperationID? = nil) -> RuntimeEventRouter.Effect {
+    .unknownOutcome(.init(key: fixture.key, environmentID: environment, cancellationTarget: cancellationTarget, failure: failure))
 }

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
@@ -1,0 +1,223 @@
+import GuesthouseCore
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeEventRouterTests {
+    static let environment = EnvironmentID(), id = OperationID()
+    static let info = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
+    static let traffic: [RuntimeEvent] = [
+        .progress(id, .init(kind: .copying)),
+        .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: id.uuid)),
+        .status(.init(environmentID: environment, vm: .running, readiness: .checking, inFlightOperation: id)),
+    ]
+
+    @Test(arguments: traffic, [RuntimeEvent.completed(id), .failed(id, .runtimeMissing)])
+    func earlyFloodPreservesAcceptanceAndTerminal(traffic: RuntimeEvent, terminal: RuntimeEvent) async throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router)
+        for _ in 0..<10_000 { #expect(router.incoming(traffic).isEmpty) }
+        #expect(router.incoming(terminal).isEmpty)
+        #expect(router.incoming(.completed(Self.id)).isEmpty)
+        #expect(router.pendingIDCount == 1)
+        #expect(router.reply(.success(.accepted(Self.id)), to: fixture.key).isEmpty)
+        let values = try await collectRouting(fixture.stream)
+        #expect(values == [.accepted(Self.id)] + Array(repeating: traffic, count: 15) + [terminal])
+        let next = try start(&router)
+        for _ in 0..<100 { #expect(router.incoming(traffic).isEmpty) }
+        #expect(router.pendingIDCount == 0) // Retired ID stays retired while another reply is pending.
+        #expect(router.rejected(next.key, error: .canceled).isEmpty)
+        #expect(router.requestCount == 0)
+    }
+
+    @Test func snapshotsAndDiagnosticsStayWithTheirEnvironment() async throws {
+        var router = RuntimeEventRouter()
+        let otherEnvironment = EnvironmentID(), otherID = OperationID()
+        let a = try start(&router), b = try start(&router, request: .startEnvironment(otherEnvironment, .init()))
+        _ = router.reply(.success(.accepted(Self.id)), to: a.key)
+        _ = router.reply(.success(.accepted(otherID)), to: b.key)
+        let wrong: [RuntimeEvent] = [
+            .status(.init(environmentID: otherEnvironment, vm: .running, readiness: .checking, inFlightOperation: Self.id)),
+            .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: Self.id.uuid, environmentID: otherEnvironment)),
+        ]
+        for event in wrong { #expect(router.incoming(event).isEmpty) }
+        let statusA = RuntimeEvent.status(.init(environmentID: Self.environment, vm: .running, readiness: .checking))
+        let statusB = RuntimeEvent.status(.init(environmentID: otherEnvironment, vm: .running, readiness: .checking))
+        _ = router.incoming(statusA); _ = router.incoming(statusB)
+        _ = router.incoming(.completed(Self.id)); _ = router.incoming(.completed(otherID))
+        #expect(try await collectRouting(a.stream) == [.accepted(Self.id), statusA, .completed(Self.id)])
+        #expect(try await collectRouting(b.stream) == [.accepted(otherID), statusB, .completed(otherID)])
+    }
+
+    @Test func queryRepliesAndKnownLocalRejectionsSettleWithoutCancellation() async throws {
+        let cases: [(RuntimeRequest, RuntimeEvent)] = [
+            (.runtimeVersion, .runtimeVersion(Self.info)),
+            (.environmentStatus(Self.environment), .status(.init(environmentID: Self.environment, vm: .stopped, readiness: .checking))),
+            (.cancelOperation(Self.id), .completed(OperationID())),
+            (.startEnvironment(Self.environment, .init()), .failed(Self.id, .runtimeMissing)),
+        ]
+        var router = RuntimeEventRouter()
+        for (request, event) in cases {
+            let fixture = try start(&router, request: request)
+            #expect(router.reply(.success(event), to: fixture.key).isEmpty)
+            #expect(try await collectRouting(fixture.stream) == [event])
+            #expect(router.consumerEnded(fixture.key, reason: .abandoned).isEmpty)
+        }
+        let unsent = try start(&router)
+        #expect(router.rejected(unsent.key, error: .invalidRequest(.malformed)).isEmpty)
+        await #expect(throws: GuesthouseError.invalidRequest(.malformed)) { try await collectRouting(unsent.stream) }
+        #expect(router.isIdle)
+    }
+
+    @Test(arguments: [false, true])
+    func unexpectedReplyRetainsIdentityAndRetires(accepted: Bool) async throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router, request: .runtimeVersion)
+        let event: RuntimeEvent = accepted ? .accepted(Self.id) : .progress(Self.id, .init(kind: .copying))
+        let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id)
+        #expect(router.reply(.success(event), to: fixture.key) == [.unknownOutcome(failure), .retireConnection])
+        await #expect(throws: failure) { try await collectRouting(fixture.stream) }
+        #expect(router.isIdle)
+    }
+
+    @Test func namedOperationsAcceptButWrongQueryShapesDoNot() async throws {
+        let operations: [RuntimeRequest] = [
+            .startEnvironment(Self.environment, .init()), .stopEnvironment(Self.environment, .force),
+            .importXcode(Self.environment, .init(kind: .fileDescriptor(token: Self.id.uuid), displayName: "Xcode")),
+        ]
+        for request in operations {
+            var router = RuntimeEventRouter()
+            let fixture = try start(&router, request: request)
+            #expect(router.reply(.success(.accepted(Self.id)), to: fixture.key).isEmpty)
+            _ = router.incoming(.completed(Self.id))
+            #expect(try await collectRouting(fixture.stream) == [.accepted(Self.id), .completed(Self.id)])
+        }
+        let cases: [(RuntimeRequest, RuntimeEvent, RuntimeSessionFailure.Cause)] = [
+            (.environmentStatus(Self.environment), .status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)), .malformedResponse),
+            (.runtimeVersion, .runtimeVersion(.init(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(11))), .protocolMismatch(service: 11)),
+        ]
+        for (request, event, cause) in cases {
+            var router = RuntimeEventRouter()
+            let fixture = try start(&router, request: request)
+            #expect(router.reply(.success(event), to: fixture.key) == [.retireConnection])
+            await #expect(throws: RuntimeSessionFailure(cause: cause)) { try await collectRouting(fixture.stream) }
+        }
+    }
+
+    @Test func pendingIDOverflowFailsClosedAndKeepsTheLateOwningReply() async throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router)
+        for _ in 0..<RuntimeEventRouter.pendingIDLimit { _ = router.incoming(.completed(OperationID())) }
+        #expect(router.pendingIDCount == RuntimeEventRouter.pendingIDLimit)
+        let failure = RuntimeSessionFailure(cause: .oversizedResponse, mayHaveMutated: true)
+        #expect(router.incoming(.completed(Self.id)) == [.retireConnection, .unknownOutcome(failure)])
+        #expect(router.pendingIDCount == 0)
+        #expect(router.requestCount == 1)
+        let refused = Fixture()
+        #expect(router.register(refused.key, request: .runtimeVersion, producer: refused.producer) == .retiring)
+        await #expect(throws: failure) { try await collectRouting(fixture.stream) }
+        #expect(router.consumerEnded(fixture.key, reason: .finished).isEmpty)
+        // Even after the consumer observed failure, reconciliation learns the late identity.
+        #expect(router.reply(.success(.accepted(Self.id)), to: fixture.key) == [
+            .unknownOutcome(failure.contextualized(operationID: Self.id)),
+        ])
+        #expect(router.isIdle)
+        #expect(router.incoming(.completed(OperationID())).isEmpty)
+    }
+
+    @Test func interruptionDoesNotEraseAwaitingRepliesFromTheReplacement() async throws {
+        var router = RuntimeEventRouter()
+        let old = try start(&router), pending = try start(&router)
+        _ = router.reply(.success(.accepted(Self.id)), to: old.key)
+        let newID = OperationID()
+        _ = router.incoming(.progress(newID, .init(kind: .copying)))
+        let failure = RuntimeSessionFailure(cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true)
+        #expect(router.interrupted(.init(cause: .protocolMismatch(service: 11), operationID: OperationID())) == [.unknownOutcome(failure)])
+        #expect(router.pendingIDCount == 0)
+        #expect(router.requestCount == 1)
+        await #expect(throws: failure) { try await collectRouting(old.stream) }
+        // A stale native acceptance must arrive as failure; this success belongs to the new generation.
+        #expect(router.reply(.success(.accepted(newID)), to: pending.key).isEmpty)
+        _ = router.incoming(.completed(newID))
+        #expect(try await collectRouting(pending.stream) == [.accepted(newID), .completed(newID)])
+    }
+
+    @Test func retiredOwningReplyStillReportsUnknownIdentity() async throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router)
+        #expect(router.interrupted(.init(cause: .connectionLost)).isEmpty)
+        let failure = RuntimeSessionFailure(cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true)
+        #expect(router.reply(.failure(failure), to: fixture.key) == [.unknownOutcome(failure)])
+        await #expect(throws: failure) { try await collectRouting(fixture.stream) }
+        #expect(router.isIdle)
+    }
+
+    @Test(arguments: [false, true])
+    func abandonedConsumersCancelOnceIncludingLateAcceptance(beforeAcceptance: Bool) throws {
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router)
+        if !beforeAcceptance { _ = router.reply(.success(.accepted(Self.id)), to: fixture.key) }
+        let first = router.consumerEnded(fixture.key, reason: .abandoned)
+        #expect(first == (beforeAcceptance ? [] : [.cancel(Self.id)]))
+        if beforeAcceptance {
+            #expect(router.requestCount == 1)
+            #expect(router.reply(.success(.accepted(Self.id)), to: fixture.key) == [.cancel(Self.id)])
+        }
+        #expect(router.consumerEnded(fixture.key, reason: .abandoned).isEmpty)
+        #expect(router.isIdle)
+        #expect(router.retiredCount == 1)
+    }
+
+    @Test(arguments: [false, true])
+    func duplicateAcceptanceNeverStealsAnExistingConsumer(sameKey: Bool) async throws {
+        var router = RuntimeEventRouter()
+        let a = try start(&router), b = try start(&router)
+        _ = router.reply(.success(.accepted(Self.id)), to: a.key)
+        let effects = router.reply(.success(.accepted(Self.id)), to: sameKey ? a.key : b.key)
+        #expect(effects.filter { $0 == .retireConnection }.count == 1)
+        let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id, mayHaveMutated: true)
+        await #expect(throws: failure) { try await collectRouting(a.stream) }
+        #expect(router.incoming(.completed(Self.id)).isEmpty)
+    }
+
+    @Test func requestAndLifetimeBudgetsAreBounded() throws {
+        var router = RuntimeEventRouter()
+        let outstanding = try (0..<RuntimeEventRouter.requestLimit).map { _ in try start(&router) }
+        let extra = Fixture()
+        #expect(router.register(extra.key, request: .runtimeVersion, producer: extra.producer) == .full)
+        for fixture in outstanding { _ = router.rejected(fixture.key, error: .canceled) }
+        for _ in RuntimeEventRouter.requestLimit..<RuntimeEventRouter.lifetimeLimit {
+            let fixture = try start(&router)
+            let id = OperationID()
+            _ = router.reply(.success(.accepted(id)), to: fixture.key)
+            _ = router.incoming(.completed(id))
+        }
+        #expect(router.isIdle)
+        #expect(router.retiredCount == RuntimeEventRouter.lifetimeLimit - RuntimeEventRouter.requestLimit)
+        #expect(router.register(extra.key, request: .runtimeVersion, producer: extra.producer) == .rotationRequired)
+        #expect(router.interrupted(.init(cause: .connectionLost)).isEmpty)
+        #expect(router.retiredCount == 0)
+        #expect(router.register(extra.key, request: .runtimeVersion, producer: extra.producer) == .admitted)
+    }
+}
+
+private struct Fixture {
+    let key = RuntimeRequestKey()
+    let producer: RuntimeEventStream
+    let stream: AsyncThrowingStream<RuntimeEvent, any Error>
+    init(mutating: Bool = false) {
+        (producer, stream) = RuntimeEventStream.make(mayHaveMutated: mutating) { _ in }
+    }
+}
+private func start(_ router: inout RuntimeEventRouter,
+                   request: RuntimeRequest = .startEnvironment(RuntimeEventRouterTests.environment, .init())) throws -> Fixture {
+    let mutating: Bool
+    switch request { case .runtimeVersion, .environmentStatus: mutating = false; default: mutating = true }
+    let fixture = Fixture(mutating: mutating)
+    try #require(router.register(fixture.key, request: request, producer: fixture.producer) == .admitted)
+    return fixture
+}
+private func collectRouting(_ stream: AsyncThrowingStream<RuntimeEvent, any Error>) async throws -> [RuntimeEvent] {
+    var values: [RuntimeEvent] = []
+    for try await value in stream { values.append(value) }
+    return values
+}


### PR DESCRIPTION
## Summary

Migrate the retained #67/#103 RuntimeClient's **serial routing state** into ClientKit, on top of #157's bounded stream delivery. This is a focused #19/#112 migration under MVP-PLAN.md §3 and §11 and ADR 0003.

Stacked on #157 (`mvp/runtime-event-stream`, approved head `2aed3584`). The owner merges the parent chain into main first, then the child base/composition and exact-head gates must be rechecked. Existing native reference PRs remain drafts until their entire retained scope has migrated and merged.

## Routing behavior

- Request keys survive consumer abandonment until the owning reply identifies the operation. Acceptance is delivered before its buffered pushes; duplicate/reused operation IDs cannot steal an existing consumer.
- Progress, typed diagnostics and scoped status correlate by operation ID. Status and explicit diagnostic environment IDs must match the request. Unscoped snapshots reach only active operations for that environment.
- Query reply shapes and runtime protocol versions are checked. Named start/stop/import operations require acceptance; a cancel-request acknowledgement is not proof that its target stopped.
- Consumer abandonment returns one named cancellation effect, including after a delayed live acceptance. No original mutation is replayed.
- Ordered connection interruption fails accepted operations but keeps pending owning replies. Those replies retain late IDs/causes and can belong to the replacement generation; the global failure cannot carry one request's identity into another.
- Typed `unknownOutcome` effects carry a retained request key, environment ID, cancellation target where relevant, and typed failure (no full request payload). They preserve reconciliation context even if the consumer already observed a failure. The owner must retain/process these with bounded storage; they are not raw diagnostics.

## Bounds and fault handling

- At most **64 outstanding requests**, **64 pre-acceptance IDs**, and **16 pending events per ID**, reserving one slot for the first terminal event.
- A pending-ID overflow returns a retirement effect and typed unknown outcomes instead of silently losing a terminal event. New admission is refused while retiring; late owning replies are still processed, never re-accepted as live work.
- A **1,024-admission connection budget** bounds retired-ID history too. Planned budget rotation waits for idle and never retries sent work. Fault retirement is separate and immediate.
- Unknown/late events have no pending buffer without an eligible unanswered operation request. Completed/abandoned IDs cannot start a new buffer while another reply is pending.

## Deliberate boundary / remaining work

This is an internal, serial-owner state component. It performs **no native send, cancellation or connection retirement itself**. Effects describe work for the owning client.

The remaining migration must supply one **bounded, ordered callback inbox**, actual native-client ownership, reply/deadline cleanup, safe effect execution outside transport callback locks, and bounded reconciliation retention. Registration is not send authority: the owner validates requests before admission. This PR does not expose RuntimeBackend mutations or complete those integration requirements.

The GUI/service stay runtimeVersion-only on epoch **12**. No protocol change, provider/backend activation, process execution, raw diagnostic output, signing/host/VM setup or hardware claim.

## Validation

- Full strict package hook: **452 test functions** — Core 392/35 suites, RuntimeKit 14/2, ClientKit 46/5; warnings as errors.
- **13 new routing tests**, with parameterized six-way 10,000-event floods, acceptance/terminal order, environment filtering, expected/foreign reply shapes, request/lifetime bounds, pending-ID overflow and late reconciliation after observed failure, replacement-generation ordering, retired owning replies, abandonment timing and duplicate acceptance.
- Routing suite passed **Release and five consecutive Debug runs**.
- Seven CI-hook scenarios and the final unsigned shared-scheme `build-for-testing` passed. No app was launched; no new Swift/C warnings.
- **516 additions/two files**, diff check clean.

## Review follow-up

Both P2 findings are fixed together in `6f668270`: a duplicate acceptance with a different ID emits a separate uncertainty effect before retirement, preserving the original consumer's first ID; pre-acceptance uncertainty retains distinct request/environment/cancellation-target context. Deterministic regressions cover both cases, including two pending environments and a pending cancel request. All validation above was rerun on the corrected source. No raw request fields or diagnostic attachments were introduced.

Fresh Xcode Cloud and a matching completed Codex review with original-message 👍 are required; local tests are not approval or signed-boundary evidence.
