### PR TITLE
Bound ordered runtime callback ingress and preserve reply capacity

### DIFF
--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
@@ -15,16 +15,21 @@ final class RuntimeClientInbox: Sendable {
     enum Message: Sendable {
         case send(Submission)
         case reply(RuntimeRequestKey, Result<RuntimeEvent, RuntimeSessionFailure>)
+        /// Reconcile directly: the normal router/consumer may already have finished.
+        case unexpectedReply(RuntimeEventRouter.UncertainRequest)
         case ended(RuntimeRequestKey, RuntimeEventStream.Termination)
         case incoming(RuntimeEvent), interrupted(RuntimeSessionFailure)
         /// Stops admission permanently. The owner must retire and reconcile, not replay.
         case fault(RuntimeSessionFailure.Cause)
     }
     enum Admission: Equatable, Sendable { case admitted, full, faulted }
+    typealias Reply = @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
     private struct Reservation: Sendable {
+        let context: RuntimeEventRouter.UncertainRequest
         var sendTaken = false, replyQueued = false, replyTaken = false
         var endQueued = false, endTaken = false, duplicateQueued = false, duplicateTaken = true
-        var complete: Bool { sendTaken && replyTaken && endTaken && duplicateTaken }
+        var handlerIssued = false, replyWindowClosed = false
+        var complete: Bool { sendTaken && replyTaken && endTaken && duplicateTaken && replyWindowClosed }
     }
     private struct State: Sendable {
         var requests: [RuntimeRequestKey: Reservation] = [:]
@@ -61,7 +66,10 @@ final class RuntimeClientInbox: Sendable {
         let result = state.withLock { state in
             guard state.fault == nil else { return Admission.faulted }
             guard state.requests.count < Self.requestLimit, state.requests[submission.key] == nil else { return .full }
-            state.requests[submission.key] = Reservation()
+            let request = submission.request
+            state.requests[submission.key] = Reservation(context: .init(key: submission.key,
+                environmentID: request.environment, cancellationTarget: request.cancellationTarget,
+                failure: .init(cause: .malformedResponse, mayHaveMutated: request.mayMutate)))
             state.queue.append(.send(submission))
             return .admitted
         }
@@ -69,16 +77,36 @@ final class RuntimeClientInbox: Sendable {
         return result
     }
 
-    /// Only the request's owning transport callback, never unsolicited wire traffic.
-    /// The first reply remains enqueueable after overflow/consumer abandonment. One unexpected
-    /// duplicate is retained too, for the router's second-ID reconciliation, then ingress faults.
-    func replied(_ key: RuntimeRequestKey, _ result: Result<RuntimeEvent, RuntimeSessionFailure>) {
+    /// Transfer this closure to the owning transport call; do not retain a separate copy.
+    /// Its capture lifetime closes the duplicate window, including after the consumer finished.
+    /// Only one handler may be issued per reservation. No arbitrary timer/tombstone history.
+    /// Keep it alive through the send's catch path until any known-unsent rejection is recorded.
+    func replyHandler(for key: RuntimeRequestKey) -> Reply? {
+        let issued = state.withLock { state in
+            guard var reservation = state.requests[key], !reservation.handlerIssued, !reservation.replyQueued else { return false }
+            reservation.handlerIssued = true; state.requests[key] = reservation
+            return true
+        }
+        guard issued else { return nil }
+        let lifetime = ReplyLifetime(inbox: self, key: key)
+        return { lifetime.inbox.replied(lifetime.key, $0) }
+    }
+
+    private func replied(_ key: RuntimeRequestKey, _ result: Result<RuntimeEvent, RuntimeSessionFailure>) {
         state.withLock { state in
             guard var reservation = state.requests[key] else { return }
             if reservation.replyQueued {
                 if !reservation.duplicateQueued {
                     reservation.duplicateQueued = true; reservation.duplicateTaken = false
-                    state.queue.append(.reply(key, result))
+                    let id: OperationID?, additionalUncertainty: Bool
+                    switch result {
+                    case .success(let event): id = event.routingID; additionalUncertainty = false
+                    case .failure(let failure): id = failure.operationID; additionalUncertainty = failure.mayHaveMutated
+                    }
+                    let context = reservation.context
+                    state.queue.append(.unexpectedReply(.init(key: key, environmentID: context.environmentID,
+                        cancellationTarget: context.cancellationTarget,
+                        failure: context.failure.contextualized(operationID: id, mayHaveMutated: additionalUncertainty))))
                 }
                 state.fail(.malformedResponse)
             } else {
@@ -86,6 +114,22 @@ final class RuntimeClientInbox: Sendable {
                 state.queue.append(.reply(key, result))
             }
             state.requests[key] = reservation
+        }
+        wake.yield(())
+    }
+
+    private func replyWindowClosed(_ key: RuntimeRequestKey) {
+        state.withLock { state in
+            guard var reservation = state.requests[key] else { return }
+            reservation.replyWindowClosed = true
+            if !reservation.replyQueued {
+                // No closure remains that can supply a later reply. Settle an unanswered
+                // invocation conservatively; known-unsent rejection must be recorded first.
+                reservation.replyQueued = true
+                state.queue.append(.reply(key, .failure(.init(cause: .connectionLost))))
+            }
+            if reservation.complete { state.requests.removeValue(forKey: key) }
+            else { state.requests[key] = reservation }
         }
         wake.yield(())
     }
@@ -135,6 +179,7 @@ final class RuntimeClientInbox: Sendable {
         state.withLock { state in
             guard var reservation = state.requests[key], reservation.sendTaken, !reservation.replyQueued else { return }
             reservation.replyQueued = true; reservation.replyTaken = true
+            if !reservation.handlerIssued { reservation.replyWindowClosed = true }
             if reservation.complete { state.requests.removeValue(forKey: key) }
             else { state.requests[key] = reservation }
         }
@@ -150,10 +195,8 @@ final class RuntimeClientInbox: Sendable {
             switch message {
             case .send(let submission):
                 key = submission.key; state.requests[submission.key]?.sendTaken = true
-            case .reply(let id, _):
-                key = id
-                if state.requests[id]?.replyTaken == false { state.requests[id]?.replyTaken = true }
-                else { state.requests[id]?.duplicateTaken = true }
+            case .reply(let id, _): key = id; state.requests[id]?.replyTaken = true
+            case .unexpectedReply(let context): key = context.key; state.requests[context.key]?.duplicateTaken = true
             case .ended(let id, _): key = id; state.requests[id]?.endTaken = true
             case .incoming: key = nil; state.incomingCount -= 1
             case .interrupted: key = nil; state.interruptionCount -= 1
@@ -162,6 +205,11 @@ final class RuntimeClientInbox: Sendable {
             if let key, state.requests[key]?.complete == true { state.requests.removeValue(forKey: key) }
             return message
         }
+    }
+    private final class ReplyLifetime: Sendable {
+        let inbox: RuntimeClientInbox, key: RuntimeRequestKey
+        init(inbox: RuntimeClientInbox, key: RuntimeRequestKey) { self.inbox = inbox; self.key = key }
+        deinit { inbox.replyWindowClosed(key) } // Enqueue/bookkeeping only, even on a native callback thread.
     }
 }
 

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
@@ -26,6 +26,7 @@ final class RuntimeClientInbox: Sendable {
     typealias Reply = @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
     private struct Reservation: Sendable {
         let context: RuntimeEventRouter.UncertainRequest
+        var firstReplyID: OperationID?
         var sendTaken = false, replyQueued = false, replyTaken = false
         var endQueued = false, endTaken = false, duplicateQueued = false, duplicateTaken = true
         var handlerIssued = false, replyWindowClosed = false
@@ -93,33 +94,40 @@ final class RuntimeClientInbox: Sendable {
     }
 
     private func replied(_ key: RuntimeRequestKey, _ result: Result<RuntimeEvent, RuntimeSessionFailure>) {
-        state.withLock { state in
+        enqueue { state in
             guard var reservation = state.requests[key] else { return }
             if reservation.replyQueued {
                 if !reservation.duplicateQueued {
-                    reservation.duplicateQueued = true; reservation.duplicateTaken = false
                     let id: OperationID?, additionalUncertainty: Bool
                     switch result {
-                    case .success(let event): id = event.routingID; additionalUncertainty = false
+                    case .success(.accepted(let accepted)): id = accepted; additionalUncertainty = false
+                    case .success: id = nil; additionalUncertainty = false
+                    // Retirement converts a late acceptance into a failure retaining its ID.
                     case .failure(let failure): id = failure.operationID; additionalUncertainty = failure.mayHaveMutated
                     }
-                    let context = reservation.context
-                    state.queue.append(.unexpectedReply(.init(key: key, environmentID: context.environmentID,
-                        cancellationTarget: context.cancellationTarget,
-                        failure: context.failure.contextualized(operationID: id, mayHaveMutated: additionalUncertainty))))
+                    if let id, id != reservation.firstReplyID {
+                        reservation.duplicateQueued = true; reservation.duplicateTaken = false
+                        let context = reservation.context
+                        state.queue.append(.unexpectedReply(.init(key: key, environmentID: context.environmentID,
+                            cancellationTarget: context.cancellationTarget,
+                            failure: context.failure.contextualized(operationID: id, mayHaveMutated: additionalUncertainty))))
+                    }
                 }
                 state.fail(.malformedResponse)
             } else {
                 reservation.replyQueued = true
+                switch result {
+                case .success(let event): reservation.firstReplyID = event.routingID
+                case .failure(let failure): reservation.firstReplyID = failure.operationID
+                }
                 state.queue.append(.reply(key, result))
             }
             state.requests[key] = reservation
         }
-        wake.yield(())
     }
 
     private func replyWindowClosed(_ key: RuntimeRequestKey) {
-        state.withLock { state in
+        enqueue { state in
             guard var reservation = state.requests[key] else { return }
             reservation.replyWindowClosed = true
             if !reservation.replyQueued {
@@ -127,24 +135,23 @@ final class RuntimeClientInbox: Sendable {
                 // invocation conservatively; known-unsent rejection must be recorded first.
                 reservation.replyQueued = true
                 state.queue.append(.reply(key, .failure(.init(cause: .connectionLost))))
+                state.fail(.connectionLost) // Do not admit more sends on a broken reply contract.
             }
             if reservation.complete { state.requests.removeValue(forKey: key) }
             else { state.requests[key] = reservation }
         }
-        wake.yield(())
     }
 
     func ended(_ key: RuntimeRequestKey, _ reason: RuntimeEventStream.Termination) {
-        state.withLock { state in
+        enqueue { state in
             guard var reservation = state.requests[key], !reservation.endQueued else { return }
             reservation.endQueued = true; state.requests[key] = reservation
             state.queue.append(.ended(key, reason))
         }
-        wake.yield(())
     }
 
     func incoming(_ event: RuntimeEvent) {
-        state.withLock { state in
+        enqueue { state in
             guard state.fault == nil else { return }
             if event.droppable, state.incomingCount >= Self.trafficLimit {
                 if state.dropped < Int.max { state.dropped += 1 }
@@ -153,24 +160,31 @@ final class RuntimeClientInbox: Sendable {
             guard state.incomingCount < Self.incomingLimit else { state.fail(.oversizedResponse); return }
             state.incomingCount += 1; state.queue.append(.incoming(event))
         }
-        wake.yield(())
     }
 
     func interrupted(_ failure: RuntimeSessionFailure) {
-        state.withLock { state in
+        enqueue { state in
             guard state.fault == nil else { return }
             guard state.interruptionCount < Self.interruptionLimit else { state.fail(.oversizedResponse); return }
             state.interruptionCount += 1
             // A generation-wide notification must not acquire one request's identity.
             state.queue.append(.interrupted(.init(cause: failure.cause)))
         }
-        wake.yield(())
     }
 
     /// Owner-side timeout/fatal error. Awaiting replies still have their reserved slots.
     func fail(_ cause: RuntimeSessionFailure.Cause) {
-        state.withLock { $0.fail(cause) }
-        wake.yield(())
+        enqueue { $0.fail(cause) }
+    }
+
+    /// Only appended work wakes the owner, never discarded traffic or bookkeeping alone.
+    private func enqueue(_ update: (inout State) -> Void) {
+        let appended = state.withLock { state in
+            let before = state.queue.count
+            update(&state)
+            return state.queue.count > before
+        }
+        if appended { wake.yield(()) }
     }
 
     /// Only after dequeuing a send that is KNOWN not to have reached native send. Marks its

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
@@ -1,0 +1,172 @@
+import GuesthouseCore
+import Synchronization
+
+/// Ordered callback handoff for the retained #67/#103 client (MVP-PLAN.md §3).
+/// Reserve before native send. Every admitted request has independent space for its send,
+/// owning reply and consumer-end notification; unsolicited traffic cannot consume it.
+/// Callbacks only enqueue. ONE owner drains `take()` after each payload-free wakeup and
+/// runs router/native effects outside callback locks. No tasks or native calls live here.
+final class RuntimeClientInbox: Sendable {
+    struct Submission: Sendable {
+        let key: RuntimeRequestKey
+        let request: RuntimeRequest
+        let producer: RuntimeEventStream
+    }
+    enum Message: Sendable {
+        case send(Submission)
+        case reply(RuntimeRequestKey, Result<RuntimeEvent, RuntimeSessionFailure>)
+        case ended(RuntimeRequestKey, RuntimeEventStream.Termination)
+        case incoming(RuntimeEvent), interrupted(RuntimeSessionFailure)
+        /// Stops admission permanently. The owner must retire and reconcile, not replay.
+        case fault(RuntimeSessionFailure.Cause)
+    }
+    enum Admission: Equatable, Sendable { case admitted, full, faulted }
+    private struct Reservation: Sendable {
+        var sendTaken = false, replyQueued = false, replyTaken = false
+        var endQueued = false, endTaken = false, duplicateQueued = false, duplicateTaken = true
+        var complete: Bool { sendTaken && replyTaken && endTaken && duplicateTaken }
+    }
+    private struct State: Sendable {
+        var requests: [RuntimeRequestKey: Reservation] = [:]
+        var queue: [Message] = []
+        var incomingCount = 0, interruptionCount = 0
+        var fault: RuntimeSessionFailure.Cause?
+        var dropped = 0
+        mutating func fail(_ cause: RuntimeSessionFailure.Cause) {
+            guard fault == nil else { return }
+            fault = cause; queue.append(.fault(cause)) // One reserved fault slot.
+        }
+    }
+    static let requestLimit = RuntimeEventRouter.requestLimit
+    static let incomingLimit = 128, trafficLimit = 96, interruptionLimit = 16
+    // Three normal controls + one defensive duplicate per reservation, plus bounded pushes,
+    // interruptions and ONE fault. Request payload sizes are validated before reservation.
+    static let queueLimit = requestLimit * 4 + incomingLimit + interruptionLimit + 1
+    private let state = Mutex(State())
+    let wakeups: AsyncStream<Void>
+    private let wake: AsyncStream<Void>.Continuation
+
+    init() { (wakeups, wake) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1)) }
+    deinit { wake.finish() }
+    var queuedCount: Int { state.withLock { $0.queue.count } }
+    var reservationCount: Int { state.withLock { $0.requests.count } }
+    var droppedTraffic: Int { state.withLock { $0.dropped } }
+    /// Owner checks before executing queued sends: reject known-unsent work after a fault.
+    /// A fault racing an actual send still requires retirement/reconciliation, never replay.
+    var terminalFailure: RuntimeSessionFailure.Cause? { state.withLock { $0.fault } }
+
+    /// Caller validates the request and encoded size first. Refusal remains known-unsent:
+    /// caller owns and rejects the producer, outside this lock. This is not router admission.
+    func submit(_ submission: Submission) -> Admission {
+        let result = state.withLock { state in
+            guard state.fault == nil else { return Admission.faulted }
+            guard state.requests.count < Self.requestLimit, state.requests[submission.key] == nil else { return .full }
+            state.requests[submission.key] = Reservation()
+            state.queue.append(.send(submission))
+            return .admitted
+        }
+        if result == .admitted { wake.yield(()) }
+        return result
+    }
+
+    /// Only the request's owning transport callback, never unsolicited wire traffic.
+    /// The first reply remains enqueueable after overflow/consumer abandonment. One unexpected
+    /// duplicate is retained too, for the router's second-ID reconciliation, then ingress faults.
+    func replied(_ key: RuntimeRequestKey, _ result: Result<RuntimeEvent, RuntimeSessionFailure>) {
+        state.withLock { state in
+            guard var reservation = state.requests[key] else { return }
+            if reservation.replyQueued {
+                if !reservation.duplicateQueued {
+                    reservation.duplicateQueued = true; reservation.duplicateTaken = false
+                    state.queue.append(.reply(key, result))
+                }
+                state.fail(.malformedResponse)
+            } else {
+                reservation.replyQueued = true
+                state.queue.append(.reply(key, result))
+            }
+            state.requests[key] = reservation
+        }
+        wake.yield(())
+    }
+
+    func ended(_ key: RuntimeRequestKey, _ reason: RuntimeEventStream.Termination) {
+        state.withLock { state in
+            guard var reservation = state.requests[key], !reservation.endQueued else { return }
+            reservation.endQueued = true; state.requests[key] = reservation
+            state.queue.append(.ended(key, reason))
+        }
+        wake.yield(())
+    }
+
+    func incoming(_ event: RuntimeEvent) {
+        state.withLock { state in
+            guard state.fault == nil else { return }
+            if event.droppable, state.incomingCount >= Self.trafficLimit {
+                if state.dropped < Int.max { state.dropped += 1 }
+                return
+            }
+            guard state.incomingCount < Self.incomingLimit else { state.fail(.oversizedResponse); return }
+            state.incomingCount += 1; state.queue.append(.incoming(event))
+        }
+        wake.yield(())
+    }
+
+    func interrupted(_ failure: RuntimeSessionFailure) {
+        state.withLock { state in
+            guard state.fault == nil else { return }
+            guard state.interruptionCount < Self.interruptionLimit else { state.fail(.oversizedResponse); return }
+            state.interruptionCount += 1
+            // A generation-wide notification must not acquire one request's identity.
+            state.queue.append(.interrupted(.init(cause: failure.cause)))
+        }
+        wake.yield(())
+    }
+
+    /// Owner-side timeout/fatal error. Awaiting replies still have their reserved slots.
+    func fail(_ cause: RuntimeSessionFailure.Cause) {
+        state.withLock { $0.fail(cause) }
+        wake.yield(())
+    }
+
+    /// Only after dequeuing a send that is KNOWN not to have reached native send. Marks its
+    /// nonexistent callback settled; never use this to erase an ambiguous/late owning reply.
+    func rejectedBeforeSend(_ key: RuntimeRequestKey) {
+        state.withLock { state in
+            guard var reservation = state.requests[key], reservation.sendTaken, !reservation.replyQueued else { return }
+            reservation.replyQueued = true; reservation.replyTaken = true
+            if reservation.complete { state.requests.removeValue(forKey: key) }
+            else { state.requests[key] = reservation }
+        }
+    }
+
+    /// Single-consumer drain. Returning the message transfers its lifetime OUT of the lock.
+    /// Taking an end notice does not release a still-pending owning reply reservation.
+    func take() -> Message? {
+        state.withLock { state in
+            guard !state.queue.isEmpty else { return nil }
+            let message = state.queue.removeFirst()
+            let key: RuntimeRequestKey?
+            switch message {
+            case .send(let submission):
+                key = submission.key; state.requests[submission.key]?.sendTaken = true
+            case .reply(let id, _):
+                key = id
+                if state.requests[id]?.replyTaken == false { state.requests[id]?.replyTaken = true }
+                else { state.requests[id]?.duplicateTaken = true }
+            case .ended(let id, _): key = id; state.requests[id]?.endTaken = true
+            case .incoming: key = nil; state.incomingCount -= 1
+            case .interrupted: key = nil; state.interruptionCount -= 1
+            case .fault: key = nil
+            }
+            if let key, state.requests[key]?.complete == true { state.requests.removeValue(forKey: key) }
+            return message
+        }
+    }
+}
+
+private extension RuntimeEvent {
+    var droppable: Bool {
+        switch self { case .progress, .diagnostic, .status: true; default: false }
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -191,6 +191,9 @@ struct RuntimeEventRouter: Sendable {
         failure.outcomeUnknown ? [.unknownOutcome(.init(key: entry.key, environmentID: entry.request.environment,
             cancellationTarget: entry.request.cancellationTarget, failure: failure))] : []
     }
+    /// Owner-side inbox overflow/deadline: end consumers, but retain pending owning replies.
+    mutating func invalidate(_ cause: RuntimeSessionFailure.Cause) -> [Effect] { fault(cause) }
+
     private mutating func fault(_ cause: RuntimeSessionFailure.Cause) -> [Effect] {
         guard !requiresRetirement else { return [] }
         requiresRetirement = true; pending.removeAll()

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -208,7 +208,7 @@ struct RuntimeEventRouter: Sendable {
     }
 }
 
-private extension RuntimeRequest {
+extension RuntimeRequest {
     var mayMutate: Bool {
         switch self { case .runtimeVersion, .environmentStatus: false; default: true }
     }
@@ -238,7 +238,7 @@ private extension RuntimeRequest {
         }
     }
 }
-private extension RuntimeEvent {
+extension RuntimeEvent {
     var routingID: OperationID? {
         switch self {
         case .accepted(let id), .progress(let id, _), .completed(let id), .failed(let id, _): id

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
@@ -6,7 +6,7 @@ import Testing
 @testable import GuesthouseClientKit
 
 @Suite(.timeLimit(.minutes(1))) struct RuntimeClientInboxTests {
-    static let id = OperationID(), environment = EnvironmentID()
+    static let id = OperationID(), otherID = OperationID(), environment = EnvironmentID()
     static let traffic: [RuntimeEvent] = [
         .progress(id, .init(kind: .copying)),
         .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: id.uuid)),
@@ -174,6 +174,28 @@ import Testing
         #expect(count == 1)
     }
 
+    @Test(arguments: traffic, [false, true])
+    func discardedCallbacksDoNotLeaveAnotherWakeup(traffic: RuntimeEvent, faulted: Bool) async throws {
+        var inbox: RuntimeClientInbox? = RuntimeClientInbox()
+        for _ in 0..<RuntimeClientInbox.trafficLimit { inbox?.incoming(traffic) }
+        if faulted { inbox?.fail(.connectionLost) }
+        var iterator = try #require(inbox).wakeups.makeAsyncIterator()
+        try #require(await iterator.next() != nil) // Consume the admitted work's coalesced signal.
+        let unknown = RuntimeRequestKey()
+        for _ in 0..<10_000 {
+            inbox?.incoming(traffic)
+            inbox?.ended(unknown, .finished)
+            if faulted {
+                inbox?.incoming(.completed(Self.id))
+                inbox?.interrupted(.init(cause: .connectionLost))
+                inbox?.fail(.connectionLost)
+            }
+        }
+        #expect(inbox?.queuedCount == RuntimeClientInbox.trafficLimit + (faulted ? 1 : 0))
+        inbox = nil // Finish deterministically; no sleep or timeout to prove absence of signals.
+        #expect(await iterator.next() == nil)
+    }
+
     @Test func concurrentEnqueueAndDrainDoNotLoseWakeupsOrReservations() async throws {
         let inbox = RuntimeClientInbox()
         let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
@@ -222,17 +244,58 @@ import Testing
         #expect(inbox.reservationCount == 0)
     }
 
-    @Test func discardedUnansweredHandlerSettlesItsOwningReply() throws {
+    static let duplicateReplies: [(Result<RuntimeEvent, RuntimeSessionFailure>, Bool)] = [
+        (.success(.accepted(id)), false), (.success(.accepted(otherID)), true),
+        (.success(.completed(otherID)), false), (.success(.progress(otherID, .init(kind: .copying))), false),
+        (.success(.failed(otherID, .invalidRequest(.malformed))), false),
+        (.success(.diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: otherID.uuid))), false),
+        (.success(.status(.init(environmentID: environment, vm: .running, readiness: .checking, inFlightOperation: otherID))), false),
+        (.failure(.init(cause: .connectionLost, mayHaveMutated: true)), false),
+        (.failure(.init(cause: .connectionLost, operationID: id, mayHaveMutated: true)), false),
+        (.failure(.init(cause: .connectionLost, operationID: otherID, mayHaveMutated: true)), true),
+    ]
+
+    @Test(arguments: duplicateReplies, [false, true])
+    func duplicateReconciliationRequiresAnAdditionalUncertainID(
+        duplicate: (Result<RuntimeEvent, RuntimeSessionFailure>, Bool), firstFailed: Bool
+    ) throws {
+        let inbox = RuntimeClientInbox(), fixture = try reserve(inbox)
+        _ = inbox.take()
+        fixture.answer(firstFailed ? .failure(.init(cause: .connectionLost, operationID: Self.id, mayHaveMutated: true))
+                                   : .success(.accepted(Self.id)))
+        _ = inbox.take(); inbox.ended(fixture.key, .finished); _ = inbox.take()
+        fixture.answer(duplicate.0)
+        if duplicate.1 {
+            guard case .unexpectedReply(let context) = inbox.take() else { Issue.record("Missing additional identity"); return }
+            #expect(context.failure.operationID == Self.otherID && context.key === fixture.key)
+        }
+        guard case .fault(.malformedResponse) = inbox.take() else { Issue.record("Missing duplicate fault"); return }
+        #expect(inbox.take() == nil) // No uncertainty for repeated IDs or non-acceptance events.
+        fixture.releaseReply()
+        #expect(inbox.reservationCount == 0)
+    }
+
+    @Test func discardedUnansweredHandlerSettlesItsOwningReplyAndRequiresRetirement() async throws {
         let inbox = RuntimeClientInbox(), fixture = try reserve(inbox: nil)
         try #require(inbox.submit(fixture.submission) == .admitted)
         try fixture.prepareReply(inbox)
         #expect(inbox.replyHandler(for: fixture.key) == nil)
-        _ = inbox.take()
+        guard case .send(let submission) = inbox.take() else { Issue.record("Missing send"); return }
+        var router = RuntimeEventRouter()
+        try #require(router.register(submission.key, request: submission.request, producer: submission.producer) == .admitted)
         fixture.releaseReply() // No closure remains that could provide a later response.
+        #expect(inbox.terminalFailure == .connectionLost && inbox.submit(InboxFixture().submission) == .faulted)
         guard case .reply(let key, .failure(let failure)) = inbox.take() else { Issue.record("Missing failure"); return }
         #expect(key === fixture.key && failure == RuntimeSessionFailure(cause: .connectionLost))
+        #expect(router.reply(.failure(failure), to: key) == [.unknownOutcome(.init(key: key, environmentID: Self.environment,
+            cancellationTarget: nil, failure: failure.contextualized(mayHaveMutated: true)))])
+        guard case .fault(let cause) = inbox.take() else { Issue.record("Missing retirement fault"); return }
+        #expect(router.invalidate(cause) == [.retireConnection])
+        var iterator = fixture.stream.makeAsyncIterator()
+        await #expect(throws: failure.contextualized(mayHaveMutated: true)) { try await iterator.next() }
         inbox.ended(key, .finished); _ = inbox.take()
         #expect(inbox.reservationCount == 0)
+        #expect(inbox.submit(InboxFixture().submission) == .faulted)
     }
 
     @Test(arguments: [false, true])
@@ -272,6 +335,26 @@ import Testing
         #expect(inbox.reservationCount == 0)
         withExtendedLifetime(client) {}
     }
+
+    @Test func retiredDuplicateAcceptanceKeepsItsTransportFailureIdentity() throws {
+        let inbox = RuntimeClientInbox(), fixture = InboxFixture()
+        let client = XPCRuntimeTransport(incoming: { inbox.incoming($0) }, interrupted: { inbox.interrupted($0) }, connect: { incoming, dropped in
+            InboxSession(id: Self.id, terminal: false, duplicateAfterDrop: Self.otherID, incoming: incoming, dropped: dropped)
+        })
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        _ = inbox.take()
+        try client.send(.init(request: fixture.submission.request), reply: #require(inbox.replyHandler(for: fixture.key)))
+        guard case .reply(_, .success(.accepted(Self.id))) = inbox.take() else { Issue.record("Missing first reply"); return }
+        guard case .interrupted = inbox.take() else { Issue.record("Missing retirement"); return }
+        // The real registry converted the second acceptance to a request-specific failure.
+        guard case .unexpectedReply(let context) = inbox.take() else { Issue.record("Lost retired acceptance ID"); return }
+        #expect(context == .init(key: fixture.key, environmentID: Self.environment, cancellationTarget: nil,
+            failure: .init(cause: .malformedResponse, operationID: Self.otherID, mayHaveMutated: true)))
+        guard case .fault(.malformedResponse) = inbox.take() else { Issue.record("Missing duplicate fault"); return }
+        inbox.ended(fixture.key, .finished); _ = inbox.take()
+        #expect(inbox.reservationCount == 0 && inbox.take() == nil)
+        withExtendedLifetime(client) {}
+    }
 }
 
 private final class InboxFixture: Sendable {
@@ -307,11 +390,14 @@ private func reserve(inbox: RuntimeClientInbox?, handler: Bool = true) throws ->
 }
 private final class InboxSession: RuntimeClientSession {
     let id: OperationID, terminal: Bool
+    let duplicateAfterDrop: OperationID?
     let incoming: @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
     let dropped: @Sendable () -> Void
-    init(id: OperationID, terminal: Bool, incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+    init(id: OperationID, terminal: Bool, duplicateAfterDrop: OperationID? = nil,
+         incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
          dropped: @escaping @Sendable () -> Void) {
         self.id = id; self.terminal = terminal; self.incoming = incoming; self.dropped = dropped
+        self.duplicateAfterDrop = duplicateAfterDrop
     }
     func activate() {}
     func cancel() { dropped() } // Synchronous reentry exercises registry cleanup outside its delivery lock.
@@ -319,5 +405,6 @@ private final class InboxSession: RuntimeClientSession {
         reply(.success(.accepted(id)))
         if terminal { incoming(.success(.completed(id))) }
         dropped()
+        if let duplicateAfterDrop { reply(.success(.accepted(duplicateAfterDrop))) }
     }
 }

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
@@ -1,0 +1,272 @@
+import Dispatch
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeClientInboxTests {
+    static let id = OperationID(), environment = EnvironmentID()
+    static let traffic: [RuntimeEvent] = [
+        .progress(id, .init(kind: .copying)),
+        .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: id.uuid)),
+        .status(.init(environmentID: environment, vm: .running, readiness: .checking)),
+    ]
+
+    @Test(arguments: traffic)
+    func progressFloodCannotConsumeOwningReplyOrEndSlots(traffic: RuntimeEvent) throws {
+        let inbox = RuntimeClientInbox()
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        for _ in 0..<10_000 { inbox.incoming(traffic) }
+        for fixture in fixtures {
+            inbox.replied(fixture.key, .success(.accepted(Self.id)))
+            inbox.ended(fixture.key, .abandoned)
+        }
+        #expect(inbox.queuedCount == fixtures.count * 3 + RuntimeClientInbox.trafficLimit)
+        #expect(inbox.droppedTraffic == 10_000 - RuntimeClientInbox.trafficLimit)
+        var sends = 0, replies = 0, ends = 0, events = 0
+        while let message = inbox.take() {
+            switch message {
+            case .send: sends += 1
+            case .reply: replies += 1
+            case .ended: ends += 1
+            case .incoming: events += 1
+            default: Issue.record("Unexpected control message")
+            }
+        }
+        #expect(sends == fixtures.count && replies == fixtures.count && ends == fixtures.count)
+        #expect(events == RuntimeClientInbox.trafficLimit)
+        #expect(inbox.reservationCount == 0)
+        inbox.incoming(traffic)
+        #expect(inbox.queuedCount == 1) // Draining actually restores traffic capacity.
+    }
+
+    @Test func totalQueueIncludesBoundedControlsAndOneFault() throws {
+        let inbox = RuntimeClientInbox()
+        for _ in 0..<RuntimeClientInbox.incomingLimit { inbox.incoming(.completed(Self.id)) }
+        for _ in 0..<RuntimeClientInbox.interruptionLimit { inbox.interrupted(.init(cause: .connectionLost)) }
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        let duplicate = OperationID()
+        for fixture in fixtures {
+            inbox.replied(fixture.key, .success(.accepted(Self.id)))
+            inbox.replied(fixture.key, .success(.accepted(duplicate)))
+            inbox.ended(fixture.key, .abandoned)
+            for _ in 0..<100 {
+                inbox.replied(fixture.key, .success(.accepted(duplicate)))
+                inbox.ended(fixture.key, .abandoned)
+                inbox.incoming(.completed(Self.id))
+                inbox.interrupted(.init(cause: .connectionLost))
+            }
+        }
+        #expect(inbox.queuedCount == RuntimeClientInbox.queueLimit)
+        #expect(inbox.terminalFailure == .malformedResponse)
+        #expect(inbox.submit(fixtures[0].submission) == .faulted)
+        var replies = 0, faults = 0
+        while let message = inbox.take() {
+            switch message {
+            case .reply(_, .success(.accepted(let id))):
+                #expect(id == Self.id || id == duplicate); replies += 1
+            case .fault(let cause): #expect(cause == .malformedResponse); faults += 1
+            default: break
+            }
+        }
+        #expect(replies == fixtures.count * 2 && faults == 1)
+        #expect(inbox.reservationCount == 0)
+        #expect(inbox.submit(fixtures[0].submission) == .faulted) // Draining does not reopen a faulted inbox.
+    }
+
+    @Test func overflowAndAbandonmentKeepTheLateOwningIdentity() throws {
+        let inbox = RuntimeClientInbox(), fixture = try reserve(inbox: nil)
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        _ = inbox.take()
+        inbox.ended(fixture.key, .abandoned)
+        _ = inbox.take()
+        #expect(inbox.reservationCount == 1)
+        for _ in 0...RuntimeClientInbox.incomingLimit { inbox.incoming(.completed(Self.id)) }
+        var faulted = false
+        while let message = inbox.take() {
+            if case .fault(let cause) = message { #expect(cause == .oversizedResponse); faulted = true }
+        }
+        #expect(faulted)
+        inbox.replied(fixture.key, .success(.accepted(Self.id)))
+        guard case .reply(let key, .success(.accepted(let id))) = inbox.take() else {
+            Issue.record("Late owning acceptance was lost"); return
+        }
+        #expect(key === fixture.key && id == Self.id)
+        #expect(inbox.reservationCount == 0)
+    }
+
+    @Test func interruptionsStayOrderedAndNeverCarryAnotherRequestsIdentity() {
+        let inbox = RuntimeClientInbox()
+        for _ in 0..<RuntimeClientInbox.interruptionLimit {
+            inbox.interrupted(.init(cause: .protocolMismatch(service: 11), operationID: Self.id, mayHaveMutated: true))
+        }
+        inbox.interrupted(.init(cause: .connectionLost))
+        for _ in 0..<RuntimeClientInbox.interruptionLimit {
+            guard case .interrupted(let failure) = inbox.take() else { Issue.record("Lost interruption"); return }
+            #expect(failure == RuntimeSessionFailure(cause: .protocolMismatch(service: 11)))
+        }
+        guard case .fault(.oversizedResponse) = inbox.take() else { Issue.record("Missing overflow fault"); return }
+        #expect(inbox.take() == nil)
+    }
+
+    @Test func deadlineFaultStillReconcilesAnAcceptanceAfterObservedFailure() async throws {
+        let inbox = RuntimeClientInbox(), fixture = InboxFixture(notifying: nil)
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        guard case .send(let submission) = inbox.take() else { Issue.record("Missing send"); return }
+        var router = RuntimeEventRouter()
+        try #require(router.register(submission.key, request: submission.request, producer: submission.producer) == .admitted)
+        inbox.fail(.connectionLost)
+        guard case .fault(let cause) = inbox.take() else { Issue.record("Missing deadline fault"); return }
+        let early = router.invalidate(cause)
+        #expect(early.count == 2 && early.contains(.retireConnection))
+        let failure = RuntimeSessionFailure(cause: .connectionLost, mayHaveMutated: true)
+        var iterator = fixture.stream.makeAsyncIterator()
+        await #expect(throws: failure) { try await iterator.next() }
+        inbox.ended(fixture.key, .finished)
+        _ = inbox.take()
+        #expect(inbox.reservationCount == 1)
+        inbox.replied(fixture.key, .success(.accepted(Self.id)))
+        guard case .reply(let key, let result) = inbox.take() else { Issue.record("Missing late acceptance"); return }
+        #expect(router.reply(result, to: key) == [.unknownOutcome(.init(key: key, environmentID: Self.environment,
+            cancellationTarget: nil, failure: failure.contextualized(operationID: Self.id)))])
+        #expect(router.isIdle && inbox.reservationCount == 0)
+    }
+
+    @Test func admissionAndKnownUnsentRejectionReleaseOnlySettledReservations() throws {
+        let inbox = RuntimeClientInbox()
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        #expect(inbox.submit(fixtures[0].submission) == .full)
+        inbox.rejectedBeforeSend(fixtures[0].key) // Still queued: cannot prematurely settle it.
+        #expect(inbox.reservationCount == fixtures.count)
+        for fixture in fixtures {
+            guard case .send(let submission) = inbox.take() else { Issue.record("Lost send ordering"); return }
+            #expect(submission.key === fixture.key)
+            inbox.rejectedBeforeSend(fixture.key)
+        }
+        #expect(inbox.reservationCount == fixtures.count) // Consumers still own their end slots.
+        for fixture in fixtures { inbox.ended(fixture.key, .finished) }
+        while inbox.take() != nil {}
+        #expect(inbox.reservationCount == 0)
+        #expect(inbox.submit(fixtures[0].submission) == .admitted)
+    }
+
+    @Test func concurrentCallbacksReserveExactlyOnce() throws {
+        let inbox = RuntimeClientInbox()
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        DispatchQueue.concurrentPerform(iterations: fixtures.count) { index in
+            let fixture = fixtures[index]
+            inbox.replied(fixture.key, .success(.accepted(Self.id)))
+            inbox.ended(fixture.key, .abandoned)
+        }
+        #expect(inbox.queuedCount == fixtures.count * 3)
+        while inbox.take() != nil {}
+        #expect(inbox.reservationCount == 0)
+    }
+
+    @Test func wakeupStorageIsOnePayloadFreeSignalAndFinishesOnRelease() async throws {
+        var inbox: RuntimeClientInbox? = RuntimeClientInbox()
+        let wakeups = try #require(inbox).wakeups
+        for _ in 0..<10_000 { inbox?.incoming(Self.traffic[0]) }
+        weak let weakInbox = inbox
+        inbox = nil
+        #expect(weakInbox == nil)
+        var count = 0
+        for await _ in wakeups { count += 1 }
+        #expect(count == 1)
+    }
+
+    @Test func concurrentEnqueueAndDrainDoNotLoseWakeupsOrReservations() async throws {
+        let inbox = RuntimeClientInbox()
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        let reader = Task {
+            var count = 0
+            for await _ in inbox.wakeups {
+                while inbox.take() != nil {
+                    count += 1
+                    if count == RuntimeClientInbox.requestLimit * 3 { return count }
+                }
+            }
+            return count
+        }
+        defer { reader.cancel() }
+        DispatchQueue.concurrentPerform(iterations: fixtures.count) { index in
+            inbox.replied(fixtures[index].key, .success(.accepted(Self.id)))
+            inbox.ended(fixtures[index].key, .finished)
+        }
+        #expect(await reader.value == fixtures.count * 3)
+        #expect(inbox.reservationCount == 0 && inbox.queuedCount == 0)
+    }
+
+    @Test(arguments: [false, true])
+    func realTransportRegistryFeedsTheRouterInCallbackOrder(terminalBeforeDrop: Bool) async throws {
+        let inbox = RuntimeClientInbox()
+        let fixture = InboxFixture(notifying: inbox)
+        let client = XPCRuntimeTransport(incoming: { inbox.incoming($0) }, interrupted: { inbox.interrupted($0) }, connect: { incoming, dropped in
+            InboxSession(id: Self.id, terminal: terminalBeforeDrop, incoming: incoming, dropped: dropped)
+        })
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        var router = RuntimeEventRouter(), effects: [RuntimeEventRouter.Effect] = []
+        while let message = inbox.take() {
+            switch message {
+            case .send(let submission):
+                try #require(router.register(submission.key, request: submission.request, producer: submission.producer) == .admitted)
+                try client.send(.init(request: submission.request)) { inbox.replied(submission.key, $0) }
+            case .reply(let key, let result): effects += router.reply(result, to: key)
+            case .incoming(let event): effects += router.incoming(event)
+            case .interrupted(let failure): effects += router.interrupted(failure)
+            case .ended(let key, let reason): effects += router.consumerEnded(key, reason: reason)
+            case .fault: Issue.record("Unexpected fault")
+            }
+        }
+        var iterator = fixture.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        if terminalBeforeDrop {
+            #expect(try await iterator.next() == .completed(Self.id))
+            #expect(try await iterator.next() == nil)
+            #expect(effects.isEmpty)
+        } else {
+            let failure = RuntimeSessionFailure(cause: .connectionLost, operationID: Self.id, mayHaveMutated: true)
+            await #expect(throws: failure) { try await iterator.next() }
+            #expect(effects == [.unknownOutcome(.init(key: fixture.key, environmentID: Self.environment, cancellationTarget: nil, failure: failure))])
+        }
+        #expect(router.isIdle)
+        #expect(inbox.reservationCount == 0)
+        withExtendedLifetime(client) {}
+    }
+}
+
+private struct InboxFixture: Sendable {
+    let key = RuntimeRequestKey()
+    let producer: RuntimeEventStream
+    let stream: AsyncThrowingStream<RuntimeEvent, any Error>
+    var submission: RuntimeClientInbox.Submission {
+        .init(key: key, request: .startEnvironment(RuntimeClientInboxTests.environment, .init()), producer: producer)
+    }
+    init(notifying inbox: RuntimeClientInbox? = nil) {
+        let key = self.key
+        (producer, stream) = RuntimeEventStream.make(mayHaveMutated: true) { inbox?.ended(key, $0) }
+    }
+}
+private func reserve(_ inbox: RuntimeClientInbox) throws -> InboxFixture { try reserve(inbox: inbox) }
+private func reserve(inbox: RuntimeClientInbox?) throws -> InboxFixture {
+    let fixture = InboxFixture()
+    if let inbox { try #require(inbox.submit(fixture.submission) == .admitted) }
+    return fixture
+}
+private final class InboxSession: RuntimeClientSession {
+    let id: OperationID, terminal: Bool
+    let incoming: @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
+    let dropped: @Sendable () -> Void
+    init(id: OperationID, terminal: Bool, incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+         dropped: @escaping @Sendable () -> Void) {
+        self.id = id; self.terminal = terminal; self.incoming = incoming; self.dropped = dropped
+    }
+    func activate() {}
+    func cancel() { dropped() } // Synchronous reentry exercises registry cleanup outside its delivery lock.
+    func send(_ payload: Data, reply: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void) {
+        reply(.success(.accepted(id)))
+        if terminal { incoming(.success(.completed(id))) }
+        dropped()
+    }
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientInboxTests.swift
@@ -19,7 +19,7 @@ import Testing
         let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
         for _ in 0..<10_000 { inbox.incoming(traffic) }
         for fixture in fixtures {
-            inbox.replied(fixture.key, .success(.accepted(Self.id)))
+            fixture.answer(.success(.accepted(Self.id)))
             inbox.ended(fixture.key, .abandoned)
         }
         #expect(inbox.queuedCount == fixtures.count * 3 + RuntimeClientInbox.trafficLimit)
@@ -36,6 +36,9 @@ import Testing
         }
         #expect(sends == fixtures.count && replies == fixtures.count && ends == fixtures.count)
         #expect(events == RuntimeClientInbox.trafficLimit)
+        #expect(inbox.reservationCount == fixtures.count) // Callback captures still own the duplicate window.
+        #expect(inbox.submit(InboxFixture().submission) == .full)
+        for fixture in fixtures { fixture.releaseReply() }
         #expect(inbox.reservationCount == 0)
         inbox.incoming(traffic)
         #expect(inbox.queuedCount == 1) // Draining actually restores traffic capacity.
@@ -48,15 +51,16 @@ import Testing
         let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
         let duplicate = OperationID()
         for fixture in fixtures {
-            inbox.replied(fixture.key, .success(.accepted(Self.id)))
-            inbox.replied(fixture.key, .success(.accepted(duplicate)))
+            fixture.answer(.success(.accepted(Self.id)))
+            fixture.answer(.success(.accepted(duplicate)))
             inbox.ended(fixture.key, .abandoned)
             for _ in 0..<100 {
-                inbox.replied(fixture.key, .success(.accepted(duplicate)))
+                fixture.answer(.success(.accepted(duplicate)))
                 inbox.ended(fixture.key, .abandoned)
                 inbox.incoming(.completed(Self.id))
                 inbox.interrupted(.init(cause: .connectionLost))
             }
+            fixture.releaseReply()
         }
         #expect(inbox.queuedCount == RuntimeClientInbox.queueLimit)
         #expect(inbox.terminalFailure == .malformedResponse)
@@ -65,7 +69,8 @@ import Testing
         while let message = inbox.take() {
             switch message {
             case .reply(_, .success(.accepted(let id))):
-                #expect(id == Self.id || id == duplicate); replies += 1
+                #expect(id == Self.id); replies += 1
+            case .unexpectedReply(let context): #expect(context.failure.operationID == duplicate); replies += 1
             case .fault(let cause): #expect(cause == .malformedResponse); faults += 1
             default: break
             }
@@ -78,6 +83,7 @@ import Testing
     @Test func overflowAndAbandonmentKeepTheLateOwningIdentity() throws {
         let inbox = RuntimeClientInbox(), fixture = try reserve(inbox: nil)
         try #require(inbox.submit(fixture.submission) == .admitted)
+        try fixture.prepareReply(inbox)
         _ = inbox.take()
         inbox.ended(fixture.key, .abandoned)
         _ = inbox.take()
@@ -88,7 +94,8 @@ import Testing
             if case .fault(let cause) = message { #expect(cause == .oversizedResponse); faulted = true }
         }
         #expect(faulted)
-        inbox.replied(fixture.key, .success(.accepted(Self.id)))
+        fixture.answer(.success(.accepted(Self.id)))
+        fixture.releaseReply()
         guard case .reply(let key, .success(.accepted(let id))) = inbox.take() else {
             Issue.record("Late owning acceptance was lost"); return
         }
@@ -113,6 +120,7 @@ import Testing
     @Test func deadlineFaultStillReconcilesAnAcceptanceAfterObservedFailure() async throws {
         let inbox = RuntimeClientInbox(), fixture = InboxFixture(notifying: nil)
         try #require(inbox.submit(fixture.submission) == .admitted)
+        try fixture.prepareReply(inbox)
         guard case .send(let submission) = inbox.take() else { Issue.record("Missing send"); return }
         var router = RuntimeEventRouter()
         try #require(router.register(submission.key, request: submission.request, producer: submission.producer) == .admitted)
@@ -126,16 +134,18 @@ import Testing
         inbox.ended(fixture.key, .finished)
         _ = inbox.take()
         #expect(inbox.reservationCount == 1)
-        inbox.replied(fixture.key, .success(.accepted(Self.id)))
+        fixture.answer(.success(.accepted(Self.id)))
+        fixture.releaseReply()
         guard case .reply(let key, let result) = inbox.take() else { Issue.record("Missing late acceptance"); return }
         #expect(router.reply(result, to: key) == [.unknownOutcome(.init(key: key, environmentID: Self.environment,
             cancellationTarget: nil, failure: failure.contextualized(operationID: Self.id)))])
         #expect(router.isIdle && inbox.reservationCount == 0)
     }
 
-    @Test func admissionAndKnownUnsentRejectionReleaseOnlySettledReservations() throws {
+    @Test(arguments: [false, true])
+    func admissionAndKnownUnsentRejectionReleaseOnlySettledReservations(withHandler: Bool) throws {
         let inbox = RuntimeClientInbox()
-        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
+        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox: inbox, handler: withHandler) }
         #expect(inbox.submit(fixtures[0].submission) == .full)
         inbox.rejectedBeforeSend(fixtures[0].key) // Still queued: cannot prematurely settle it.
         #expect(inbox.reservationCount == fixtures.count)
@@ -143,25 +153,13 @@ import Testing
             guard case .send(let submission) = inbox.take() else { Issue.record("Lost send ordering"); return }
             #expect(submission.key === fixture.key)
             inbox.rejectedBeforeSend(fixture.key)
+            fixture.releaseReply()
         }
         #expect(inbox.reservationCount == fixtures.count) // Consumers still own their end slots.
         for fixture in fixtures { inbox.ended(fixture.key, .finished) }
         while inbox.take() != nil {}
         #expect(inbox.reservationCount == 0)
         #expect(inbox.submit(fixtures[0].submission) == .admitted)
-    }
-
-    @Test func concurrentCallbacksReserveExactlyOnce() throws {
-        let inbox = RuntimeClientInbox()
-        let fixtures = try (0..<RuntimeClientInbox.requestLimit).map { _ in try reserve(inbox) }
-        DispatchQueue.concurrentPerform(iterations: fixtures.count) { index in
-            let fixture = fixtures[index]
-            inbox.replied(fixture.key, .success(.accepted(Self.id)))
-            inbox.ended(fixture.key, .abandoned)
-        }
-        #expect(inbox.queuedCount == fixtures.count * 3)
-        while inbox.take() != nil {}
-        #expect(inbox.reservationCount == 0)
     }
 
     @Test func wakeupStorageIsOnePayloadFreeSignalAndFinishesOnRelease() async throws {
@@ -191,11 +189,50 @@ import Testing
         }
         defer { reader.cancel() }
         DispatchQueue.concurrentPerform(iterations: fixtures.count) { index in
-            inbox.replied(fixtures[index].key, .success(.accepted(Self.id)))
+            fixtures[index].answer(.success(.accepted(Self.id)))
             inbox.ended(fixtures[index].key, .finished)
+            fixtures[index].releaseReply()
         }
         #expect(await reader.value == fixtures.count * 3)
         #expect(inbox.reservationCount == 0 && inbox.queuedCount == 0)
+    }
+
+    @Test func completedConsumerStillRetainsTheDuplicateAcceptanceIdentity() async throws {
+        let inbox = RuntimeClientInbox(), secondID = OperationID()
+        let fixture = InboxFixture(notifying: inbox)
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        try fixture.prepareReply(inbox)
+        _ = inbox.take() // Send; the owner has registered it with the router.
+        fixture.answer(.success(.accepted(Self.id)))
+        _ = inbox.take()
+        fixture.producer.reply(.accepted(Self.id)); fixture.producer.push(.completed(Self.id))
+        _ = inbox.take() // Automatic consumer-end notice; normal routing has finished.
+        var iterator = fixture.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        #expect(try await iterator.next() == .completed(Self.id))
+        #expect(try await iterator.next() == nil)
+        #expect(inbox.reservationCount == 1)
+        fixture.answer(.success(.accepted(secondID)))
+        guard case .unexpectedReply(let context) = inbox.take() else { Issue.record("Lost second identity"); return }
+        #expect(context == .init(key: fixture.key, environmentID: Self.environment, cancellationTarget: nil,
+            failure: .init(cause: .malformedResponse, operationID: secondID, mayHaveMutated: true)))
+        guard case .fault(.malformedResponse) = inbox.take() else { Issue.record("Missing duplicate fault"); return }
+        #expect(try await iterator.next() == nil) // Do not rewrite the completed consumer.
+        fixture.releaseReply()
+        #expect(inbox.reservationCount == 0)
+    }
+
+    @Test func discardedUnansweredHandlerSettlesItsOwningReply() throws {
+        let inbox = RuntimeClientInbox(), fixture = try reserve(inbox: nil)
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        try fixture.prepareReply(inbox)
+        #expect(inbox.replyHandler(for: fixture.key) == nil)
+        _ = inbox.take()
+        fixture.releaseReply() // No closure remains that could provide a later response.
+        guard case .reply(let key, .failure(let failure)) = inbox.take() else { Issue.record("Missing failure"); return }
+        #expect(key === fixture.key && failure == RuntimeSessionFailure(cause: .connectionLost))
+        inbox.ended(key, .finished); _ = inbox.take()
+        #expect(inbox.reservationCount == 0)
     }
 
     @Test(arguments: [false, true])
@@ -211,11 +248,12 @@ import Testing
             switch message {
             case .send(let submission):
                 try #require(router.register(submission.key, request: submission.request, producer: submission.producer) == .admitted)
-                try client.send(.init(request: submission.request)) { inbox.replied(submission.key, $0) }
+                try client.send(.init(request: submission.request), reply: #require(inbox.replyHandler(for: submission.key)))
             case .reply(let key, let result): effects += router.reply(result, to: key)
             case .incoming(let event): effects += router.incoming(event)
             case .interrupted(let failure): effects += router.interrupted(failure)
             case .ended(let key, let reason): effects += router.consumerEnded(key, reason: reason)
+            case .unexpectedReply: Issue.record("Unexpected duplicate reply")
             case .fault: Issue.record("Unexpected fault")
             }
         }
@@ -236,22 +274,35 @@ import Testing
     }
 }
 
-private struct InboxFixture: Sendable {
-    let key = RuntimeRequestKey()
+private final class InboxFixture: Sendable {
+    let key: RuntimeRequestKey
     let producer: RuntimeEventStream
     let stream: AsyncThrowingStream<RuntimeEvent, any Error>
+    private let reply = Mutex<RuntimeClientInbox.Reply?>(nil)
     var submission: RuntimeClientInbox.Submission {
         .init(key: key, request: .startEnvironment(RuntimeClientInboxTests.environment, .init()), producer: producer)
     }
     init(notifying inbox: RuntimeClientInbox? = nil) {
-        let key = self.key
+        let key = RuntimeRequestKey(); self.key = key
         (producer, stream) = RuntimeEventStream.make(mayHaveMutated: true) { inbox?.ended(key, $0) }
+    }
+    func prepareReply(_ inbox: RuntimeClientInbox) throws {
+        let handler = try #require(inbox.replyHandler(for: key))
+        reply.withLock { $0 = handler }
+    }
+    func answer(_ result: Result<RuntimeEvent, RuntimeSessionFailure>) { reply.withLock { $0 }?(result) }
+    func releaseReply() {
+        let old = reply.withLock { value in let old = value; value = nil; return old }
+        withExtendedLifetime(old) {} // Release the callback outside the fixture lock too.
     }
 }
 private func reserve(_ inbox: RuntimeClientInbox) throws -> InboxFixture { try reserve(inbox: inbox) }
-private func reserve(inbox: RuntimeClientInbox?) throws -> InboxFixture {
+private func reserve(inbox: RuntimeClientInbox?, handler: Bool = true) throws -> InboxFixture {
     let fixture = InboxFixture()
-    if let inbox { try #require(inbox.submit(fixture.submission) == .admitted) }
+    if let inbox {
+        try #require(inbox.submit(fixture.submission) == .admitted)
+        if handler { try fixture.prepareReply(inbox) }
+    }
     return fixture
 }
 private final class InboxSession: RuntimeClientSession {


### PR DESCRIPTION
## Summary

Migrate the retained #67/#103 client's ordered callback handoff without its unbounded control queue. This #19/#112 slice builds on #157's stream and #158's router under MVP-PLAN.md §3/§11 and ADR 0003.

Stacked on approved #158 (`mvp/runtime-event-routing`, `6f668270`). Merge the parent chain into main first, then settle this PR's base and recheck its exact-head gates. Old native PRs remain draft references until their entire retained scope has migrated and merged.

## What changes

- Internal `RuntimeClientInbox` reserves separate capacity for each admitted request's send, owning reply and consumer-end notice. An end notice cannot release a still-pending reply reservation. The owning reply closure also retains a bounded, minimal request identity until its last copy is released, even after the first reply and consumer have finished.
- One mutex-ordered queue preserves send/reply/push/interruption/end order. Callbacks only enqueue; a single owner takes messages and runs router/native effects outside callback locks.
- **64 reservations**, **128 unsolicited events**, droppable traffic refused once queued incoming events reach **96**, **16 interruption notices**, and one reserved fault slot. One defensive additional-identity notice per reservation is also retained; all duplicate callbacks fault ingress. Repeated IDs and successful non-acceptance replies do not create another unknown mutation. Distinct acceptance IDs, including those converted to typed failures by a retired transport, retain their reconciliation identity. The extra reply produces a typed reconciliation notice directly, because the normal router may already have removed the completed request. The complete queue is bounded at **401 messages**, including controls.
- Excess droppable progress/diagnostics/status increments a saturating counter; draining restores capacity. Control overflow faults permanently instead of silently dropping a possible terminal and continuing as healthy.
- First owning replies and consumer-end notices retain their reserved space after a fault. A late acceptance can still reach the router after a consumer observed a deadline failure.
- One payload-free `AsyncStream<Void>` wakeup slot, not an unbounded payload stream or a task per callback. Only appended work wakes the owner; discarded traffic, duplicate notices, repeated faults and bookkeeping without a new message do not generate signals.
- An internal router `invalidate` entry point lets the owner fail consumers on an inbox fault/deadline while retaining pending owning-reply identity. Existing request/event correlation helpers are shared within ClientKit, not exposed publicly.

## Ownership and deliberate limits

Submission requires request/encoded-size validation first. Inbox reservation is not router admission or native send authority. The owner checks `terminalFailure` before executing queued sends, rejects known-unsent work, and retires/reconciles any send racing a fault. `rejectedBeforeSend` must never settle an ambiguous native send. Faulted ingress is not reopened by draining.

The owner transfers the one issued `replyHandler` to the transport without retaining a separate copy. Keep it alive through a throwing send's catch path until any known-unsent rejection is recorded. Releasing an unanswered handler queues one conservative connection-lost reply and permanently faults ingress for transport retirement; releasing a settled handler closes its duplicate window. This uses actual closure lifetime, not an arbitrary timer or growing tombstone history. No full request payload or producer is retained in the post-send reservation; all such identities still count toward the same 64-reservation admission limit. The owner must retain `unexpectedReply` reconciliation notices even after the original consumer completed.

This PR supplies the concrete inbox and transport-to-router integration tests, **not the production RuntimeBackend owner/drain loop**. The next slice must wire that owner, finite pending-reply deadlines, cancellation/retirement outside callback locks and bounded reconciliation retention. Do not enable mutations until that integration is covered.

The GUI/service remain query-only on wire epoch **12**. No public mutation API, provider activation, processes, raw diagnostics, signing, host/VM setup or hardware proof.

## Validation

- Full strict package hook: **466 test functions** (Core392/35 suites, RuntimeKit14/2, ClientKit60/6), warnings as errors.
- **14 inbox tests**, including parameterized 10,000-event progress/diagnostic/status floods, the full 401-message bound including controls, late owning acceptance after overflow/abandonment, ordered identity-free interruptions, admission/known-unsent lifecycle, concurrent callback/drain wakeups and inbox release.
- Real `XPCRuntimeTransport` / `RuntimeSessionRegistry` / router / stream composition is exercised with an **inert injected session**: acceptance followed by terminal-before-drop versus interruption, automatic consumer-end notification, original operation identity and complete reservation release. This is not an actual signed connection or native XPC peer.
- Deadline-fault integration verifies reconciliation still learns the late operation ID **after** the stream's failure was observed.
- Review regression fully drains the first reply and automatic end, observes the completed consumer, then supplies a second acceptance: its new operation ID and request/environment context survive without rewriting that consumer. Additional tests cover unanswered-handler release, admission remaining bounded while completed callbacks are retained, and known-unsent rejection both with and without a handler.
- Follow-up review regressions cover **20 duplicate-classification cases**, **six deterministic discarded-wakeup cases**, unanswered-handler admission refusal plus the router's retirement effect, and a real transport/registry conversion of a late duplicate acceptance to a typed failure. The transport fixture is inert; this is not signed-app or actual-peer proof.
- Inbox suite passes Release and **five consecutive Debug runs**. Seven CI-hook scenarios and unsigned shared-scheme `build-for-testing` pass.
- **649 additions/2 deletions across three files**, clean diff, no new Swift/C warnings; existing optional AppIntents extraction notices only. No tests disabled and no app launched.

Fresh exact-head Xcode Cloud and completed matching Codex review with original-message 👍 are required; local validation alone is not merge approval.
