### PR TITLE
Connect the bounded runtime backend owner to the GUI query

### DIFF
--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
@@ -1,0 +1,201 @@
+import Foundation
+import GuesthouseCore
+
+/// Native backend owner migrated from #67/#103 (MVP-PLAN.md §3, ADR 0003).
+/// The public configuration remains query-only until runtime mutations/recovery integrate.
+/// Keep the backend alive while inspecting reconciliation; dropping it retires its transport.
+public final class RuntimeClient: RuntimeBackend {
+    typealias Deadline = @Sendable () async throws -> Void
+    private let inbox: RuntimeClientInbox
+    private let driver: Driver
+    private let drain: Task<Void, Never>
+    private let permitsOperations: Bool
+
+    public convenience init() { self.init(connect: nil, permitsOperations: false) }
+
+    init(connect: XPCRuntimeTransport.Connect?, permitsOperations: Bool = true,
+         deadline: @escaping Deadline = { try await Task.sleep(for: .seconds(10)) }) {
+        let inbox = RuntimeClientInbox()
+        let transport: XPCRuntimeTransport
+        if let connect { transport = .init(incoming: { inbox.incoming($0) }, interrupted: { inbox.interrupted($0) }, connect: connect) }
+        else { transport = .init(incoming: { inbox.incoming($0) }, interrupted: { inbox.interrupted($0) }) }
+        let driver = Driver(inbox: inbox, transport: transport, deadline: deadline)
+        self.inbox = inbox; self.driver = driver; self.permitsOperations = permitsOperations
+        drain = Task { [weak driver] in
+            for await _ in inbox.wakeups {
+                if Task.isCancelled { return }
+                guard let driver else { return }
+                await driver.flush() // Take AND route on one actor; no competing mailbox.
+            }
+        }
+    }
+
+    deinit { drain.cancel() } // Driver's isolated cleanup retires native state, never a callback.
+
+    public func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error> {
+        let key = RuntimeRequestKey()
+        let (producer, stream) = RuntimeEventStream.make(mayHaveMutated: request.mayMutate) { [self] reason in
+            inbox.ended(key, reason) // End callback only enqueues; never performs native cleanup.
+        }
+        do {
+            if !permitsOperations, request != .runtimeVersion { throw GuesthouseError.invalidRequest(.unsupportedOperation) }
+            let envelope = RuntimeRequestEnvelope(request: request)
+            try RequestValidator.validate(envelope)
+            try RequestValidator.validateEncodedSize(JSONEncoder().encode(envelope))
+            if Task.isCancelled { throw GuesthouseError.canceled }
+            switch inbox.submit(.init(key: key, request: request, producer: producer)) {
+            case .admitted: break
+            case .full: producer.rejectBeforeSend(.invalidRequest(.tooManyInFlight))
+            case .faulted: producer.rejectBeforeSend(.runtimeIncompatible)
+            }
+        } catch let error as GuesthouseError { producer.rejectBeforeSend(error) }
+        catch let error as RequestValidationError { producer.rejectBeforeSend(error.guesthouseError) }
+        catch { producer.rejectBeforeSend(.invalidRequest(.malformed)) }
+        return stream
+    }
+
+    // Package-only recovery/test seam. No raw requests, bytes or diagnostics are exported.
+    func reconciliation() async -> ([RuntimeEventRouter.UncertainRequest], Set<OperationID>) {
+        await driver.reconciliation()
+    }
+    func flush() async { await driver.flush() }
+    /// Finish admission and issue native cleanup before the GUI enables another check.
+    /// Pending owning replies may still enrich reconciliation while this backend is retained.
+    func close() async { await driver.close() }
+
+    private actor Driver {
+        let inbox: RuntimeClientInbox, transport: XPCRuntimeTransport, deadline: Deadline
+        var router = RuntimeEventRouter()
+        var timers: [RuntimeRequestKey: Task<Void, Never>] = [:]
+        var cancelStreams: [RuntimeRequestKey: AsyncThrowingStream<RuntimeEvent, any Error>] = [:]
+        var uncertain: [RuntimeEventRouter.UncertainRequest] = []
+        var inspectTargets: Set<OperationID> = []
+        var admissions = 0
+        init(inbox: RuntimeClientInbox, transport: XPCRuntimeTransport, deadline: @escaping Deadline) {
+            self.inbox = inbox; self.transport = transport; self.deadline = deadline
+        }
+        isolated deinit {
+            for timer in timers.values { timer.cancel() }
+            transport.retireCurrent()
+        }
+        func reconciliation() -> ([RuntimeEventRouter.UncertainRequest], Set<OperationID>) { (uncertain, inspectTargets) }
+        func close() {
+            inbox.fail(.connectionLost)
+            flush()
+            transport.retireCurrent()
+            for timer in timers.values { timer.cancel() }
+        }
+        func flush() {
+            // Bound one actor turn. Any work left arrived during this batch and queued a wakeup.
+            for _ in 0..<RuntimeClientInbox.queueLimit {
+                guard !Task.isCancelled, let item = inbox.take() else { return }
+                handle(item)
+            }
+        }
+
+        func handle(_ item: RuntimeClientInbox.Message) {
+            let effects: [RuntimeEventRouter.Effect]
+            switch item {
+            case .send(let submission): start(submission); return
+            case .reply(let key, let result):
+                timers.removeValue(forKey: key)?.cancel()
+                effects = router.reply(result, to: key)
+            case .unexpectedReply(let context): effects = [.unknownOutcome(context)]
+            case .incoming(let event): effects = router.incoming(event)
+            case .interrupted(let failure): effects = router.interrupted(failure)
+            case .ended(let key, let reason):
+                cancelStreams.removeValue(forKey: key)
+                effects = router.consumerEnded(key, reason: reason)
+            case .fault(let cause): effects = router.invalidate(cause)
+            }
+            apply(effects)
+        }
+
+        private func start(_ submission: RuntimeClientInbox.Submission) {
+            let key = submission.key, request = submission.request
+            // Finite lifetime budget also bounds retained recovery facts (at most two IDs
+            // per admitted request). A new backend requires explicit reconciliation, not replay.
+            guard admissions < RuntimeEventRouter.lifetimeLimit, inbox.terminalFailure == nil else {
+                reject(submission, .runtimeIncompatible); return
+            }
+            if request.mayMutate, request.cancellationTarget == nil, !uncertain.isEmpty || !inspectTargets.isEmpty {
+                reject(submission, .runtimeIncompatible); return
+            }
+            guard router.register(key, request: request, producer: submission.producer) == .admitted else {
+                reject(submission, .invalidRequest(.tooManyInFlight)); return
+            }
+            guard let reply = inbox.replyHandler(for: key) else {
+                _ = router.rejected(key, error: .invalidRequest(.malformed))
+                inbox.rejectedBeforeSend(key); inbox.fail(.malformedResponse); return
+            }
+            defer { withExtendedLifetime(reply) {} } // Keep catch's known-unsent settlement ahead of closure release.
+            timers[key] = Self.timer(inbox: inbox, key: key, deadline: deadline)
+            do {
+                try transport.send(.init(request: request), reply: reply)
+                admissions += 1
+            } catch {
+                timers.removeValue(forKey: key)?.cancel()
+                let fixed: GuesthouseError
+                if let error = error as? GuesthouseError { fixed = error }
+                else if let failure = error as? RuntimeSessionFailure {
+                    switch failure.cause {
+                    case .connectionLost: fixed = .runtimeIncompatible
+                    case .malformedResponse: fixed = .invalidRuntimeReply(.malformed)
+                    case .oversizedResponse: fixed = .invalidRuntimeReply(.oversized)
+                    case .protocolMismatch(let service): fixed = .protocolMismatch(client: RuntimeProtocolVersion.current.rawValue, service: service)
+                    }
+                } else { fixed = .runtimeIncompatible }
+                _ = router.rejected(key, error: fixed)
+                inbox.rejectedBeforeSend(key) // XPCRuntimeTransport throws only before native send.
+                if request.cancellationTarget != nil { inbox.fail(.connectionLost) }
+            }
+        }
+
+        private func reject(_ submission: RuntimeClientInbox.Submission, _ error: GuesthouseError) {
+            inbox.rejectedBeforeSend(submission.key)
+            submission.producer.rejectBeforeSend(error)
+            if submission.request.cancellationTarget != nil { inbox.fail(.connectionLost) }
+        }
+
+        private func apply(_ effects: [RuntimeEventRouter.Effect]) {
+            // Store uncertainty before executing any effect that could produce more callbacks.
+            for case .unknownOutcome(let context) in effects { remember(context) }
+            for effect in effects {
+                switch effect {
+                case .unknownOutcome: break
+                case .retireConnection: transport.retireCurrent()
+                case .cancel(let id): cancel(id)
+                }
+            }
+        }
+
+        private func remember(_ context: RuntimeEventRouter.UncertainRequest) {
+            // A late first ID enriches the earlier ID-less failure, not another operation.
+            if let index = uncertain.firstIndex(where: { $0.key === context.key &&
+                ($0.failure.operationID == context.failure.operationID || $0.failure.operationID == nil) }) {
+                uncertain[index] = context
+            } else { uncertain.append(context) }
+        }
+
+        private func cancel(_ id: OperationID) {
+            inspectTargets.insert(id) // Even a cancel acknowledgment does not prove the target stopped.
+            let key = RuntimeRequestKey()
+            let (producer, stream) = RuntimeEventStream.make(mayHaveMutated: true) { [inbox] in inbox.ended(key, $0) }
+            // Retain this internal consumer until its end notice; never fire-and-forget the reply.
+            cancelStreams[key] = stream
+            if inbox.submit(.init(key: key, request: .cancelOperation(id), producer: producer)) != .admitted {
+                cancelStreams.removeValue(forKey: key)
+                producer.rejectBeforeSend(.runtimeIncompatible)
+                inbox.fail(.connectionLost) // Cannot safely cancel: retire and preserve the target for inspection.
+            }
+        }
+
+        private nonisolated static func timer(inbox: RuntimeClientInbox, key: RuntimeRequestKey,
+                                             deadline: @escaping Deadline) -> Task<Void, Never> {
+            Task {
+                do { try await deadline(); if !Task.isCancelled { inbox.expireReply(key) } }
+                catch {} // Cancellation ends the timer; no fabricated native reply or retry.
+            }
+        }
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
@@ -14,7 +14,7 @@ public final class RuntimeClient: RuntimeBackend {
     public convenience init() { self.init(connect: nil, permitsOperations: false) }
 
     init(connect: XPCRuntimeTransport.Connect?, permitsOperations: Bool = true,
-         deadline: @escaping Deadline = { try await Task.sleep(for: .seconds(10)) }) {
+         deadline: Deadline? = { try await Task.sleep(for: .seconds(10)) }) {
         let inbox = RuntimeClientInbox()
         let transport: XPCRuntimeTransport
         if let connect { transport = .init(incoming: { inbox.incoming($0) }, interrupted: { inbox.interrupted($0) }, connect: connect) }
@@ -64,14 +64,15 @@ public final class RuntimeClient: RuntimeBackend {
     func close() async { await driver.close() }
 
     private actor Driver {
-        let inbox: RuntimeClientInbox, transport: XPCRuntimeTransport, deadline: Deadline
+        let inbox: RuntimeClientInbox, transport: XPCRuntimeTransport
+        let deadline: Deadline?
         var router = RuntimeEventRouter()
         var timers: [RuntimeRequestKey: Task<Void, Never>] = [:]
         var cancelStreams: [RuntimeRequestKey: AsyncThrowingStream<RuntimeEvent, any Error>] = [:]
         var uncertain: [RuntimeEventRouter.UncertainRequest] = []
         var inspectTargets: Set<OperationID> = []
         var admissions = 0
-        init(inbox: RuntimeClientInbox, transport: XPCRuntimeTransport, deadline: @escaping Deadline) {
+        init(inbox: RuntimeClientInbox, transport: XPCRuntimeTransport, deadline: Deadline?) {
             self.inbox = inbox; self.transport = transport; self.deadline = deadline
         }
         isolated deinit {
@@ -121,15 +122,17 @@ public final class RuntimeClient: RuntimeBackend {
             if request.mayMutate, request.cancellationTarget == nil, !uncertain.isEmpty || !inspectTargets.isEmpty {
                 reject(submission, .runtimeIncompatible); return
             }
-            guard router.register(key, request: request, producer: submission.producer) == .admitted else {
-                reject(submission, .invalidRequest(.tooManyInFlight)); return
+            switch router.register(key, request: request, producer: submission.producer) {
+            case .admitted: break
+            case .full: reject(submission, .invalidRequest(.tooManyInFlight)); return
+            case .retiring, .rotationRequired: reject(submission, .runtimeIncompatible); return
             }
             guard let reply = inbox.replyHandler(for: key) else {
                 _ = router.rejected(key, error: .invalidRequest(.malformed))
                 inbox.rejectedBeforeSend(key); inbox.fail(.malformedResponse); return
             }
             defer { withExtendedLifetime(reply) {} } // Keep catch's known-unsent settlement ahead of closure release.
-            timers[key] = Self.timer(inbox: inbox, key: key, deadline: deadline)
+            if let deadline { timers[key] = Self.timer(inbox: inbox, key: key, deadline: deadline) }
             do {
                 try transport.send(.init(request: request), reply: reply)
                 admissions += 1

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClientInbox.swift
@@ -177,6 +177,13 @@ final class RuntimeClientInbox: Sendable {
         enqueue { $0.fail(cause) }
     }
 
+    /// A queued owning reply beats its deadline even if the owner has not drained it yet.
+    func expireReply(_ key: RuntimeRequestKey) {
+        enqueue { state in
+            if state.requests[key]?.replyQueued == false { state.fail(.connectionLost) }
+        }
+    }
+
     /// Only appended work wakes the owner, never discarded traffic or bookkeeping alone.
     private func enqueue(_ update: (inout State) -> Void) {
         let appended = state.withLock { state in

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -66,6 +66,7 @@ struct RuntimeEventRouter: Sendable {
         guard let entry = requests[key] else { return [] }
         guard entry.awaiting else { return fault(.malformedResponse) }
         requests.removeValue(forKey: key)
+        admitted -= 1 // Return the reservation only when the owner proves no native send occurred.
         entry.producer.rejectBeforeSend(error)
         discardUnjustifiedPending()
         return []

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
@@ -1,7 +1,7 @@
 import GuesthouseCore
 
-/// One user-requested, read-only connection check. Not RuntimeBackend or a streaming inbox.
-/// Native callbacks only enqueue one bounded result; connection disposal is outside them.
+/// One user-requested, read-only check through the production RuntimeBackend owner.
+/// Native callbacks only enqueue; explicit connection cleanup finishes before returning.
 public enum RuntimeVersionQuery {
     public enum Failure: Error, Hashable, Sendable {
         case runtime(GuesthouseError), connection(RuntimeSessionFailure), timedOut, canceled
@@ -34,26 +34,19 @@ public enum RuntimeVersionQuery {
     static func perform(connect: XPCRuntimeTransport.Connect?,
                         deadline: @escaping @Sendable () async throws -> Void) async -> Outcome {
         guard !Task.isCancelled else { return .failure(.canceled) }
-        let (stream, continuation) = AsyncStream<Outcome>.makeStream(bufferingPolicy: .bufferingOldest(1))
-        let client: XPCRuntimeTransport
-        // A query consumes its correlated reply, never unsolicited pushes. Native failures
-        // retire the session and reach the pending reply; a missing reply hits the deadline.
-        if let connect { client = XPCRuntimeTransport(incoming: { _ in }, interrupted: { _ in }, connect: connect) }
-        else { client = XPCRuntimeTransport(incoming: { _ in }, interrupted: { _ in }) }
-        defer { continuation.finish(); withExtendedLifetime(client) {} }
-        do {
-            try client.queryRuntimeVersion { reply in
-                continuation.yield(result(reply))
-                continuation.finish()
-            }
-        } catch let error as GuesthouseError { return .failure(.runtime(error)) }
-        catch let error as RuntimeSessionFailure { return .failure(.connection(error)) }
-        catch { return .failure(.connection(.init(cause: .connectionLost))) }
-
-        return await withTaskGroup(of: Outcome.self) { group in
+        let client = RuntimeClient(connect: connect, permitsOperations: false)
+        let stream = client.send(.runtimeVersion)
+        await client.flush()
+        let outcome = await withTaskGroup(of: Outcome.self) { group in
             group.addTask {
-                for await value in stream { return value }
-                return .failure(.canceled)
+                do {
+                    for try await event in stream { return result(.success(event)) }
+                    return .failure(.canceled)
+                } catch let failure as RuntimeSessionFailure { return .failure(.connection(failure)) }
+                catch GuesthouseError.canceled { return .failure(.canceled) }
+                catch GuesthouseError.runtimeIncompatible { return .failure(.connection(.init(cause: .connectionLost))) }
+                catch let error as GuesthouseError { return .failure(.runtime(error)) }
+                catch { return .failure(.connection(.init(cause: .connectionLost))) }
             }
             group.addTask {
                 do { try await deadline(); return .failure(.timedOut) }
@@ -63,6 +56,8 @@ public enum RuntimeVersionQuery {
             let value = await group.next() ?? .failure(.canceled)
             return Task.isCancelled ? .failure(.canceled) : value
         }
+        await client.close()
+        return outcome
     }
 
     private static func result(_ reply: Result<RuntimeEvent, RuntimeSessionFailure>) -> Outcome {

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeVersionQuery.swift
@@ -34,7 +34,9 @@ public enum RuntimeVersionQuery {
     static func perform(connect: XPCRuntimeTransport.Connect?,
                         deadline: @escaping @Sendable () async throws -> Void) async -> Outcome {
         guard !Task.isCancelled else { return .failure(.canceled) }
-        let client = RuntimeClient(connect: connect, permitsOperations: false)
+        // This structured group owns the query's ONLY deadline and always awaits close.
+        // A second client timer could win with connectionLost instead of timedOut.
+        let client = RuntimeClient(connect: connect, permitsOperations: false, deadline: nil)
         let stream = client.send(.runtimeVersion)
         await client.flush()
         let outcome = await withTaskGroup(of: Outcome.self) { group in

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
@@ -30,6 +30,11 @@ public final class XPCRuntimeTransport: Sendable {
     }
 
     deinit {
+        retireCurrent()
+    }
+
+    /// Owner/drain only, never from a callback executing under the registry delivery lock.
+    func retireCurrent() {
         if let lease = registry.current { Self.retire(lease.generation, in: registry) }
     }
 

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
@@ -1,0 +1,236 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseClientKit
+
+@Suite(.timeLimit(.minutes(1))) struct RuntimeClientTests {
+    static let info = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
+    static let environment = EnvironmentID(), id = OperationID()
+    static let start = RuntimeRequest.startEnvironment(environment, .init())
+
+    @Test func publicBackendRefusesMutationsWithoutConnecting() async {
+        let client: any RuntimeBackend = RuntimeClient()
+        var iterator = client.send(Self.start).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.invalidRequest(.unsupportedOperation)) { try await iterator.next() }
+    }
+
+    @Test func orderedRequestsAndPushesUseTheActualOwner() async throws {
+        let fixture = OwnerFixture(), client = fixture.client()
+        let first = client.send(Self.start), second = client.send(.runtimeVersion)
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        #expect(peer.requests == [Self.start, .runtimeVersion])
+        peer.incoming(.success(.completed(Self.id))) // Terminal before owning acceptance.
+        peer.answer(1, .success(.runtimeVersion(Self.info)))
+        peer.answer(0, .success(.accepted(Self.id)))
+        var operation = first.makeAsyncIterator(), query = second.makeAsyncIterator()
+        #expect(try await query.next() == .runtimeVersion(Self.info))
+        #expect(try await query.next() == nil)
+        #expect(try await operation.next() == .accepted(Self.id))
+        #expect(try await operation.next() == .completed(Self.id))
+        #expect(try await operation.next() == nil)
+        await client.flush()
+        #expect(await client.reconciliation().0.isEmpty)
+    }
+
+    @Test(arguments: [false, true])
+    func abandoningAnOperationSendsOneTrackedCancellation(beforeReply: Bool) async throws {
+        let fixture = OwnerFixture(), client = fixture.client()
+        var stream: AsyncThrowingStream<RuntimeEvent, any Error>? = client.send(Self.start)
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        if !beforeReply { peer.answer(0, .success(.accepted(Self.id))); await client.flush() }
+        withExtendedLifetime(stream) {}; stream = nil
+        await client.flush()
+        if beforeReply { peer.answer(0, .success(.accepted(Self.id))); await client.flush() }
+        #expect(peer.requests == [Self.start, .cancelOperation(Self.id)])
+        peer.answer(1, .success(.completed(OperationID()))) // Acknowledgment is not target completion.
+        await client.flush()
+        #expect(await client.reconciliation().1 == [Self.id])
+        var next = client.send(Self.start).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.runtimeIncompatible) { try await next.next() }
+        #expect(peer.requests.count == 2)
+    }
+
+    @Test func deadlineFailureStillLearnsLateAcceptanceAndNeverReplays() async throws {
+        let fixture = OwnerFixture(), client = fixture.client(deadline: {})
+        var iterator = client.send(Self.start).makeAsyncIterator()
+        await #expect(throws: RuntimeSessionFailure(cause: .connectionLost, mayHaveMutated: true)) { try await iterator.next() }
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        #expect(peer.cancelCount == 1 && peer.requests.count == 1)
+        peer.answer(0, .success(.accepted(Self.id)))
+        await client.flush()
+        let pending = await client.reconciliation().0
+        #expect(pending.count == 1 && pending.first?.environmentID == Self.environment)
+        #expect(pending.first?.failure.operationID == Self.id && pending.first?.failure.mayHaveMutated == true)
+        var refused = client.send(Self.start).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.runtimeIncompatible) { try await refused.next() }
+        #expect(fixture.connectionCount == 1 && peer.requests.count == 1)
+    }
+
+    @Test func owningReplyAlreadyQueuedBeatsItsDeadline() throws {
+        let inbox = RuntimeClientInbox(), key = RuntimeRequestKey()
+        let (producer, stream) = RuntimeEventStream.make(mayHaveMutated: false) { _ in }
+        try #require(inbox.submit(.init(key: key, request: .runtimeVersion, producer: producer)) == .admitted)
+        _ = inbox.take()
+        let reply = try #require(inbox.replyHandler(for: key))
+        reply(.success(.runtimeVersion(Self.info)))
+        inbox.expireReply(key)
+        #expect(inbox.terminalFailure == nil)
+        withExtendedLifetime((stream, reply)) {}
+    }
+
+    @Test func aDroppedReadOnlyConnectionReconnectsOnlyForANewRequest() async throws {
+        let fixture = OwnerFixture(), client = fixture.client()
+        var first = client.send(.runtimeVersion).makeAsyncIterator()
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        peer.answer(0, .failure(.init(cause: .connectionLost)))
+        await #expect(throws: RuntimeSessionFailure(cause: .connectionLost)) { try await first.next() }
+        await client.flush()
+        #expect(fixture.connectionCount == 1)
+        var second = client.send(.runtimeVersion).makeAsyncIterator()
+        await client.flush()
+        #expect(fixture.connectionCount == 2)
+        fixture.latest?.answer(0, .success(.runtimeVersion(Self.info)))
+        #expect(try await second.next() == .runtimeVersion(Self.info))
+        #expect(peer.requests.count == 1)
+    }
+
+    @Test func opaqueSetupFailureIsKnownUnsentAndReleasesItsReservation() async {
+        let calls = Mutex(0)
+        let client = RuntimeClient(connect: { _, _ in
+            calls.withLock { $0 += 1 }; throw NSError(domain: "private-marker", code: 1)
+        })
+        for _ in 0..<70 {
+            var iterator = client.send(Self.start).makeAsyncIterator()
+            await #expect(throws: GuesthouseError.runtimeIncompatible) { try await iterator.next() }
+            await client.flush()
+        }
+        #expect(calls.withLock { $0 } == 70)
+        #expect(await client.reconciliation().0.isEmpty)
+    }
+
+    @Test func capacityRefusalDoesNotSendOrLeakAnotherPendingRequest() async throws {
+        let fixture = OwnerFixture(), client = fixture.client()
+        let streams = (0..<64).map { _ in client.send(.runtimeVersion) }
+        await client.flush()
+        var refused = client.send(.runtimeVersion).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.invalidRequest(.tooManyInFlight)) { try await refused.next() }
+        let peer = try #require(fixture.latest)
+        #expect(peer.requests.count == 64)
+        for index in 0..<64 { peer.answer(index, .success(.runtimeVersion(Self.info))) }
+        await client.flush()
+        var next = client.send(.runtimeVersion).makeAsyncIterator()
+        await client.flush()
+        peer.answer(64, .success(.runtimeVersion(Self.info)))
+        #expect(try await next.next() == .runtimeVersion(Self.info))
+        withExtendedLifetime(streams) {}
+    }
+
+    @Test func streamKeepsClientAliveUntilCompletionThenReleasesNativeState() async throws {
+        let fixture = OwnerFixture()
+        var client: RuntimeClient? = fixture.client()
+        weak let weakClient = client
+        let stream = try #require(client).send(.runtimeVersion)
+        await client?.flush()
+        client = nil
+        #expect(weakClient != nil)
+        let peer = try #require(fixture.latest)
+        peer.answer(0, .success(.runtimeVersion(Self.info)))
+        var iterator = stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .runtimeVersion(Self.info))
+        #expect(try await iterator.next() == nil)
+        for await _ in peer.canceled { break } // Await isolated native cleanup, not a sleep.
+        #expect(weakClient == nil && peer.cancelCount == 1)
+    }
+
+    @Test func completedConsumerDoesNotLoseADistinctDuplicateAcceptance() async throws {
+        let fixture = OwnerFixture(), client = fixture.client(), other = OperationID()
+        var iterator = client.send(Self.start).makeAsyncIterator()
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        peer.answer(0, .success(.accepted(Self.id)), retaining: true)
+        peer.incoming(.success(.completed(Self.id)))
+        #expect(try await iterator.next() == .accepted(Self.id))
+        #expect(try await iterator.next() == .completed(Self.id))
+        #expect(try await iterator.next() == nil)
+        await client.flush()
+        peer.answer(0, .success(.accepted(other)))
+        await client.flush()
+        let unknown = await client.reconciliation().0
+        #expect(unknown.count == 1 && unknown.first?.failure.operationID == other)
+        #expect(unknown.first?.environmentID == Self.environment && peer.cancelCount == 1)
+        #expect(try await iterator.next() == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func finiteClientLifetimeRefusesAdditionalNativeWork(lastOperation: Bool) async throws {
+        let fixture = OwnerFixture(), client = fixture.client()
+        for index in 0..<(RuntimeEventRouter.lifetimeLimit - 1) {
+            var iterator = client.send(.runtimeVersion).makeAsyncIterator()
+            await client.flush()
+            fixture.latest?.answer(index, .success(.runtimeVersion(Self.info)))
+            #expect(try await iterator.next() == .runtimeVersion(Self.info))
+            await client.flush()
+        }
+        var last: AsyncThrowingStream<RuntimeEvent, any Error>? = client.send(lastOperation ? Self.start : .runtimeVersion)
+        await client.flush()
+        fixture.latest?.answer(RuntimeEventRouter.lifetimeLimit - 1,
+                              .success(lastOperation ? .accepted(Self.id) : .runtimeVersion(Self.info)))
+        await client.flush()
+        withExtendedLifetime(last) {}; last = nil
+        await client.flush()
+        if lastOperation {
+            #expect(await client.reconciliation().1 == [Self.id])
+            #expect(fixture.latest?.cancelCount == 1) // Cancellation refusal must retire too.
+        }
+        var refused = client.send(.runtimeVersion).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.runtimeIncompatible) { try await refused.next() }
+        #expect(fixture.latest?.requests.count == RuntimeEventRouter.lifetimeLimit)
+    }
+}
+
+private final class OwnerFixture: Sendable {
+    private let peers = Mutex<[OwnerPeer]>([])
+    var latest: OwnerPeer? { peers.withLock { $0.last } }
+    var connectionCount: Int { peers.withLock { $0.count } }
+    func client(deadline: @escaping RuntimeClient.Deadline = { try await Task.sleep(for: .seconds(10)) }) -> RuntimeClient {
+        RuntimeClient(connect: { [self] incoming, dropped in
+            let peer = OwnerPeer(incoming: incoming, dropped: dropped)
+            peers.withLock { $0.append(peer) }; return peer
+        }, deadline: deadline)
+    }
+}
+private final class OwnerPeer: RuntimeClientSession {
+    struct State { var requests: [RuntimeRequest] = []; var replies: [RuntimeClientInbox.Reply?] = []; var cancels = 0 }
+    private let state = Mutex(State())
+    let incoming: @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
+    let dropped: @Sendable () -> Void
+    let canceled: AsyncStream<Void>
+    let signal: AsyncStream<Void>.Continuation
+    var requests: [RuntimeRequest] { state.withLock { $0.requests } }
+    var cancelCount: Int { state.withLock { $0.cancels } }
+    init(incoming: @escaping @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void,
+         dropped: @escaping @Sendable () -> Void) {
+        self.incoming = incoming; self.dropped = dropped
+        (canceled, signal) = AsyncStream.makeStream(bufferingPolicy: .bufferingNewest(1))
+    }
+    func activate() {}
+    func cancel() { state.withLock { $0.cancels += 1 }; dropped(); signal.yield(()); signal.finish() }
+    func send(_ data: Data, reply: @escaping RuntimeClientInbox.Reply) {
+        do {
+            let request = try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data).request
+            state.withLock { $0.requests.append(request); $0.replies.append(reply) }
+        } catch { Issue.record("Invalid test request"); reply(.failure(.init(cause: .malformedResponse))) }
+    }
+    func answer(_ index: Int, _ result: Result<RuntimeEvent, RuntimeSessionFailure>, retaining: Bool = false) {
+        let reply = state.withLock { state in
+            guard state.replies.indices.contains(index) else { Issue.record("Missing test reply"); return RuntimeClientInbox.Reply?.none }
+            let reply = state.replies[index]; if !retaining { state.replies[index] = nil }; return reply
+        }
+        reply?(result) // Invocations and last callback releases stay outside fixture locks.
+    }
+}

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
@@ -99,17 +99,27 @@ import Testing
         #expect(peer.requests.count == 1)
     }
 
-    @Test func opaqueSetupFailureIsKnownUnsentAndReleasesItsReservation() async {
+    @Test func opaqueSetupFailureIsKnownUnsentAndReleasesItsReservation() async throws {
         let calls = Mutex(0)
+        let failures = RuntimeEventRouter.lifetimeLimit + 1
+        let peer = OwnerPeer(incoming: { _ in }, dropped: {})
         let client = RuntimeClient(connect: { _, _ in
-            calls.withLock { $0 += 1 }; throw NSError(domain: "private-marker", code: 1)
+            if calls.withLock({ $0 += 1; return $0 }) <= failures {
+                throw NSError(domain: "private-marker", code: 1)
+            }
+            return peer
         })
-        for _ in 0..<70 {
+        for _ in 0..<failures {
             var iterator = client.send(Self.start).makeAsyncIterator()
             await #expect(throws: GuesthouseError.runtimeIncompatible) { try await iterator.next() }
             await client.flush()
         }
-        #expect(calls.withLock { $0 } == 70)
+        var recovered = client.send(.runtimeVersion).makeAsyncIterator()
+        await client.flush()
+        peer.answer(0, .success(.runtimeVersion(Self.info)))
+        #expect(try await recovered.next() == .runtimeVersion(Self.info))
+        #expect(calls.withLock { $0 } == failures + 1)
+        #expect(peer.requests == [.runtimeVersion])
         #expect(await client.reconciliation().0.isEmpty)
     }
 

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
@@ -215,15 +215,18 @@ import Testing
         let outstanding = try (0..<RuntimeEventRouter.requestLimit).map { _ in try start(&router) }
         let extra = Fixture()
         #expect(router.register(extra.key, request: .runtimeVersion, producer: extra.producer) == .full)
-        for fixture in outstanding { _ = router.rejected(fixture.key, error: .canceled) }
-        for _ in RuntimeEventRouter.requestLimit..<RuntimeEventRouter.lifetimeLimit {
+        for fixture in outstanding {
+            _ = router.rejected(fixture.key, error: .canceled)
+            _ = router.rejected(fixture.key, error: .canceled) // A duplicate cannot refund twice.
+        }
+        for _ in 0..<RuntimeEventRouter.lifetimeLimit {
             let fixture = try start(&router)
             let id = OperationID()
             _ = router.reply(.success(.accepted(id)), to: fixture.key)
             _ = router.incoming(.completed(id))
         }
         #expect(router.isIdle)
-        #expect(router.retiredCount == RuntimeEventRouter.lifetimeLimit - RuntimeEventRouter.requestLimit)
+        #expect(router.retiredCount == RuntimeEventRouter.lifetimeLimit)
         #expect(router.register(extra.key, request: .runtimeVersion, producer: extra.producer) == .rotationRequired)
         #expect(router.interrupted(.init(cause: .connectionLost)).isEmpty)
         #expect(router.retiredCount == 0)

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
@@ -72,6 +72,17 @@ import Testing
         #expect(session.sends.withLock { $0 } == 1)
     }
 
+    @Test func suppliedDeadlineBeyondTenSecondsIsTheOnlyTimeout() async {
+        let session = QuerySession([])
+        defer { session.releaseReply() }
+        // Intentionally crosses the old hidden ten-second timer; an immediate fake
+        // deadline cannot expose that competing clock. No timing-based state polling.
+        let value = await run(session, deadline: { try await ContinuousClock().sleep(for: .seconds(11)) })
+        #expect(value == .failure(.timedOut))
+        #expect(session.cancellations.withLock { $0 } == 1)
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
     @Test func cancelingAPendingCheckDisposesItWithoutWaitingForTheTimeout() async {
         let (started, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingOldest(1))
         let session = QuerySession([], didSend: { signal.yield(()); signal.finish() })

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
@@ -10,13 +10,13 @@ import Testing
     static let cases: [(RuntimeEvent, RuntimeVersionQuery.Outcome)] = [
         (.runtimeVersion(info), .success(info)),
         (.runtimeVersion(.init(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(11))),
-         .failure(.connection(.init(cause: .malformedResponse)))),
+         .failure(.connection(.init(cause: .protocolMismatch(service: 11))))),
         (.failed(id, .unauthorizedCaller), .failure(.runtime(.unauthorizedCaller))),
         (.accepted(id), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
         (.completed(id), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
         (.progress(id, .init(kind: .copying)), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
         (.diagnostic(.init(operation: .runtimeRequest, outcome: .started, operationID: id.uuid)),
-         .failure(.connection(.init(cause: .malformedResponse)))),
+         .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
         (.status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)),
          .failure(.connection(.init(cause: .malformedResponse)))),
     ]

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeBackend.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeBackend.swift
@@ -1,0 +1,6 @@
+/// GUI/backend seam retained from #60 (#19/#112, MVP-PLAN.md §3).
+/// Operations end with a terminal event; queries end after their owning reply.
+/// A transport failure is not proof that a mutation did not run. Never replay it blindly.
+public protocol RuntimeBackend: Sendable {
+    func send(_ request: RuntimeRequest) -> AsyncThrowingStream<RuntimeEvent, any Error>
+}


### PR DESCRIPTION
## Summary

Wire the actual production `RuntimeClient` owner and use it for the existing GUI connection check. This migrates the retained #60 backend seam and #67/#103 client behavior onto #157–#159's validated stream/router/inbox, under #19/#112, MVP-PLAN.md §3/§11 and ADR 0003.

Stacked on approved #159 (`mvp/runtime-client-inbox`, `d39a7566`). Merge the parent chain into main first, then settle this base and recheck its exact-head gates. Legacy PRs remain draft references until their entire retained scope has migrated and merged.

## What is connected

- Public, Sendable `RuntimeBackend` seam and a concrete `RuntimeClient` with the fixed native transport. The **public configuration permits only runtimeVersion**; other named requests are refused locally. Only package tests can enable the retained operation-routing paths.
- A Sendable facade and private actor driver. One drain takes and handles FIFO messages on that actor; each turn is bounded at401 messages. Callback threads only enqueue, never reenter native transport or perform native cleanup.
- A live consumer retains its backend until termination. The driver task borrows its owner per batch, not across an indefinite stream wait. Isolated driver cleanup cancels request timers and retires native state outside callback locks.
- Request/encoded-size validation before inbox reservation, router registration before native send, and explicit known-unsent rejection cleanup. A throwing send's reply closure stays alive until that rejection is recorded.
- At most64 reserved requests; direct backend requests have ten-second pending-reply deadlines. The GUI query instead uses its single structured deadline and always awaits explicit cleanup. Expiration checks the owning-reply slot under the inbox mutex: a reply already queued beats its deadline even before the driver drains it. Timeout faults/retirement preserve pending identity instead of fabricating an early reply or replaying mutations.
- Tracked cancellation requests use the same bounded inbox/reply handling. Admission/setup refusal of a cancellation faults for retirement. A cancellation acknowledgment **does not prove the original target stopped**; its ID remains marked for inspection.
- Typed reconciliation survives consumer completion while the backend is retained, including a distinct duplicate acceptance and late acceptance after an already-observed timeout. A newly learned first ID enriches its prior ID-less record.
- The GUI's existing `RuntimeVersionQuery` now uses this backend and explicitly closes native transport before returning. Existing cancellation, timeout, fixed-error presentation and cleanup tests remain active. Protocol mismatch and unexpected diagnostic identity are now preserved by the shared router.

## Deliberate limits

A backend has a finite **1,024-native-admission lifetime budget**, bounding retained recovery identities (at most two per admitted request) and cancellation inspection targets. Exhaustion refuses known-unsent work; it does not automatically rotate/replay requests. The existing GUI connection check creates a fresh backend for each user action.

Normal read-only connection loss permits a new connection only for a new explicit request. Unresolved mutation/cancellation state prevents new non-cancellation mutations. Reconciliation/inspection access is package-internal for this slice: public recovery UI, durable reconciliation and mutation activation still require follow-up integration. Keep a backend alive while inspecting its recovery state; these client-local facts are not a persisted journal.

No service operation beyond runtimeVersion is enabled. Wire epoch remains12. No raw diagnostic strings, third-party dependencies, host processes, provider activation, signing or host/VM setup. Software fixtures and an unsigned build are not positive signed-GUI or hardware proof.

## Validation

- **478 strict package test functions**: Core392/35 suites, RuntimeKit14/2, ClientKit72/7.
- **11 new owner test functions**, including parameterized cancellation-before/after-acceptance and lifetime-budget exhaustion with a final operation versus query.
- Request order, terminal-before-acceptance routing, tracked cancellation, late timeout identity without replay, queued-reply/deadline ordering, explicit read-only reconnect,1,025 opaque setup failures followed by successful recovery without reservation leakage,64-request saturation/reuse, stream-only backend lifetime, post-completion duplicate-ID recovery, and1,024-admission refusal covered.
- The owner, router and GUI-query suites (**32 functions**) pass Release and **five consecutive Debug runs**. Seven CI-hook scenarios and unsigned shared-scheme `build-for-testing` pass.
- **506 additions/26 deletions across nine files**; clean diff, no Swift/C warnings. Optional AppIntents metadata notices only.
- Native transport/registry composition uses inert injected sessions for owner lifecycle tests. No app launched, tests disabled or signing/hardware proof claimed.

## Review follow-up

Both initial P2 findings are fixed in `f3fb0e69` and have explanatory replies: [single deadline](https://github.com/PicoMLX/Guesthouse/pull/160#discussion_r3968813884), [known-unsent budget](https://github.com/PicoMLX/Guesthouse/pull/160#discussion_r3968814802). The query's structured task group owns its only timeout; the public backend retains its default ten-second reply deadline. Verified pre-send rejection refunds the router reservation once, while sent work still consumes the finite lifetime budget. New/expanded regressions cover an eleven-second injected query deadline, 1,025 setup failures followed by successful recovery on the same backend, and duplicate-refund prevention. Corrected head `f3fb0e69` passed exact-head Xcode Cloud at13:17:55 UTC, completed matching Codex review at13:18:47 UTC and original-message bot 👍 at13:18:50 UTC. Both findings are resolved. **Validated; parent-blocked.**

These exact-head gates now pass. Merge the parent chain first, then settle the base and recheck composition before merging this PR.