### PR TITLE
Migrate bounded process responses without raw-output logging

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OutputReaders.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/OutputReaders.swift
@@ -1,0 +1,124 @@
+import Darwin
+import Foundation
+import Synchronization
+
+/// The nonblocking pipe owner retained from #69, with ADR 0003's temporary byte capture.
+/// Runtime adapters may parse a complete response; these bytes are NEVER diagnostics.
+/// No text decoding, record splitting, redaction, logging, Codable or XPC bridge exists here.
+final class OutputReaders: Sendable {
+    enum Kind: Hashable, Sendable { case stdout, stderr }
+    enum End: Equatable, Sendable { case notAttached, active, eof, abandoned, failed(Int32) }
+    enum Failure: Error, Equatable, Sendable { case closed, duplicateStream, configure(Int32) }
+    struct Response: Sendable {
+        let stdout: Data, stderr: Data
+        let stdoutEnd: End, stderrEnd: End
+        let truncated: Bool
+        /// Only output completeness, NEVER process/descendant quiescence or mutation success.
+        var isComplete: Bool { stdoutEnd == .eof && stderrEnd == .eof && !truncated }
+    }
+    static let captureCeiling = 16 << 20
+    let maximumBytes: Int
+    private let capturing: Set<Kind>
+    private let drained = DispatchGroup()
+    private struct State {
+        var handles: [Kind: FileHandle] = [:]
+        var ends: [Kind: End] = [:]
+        var stdout = Data(), stderr = Data()
+        var captured = 0
+        var truncated = false, sealed = false, taken = false
+    }
+    private let state = Mutex(State())
+
+    /// Discard both streams by default. Selected streams share ONE clamped byte budget.
+    init(maximumBytes: Int = 0, capturing: Set<Kind> = []) {
+        self.maximumBytes = min(Self.captureCeiling, max(0, maximumBytes))
+        self.capturing = capturing
+    }
+    deinit { detach() }
+
+    /// Takes ownership on success. The caller must not read, close or reuse this handle.
+    /// At most one handle per stream; all attachment finishes before waiting/taking output.
+    func attach(_ handle: FileHandle, kind: Kind) throws {
+        try state.withLock { state in
+            guard !state.sealed else { throw Failure.closed }
+            guard state.ends[kind] == nil, !state.handles.values.contains(where: { $0 === handle }) else {
+                throw Failure.duplicateStream
+            }
+            let descriptor = handle.fileDescriptor
+            guard !state.handles.values.contains(where: { $0.fileDescriptor == descriptor }) else {
+                throw Failure.duplicateStream
+            }
+            let flags = fcntl(descriptor, F_GETFL)
+            guard flags >= 0, fcntl(descriptor, F_SETFL, flags | O_NONBLOCK) == 0 else {
+                throw Failure.configure(errno)
+            }
+            drained.enter()
+            state.handles[kind] = handle; state.ends[kind] = .active
+            let id = ObjectIdentifier(handle)
+            handle.readabilityHandler = { [weak self] _ in self?.readAvailable(kind, id: id) }
+        }
+    }
+
+    /// Closes pending pipes, even when a surviving writer never sends EOF. Idempotent.
+    /// Does not signal any process or claim that closing the pipes stopped a descendant.
+    func detach() {
+        state.withLock { state in
+            state.sealed = true
+            for kind in Array(state.handles.keys) { close(kind, end: .abandoned, state: &state) }
+        }
+    }
+
+    /// Blocking wait for a dedicated noncooperative queue, never an actor/cooperative task.
+    /// The run owner can detach to end this wait early at its own deadline or cancellation.
+    @discardableResult
+    func waitUntilDrained(by deadline: DispatchTime) -> DispatchTimeoutResult {
+        state.withLock { $0.sealed = true } // No future enter can race a completed group.
+        let result = drained.wait(timeout: deadline)
+        if result == .timedOut { detach() }
+        return result
+    }
+
+    /// Transfers the bounded response once, after EOF/detach, and releases retained bytes.
+    /// An incomplete response must not be parsed as a complete command result.
+    func takeResponse() -> Response? {
+        state.withLock { state in
+            guard state.sealed, state.handles.isEmpty, !state.taken else { return nil }
+            state.taken = true
+            let response = Response(stdout: state.stdout, stderr: state.stderr,
+                stdoutEnd: state.ends[.stdout] ?? .notAttached, stderrEnd: state.ends[.stderr] ?? .notAttached,
+                truncated: state.truncated)
+            state.stdout.removeAll(); state.stderr.removeAll()
+            return response
+        }
+    }
+
+    private func readAvailable(_ kind: Kind, id: ObjectIdentifier) {
+        state.withLock { state in
+            // A queued callback after detach cannot touch a closed or subsequently reused fd.
+            guard let handle = state.handles[kind], ObjectIdentifier(handle) == id else { return }
+            var bytes = [UInt8](repeating: 0, count: 16 << 10)
+            let count = Darwin.read(handle.fileDescriptor, &bytes, bytes.count)
+            if count > 0, capturing.contains(kind) {
+                let keep = min(count, maximumBytes - state.captured)
+                if kind == .stdout { state.stdout.append(contentsOf: bytes.prefix(keep)) }
+                else { state.stderr.append(contentsOf: bytes.prefix(keep)) }
+                state.captured += keep
+                if keep < count { state.truncated = true }
+            } else if count == 0 {
+                close(kind, end: .eof, state: &state)
+            } else if count < 0, errno != EAGAIN, errno != EINTR {
+                close(kind, end: .failed(errno), state: &state)
+            }
+            // Unselected bytes and all bytes beyond the cap are drained and discarded.
+        }
+    }
+
+    /// Reads, closure and drain-group departure share the same mutex; callbacks never reenter.
+    private func close(_ kind: Kind, end: End, state: inout State) {
+        guard let handle = state.handles.removeValue(forKey: kind) else { return }
+        handle.readabilityHandler = nil
+        try? handle.close()
+        state.ends[kind] = end
+        drained.leave()
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessOutputCaptureTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessOutputCaptureTests.swift
@@ -1,0 +1,115 @@
+import Darwin
+import Foundation
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.timeLimit(.minutes(1))) struct ProcessOutputCaptureTests {
+    @Test func commandResponseBytesAreUnchangedAndTransferredOnce() async throws {
+        let stdout = Pipe(), stderr = Pipe()
+        let readers = OutputReaders(maximumBytes: 1_024, capturing: [.stdout, .stderr])
+        defer { readers.detach() }
+        try readers.attach(stdout.fileHandleForReading, kind: .stdout)
+        try readers.attach(stderr.fileHandleForReading, kind: .stderr)
+        // Synthetic response data must remain parseable, not modified by text redaction.
+        let original = Data("{\"code\":\"AB12-CD34\"}\r\n".utf8) + Data([0, 0xFF, 0xE2, 0x82, 0xAC])
+        for byte in original { try stdout.fileHandleForWriting.write(contentsOf: Data([byte])) }
+        try stderr.fileHandleForWriting.write(contentsOf: Data("failure\n".utf8))
+        try stdout.fileHandleForWriting.close(); try stderr.fileHandleForWriting.close()
+        #expect(readers.takeResponse() == nil) // Attachment is not sealed yet, even if EOF won.
+        #expect(await awaitOutputDrain(readers) == .success)
+        let response = try #require(readers.takeResponse())
+        #expect(response.stdout == original && response.stderr == Data("failure\n".utf8))
+        #expect(response.isComplete && !response.truncated)
+        #expect(readers.takeResponse() == nil)
+    }
+
+    @Test(arguments: [Int.min, 0, 128, Int.max])
+    func ownedSpawnComposesWithBoundedReadersAndBothEOFs(limit: Int) async throws {
+        let readers = OutputReaders(maximumBytes: limit, capturing: [.stdout, .stderr])
+        let response = try await printedResponse(readers)
+        let expected = min(2_000_000, min(OutputReaders.captureCeiling, max(0, limit)))
+        #expect(readers.maximumBytes == min(OutputReaders.captureCeiling, max(0, limit)))
+        #expect(response.stdout.count == expected && response.stderr.isEmpty)
+        #expect(response.stdoutEnd == .eof && response.stderrEnd == .eof)
+        #expect(response.truncated == (expected < 2_000_000))
+        #expect(response.isComplete == !response.truncated)
+    }
+
+    @Test(arguments: [false, true])
+    func unneededOutputIsDrainedWithoutCaptureOrTruncation(captureOnlyStderr: Bool) async throws {
+        let readers = captureOnlyStderr
+            ? OutputReaders(maximumBytes: 128, capturing: [.stderr]) : OutputReaders()
+        let response = try await printedResponse(readers)
+        #expect(response.stdout.isEmpty && response.stderr.isEmpty)
+        #expect(response.isComplete && !response.truncated)
+    }
+
+    @Test func bothStreamsShareTheSameByteBudgetIncludingNewlines() async throws {
+        let stdout = Pipe(), stderr = Pipe()
+        let readers = OutputReaders(maximumBytes: 5, capturing: [.stdout, .stderr])
+        defer { readers.detach() }
+        try readers.attach(stdout.fileHandleForReading, kind: .stdout)
+        try readers.attach(stderr.fileHandleForReading, kind: .stderr)
+        try stdout.fileHandleForWriting.write(contentsOf: Data(repeating: 10, count: 512))
+        try stderr.fileHandleForWriting.write(contentsOf: Data(repeating: 10, count: 512))
+        try stdout.fileHandleForWriting.close(); try stderr.fileHandleForWriting.close()
+        #expect(await awaitOutputDrain(readers) == .success)
+        let response = try #require(readers.takeResponse())
+        #expect(response.stdout.count + response.stderr.count == 5)
+        #expect(response.truncated && !response.isComplete)
+        #expect(response.stdoutEnd == .eof && response.stderrEnd == .eof)
+    }
+
+    @Test func abandonedOrMissingPipesCannotLookComplete() async throws {
+        let pipe = Pipe(), readers = OutputReaders()
+        defer { try? pipe.fileHandleForWriting.close() }
+        try readers.attach(pipe.fileHandleForReading, kind: .stdout)
+        #expect(await awaitOutputDrain(readers, by: .now()) == .timedOut)
+        let response = try #require(readers.takeResponse())
+        #expect(response.stdoutEnd == .abandoned && response.stderrEnd == .notAttached)
+        #expect(!response.isComplete)
+        #expect(readers.takeResponse() == nil)
+    }
+
+    @Test func refusedAttachmentDoesNotConsumeABorrowedHandle() async throws {
+        let first = Pipe(), refused = Pipe(), readers = OutputReaders()
+        defer { readers.detach(); try? first.fileHandleForWriting.close(); try? refused.fileHandleForWriting.close() }
+        try readers.attach(first.fileHandleForReading, kind: .stdout)
+        #expect(throws: OutputReaders.Failure.duplicateStream) {
+            try readers.attach(refused.fileHandleForReading, kind: .stdout)
+        }
+        #expect(throws: OutputReaders.Failure.duplicateStream) {
+            try readers.attach(first.fileHandleForReading, kind: .stderr)
+        }
+        let alias = FileHandle(fileDescriptor: first.fileHandleForReading.fileDescriptor, closeOnDealloc: false)
+        #expect(throws: OutputReaders.Failure.duplicateStream) { try readers.attach(alias, kind: .stderr) }
+        readers.detach()
+        #expect(throws: OutputReaders.Failure.closed) {
+            try readers.attach(refused.fileHandleForReading, kind: .stderr)
+        }
+        #expect(fcntl(refused.fileHandleForReading.fileDescriptor, F_GETFD) >= 0)
+        #expect(await awaitOutputDrain(readers) == .success)
+    }
+
+    /// Retains #108's real owned-spawn/reader composition, now without the redactor pipeline.
+    private func printedResponse(_ readers: OutputReaders) async throws -> OutputReaders.Response {
+        let stdout = Pipe(), stderr = Pipe()
+        defer { readers.detach(); try? stdout.fileHandleForWriting.close(); try? stderr.fileHandleForWriting.close() }
+        try readers.attach(stdout.fileHandleForReading, kind: .stdout)
+        try readers.attach(stderr.fileHandleForReading, kind: .stderr)
+        let input = try FileHandle(forReadingFrom: URL(fileURLWithPath: "/dev/null"))
+        let child = try OwnedChild.spawn(executable: URL(fileURLWithPath: "/usr/bin/printf"),
+            arguments: ["%02000000d", "0"], standardInput: input.fileDescriptor,
+            standardOutput: stdout.fileHandleForWriting.fileDescriptor,
+            standardError: stderr.fileHandleForWriting.fileDescriptor)
+        let watchdog = Task {
+            do { try await Task.sleep(for: .seconds(5)); if !Task.isCancelled { child.signal(SIGKILL) } }
+            catch {} // A failed drain cannot leave this controlled fixture blocked forever.
+        }
+        defer { watchdog.cancel() }
+        try stdout.fileHandleForWriting.close(); try stderr.fileHandleForWriting.close()
+        #expect(await child.waitForReapedExit() == .success(.status(0)))
+        #expect(await awaitOutputDrain(readers) == .success)
+        return try #require(readers.takeResponse())
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessOutputCleanupTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessOutputCleanupTests.swift
@@ -1,0 +1,100 @@
+import Darwin
+import Foundation
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.timeLimit(.minutes(1))) struct ProcessOutputCleanupTests {
+    /// Check the kernel's pipe ownership without inspecting a closed FileHandle or a saved
+    /// fd number that another parallel test may have reused. Suppress SIGPIPE only here.
+    private func expectNoReaders(_ pipe: Pipe, sourceLocation: SourceLocation = #_sourceLocation) async throws {
+        let writer = pipe.fileHandleForWriting.fileDescriptor
+        try #require(fcntl(writer, F_SETNOSIGPIPE, 1) == 0)
+        var byte: UInt8 = 0
+        // Foundation's cancelled readiness source can briefly hold a duplicated descriptor
+        // after FileHandle.close returns. Wait for that asynchronous cancellation too.
+        for _ in 0..<100 {
+            let written = Darwin.write(writer, &byte, 1)
+            let code = errno
+            if written == -1, code == EPIPE { return }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        Issue.record("The pipe still has a reader after cancellation", sourceLocation: sourceLocation)
+    }
+
+    @Test func aDrainTimeoutClosesBothReadersWhileWritersRemainOpen() async throws {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        defer {
+            try? stdout.fileHandleForWriting.close()
+            try? stderr.fileHandleForWriting.close()
+        }
+        let readers = OutputReaders(maximumBytes: 1_024, capturing: [.stdout, .stderr])
+        try readers.attach(stdout.fileHandleForReading, kind: .stdout)
+        try readers.attach(stderr.fileHandleForReading, kind: .stderr)
+
+        #expect(await awaitOutputDrain(readers, by: .now()) == .timedOut)
+        #expect(stdout.fileHandleForReading.readabilityHandler == nil)
+        #expect(stderr.fileHandleForReading.readabilityHandler == nil)
+        try await expectNoReaders(stdout)
+        try await expectNoReaders(stderr)
+        #expect(await awaitOutputDrain(readers, by: .now()) == .success)
+    }
+
+    @Test func endOfFileRemovesItsHandlerAndCompletesTheDrain() async throws {
+        let pipe = Pipe()
+        let readers = OutputReaders(maximumBytes: 1_024, capturing: [.stdout, .stderr])
+        try readers.attach(pipe.fileHandleForReading, kind: .stdout)
+        try pipe.fileHandleForWriting.write(contentsOf: Data("done\n".utf8))
+        try pipe.fileHandleForWriting.close()
+
+        #expect(await awaitOutputDrain(readers) == .success)
+        #expect(pipe.fileHandleForReading.readabilityHandler == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func staleReadCallbacksAndConcurrentDetachCloseOnlyOnce(endOfFile: Bool) async throws {
+        let pipe = Pipe()
+        defer { try? pipe.fileHandleForWriting.close() }
+        let readers = OutputReaders(maximumBytes: 1_024, capturing: [.stdout, .stderr])
+        try readers.attach(pipe.fileHandleForReading, kind: .stdout)
+        let queuedCallback = try #require(pipe.fileHandleForReading.readabilityHandler)
+        if endOfFile { try pipe.fileHandleForWriting.close() }
+
+        // Exercise an already queued callback even after cancellation, including a stale
+        // readiness notification with no bytes available. Neither may read a reused fd or
+        // leave the drain group a second time when EOF and detach overlap.
+        DispatchQueue.concurrentPerform(iterations: 32) { index in
+            if index.isMultiple(of: 2) {
+                queuedCallback(pipe.fileHandleForReading)
+            } else {
+                readers.detach()
+            }
+        }
+        #expect(await awaitOutputDrain(readers, by: .now()) == .success)
+        #expect(pipe.fileHandleForReading.readabilityHandler == nil)
+        if !endOfFile { try await expectNoReaders(pipe) }
+    }
+
+    @Test func releasingReadersDetachesAnOpenPipe() async throws {
+        let pipe = Pipe()
+        defer { try? pipe.fileHandleForWriting.close() }
+        weak var released: OutputReaders?
+        do {
+            let readers = OutputReaders(maximumBytes: 1_024, capturing: [.stdout, .stderr])
+            try readers.attach(pipe.fileHandleForReading, kind: .stdout)
+            released = readers
+        }
+
+        #expect(released == nil)
+        #expect(pipe.fileHandleForReading.readabilityHandler == nil)
+        try await expectNoReaders(pipe)
+    }
+}
+
+func awaitOutputDrain(_ readers: OutputReaders, by deadline: DispatchTime = .now() + .seconds(2)) async -> DispatchTimeoutResult {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global(qos: .utility).async {
+            continuation.resume(returning: readers.waitUntilDrained(by: deadline))
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Migrate #69's existing nonblocking pipe owner and cleanup regressions to ADR 0003's **bounded temporary adapter input**, and finish migrating #108's real owned-child/output-reader composition test. Implements a focused #21 prerequisite under MVP-PLAN.md §3; does not activate ProcessRunner or a provider operation.

Stacked on approved #161 (`mvp/owned-child`, `a08bbde3`). The owner merges the parent chain into main first, then settles this base and rechecks its exact-head gates. No automatic merges or historical branch deletion.

## Changed behavior

- Runtime-internal `OutputReaders` owns at most one stdout and one stderr handle. Successful attachment transfers ownership; refusal leaves the supplied handle with its caller. Duplicate stream, identical handle and same-descriptor alias attachment are refused.
- Retain the old nonblocking 16 KiB reads and serialized read/close/group-departure boundary, now with a checked-Sendable Mutex state instead of unchecked Sendable/NSLock. Stale queued callbacks cannot read closed/reused descriptors or leave the drain group twice.
- **Discard both streams by default.** Only explicitly selected streams are captured. They share one byte budget clamped to0–16 MiB; other bytes keep draining and are discarded.
- Capture exact bytes without UTF-8 conversion, record splitting or redaction. Known command-response parsing must not have its data changed by a logging filter.
- Seal attachment before waiting so a later group enter cannot race successful completion. The blocking wait is for a dedicated noncooperative queue, not an actor/cooperative task. Timeout detaches active pipes; the future run owner may also detach to end the wait at its own deadline/cancellation.
- Transfer the response once after EOF/detach and release this owner's retained bytes. Typed per-stream end states distinguish EOF, abandonment, missing attachment and numeric read failure. `isComplete` requires both EOFs and no truncation.
- No Core diagnostic import, text/error-description bridge, Codable/XPC/export path, arbitrary log metadata or raw-output fallback. Adapters remain responsible for consuming/releasing temporary data and emitting only known typed diagnostics/errors.

## Preserved evidence and limits

Four #69 cleanup tests cover drain timeout with open writers, EOF handler removal, stale callback/concurrent detach races and deallocation. Six capture tests cover byte preservation/single transfer,2 MB real owned-child output across four cap settings, discard/selective capture, shared newline-inclusive limits, abandoned/missing pipes and refused descriptor attachment.

The real spawn composition adapts #108's previously deferred redactor-dependent test: OwnedChild launches a controlled printf fixture, both pipes drain to EOF despite capture saturation, and the exact child is reaped. A bounded test watchdog uses that owner, never a sampled PID.

**Output completeness is not direct-child exit, descendant quiescence or mutation success.** This does not migrate the runner's stdin writer, timeout/escalation owner, whole-run outcome/recovery contract or process graph behavior. No production spawn call site, provider/VM operation or generic GUI command API is enabled. No incomplete response may be treated as a complete command result.

#108's retained scope is covered by #161 plus this PR, but it stays open until both are approved and merged. #69/#21 remain open for runner integration and their remaining acceptance criteria. Original code, tests, branches and unresolved review history remain preserved.

## Validation

- **499 strict package test functions**: Core392/35 suites, RuntimeKit35/5, ClientKit72/7.
- Output capture/cleanup and ownership suites (**21 functions**) pass Release, **five consecutive Debug runs**, and **Thread Sanitizer**.
- Seven CI-hook scenarios and unsigned shared-scheme `build-for-testing` pass.
- **339 added lines across three files**; no new Swift/C warnings. Optional AppIntents metadata notices only.
- Only controlled test children/pipes ran. No app/provider/VM launch, signing or host setup, disabled tests or hardware evidence.

Fresh exact-head Xcode Cloud and completed matching Codex review with original-message 👍 are required before a merge recommendation.

## Current gates — September 9, 2026, 07:19 Pacific

Head `c1c16f2cc63ab8410cc62e1aa0b5785272c7df39` has a completed matching Codex review (14:03:30 UTC), original-message bot 👍 (14:03:33 UTC), and no inline or standalone findings. The exact-head Xcode Cloud suite is **queued**, with no check run or commit status reported yet. This is **not green CI** and the PR is not merge-ready; parent composition must also settle first.

GitHub check-suite metadata confirms the queued Xcode Cloud suite. Apple-side queue details require App Store Connect sign-in, which is unavailable in this session. No empty commit, redundant review request, credential change or CI settings change was made.
