### PR TITLE
Migrate the owned process runner lifecycle and bounded stdin

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/InputDelivery.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/InputDelivery.swift
@@ -1,0 +1,69 @@
+import Darwin
+import Foundation
+import Synchronization
+
+/// Retains #69's asynchronous stdin delivery, never changing process-wide SIGPIPE policy.
+final class InputDelivery: Sendable {
+    enum End: Equatable, Sendable { case pending, delivered, failed(Int32), abandoned }
+    private final class Storage: Sendable {
+        struct State { var end = End.pending; var started = false; var closedSuccessfully = false }
+        let state = Mutex(State())
+        let closed = DispatchGroup()
+    }
+    private static let queue = DispatchQueue(label: "GuesthouseRuntimeKit.stdin", qos: .utility, attributes: .concurrent)
+    private let storage: Storage
+    private let channel: DispatchIO
+
+    /// Takes the writer only on success. DispatchIO cleanup alone closes the borrowed fd.
+    init(_ writer: FileHandle) throws {
+        guard fcntl(writer.fileDescriptor, F_SETNOSIGPIPE, 1) == 0 else { throw ProcessLaunchFailure.pipeUnavailable }
+        let storage = Storage()
+        storage.closed.enter()
+        self.storage = storage
+        channel = DispatchIO(type: .stream, fileDescriptor: writer.fileDescriptor, queue: Self.queue) { error in
+            let closedSuccessfully: Bool
+            do { try writer.close(); closedSuccessfully = true } catch { closedSuccessfully = false }
+            storage.state.withLock { state in
+                state.closedSuccessfully = closedSuccessfully
+                if state.end == .pending { state.end = .failed(error == 0 ? EIO : error) }
+            }
+            storage.closed.leave()
+        }
+    }
+    deinit { cancel() }
+
+    /// Called once, only after the run owner has armed its lifetime deadline.
+    func start(_ data: Data) {
+        let admitted = storage.state.withLock { state in
+            guard !state.started, state.end == .pending else { return false }
+            state.started = true
+            return true
+        }
+        guard admitted else { return }
+        let bytes = data.withUnsafeBytes { DispatchData(bytes: $0) }
+        channel.write(offset: 0, data: bytes, queue: Self.queue) { [storage, channel] done, remainder, error in
+            guard done || error != 0 else { return }
+            storage.state.withLock { state in
+                guard state.end == .pending else { return }
+                state.end = error == 0 && (remainder?.isEmpty ?? true) ? .delivered : .failed(error == 0 ? EIO : error)
+            }
+            channel.close(flags: error == 0 ? [] : .stop)
+        }
+    }
+    func cancel() {
+        storage.state.withLock { state in
+            if state.end == .pending { state.end = .abandoned }
+        }
+        channel.close(flags: .stop)
+    }
+    var end: End { storage.state.withLock { $0.end } }
+
+    /// Dedicated dispatch waiter only, not a cooperative task or actor.
+    func waitUntilClosed(by deadline: DispatchTime) -> Bool {
+        if storage.closed.wait(timeout: deadline) == .success {
+            return storage.state.withLock { $0.closedSuccessfully }
+        }
+        cancel()
+        return false
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessRun.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessRun.swift
@@ -1,0 +1,142 @@
+import Darwin
+import Foundation
+
+/// Direct-child execution evidence, NOT provider/mutation success or descendant quiescence.
+/// No raw bytes/arguments/errors can enter diagnostics through this report (ADR 0003).
+struct ProcessReport: Sendable {
+    let childExit: Result<OwnedChild.ExitReason, OwnedChild.Failure>?
+    let timedOut: Bool, canceled: Bool, terminationRefused: Bool
+    let input: InputDelivery.End?, inputClosed: Bool, outputComplete: Bool
+    /// Always requires a separate operation-specific inspection/ownership decision.
+    let descendantScopeUnproven = true
+}
+
+/// A facade's release discards temporary responses, but never abandons owned-child reaping.
+final class ProcessRun: Sendable {
+    enum WaitFailure: Error { case alreadyWaiting }
+    private let driver: Driver
+    init(child: OwnedChild, readers: OutputReaders, input: InputDelivery?, grace: Duration) {
+        driver = Driver(child: child, readers: readers, input: input, grace: grace)
+    }
+    deinit { let driver = driver; Task { await driver.abandonResponse() } }
+    func start(deadline: ContinuousClock.Instant, input: Data?) async { await driver.start(deadline: deadline, data: input) }
+    func terminate(gracePeriod: Duration) async { await driver.stop(grace: gracePeriod, timedOut: false) }
+    func waitForExit() async throws -> ProcessReport {
+        try await withTaskCancellationHandler {
+            try await driver.waitForExit()
+        } onCancel: {
+            Task { await self.driver.cancelWait() }
+        }
+    }
+    /// One transfer after completion. Callers parse only complete responses and release bytes.
+    func takeOutput() async -> OutputReaders.Response? { await driver.takeOutput() }
+
+    private actor Driver {
+        let child: OwnedChild, readers: OutputReaders, input: InputDelivery?, grace: Duration
+        var report: ProcessReport?
+        var response: OutputReaders.Response?
+        var waiter: CheckedContinuation<ProcessReport, Never>?
+        var childExit: Result<OwnedChild.ExitReason, OwnedChild.Failure>?
+        var timedOut = false, canceled = false, refused = false, abandoned = false
+        var began = false, stopping = false, generation = 0
+        var killAt: ContinuousClock.Instant?
+        var timeoutTask: Task<Void, Never>?, escalationTask: Task<Void, Never>?, recoveryTask: Task<Void, Never>?
+
+        init(child: OwnedChild, readers: OutputReaders, input: InputDelivery?, grace: Duration) {
+            self.child = child; self.readers = readers; self.input = input; self.grace = grace
+        }
+        func start(deadline: ContinuousClock.Instant, data: Data?) {
+            guard !began else { return }
+            began = true
+            // One observer retains this controller until this exact child is reaped, even
+            // when every facade/waiter is gone. It retains no raw response after abandonment.
+            Task { [self, child] in reaped(await child.waitForReapedExit()) }
+            timeoutTask = Task { [weak self] in
+                do { try await Task.sleep(until: deadline, clock: .continuous) } catch { return }
+                await self?.deadlineExpired()
+            }
+            if let data { input?.start(data) }
+        }
+        func waitForExit() async throws -> ProcessReport {
+            if let report { return report }
+            guard waiter == nil else { throw WaitFailure.alreadyWaiting }
+            return await withCheckedContinuation { waiter = $0 }
+        }
+        func takeOutput() -> OutputReaders.Response? {
+            defer { response = nil }
+            return response
+        }
+        func abandonResponse() { abandoned = true; response = nil }
+        func cancelWait() { stop(grace: grace, timedOut: false) }
+        func deadlineExpired() { stop(grace: grace, timedOut: true) }
+
+        func stop(grace: Duration, timedOut becauseOfTimeout: Bool) {
+            guard report == nil else { return } // Never rewrite a completed outcome.
+            if becauseOfTimeout { timedOut = true } else { canceled = true }
+            if childExit != nil {
+                readers.detach(); input?.cancel()
+                return // The bounded drain worker commits all interruption flags.
+            }
+            let deadline = ContinuousClock.now + min(.seconds(60), max(.zero, grace))
+            if let killAt, deadline >= killAt { return }
+            killAt = deadline; generation += 1
+            let current = generation
+            if !stopping { stopping = true; record(child.signal(SIGTERM)) }
+            escalationTask?.cancel()
+            escalationTask = Task { [weak self] in
+                do { try await Task.sleep(until: deadline, clock: .continuous) } catch { return }
+                await self?.escalate(current)
+            }
+        }
+        func record(_ result: OwnedChild.SignalResult) {
+            switch result {
+            case .refused, .authorityLost: refused = true
+            case .delivered, .alreadyExited, .alreadyReaped: break
+            }
+        }
+        func escalate(_ current: Int) {
+            guard report == nil, childExit == nil, generation == current else { return }
+            record(child.signal(SIGKILL))
+            // Delivery is not exit. Bound the caller's cleanup wait even if a signal was
+            // refused or the kernel has not made the child waitable. Its owner keeps reaping.
+            escalationTask = nil
+            recoveryTask = Task { [weak self] in
+                do { try await Task.sleep(for: .seconds(2)) } catch { return }
+                await self?.finish(inputClosed: false)
+            }
+        }
+        func reaped(_ result: Result<OwnedChild.ExitReason, OwnedChild.Failure>) {
+            guard report == nil else { return }
+            childExit = result
+            escalationTask?.cancel(); escalationTask = nil
+            recoveryTask?.cancel(); recoveryTask = nil
+            // Both channels share one absolute shutdown window. Never block this actor.
+            let deadline = DispatchTime.now() + .seconds(5)
+            let readers = readers, input = input
+            Task { [self] in
+                let closed = await withCheckedContinuation { continuation in
+                    DispatchQueue.global(qos: .utility).async {
+                        readers.waitUntilDrained(by: deadline)
+                        continuation.resume(returning: input?.waitUntilClosed(by: deadline) ?? true)
+                    }
+                }
+                finish(inputClosed: closed)
+            }
+        }
+        func finish(inputClosed: Bool) {
+            guard report == nil else { return }
+            readers.detach(); input?.cancel()
+            let bytes = readers.takeResponse()
+            let value = ProcessReport(childExit: childExit, timedOut: timedOut, canceled: canceled,
+                terminationRefused: refused, input: input?.end, inputClosed: inputClosed,
+                outputComplete: bytes?.isComplete == true)
+            report = value
+            if !abandoned { response = bytes }
+            timeoutTask?.cancel(); timeoutTask = nil
+            escalationTask?.cancel(); escalationTask = nil
+            recoveryTask?.cancel(); recoveryTask = nil
+            let pending = waiter; waiter = nil
+            pending?.resume(returning: value)
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessRunner.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Processes/ProcessRunner.swift
@@ -1,0 +1,97 @@
+import Foundation
+import GuesthouseCore
+
+/// Runtime-only invocation retained from #69. The service selects trusted executables/options;
+/// this is not a GUI request, root-containment check, or provider verification (MVP-PLAN.md §3).
+struct ProcessInvocation: Sendable {
+    enum StandardInput: Sendable { case none, data(Data) }
+    let executable: URL
+    var arguments: [String] = []
+    var environment: [String: String] = [:]
+    var currentDirectory: URL?
+    var standardInput: StandardInput = .none
+    var timeout: Duration = .seconds(60)
+    var terminationGracePeriod: Duration = .seconds(5)
+    var maximumOutputBytes = 0
+    var capturing: Set<OutputReaders.Kind> = []
+}
+
+enum ProcessLaunchFailure: Error, Equatable, Sendable {
+    case invalidOptions, canceled, workingDirectoryUnavailable, pipeUnavailable, executableUnavailable
+    var message: String {
+        switch self {
+        case .invalidOptions: "The requested tool operation exceeds Guesthouse's supported limits."
+        case .canceled: "The tool operation was canceled before it started."
+        case .workingDirectoryUnavailable: "The operation's working folder is missing or cannot be opened safely."
+        case .pipeUnavailable: "Guesthouse could not prepare the tool's input and output."
+        case .executableUnavailable: DiagnosticFailure.executableUnavailable.message
+        }
+    }
+    var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .invalidOptions: [.reviewRequest, .cancel]
+        case .canceled, .workingDirectoryUnavailable: [.inspectState, .cancel]
+        case .pipeUnavailable: [.inspectState, .reinstallApp, .cancel]
+        case .executableUnavailable: [.repair(.runtime), .cancel]
+        }
+    }
+}
+
+struct ProcessRunner: Sendable {
+    func run(_ invocation: ProcessInvocation) async throws -> ProcessRun {
+        guard !Task.isCancelled else { throw ProcessLaunchFailure.canceled }
+        guard invocation.timeout >= .zero, invocation.timeout <= .seconds(86_400),
+              invocation.terminationGracePeriod >= .zero, invocation.terminationGracePeriod <= .seconds(60)
+        else { throw ProcessLaunchFailure.invalidOptions }
+        let data: Data?
+        switch invocation.standardInput {
+        case .none: data = nil
+        case .data(let bytes):
+            guard bytes.count <= 4 << 20 else { throw ProcessLaunchFailure.invalidOptions }
+            data = bytes
+        }
+        let directory: PinnedWorkingDirectory?
+        do { directory = try invocation.currentDirectory.map(PinnedWorkingDirectory.init) }
+        catch { throw ProcessLaunchFailure.workingDirectoryUnavailable }
+        let stdout = Pipe(), stderr = Pipe(), stdin = data == nil ? nil : Pipe()
+        let readers = OutputReaders(maximumBytes: invocation.maximumOutputBytes, capturing: invocation.capturing)
+        var outReader: FileHandle? = stdout.fileHandleForReading
+        var errReader: FileHandle? = stderr.fileHandleForReading
+        var inputWriter = stdin?.fileHandleForWriting
+        var delivery: InputDelivery?
+        var nullInput: FileHandle?
+        defer {
+            try? outReader?.close(); try? errReader?.close(); try? inputWriter?.close()
+            try? nullInput?.close()
+            try? stdout.fileHandleForWriting.close(); try? stderr.fileHandleForWriting.close()
+            try? stdin?.fileHandleForReading.close()
+        }
+        do {
+            // Foundation.Process understands FileHandle.nullDevice's sentinel. posix_spawn
+            // needs a real borrowed descriptor, owned here only until launch returns.
+            if data == nil { nullInput = try FileHandle(forReadingFrom: URL(fileURLWithPath: "/dev/null")) }
+            try readers.attach(stdout.fileHandleForReading, kind: .stdout); outReader = nil
+            try readers.attach(stderr.fileHandleForReading, kind: .stderr); errReader = nil
+            if let writer = inputWriter { delivery = try InputDelivery(writer); inputWriter = nil }
+        } catch {
+            readers.detach(); delivery?.cancel()
+            throw ProcessLaunchFailure.pipeUnavailable
+        }
+        let child: OwnedChild
+        let deadline = ContinuousClock.now + invocation.timeout
+        do {
+            guard !Task.isCancelled else { throw ProcessLaunchFailure.canceled }
+            child = try OwnedChild.spawn(executable: invocation.executable, arguments: invocation.arguments,
+                environment: invocation.environment, workingDirectory: directory,
+                standardInput: stdin?.fileHandleForReading.fileDescriptor ?? nullInput?.fileDescriptor ?? -1,
+                standardOutput: stdout.fileHandleForWriting.fileDescriptor, standardError: stderr.fileHandleForWriting.fileDescriptor)
+        } catch {
+            readers.detach(); delivery?.cancel()
+            throw (error as? ProcessLaunchFailure) ?? .executableUnavailable
+        }
+        let run = ProcessRun(child: child, readers: readers, input: delivery, grace: invocation.terminationGracePeriod)
+        await run.start(deadline: deadline, input: data)
+        if Task.isCancelled { await run.terminate(gracePeriod: invocation.terminationGracePeriod) }
+        return run
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessRunnerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessRunnerTests.swift
@@ -117,15 +117,39 @@ import Testing
         #expect(report.timedOut && !report.outputComplete && report.descendantScopeUnproven)
     }
 
-    @Test func droppedFacadePreservesItsDeadline() async throws {
-        let fixture = try Fixture()
+    @Test(arguments: [false, true]) func droppedFacadePreservesItsDeadline(_ stopAlreadyPending: Bool) async throws {
+        var calls = OwnedChild.SystemCalls.live
+        if stopAlreadyPending {
+            calls.signal = { pid, signal in
+                signal == SIGTERM ? .delivered : OwnedChild.SystemCalls.live.signal(pid, signal)
+            }
+        }
+        let fixture = try Fixture(calls: calls)
         defer { fixture.closeWriters() }
         var run: ProcessRun? = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
         weak let facade = run
+        let began = ContinuousClock.now
         await run?.start(deadline: .now + .milliseconds(100), input: nil)
+        if stopAlreadyPending { await run?.terminate(gracePeriod: .seconds(60)) }
         run = nil
         #expect(facade == nil)
-        #expect(try await fixture.child.waitForReapedExit().get() == .signal(SIGTERM))
+        #expect(try await fixture.child.waitForReapedExit().get() == .signal(stopAlreadyPending ? SIGKILL : SIGTERM))
+        #expect(ContinuousClock.now - began < .seconds(3)) // The invocation deadline, not the fixture watchdog.
+    }
+
+    @Test func zeroExitDoesNotEraseCancellation() async throws {
+        var calls = OwnedChild.SystemCalls.live
+        // Model a child that finishes cleanly after a termination request. Do not kill it.
+        calls.signal = { _, _ in .delivered }
+        let fixture = try Fixture(calls: calls)
+        defer { fixture.closeWriters() }
+        let run = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
+        await run.start(deadline: .now + .seconds(10), input: nil)
+        await run.terminate(gracePeriod: .seconds(60))
+        fixture.closeWriters() // Actual cat receives EOF and exits zero after cancellation is recorded.
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(report.canceled && !report.timedOut && report.descendantScopeUnproven)
     }
 
     @Test func concurrentTerminationShortensOneEscalation() async throws {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessRunnerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/ProcessRunnerTests.swift
@@ -1,0 +1,225 @@
+import Darwin
+import Foundation
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite(.timeLimit(.minutes(1))) struct ProcessRunnerTests {
+    let runner = ProcessRunner()
+    let stdout: Set<OutputReaders.Kind> = [.stdout]
+
+    @Test func knownResponseParsesUnmodifiedTemporaryInput() async throws {
+        struct Reply: Decodable { let value: String }
+        let data = Data(#"{"value":"temporary-response"}"#.utf8)
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/cat"),
+            standardInput: .data(data), maximumOutputBytes: 4096, capturing: stdout))
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(report.input == .delivered && report.inputClosed && report.outputComplete)
+        #expect(report.descendantScopeUnproven) // Parsing/exit success is not mutation proof.
+        let response = try #require(await run.takeOutput())
+        #expect(try JSONDecoder().decode(Reply.self, from: response.stdout).value == "temporary-response")
+        #expect(await run.takeOutput() == nil)
+    }
+
+    @Test(arguments: [0, 128, 4 << 20])
+    func stdinDeliveryAndEOF(_ count: Int) async throws {
+        let bytes = Data(repeating: 65, count: count)
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/cat"),
+            standardInput: .data(bytes), maximumOutputBytes: 4 << 20, capturing: stdout))
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(report.input == .delivered && report.inputClosed)
+        #expect(try #require(await run.takeOutput()).stdout == bytes)
+    }
+
+    @Test func stderrAndFailureAreNotDiagnosticText() async throws {
+        let marker = "guesthouse-missing-" + UUID().uuidString
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/ls"),
+            arguments: ["/private/tmp/" + marker], maximumOutputBytes: 4096, capturing: [.stderr]))
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(1))
+        #expect(report.outputComplete)
+        let response = try #require(await run.takeOutput())
+        #expect(response.stdout.isEmpty)
+        #expect(String(decoding: response.stderr, as: UTF8.self).contains(marker))
+        #expect(!ProcessLaunchFailure.executableUnavailable.message.contains(marker))
+    }
+
+    @Test func environmentAndWorkingDirectoryAreExplicit() async throws {
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/env"),
+            environment: ["GUESTHOUSE_TEST": "1"], maximumOutputBytes: 4096, capturing: stdout))
+        _ = try await run.waitForExit()
+        #expect(try #require(await run.takeOutput()).stdout == Data("GUESTHOUSE_TEST=1\n".utf8))
+        let pwd = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/pwd"),
+            currentDirectory: URL(fileURLWithPath: "/private/tmp"), maximumOutputBytes: 4096, capturing: stdout))
+        _ = try await pwd.waitForExit()
+        #expect(try #require(await pwd.takeOutput()).stdout == Data("/private/tmp\n".utf8))
+    }
+
+    @Test func largeOutputKeepsDrainingAfterCaptureSaturates() async throws {
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/printf"),
+            arguments: ["%02000000d", "0"], maximumOutputBytes: 128, capturing: stdout))
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(!report.outputComplete && !report.timedOut)
+        let response = try #require(await run.takeOutput())
+        #expect(response.stdout.count == 128 && response.truncated)
+        #expect(response.stdoutEnd == .eof && response.stderrEnd == .eof)
+    }
+
+    @Test(arguments: [false, true]) func unreadInputCannotBlockDeadline(_ supplyInput: Bool) async throws {
+        let began = ContinuousClock.now
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"),
+            arguments: ["60"], standardInput: supplyInput ? .data(Data(repeating: 65, count: 4 << 20)) : .none,
+            timeout: .milliseconds(100), terminationGracePeriod: .milliseconds(100)))
+        let report = try await run.waitForExit()
+        #expect(report.timedOut && !report.canceled)
+        #expect(try report.childExit?.get() == .signal(SIGTERM))
+        if supplyInput { #expect(report.input != .delivered) }
+        #expect(ContinuousClock.now - began < .seconds(3))
+    }
+
+    @Test func earlyExitReportsUndeliveredInput() async throws {
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/true"),
+            standardInput: .data(Data(repeating: 65, count: 4 << 20))))
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(report.input != .delivered && report.inputClosed)
+    }
+
+    @Test func canceledWaitStillObservesReapedChild() async throws {
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/sleep"),
+            arguments: ["60"], terminationGracePeriod: .milliseconds(50)))
+        let waiting = Task { try await run.waitForExit() }
+        waiting.cancel()
+        let report = try await waiting.value
+        #expect(report.canceled && !report.timedOut)
+        #expect(try report.childExit?.get() == .signal(SIGTERM))
+    }
+
+    @Test func completedOutcomeCannotBeRewritten() async throws {
+        let run = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/true")))
+        let first = try await run.waitForExit()
+        await run.terminate(gracePeriod: .zero)
+        let second = try await run.waitForExit()
+        #expect(!first.canceled && !second.canceled && !second.timedOut)
+        #expect(try second.childExit?.get() == .status(0))
+    }
+
+    @Test func timeoutAfterRootExitAbandonsInheritedPipes() async throws {
+        let fixture = try Fixture(executable: "/usr/bin/true")
+        defer { fixture.closeWriters() }
+        let run = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
+        await run.start(deadline: .now + .milliseconds(100), input: nil)
+        let report = try await run.waitForExit()
+        #expect(try report.childExit?.get() == .status(0))
+        #expect(report.timedOut && !report.outputComplete && report.descendantScopeUnproven)
+    }
+
+    @Test func droppedFacadePreservesItsDeadline() async throws {
+        let fixture = try Fixture()
+        defer { fixture.closeWriters() }
+        var run: ProcessRun? = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
+        weak let facade = run
+        await run?.start(deadline: .now + .milliseconds(100), input: nil)
+        run = nil
+        #expect(facade == nil)
+        #expect(try await fixture.child.waitForReapedExit().get() == .signal(SIGTERM))
+    }
+
+    @Test func concurrentTerminationShortensOneEscalation() async throws {
+        // Signal spy only affects our direct fixture; real SIGKILL still uses owned authority.
+        let storage = SignalStorage()
+        var calls = OwnedChild.SystemCalls.live
+        calls.signal = { pid, signal in
+            storage.signals.withLock { $0.append(signal) }
+            return signal == SIGTERM ? .delivered : OwnedChild.SystemCalls.live.signal(pid, signal)
+        }
+        let fixture = try Fixture(calls: calls)
+        defer { fixture.closeWriters() }
+        let run = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
+        await run.start(deadline: .now + .seconds(10), input: nil)
+        await run.terminate(gracePeriod: .seconds(60))
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<32 { group.addTask { await run.terminate(gracePeriod: .milliseconds(50)) } }
+        }
+        #expect(try await fixture.child.waitForReapedExit().get() == .signal(SIGKILL))
+        fixture.closeWriters()
+        let report = try await run.waitForExit()
+        #expect(report.canceled && !report.timedOut)
+        #expect(storage.signals.withLock { $0 } == [SIGTERM, SIGKILL])
+    }
+
+    @Test func invalidOptionsAndLaunchFailuresAreFixedAndActionable() async throws {
+        let cases: [(ProcessInvocation, ProcessLaunchFailure)] = [
+            (.init(executable: URL(fileURLWithPath: "/usr/bin/true"), timeout: .seconds(-1)), .invalidOptions),
+            (.init(executable: URL(fileURLWithPath: "/usr/bin/true"), standardInput: .data(Data(count: (4 << 20) + 1))), .invalidOptions),
+            (.init(executable: URL(fileURLWithPath: "/guesthouse-missing-tool")), .executableUnavailable),
+            (.init(executable: URL(fileURLWithPath: "/usr/bin/true"), currentDirectory: URL(fileURLWithPath: "/guesthouse-missing-folder")), .workingDirectoryUnavailable)
+        ]
+        for (invocation, failure) in cases {
+            await #expect(throws: failure) { _ = try await runner.run(invocation) }
+            #expect(!failure.message.isEmpty && !failure.recoveryActions.isEmpty)
+            #expect(!failure.message.contains(invocation.executable.path))
+        }
+    }
+
+    @Test func refusedKillReportsUnconfirmedExitWithoutRewritingItLater() async throws {
+        let storage = SignalStorage()
+        var calls = OwnedChild.SystemCalls.live
+        calls.signal = { pid, signal in
+            storage.allow.withLock { $0 } ? OwnedChild.SystemCalls.live.signal(pid, signal) : .refused(EPERM)
+        }
+        let fixture = try Fixture(calls: calls)
+        defer { storage.allow.withLock { $0 = true }; fixture.closeWriters() }
+        let run = ProcessRun(child: fixture.child, readers: fixture.readers, input: nil, grace: .zero)
+        await run.start(deadline: .now, input: nil)
+        let report = try await run.waitForExit()
+        #expect(report.childExit == nil && report.timedOut && report.terminationRefused)
+        #expect(!report.outputComplete && report.descendantScopeUnproven)
+        storage.allow.withLock { $0 = true }
+        #expect(fixture.child.signal(SIGKILL) == .delivered)
+        #expect(try await fixture.child.waitForReapedExit().get() == .signal(SIGKILL))
+        #expect(try await run.waitForExit().childExit == nil)
+    }
+
+    @Test func alreadyCanceledTaskDoesNotLaunch() async {
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            await #expect(throws: ProcessLaunchFailure.canceled) {
+                _ = try await runner.run(ProcessInvocation(executable: URL(fileURLWithPath: "/usr/bin/true")))
+            }
+        }
+        await task.value
+    }
+
+    private final class SignalStorage: Sendable {
+        let signals = Mutex<[Int32]>([])
+        let allow = Mutex(false)
+    }
+    private struct Fixture {
+        let child: OwnedChild, readers = OutputReaders()
+        let stdout = Pipe(), stderr = Pipe(), stdin = Pipe()
+        let watchdog: Task<Void, Never>
+        init(executable: String = "/bin/cat", calls: OwnedChild.SystemCalls = .live) throws {
+            try readers.attach(stdout.fileHandleForReading, kind: .stdout)
+            try readers.attach(stderr.fileHandleForReading, kind: .stderr)
+            let child = try OwnedChild.spawn(executable: URL(fileURLWithPath: executable),
+                standardInput: stdin.fileHandleForReading.fileDescriptor,
+                standardOutput: stdout.fileHandleForWriting.fileDescriptor,
+                standardError: stderr.fileHandleForWriting.fileDescriptor, calls: calls)
+            self.child = child
+            watchdog = Task {
+                do { try await Task.sleep(for: .seconds(5)) } catch { return }
+                child.signal(SIGKILL)
+            }
+            try stdin.fileHandleForReading.close()
+        }
+        func closeWriters() {
+            watchdog.cancel()
+            try? stdout.fileHandleForWriting.close(); try? stderr.fileHandleForWriting.close()
+            try? stdin.fileHandleForWriting.close()
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Migrates the retained ProcessRunner lifecycle from #69 onto the reviewed direct-child/output prerequisites #161 and #162. Implements a bounded part of MVP-PLAN.md §3 (application components and process/trust boundaries) and §4 (truthful interrupted outcomes), following ADR 0003. Related: #21, #69, closed reference #108.

**Targets main after the owner merged #162.** Main `10e5b12eed7644602380bf8b8ddbe23792333fe9` contains the tested parent `c1c16f2cc63ab8410cc62e1aa0b5785272c7df39` and has exactly the same tree. The parent passed exact-head Xcode Cloud at16:36:56 UTC, matching completed Codex review and original-message 👍. This PR needs its own fresh gates.

- Connects existing OwnedChild and bounded output readers to actual launch, bounded nonblocking stdin, deadline, cancellation, escalation, drain and final outcome handling.
- Keeps executable/argv/environment explicit and cwd descriptor-pinned. No shell or inherited credentials; runtime-internal only, no generic GUI command API.
- Distinguishes normal exit, cancellation, timeout, uncertain exit, input delivery and output completeness. Completed reports are immutable; parser bytes transfer separately once and never become diagnostic events.
- Preserves original deadlines after direct-child exit, permits shortening an already-pending escalation, and retains cleanup after the caller drops its handle.

## Deliberate limits

Direct-child exit, output EOF, delivered stdin and delivered signals are separate facts—not proof of descendant quiescence, provider success or completed mutation cleanup. No sampled-PID/process-group signaling, automatic mutation retry or fabricated successful shutdown.

No production adapter or service mutation activation. The public service remains runtimeVersion-only. Provider-specific parsing, typed diagnostic mapping, whole-mutation recovery and downstream diagnostic/export isolation remain tracked by #21/#69; this PR does not close them. No raw-output log/export bridge, generic redactor, host storage setup, signing or VM/hardware action.

## Validation

Head `c603ce63f4c46f195ac1f31a752b3d940a5fb988`: 557 additions across four files (239 runner/run lines, 69 input-delivery lines and 249 test lines). The cohesive lifecycle and retained regressions are kept together; no unrelated package/project edits.

- All 515 strict local package test functions pass: Core392/35 suites, RuntimeKit51/6, ClientKit72/7.
- Sixteen runner test functions pass Release, five consecutive Debug runs and Thread Sanitizer.
- Seven CI-hook scenarios and the unsigned shared-scheme Xcode build-for-testing pass.
- Tests include exact-byte stdin/stdout JSON parsing, unused-output discard, bounded/unread stdin, environment isolation, launch error categories, cancellation/reaping, deadline after direct-child exit with open pipes, refused signals, truthful unconfirmed exit, concurrent termination/deadline shortening, dropped-caller cleanup and cancellation followed by an actual zero exit.

The zero-exit fixture uses an owned actual cat child and an injected termination result; it proves cancellation is not overwritten, not provider graceful shutdown. No disabled tests or new Swift/C warnings. Local results are not GitHub approval, positive signed-service evidence or hardware proof.

## Review and integration

Await fresh exact-head Xcode Cloud and completed Codex review with original-message 👍 and no unaddressed inline or standalone findings. The owner alone merges. Issue #48 is the integration dashboard; the read-only storage migration remains local and will follow only after this PR converges.
