### PR TITLE
Migrate read-only private storage protection checks

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
@@ -1,0 +1,168 @@
+import Darwin
+import Darwin.membership
+import Foundation
+import GuesthouseCore
+
+/// Closed failures only: no filesystem paths, ACL text or underlying error descriptions
+/// reach error presentation or diagnostics (ADR 0003). No repair workflow is implied.
+enum StorageFailure: Error, Equatable, Sendable, CaseIterable {
+    case invalidLocation, inspectionFailed, unsafeStructure, protectionDrift
+
+    var message: String {
+        switch self {
+        case .invalidLocation:
+            "Guesthouse refused an invalid managed-storage location. Cancel and preserve existing storage."
+        case .inspectionFailed:
+            "Guesthouse could not inspect its storage protection. Cancel and preserve the folders and any unpublished work."
+        case .unsafeStructure:
+            "Guesthouse cannot safely use its storage hierarchy. Preserve the folders and linked destinations; they may contain unpublished work. Cancel before changing anything."
+        case .protectionDrift:
+            "Guesthouse storage is no longer private. Cancel and leave its contents in place; they may contain unpublished work."
+        }
+    }
+    var recoveryActions: [RecoveryAction] { [.cancel] }
+}
+
+/// Read-only checks adapted from #70/#88 for MVP-PLAN.md §§3 and 9. These are point-in-time
+/// observations, NOT durable authority against concurrent namespace changes. Only runtime-
+/// selected paths belong here. Preparation and every managed-component reuse must integrate
+/// these checks before any production storage/VM operation is enabled.
+enum StorageProtection {
+    static func verify(_ url: URL) throws {
+        let info = try structure(url)
+        guard info.st_mode & 0o7777 == 0o700 else { throw StorageFailure.protectionDrift }
+        try entries(at: try path(url), followLinks: false, expected: info) { _ in throw StorageFailure.protectionDrift }
+    }
+
+    /// Preparation may later repair leaf mode/ACL drift, but never an unsafe structure.
+    @discardableResult static func structure(_ url: URL) throws -> stat {
+        let name = try path(url)
+        var info = stat()
+        guard lstat(name, &info) == 0 else { throw StorageFailure.inspectionFailed }
+        guard info.st_mode & S_IFMT == S_IFDIR, info.st_uid == getuid() else {
+            throw StorageFailure.unsafeStructure
+        }
+        try ancestors(from: parent(name))
+        return info
+    }
+
+    /// Find the existing prefix before creation; missing suffixes never authorize mutation.
+    static func existingAncestors(of url: URL) throws {
+        var candidate = parent(try path(url))
+        while true {
+            var info = stat()
+            if lstat(candidate, &info) == 0 { try ancestors(from: candidate); return }
+            guard [ENOENT, ENOTDIR, ELOOP].contains(errno), candidate != "/" else {
+                throw StorageFailure.inspectionFailed
+            }
+            candidate = parent(candidate)
+        }
+    }
+
+    private static func path(_ url: URL) throws -> String {
+        let name = url.path(percentEncoded: false)
+        guard url.isFileURL, url.host == nil || url.host == "" || url.host == "localhost",
+              url.query == nil, url.fragment == nil, name.hasPrefix("/"),
+              !name.utf8.contains(0), name.utf8.count < Int(PATH_MAX),
+              !name.split(separator: "/").contains(where: { $0 == "." || $0 == ".." }) else {
+            throw StorageFailure.invalidLocation
+        }
+        return name
+    }
+    private static func parent(_ path: String) -> String {
+        let value = (path as NSString).deletingLastPathComponent
+        return value.isEmpty ? "/" : value
+    }
+    private static func ancestors(from start: String) throws {
+        var visited: Set<String> = []
+        try walk(start, visited: &visited)
+        guard let resolved = realpath(start, nil) else { throw StorageFailure.inspectionFailed }
+        defer { free(resolved) }
+        // Lexical checks alone miss the parents that control a symlink's target.
+        try walk(String(cString: resolved), visited: &visited)
+    }
+    private static func walk(_ start: String, visited: inout Set<String>) throws {
+        var candidate = start
+        while true {
+            if visited.insert(candidate).inserted { try ancestor(candidate) }
+            if candidate == "/" { return }
+            candidate = parent(candidate)
+        }
+    }
+    private static func ancestor(_ path: String) throws {
+        var info = stat()
+        guard lstat(path, &info) == 0 else { throw StorageFailure.inspectionFailed }
+        if info.st_mode & S_IFMT == S_IFLNK {
+            // In a sticky parent, the link's owner may replace it regardless of its target.
+            guard mayHoldEntry(owner: info.st_uid) else { throw StorageFailure.unsafeStructure }
+            guard stat(path, &info) == 0 else { throw StorageFailure.unsafeStructure }
+        }
+        guard info.st_mode & S_IFMT == S_IFDIR, mayHoldEntry(owner: info.st_uid),
+              info.st_mode & (S_IWGRP | S_IWOTH) == 0 || info.st_mode & S_ISVTX != 0 else {
+            throw StorageFailure.unsafeStructure
+        }
+        try entries(at: path, followLinks: true, expected: info) { entry in
+            var tag = acl_tag_t(0)
+            guard acl_get_tag_type(entry, &tag) == 0 else { throw StorageFailure.inspectionFailed }
+            if tag == ACL_EXTENDED_DENY { return }
+            guard tag == ACL_EXTENDED_ALLOW else { throw StorageFailure.inspectionFailed }
+            if try grantsReplacement(entry), !isCurrentUser(entry) { throw StorageFailure.unsafeStructure }
+        }
+    }
+    static func mayHoldEntry(owner: uid_t) -> Bool { owner == getuid() || owner == 0 }
+
+    /// The SDK's acl_get_entry(3) specifies -1/EINVAL for exhaustion. Other failures are not
+    /// an empty list. This is separate from absent metadata in a successful statx snapshot.
+    static func enumerationFinished(result: Int32, error: Int32) -> Bool { result == -1 && error == EINVAL }
+    private static func entries(at path: String, followLinks: Bool, expected: stat, visit: (acl_entry_t) throws -> Void) throws {
+        // Apple's acl_get_file conflates lookup ENOENT with absent FILESEC_ACL metadata.
+        // Query presence only AFTER a successful statx; never turn a lookup error into "none".
+        // Evidence: apple-oss-distributions/Libc 71bbe350, acl_file.c + filesec.c + statx_np.c.
+        guard let security = filesec_init() else { throw StorageFailure.inspectionFailed }
+        defer { filesec_free(security) }
+        var current = stat(), present: Int32 = 0
+        var owner = uid_t(0), mode = mode_t(0)
+        let result = followLinks ? statx_np(path, &current, security) : lstatx_np(path, &current, security)
+        guard result == 0, current.st_dev == expected.st_dev, current.st_ino == expected.st_ino,
+              current.st_uid == expected.st_uid, current.st_mode == expected.st_mode,
+              filesec_get_property(security, FILESEC_OWNER, &owner) == 0, owner == current.st_uid,
+              filesec_get_property(security, FILESEC_MODE, &mode) == 0, mode == current.st_mode,
+              filesec_query_property(security, FILESEC_ACL, &present) == 0 else { throw StorageFailure.inspectionFailed }
+        guard present != 0 else { return }
+        var value: acl_t?
+        guard filesec_get_property(security, FILESEC_ACL, &value) == 0, let acl = value else { throw StorageFailure.inspectionFailed }
+        defer { acl_free(UnsafeMutableRawPointer(acl)) }
+        var position = ACL_FIRST_ENTRY.rawValue
+        while true {
+            var entry: acl_entry_t?
+            errno = 0
+            let result = acl_get_entry(acl, position, &entry), error = errno
+            if enumerationFinished(result: result, error: error) { return }
+            guard result == 0, let entry else { throw StorageFailure.inspectionFailed }
+            try visit(entry)
+            position = ACL_NEXT_ENTRY.rawValue
+        }
+    }
+    private static let replacementRights: [acl_perm_t] = [
+        ACL_ADD_FILE, ACL_ADD_SUBDIRECTORY, ACL_DELETE_CHILD, ACL_DELETE,
+        ACL_WRITE_ATTRIBUTES, ACL_WRITE_EXTATTRIBUTES, ACL_WRITE_SECURITY, ACL_CHANGE_OWNER,
+    ]
+    private static func grantsReplacement(_ entry: acl_entry_t) throws -> Bool {
+        var permissions: acl_permset_t?
+        guard acl_get_permset(entry, &permissions) == 0, let permissions else { throw StorageFailure.inspectionFailed }
+        var grants = false
+        for right in replacementRights {
+            let result = acl_get_perm_np(permissions, right)
+            guard result == 0 || result == 1 else { throw StorageFailure.inspectionFailed }
+            grants = grants || result == 1
+        }
+        return grants
+    }
+    private static func isCurrentUser(_ entry: acl_entry_t) -> Bool {
+        guard let qualifier = acl_get_qualifier(entry) else { return false }
+        defer { acl_free(qualifier) }
+        var identifier = uid_t(0), kind = Int32(0)
+        guard mbr_uuid_to_id(qualifier.assumingMemoryBound(to: UInt8.self), &identifier, &kind) == 0 else { return false }
+        return kind == ID_TYPE_UID && identifier == getuid()
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
@@ -59,14 +59,18 @@ enum StorageProtection {
         }
     }
 
-    private static func path(_ url: URL) throws -> String {
-        let name = url.path(percentEncoded: false)
+    static func path(_ url: URL) throws -> String {
+        var name = url.path(percentEncoded: false)
         guard url.isFileURL, url.host == nil || url.host == "" || url.host == "localhost",
               url.query == nil, url.fragment == nil, name.hasPrefix("/"),
               !name.utf8.contains(0), name.utf8.count < Int(PATH_MAX),
               !name.split(separator: "/").contains(where: { $0 == "." || $0 == ".." }) else {
             throw StorageFailure.invalidLocation
         }
+        // A directory URL retains its trailing slash in this decoded representation. POSIX
+        // would follow the final symlink for "link/", even with lstat/O_NOFOLLOW. Inspect the
+        // entry itself instead, without resolving links or normalizing away rejected dots.
+        while name.count > 1 && name.hasSuffix("/") { name.removeLast() }
         return name
     }
     private static func parent(_ path: String) -> String {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageProtectionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageProtectionTests.swift
@@ -5,12 +5,12 @@ import Testing
 @testable import GuesthouseRuntimeKit
 
 @Suite struct StorageProtectionTests {
-    @Test func privateDirectoryPassesWithoutChangingItsContents() throws {
+    @Test(arguments: [false, true]) func privateDirectoryPassesWithoutChangingItsContents(_ directoryURL: Bool) throws {
         let fixture = try Fixture()
         let directory = try fixture.directory("storage")
         let sentinel = directory.appending(path: "unpublished-work")
         try Data("keep me".utf8).write(to: sentinel)
-        try StorageProtection.verify(directory)
+        try StorageProtection.verify(directoryURL ? URL(fileURLWithPath: directory.path, isDirectory: true) : directory)
         #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
         #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["unpublished-work"])
     }
@@ -33,13 +33,15 @@ import Testing
         try StorageProtection.verify(directory) // Explicit empty ACL after fixture cleanup also passes.
     }
 
-    @Test(arguments: [false, true]) func finalLinksAreRefusedAndPreserved(_ dangling: Bool) throws {
+    @Test(arguments: [false, true], [false, true])
+    func finalLinksAreRefusedAndPreserved(_ dangling: Bool, _ directoryURL: Bool) throws {
         let fixture = try Fixture()
         let destination = fixture.root.appending(path: "target")
         if !dangling { _ = try fixture.directory("target") }
         let link = fixture.root.appending(path: "storage")
         try FileManager.default.createSymbolicLink(at: link, withDestinationURL: destination)
-        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.verify(link) }
+        let inspected = directoryURL ? URL(fileURLWithPath: link.path, isDirectory: true) : link
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.verify(inspected) }
         #expect(try FileManager.default.destinationOfSymbolicLink(atPath: link.path) == destination.path)
     }
 

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageProtectionTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageProtectionTests.swift
@@ -1,0 +1,163 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite struct StorageProtectionTests {
+    @Test func privateDirectoryPassesWithoutChangingItsContents() throws {
+        let fixture = try Fixture()
+        let directory = try fixture.directory("storage")
+        let sentinel = directory.appending(path: "unpublished-work")
+        try Data("keep me".utf8).write(to: sentinel)
+        try StorageProtection.verify(directory)
+        #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["unpublished-work"])
+    }
+
+    @Test(arguments: [0o755, 0o770, 0o1700]) func modeDriftIsRefusedWithoutRepair(_ mode: Int) throws {
+        let fixture = try Fixture()
+        let directory = try fixture.directory("storage", mode: mode)
+        #expect(throws: StorageFailure.protectionDrift) { try StorageProtection.verify(directory) }
+        #expect(try StorageProtection.structure(directory).st_mode & 0o7777 == mode_t(mode))
+    }
+
+    @Test func leafACLIsRefusedButNeverRemoved() async throws {
+        let fixture = try Fixture()
+        let directory = try fixture.directory("storage")
+        try await fixture.withACL("everyone allow read,list", at: directory) {
+            #expect(throws: StorageFailure.protectionDrift) { try StorageProtection.verify(directory) }
+            _ = try StorageProtection.structure(directory)
+            #expect(throws: StorageFailure.protectionDrift) { try StorageProtection.verify(directory) }
+        }
+        try StorageProtection.verify(directory) // Explicit empty ACL after fixture cleanup also passes.
+    }
+
+    @Test(arguments: [false, true]) func finalLinksAreRefusedAndPreserved(_ dangling: Bool) throws {
+        let fixture = try Fixture()
+        let destination = fixture.root.appending(path: "target")
+        if !dangling { _ = try fixture.directory("target") }
+        let link = fixture.root.appending(path: "storage")
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: destination)
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.verify(link) }
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: link.path) == destination.path)
+    }
+
+    @Test func danglingAndNonDirectoryAncestorsArePreserved() throws {
+        let fixture = try Fixture()
+        let missing = fixture.root.appending(path: "missing")
+        let alias = fixture.root.appending(path: "alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: missing)
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.existingAncestors(of: alias.appending(path: "new")) }
+        #expect(!FileManager.default.fileExists(atPath: missing.path))
+        let blocker = fixture.root.appending(path: "blocker")
+        try Data("keep me".utf8).write(to: blocker)
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.verify(blocker) }
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.existingAncestors(of: blocker.appending(path: "new")) }
+        #expect(try Data(contentsOf: blocker) == Data("keep me".utf8))
+    }
+
+    @Test func validAncestorAliasAndItsRealParentsAreInspected() throws {
+        let fixture = try Fixture()
+        let target = try fixture.directory("target")
+        let directory = try fixture.directory("target/storage")
+        let alias = fixture.root.appending(path: "alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: target)
+        try StorageProtection.verify(alias.appending(path: "storage"))
+        try StorageProtection.verify(directory)
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: alias.path) == target.path)
+    }
+
+    @Test func unsafeAncestryIsRefusedBeforeCreation() throws {
+        let fixture = try Fixture()
+        let parent = try fixture.directory("exposed", mode: 0o777)
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.existingAncestors(of: parent.appending(path: "missing/deeper")) }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+        try FileManager.default.setAttributes([.posixPermissions: 0o1777], ofItemAtPath: parent.path)
+        try StorageProtection.existingAncestors(of: parent.appending(path: "missing/deeper"))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: parent.path).isEmpty)
+    }
+
+    @Test func resolvedUnsafeAncestryCannotHideBehindAnAlias() throws {
+        let fixture = try Fixture()
+        _ = try fixture.directory("exposed", mode: 0o777)
+        let target = try fixture.directory("exposed/target")
+        let alias = fixture.root.appending(path: "alias")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: target)
+        #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.existingAncestors(of: alias.appending(path: "storage")) }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: target.path).isEmpty)
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: alias.path) == target.path)
+    }
+
+    @Test(arguments: ["everyone deny delete", "everyone allow read,list"])
+    func harmlessAncestorACLsRemainUsable(_ rule: String) async throws {
+        let fixture = try Fixture()
+        let parent = try fixture.directory("parent")
+        try await fixture.withACL(rule, at: parent) {
+            try StorageProtection.existingAncestors(of: parent.appending(path: "storage"))
+        }
+    }
+
+    @Test func replacementRightsForAnotherPrincipalAreRefused() async throws {
+        let fixture = try Fixture()
+        let parent = try fixture.directory("parent")
+        try await fixture.withACL("everyone allow add_file,delete_child", at: parent) {
+            #expect(throws: StorageFailure.unsafeStructure) { try StorageProtection.existingAncestors(of: parent.appending(path: "storage")) }
+        }
+        try await fixture.withACL("\(NSUserName()) allow add_file,delete_child", at: parent) {
+            try StorageProtection.existingAncestors(of: parent.appending(path: "storage"))
+        }
+    }
+
+    @Test(arguments: [(Int32(-1), EINVAL, true), (-1, ENOENT, false), (-1, EIO, false),
+                     (-1, EACCES, false), (-1, EBADF, false), (-1, EPERM, false),
+                     (-1, ENOMEM, false), (-1, 0, false), (0, EINVAL, false)])
+    func onlyDocumentedACLExhaustionIsAccepted(_ result: Int32, _ error: Int32, _ expected: Bool) {
+        #expect(StorageProtection.enumerationFinished(result: result, error: error) == expected)
+    }
+
+    @Test func ownerPolicyAndUninspectableLocationsFailClosed() throws {
+        #expect(StorageProtection.mayHoldEntry(owner: getuid()))
+        #expect(StorageProtection.mayHoldEntry(owner: 0))
+        #expect(!StorageProtection.mayHoldEntry(owner: getuid() &+ 1)) // Policy only; no foreign-owned fixture.
+        let fixture = try Fixture()
+        #expect(throws: StorageFailure.inspectionFailed) { try StorageProtection.verify(fixture.root.appending(path: "missing")) }
+        #expect(throws: StorageFailure.invalidLocation) { try StorageProtection.verify(URL(string: "https://example.invalid/storage")!) }
+        #expect(throws: StorageFailure.invalidLocation) { try StorageProtection.verify(URL(fileURLWithPath: fixture.root.path + "/bad\0suffix")) }
+    }
+
+    @Test(arguments: StorageFailure.allCases) func failuresContainOnlyFixedUsefulGuidance(_ failure: StorageFailure) {
+        #expect(!failure.message.isEmpty)
+        #expect(failure.recoveryActions == [.cancel])
+        #expect(!failure.message.contains("Settings") && !failure.message.contains("/private/"))
+    }
+
+    private final class Fixture: Sendable {
+        let root: URL
+        init() throws {
+            var template = Array("/private/tmp/guesthouse-storage-protection-XXXXXX".utf8CString)
+            guard let path = mkdtemp(&template) else { throw StorageFailure.inspectionFailed }
+            root = URL(fileURLWithPath: String(cString: path), isDirectory: true)
+        }
+        deinit { try? FileManager.default.removeItem(at: root) } // Only this mkdtemp-owned fixture.
+        func directory(_ name: String, mode: Int = 0o700) throws -> URL {
+            let url = root.appending(path: name)
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+            try FileManager.default.setAttributes([.posixPermissions: mode], ofItemAtPath: url.path)
+            return url
+        }
+        func withACL(_ rule: String, at url: URL, body: () throws -> Void) async throws {
+            defer {
+                if let empty = acl_init(0) {
+                    #expect(acl_set_link_np(url.path, ACL_TYPE_EXTENDED, empty) == 0)
+                    acl_free(UnsafeMutableRawPointer(empty))
+                } else { Issue.record("Could not clear the owned fixture ACL") }
+            }
+            let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/chmod"),
+                arguments: ["+a", rule, url.path], timeout: .seconds(5)))
+            let report = try await run.waitForExit()
+            try #require(try report.childExit?.get() == .status(0) && !report.timedOut && !report.canceled)
+            try body()
+        }
+    }
+}


### PR DESCRIPTION
## Scope

Adapt the retained read-only storage protections and regressions from #70 + #88 to current RuntimeKit and ADR 0003. Implements a bounded part of MVP-PLAN.md §3 (private managed storage) and §9 (preserving unpublished work). Related: #22; does not close it or either historical reference.

**Stacked on #163 at `c603ce63f4c46f195ac1f31a752b3d940a5fb988`.** The parent has exact-head green Xcode Cloud, completed matching Codex review, original-message 👍 and no findings. The owner alone merges; after #163 lands, settle this PR on main and recheck composition. Do not merge this child into the feature-parent branch.

- Internal read-only checks for real current-user-owned directories, exact0700 and empty leaf extended ACL.
- Preserve lexical/canonical ancestor, link-entry ownership, shared-write/sticky and ACL replacement-right checks. Refuse unsafe or uninspectable ancestors before future creation.
- Explicit filesec ACL-property presence after successful statx/lstatx and matching identity metadata. A failed ACL lookup is never accepted as an empty ACL.
- Validate the decoded local path before POSIX use, including NUL rejection, then remove trailing separators so a directory URL cannot make lstat follow the final symlink.
- Four closed failures with useful Guesthouse-written preservation guidance and Cancel recovery. No raw paths, ACL strings or underlying errors enter diagnostic/error payloads; no nonexistent Settings/repair flow.

## Deliberate limits

**No production storage creation, repair or usable RuntimeStorage API yet.** The next preparation/reuse slice must connect these checks for every managed area and intermediate component before storage/VM operations are enabled. This inspection is point-in-time, not a permanent namespace capability or proof against every concurrent filesystem substitution.

No provider selection, invented Lume flags, backup-policy mutation, StateStore, signing or hardware action. VM disks must remain backup-eligible in the subsequent integration; only staging/downloads are excluded. Eligibility alone does not prove a consistent, restorable VM backup.

## Validation

Head `104bc20eba3180cf875b0e42473dc088079a609f`:337 additions/two files, no package/project/epoch/caller changes.

- All528 strict local package test functions pass (Core392/35 suites, RuntimeKit64/7, ClientKit72/7).
- Thirteen storage functions pass Release, five Debug repetitions and Thread Sanitizer.
- Seven CI-hook scenarios and unsigned shared-scheme Xcode build-for-testing pass.
- Fixtures cover leaf mode/ACL drift without repair, preserved files/links, dangling and non-directory ancestors, canonical alias ancestry, sticky/shared-write rules, ACL read/deny/replacement policy, inspection failures, decoded NUL and fixed guidance.
- Every filesystem fixture owns an isolated mkdtemp root; cleanup removes only that root. Foreign ownership is tested as policy, not claimed as a privileged fixture.
- Initial absent-ACL and decoded-NUL failures were corrected locally before publication. No disabled tests, Swift/C warnings, redundant CI runs or fabricated hardware evidence.

Primary implementation evidence: [Apple Libc acl_file.c](https://github.com/apple-oss-distributions/Libc/blob/71bbe350ab79eef58113991d817ccc6165061a64/posix1e/acl_file.c), [filesec.c](https://github.com/apple-oss-distributions/Libc/blob/71bbe350ab79eef58113991d817ccc6165061a64/gen/filesec.c), and [statx_np.c](https://github.com/apple-oss-distributions/Libc/blob/71bbe350ab79eef58113991d817ccc6165061a64/sys/statx_np.c), plus local SDK declarations and acl_get_entry/acl_get_file man pages.

## Local audit correction

`104bc20e` fixes the reproduced directory-URL final-link gap, with four real/dangling × plain/directory-URL refusal cases and valid-directory URL coverage. The failing-before/passing-after evidence is described in the [audit explanation](https://github.com/PicoMLX/Guesthouse/pull/164#issuecomment-5605887287). All528 strict package functions, thirteen storage functions in Release/five Debug repetitions/Thread Sanitizer, seven hook scenarios and unsigned shared-scheme test build pass again.

The first head passed Xcode Cloud, but its review and one unchanged-head retry failed; the retry reported a missing git ref that GitHub's API and branch both confirm exists. This is not a code approval or a proven root cause. One fresh review is requested for this genuinely changed, validated head; no empty commit or CI restart is used.

Await this head's own Xcode Cloud and completed Codex review with original-message 👍 and no unaddressed findings. Follow #48 for the current queue.
