### PR TITLE
Migrate private runtime storage preparation and reuse

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -20,6 +20,8 @@ struct RuntimeStorage: Sendable {
 
     /// Runtime-only injection for isolated fixtures; never exposed in an XPC request.
     init(root: URL, backup: BackupWriter) throws {
+        // Use the same validated, trailing-separator-free spelling for inspection AND writes.
+        let root = URL(fileURLWithPath: try StorageProtection.path(root), isDirectory: false)
         try StorageProtection.existingAncestors(of: root) // Validate the original decoded path first.
         self.root = root
         // Inspect the entire existing managed layout BEFORE changing any protection or creating

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -4,6 +4,8 @@ import Foundation
 /// Service-only storage layout migrated from #70/#88 (MVP-PLAN.md §§3 and 9). No GUI-supplied
 /// root or provider environment adapter. Preparation is explicit; reuse only checks and never
 /// silently repairs. Paths remain point-in-time observations, not permanent filesystem leases.
+/// Repair needs read or search access to open each directory. Refuse inaccessible existing
+/// layouts before mutation; never use privileged policy changes or pathname chmod for access.
 struct RuntimeStorage: Sendable {
     enum Area: String, CaseIterable, Sendable {
         case runtime, vms, state, staging, downloads, diagnostics
@@ -72,7 +74,21 @@ struct RuntimeStorage: Sendable {
         var info = stat()
         if lstat(url.path(percentEncoded: false), &info) == 0 {
             try StorageProtection.structure(url)
+            // Check access across the whole layout before repairing earlier components.
+            let fd = try openForPreparation(url)
+            close(fd)
         } else if errno != ENOENT { throw StorageFailure.inspectionFailed }
+    }
+
+    private static func openForPreparation(_ url: URL) throws -> Int32 {
+        // O_SEARCH includes O_DIRECTORY and permits descriptor-bound metadata repair without
+        // list/read access. O_EVTONLY still needs read access without an Apple-only entitlement.
+        // Retain O_RDONLY for readable leaves lacking search permission (for example, 0400).
+        let path = url.path(percentEncoded: false)
+        var fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        if fd < 0 && errno == EACCES { fd = open(path, O_SEARCH | O_NOFOLLOW | O_CLOEXEC) }
+        guard fd >= 0 else { throw StorageFailure.inspectionFailed }
+        return fd
     }
 
     private static func missingParents(of url: URL) throws -> [URL] {
@@ -97,8 +113,7 @@ struct RuntimeStorage: Sendable {
             guard mkdir(path, 0o700) == 0 || errno == EEXIST else { throw StorageFailure.preparationFailed }
         }
         let expected = try StorageProtection.structure(url)
-        let fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
-        guard fd >= 0 else { throw StorageFailure.inspectionFailed }
+        let fd = try openForPreparation(url)
         defer { close(fd) }
         var opened = stat()
         guard fstat(fd, &opened) == 0, sameIdentity(opened, expected), opened.st_mode == expected.st_mode else {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/RuntimeStorage.swift
@@ -1,0 +1,140 @@
+import Darwin
+import Foundation
+
+/// Service-only storage layout migrated from #70/#88 (MVP-PLAN.md §§3 and 9). No GUI-supplied
+/// root or provider environment adapter. Preparation is explicit; reuse only checks and never
+/// silently repairs. Paths remain point-in-time observations, not permanent filesystem leases.
+struct RuntimeStorage: Sendable {
+    enum Area: String, CaseIterable, Sendable {
+        case runtime, vms, state, staging, downloads, diagnostics
+        case sshMaintenance = "ssh/maintenance"
+
+        // A VM disk may be the only copy of unpublished work. Eligibility is NOT a verified backup.
+        var excludedFromBackup: Bool { self == .staging || self == .downloads }
+    }
+    private let root: URL
+    typealias BackupWriter = @Sendable (URL, Bool) throws -> Void
+
+    init() throws { try self.init(root: Self.defaultRoot()) }
+    init(root: URL) throws { try self.init(root: root, backup: Self.writeBackupExclusion) }
+
+    /// Runtime-only injection for isolated fixtures; never exposed in an XPC request.
+    init(root: URL, backup: BackupWriter) throws {
+        try StorageProtection.existingAncestors(of: root) // Validate the original decoded path first.
+        self.root = root
+        // Inspect the entire existing managed layout BEFORE changing any protection or creating
+        // siblings. A link/file/unsafe ancestor anywhere causes a preservation-first refusal.
+        let layout = [(root, false)] + Self.components(root: root)
+        for (url, _) in layout { try Self.preflight(url) }
+        let preparation = try Self.missingParents(of: root).map { ($0, false) } + layout
+        for (url, excluded) in preparation { try Self.prepare(url, excluded: excluded, backup: backup) }
+        for (url, excluded) in preparation { try Self.verify(url, excluded: excluded) }
+    }
+
+    /// Resolution only. No Application Support directory is created before ancestry checks.
+    static func defaultRoot() throws -> URL {
+        do {
+            return try FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask,
+                appropriateFor: nil, create: false).appending(path: "Guesthouse")
+        } catch { throw StorageFailure.inspectionFailed }
+    }
+
+    /// Each use rechecks the root, every managed intermediate, and the selected leaf, including
+    /// backup-policy drift. Returning this URL does not authorize arbitrary child paths or writes.
+    func location(for area: Area) throws -> URL {
+        try Self.verify(root, excluded: false)
+        var result = root
+        let parts = area.rawValue.split(separator: "/")
+        for (index, part) in parts.enumerated() {
+            result.append(path: String(part))
+            try Self.verify(result, excluded: index == parts.count - 1 && area.excludedFromBackup)
+        }
+        return result
+    }
+
+    private static func components(root: URL) -> [(URL, Bool)] {
+        var result: [(URL, Bool)] = []
+        for area in Area.allCases {
+            var url = root
+            let parts = area.rawValue.split(separator: "/")
+            for (index, part) in parts.enumerated() {
+                url.append(path: String(part))
+                result.append((url, index == parts.count - 1 && area.excludedFromBackup))
+            }
+        }
+        return result
+    }
+
+    private static func preflight(_ url: URL) throws {
+        try StorageProtection.existingAncestors(of: url)
+        var info = stat()
+        if lstat(url.path(percentEncoded: false), &info) == 0 {
+            try StorageProtection.structure(url)
+        } else if errno != ENOENT { throw StorageFailure.inspectionFailed }
+    }
+
+    private static func missingParents(of url: URL) throws -> [URL] {
+        var missing: [URL] = [], candidate = url.deletingLastPathComponent()
+        while true {
+            var info = stat()
+            if lstat(candidate.path(percentEncoded: false), &info) == 0 { return missing.reversed() }
+            guard errno == ENOENT, candidate.path != "/" else { throw StorageFailure.inspectionFailed }
+            missing.append(candidate)
+            candidate.deleteLastPathComponent()
+        }
+    }
+
+    private static func prepare(_ url: URL, excluded: Bool, backup: BackupWriter) throws {
+        try preflight(url)
+        let path = url.path(percentEncoded: false)
+        var info = stat()
+        if lstat(path, &info) != 0 {
+            guard errno == ENOENT else { throw StorageFailure.inspectionFailed }
+            // One component at a time, private from birth; never recursively traverse an
+            // uninspected missing suffix. EEXIST still requires real-directory/owner checks.
+            guard mkdir(path, 0o700) == 0 || errno == EEXIST else { throw StorageFailure.preparationFailed }
+        }
+        let expected = try StorageProtection.structure(url)
+        let fd = open(path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        guard fd >= 0 else { throw StorageFailure.inspectionFailed }
+        defer { close(fd) }
+        var opened = stat()
+        guard fstat(fd, &opened) == 0, sameIdentity(opened, expected), opened.st_mode == expected.st_mode else {
+            throw StorageFailure.unsafeStructure
+        }
+        guard let empty = acl_init(0) else { throw StorageFailure.preparationFailed }
+        defer { acl_free(UnsafeMutableRawPointer(empty)) }
+        // Mutate the inspected open directory, never chmod or set an ACL through a final link.
+        guard fchmod(fd, 0o700) == 0, acl_set_fd(fd, empty) == 0 else { throw StorageFailure.preparationFailed }
+        try verifyIdentity(url, expected: expected)
+        try StorageProtection.verify(url)
+        do { try backup(url, excluded) } catch { throw StorageFailure.preparationFailed }
+        // Foundation's backup metadata API is path-based. Refuse a changed binding afterward;
+        // this is not an atomic tree transaction or authority against hostile same-user races.
+        try verifyIdentity(url, expected: expected)
+        try verify(url, excluded: excluded)
+    }
+
+    private static func sameIdentity(_ a: stat, _ b: stat) -> Bool {
+        a.st_dev == b.st_dev && a.st_ino == b.st_ino && a.st_uid == b.st_uid && a.st_mode & S_IFMT == S_IFDIR
+    }
+    private static func verifyIdentity(_ url: URL, expected: stat) throws {
+        let current = try StorageProtection.structure(url)
+        guard sameIdentity(current, expected) else { throw StorageFailure.unsafeStructure }
+    }
+    private static func verify(_ url: URL, excluded: Bool) throws {
+        try StorageProtection.verify(url)
+        // A fresh URL avoids Foundation's cached resource values masking subsequent drift.
+        let fresh = URL(fileURLWithPath: url.path(percentEncoded: false), isDirectory: true)
+        let actual: Bool?
+        do { actual = try fresh.resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup }
+        catch { throw StorageFailure.inspectionFailed }
+        guard actual == excluded else { throw StorageFailure.protectionDrift }
+    }
+    static func writeBackupExclusion(_ url: URL, _ excluded: Bool) throws {
+        var fresh = URL(fileURLWithPath: url.path(percentEncoded: false), isDirectory: true)
+        var values = URLResourceValues()
+        values.isExcludedFromBackup = excluded
+        try fresh.setResourceValues(values)
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
@@ -6,7 +6,7 @@ import GuesthouseCore
 /// Closed failures only: no filesystem paths, ACL text or underlying error descriptions
 /// reach error presentation or diagnostics (ADR 0003). No repair workflow is implied.
 enum StorageFailure: Error, Equatable, Sendable, CaseIterable {
-    case invalidLocation, inspectionFailed, unsafeStructure, protectionDrift
+    case invalidLocation, inspectionFailed, unsafeStructure, protectionDrift, preparationFailed
 
     var message: String {
         switch self {
@@ -18,6 +18,8 @@ enum StorageFailure: Error, Equatable, Sendable, CaseIterable {
             "Guesthouse cannot safely use its storage hierarchy. Preserve the folders and linked destinations; they may contain unpublished work. Cancel before changing anything."
         case .protectionDrift:
             "Guesthouse storage is no longer private. Cancel and leave its contents in place; they may contain unpublished work."
+        case .preparationFailed:
+            "Guesthouse could not finish preparing its private storage. Cancel and preserve the folders and any unpublished work. No storage operation has been authorized."
         }
     }
     var recoveryActions: [RecoveryAction] { [.cancel] }

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Storage/StorageProtection.swift
@@ -19,7 +19,7 @@ enum StorageFailure: Error, Equatable, Sendable, CaseIterable {
         case .protectionDrift:
             "Guesthouse storage is no longer private. Cancel and leave its contents in place; they may contain unpublished work."
         case .preparationFailed:
-            "Guesthouse could not finish preparing its private storage. Cancel and preserve the folders and any unpublished work. No storage operation has been authorized."
+            "Guesthouse could not finish preparing its private storage. Cancel and preserve the folders and any unpublished work; some storage metadata may already have changed."
         }
     }
     var recoveryActions: [RecoveryAction] { [.cancel] }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
@@ -111,6 +111,72 @@ import Testing
         #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
     }
 
+    @Test(arguments: [RuntimeStorage.Area.vms, .sshMaintenance], [(0o300, false), (0o100, false), (0o700, true)])
+    func unreadableSearchableLeavesAreRepairedWithoutReplacingWork(_ area: RuntimeStorage.Area, _ options: (Int, Bool)) async throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let leaf = try storage.location(for: area)
+        let before = try StorageProtection.structure(leaf)
+        let sentinel = leaf.appending(path: "unpublished")
+        try Data("keep me".utf8).write(to: sentinel)
+        // Hold cleanup authority before restricting access, including if preparation throws.
+        let cleanup = open(leaf.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        try #require(cleanup >= 0)
+        defer { close(cleanup) }
+        let empty = try #require(acl_init(0))
+        defer { fchmod(cleanup, 0o700); acl_set_fd(cleanup, empty); acl_free(UnsafeMutableRawPointer(empty)) }
+        try #require(fchmod(cleanup, mode_t(options.0)) == 0)
+        if options.1 { try await fixture.addACL("everyone deny read,list", at: leaf) }
+        let readFD = open(leaf.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        let readError = errno
+        if readFD >= 0 { close(readFD) }
+        try #require(readFD == -1 && readError == EACCES)
+        #expect(throws: StorageFailure.protectionDrift) { _ = try storage.location(for: area) }
+        let reopened = try RuntimeStorage(root: fixture.storage)
+        let after = try StorageProtection.structure(reopened.location(for: area))
+        #expect(after.st_dev == before.st_dev && after.st_ino == before.st_ino)
+        #expect(after.st_mode & 0o7777 == 0o700)
+        #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
+    }
+
+    @Test func readableUnsearchableLeafRemainsRepairable() throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let leaf = try storage.location(for: .vms)
+        let cleanup = open(leaf.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        try #require(cleanup >= 0)
+        defer { fchmod(cleanup, 0o700); close(cleanup) }
+        try #require(fchmod(cleanup, 0o400) == 0)
+        let reopened = try RuntimeStorage(root: fixture.storage)
+        try StorageProtection.verify(reopened.location(for: .vms))
+    }
+
+    @Test(arguments: [false, true])
+    func inaccessibleLeafIsRefusedBeforeAnyPreparation(_ denyAccess: Bool) async throws {
+        let fixture = try Fixture()
+        try fixture.directory(fixture.storage, mode: 0o755)
+        let leaf = fixture.storage.appending(path: "vms")
+        try fixture.directory(leaf)
+        let sentinel = leaf.appending(path: "unpublished")
+        try Data("keep me".utf8).write(to: sentinel)
+        let cleanup = open(leaf.path, O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
+        try #require(cleanup >= 0)
+        defer { close(cleanup) }
+        let empty = try #require(acl_init(0))
+        defer { fchmod(cleanup, 0o700); acl_set_fd(cleanup, empty); acl_free(UnsafeMutableRawPointer(empty)) }
+        if denyAccess { try await fixture.addACL("everyone deny read,list,search", at: leaf) }
+        else { try #require(fchmod(cleanup, 0o000) == 0) }
+        #expect(throws: StorageFailure.inspectionFailed) { _ = try RuntimeStorage(root: fixture.storage) }
+        #expect(try StorageProtection.structure(fixture.storage).st_mode & 0o7777 == 0o755)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.storage.path) == ["vms"])
+        let searchFD = open(leaf.path, O_SEARCH | O_NOFOLLOW | O_CLOEXEC)
+        let searchError = errno
+        if searchFD >= 0 { close(searchFD) }
+        #expect(searchFD == -1 && searchError == EACCES) // Refusal has not repaired access.
+        try #require(fchmod(cleanup, 0o700) == 0 && acl_set_fd(cleanup, empty) == 0)
+        #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
+    }
+
     @Test(arguments: ["", "vms", "state", "ssh"])
     func staleBackupExclusionIsRefusedThenClearedOnExplicitPreparation(_ suffix: String) throws {
         let fixture = try Fixture()

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
@@ -30,14 +30,17 @@ import Testing
         }
     }
 
-    @Test(arguments: [false, true], ["Guesthouse", "Guesthouse/vms", "Guesthouse/ssh"])
-    func linksAreRefusedBeforeAnyPreparation(_ dangling: Bool, _ suffix: String) throws {
+    @Test(arguments: [(false, false), (false, true), (true, false), (true, true)],
+          ["Guesthouse", "Guesthouse/vms", "Guesthouse/ssh"])
+    func linksAreRefusedBeforeAnyPreparation(_ options: (Bool, Bool), _ suffix: String) throws {
+        let (dangling, directoryURL) = options
         let fixture = try Fixture()
         let link = fixture.base.appending(path: suffix), target = fixture.base.appending(path: "outside")
         if !dangling { try fixture.directory(target) }
         try fixture.directory(link.deletingLastPathComponent())
         try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
-        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: fixture.storage) }
+        let root = directoryURL ? URL(fileURLWithPath: fixture.storage.path, isDirectory: true) : fixture.storage
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: root) }
         #expect(try FileManager.default.destinationOfSymbolicLink(atPath: link.path) == target.path)
         #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "runtime").path))
         #expect(!FileManager.default.fileExists(atPath: target.appending(path: "maintenance").path))
@@ -242,6 +245,14 @@ import Testing
 
     @Test func defaultLocationIsResolvedWithoutPreparation() throws {
         #expect(try RuntimeStorage.defaultRoot().path.hasSuffix("/Library/Application Support/Guesthouse"))
+    }
+
+    @Test func directoryURLPreparesTheSamePrivateLayout() throws {
+        let fixture = try Fixture()
+        let root = URL(fileURLWithPath: fixture.storage.path, isDirectory: true)
+        let storage = try RuntimeStorage(root: root)
+        #expect(try storage.location(for: .vms) == fixture.storage.appending(path: "vms"))
+        try StorageProtection.verify(root)
     }
 
     private func backupExcluded(_ url: URL) throws -> Bool {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeStorageTests.swift
@@ -1,0 +1,270 @@
+import Darwin
+import Foundation
+import Testing
+@testable import GuesthouseRuntimeKit
+
+@Suite struct RuntimeStorageTests {
+    @Test(arguments: [
+        (RuntimeStorage.Area.runtime, "runtime", false), (.vms, "vms", false), (.state, "state", false),
+        (.staging, "staging", true), (.downloads, "downloads", true), (.diagnostics, "diagnostics", false),
+        (.sshMaintenance, "ssh/maintenance", false),
+    ])
+    func preparesTheFixedPrivateLayout(_ area: RuntimeStorage.Area, _ path: String, _ excluded: Bool) throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let result = try storage.location(for: area)
+        #expect(result == fixture.storage.appending(path: path))
+        try StorageProtection.verify(result)
+        try StorageProtection.verify(fixture.storage)
+        try StorageProtection.verify(fixture.storage.appending(path: "ssh"))
+        #expect(try backupExcluded(result) == excluded)
+        #expect(try !backupExcluded(fixture.storage))
+    }
+
+    @Test func missingIntermediatesAreCreatedPrivatelyAfterPreflight() throws {
+        let fixture = try Fixture()
+        let root = fixture.base.appending(path: "Library/Application Support/Guesthouse")
+        _ = try RuntimeStorage(root: root)
+        for suffix in ["Library", "Library/Application Support", "Library/Application Support/Guesthouse"] {
+            try StorageProtection.verify(fixture.base.appending(path: suffix))
+        }
+    }
+
+    @Test(arguments: [false, true], ["Guesthouse", "Guesthouse/vms", "Guesthouse/ssh"])
+    func linksAreRefusedBeforeAnyPreparation(_ dangling: Bool, _ suffix: String) throws {
+        let fixture = try Fixture()
+        let link = fixture.base.appending(path: suffix), target = fixture.base.appending(path: "outside")
+        if !dangling { try fixture.directory(target) }
+        try fixture.directory(link.deletingLastPathComponent())
+        try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: fixture.storage) }
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: link.path) == target.path)
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "runtime").path))
+        #expect(!FileManager.default.fileExists(atPath: target.appending(path: "maintenance").path))
+    }
+
+    @Test func lateLayoutBlockerIsRefusedBeforeRepairingRootOrCreatingSiblings() throws {
+        let fixture = try Fixture()
+        try fixture.directory(fixture.storage, mode: 0o755)
+        let blocker = fixture.storage.appending(path: "diagnostics")
+        try Data("keep me".utf8).write(to: blocker)
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: fixture.storage) }
+        #expect(try StorageProtection.structure(fixture.storage).st_mode & 0o7777 == 0o755)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.storage.path) == ["diagnostics"])
+        #expect(try Data(contentsOf: blocker) == Data("keep me".utf8))
+    }
+
+    @Test(arguments: [false, true]) func unsafeAncestorPreventsCreationAndRepair(_ exists: Bool) async throws {
+        let fixture = try Fixture()
+        let root = fixture.base.appending(path: "parent/Guesthouse")
+        try fixture.directory(root.deletingLastPathComponent())
+        if exists {
+            try fixture.directory(root, mode: 0o755)
+            try await fixture.addACL("everyone allow read,list", at: root)
+            try Data("keep me".utf8).write(to: root.appending(path: "unpublished"))
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o777], ofItemAtPath: root.deletingLastPathComponent().path)
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: root) }
+        #expect(FileManager.default.fileExists(atPath: root.path) == exists)
+        #expect(!FileManager.default.fileExists(atPath: root.appending(path: "runtime").path))
+        if exists {
+            let attributes = try FileManager.default.attributesOfItem(atPath: root.path)
+            #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o755)
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.deletingLastPathComponent().path)
+            // Restoring the ancestor does not erase the refused root ACL or unpublished file.
+            try FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: root.path)
+            #expect(throws: StorageFailure.protectionDrift) { try StorageProtection.verify(root) }
+            #expect(try Data(contentsOf: root.appending(path: "unpublished")) == Data("keep me".utf8))
+        }
+    }
+
+    @Test func validAncestorAliasIsPreserved() throws {
+        let fixture = try Fixture()
+        let target = fixture.base.appending(path: "target"), alias = fixture.base.appending(path: "alias")
+        try fixture.directory(target)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: target)
+        let storage = try RuntimeStorage(root: alias.appending(path: "Guesthouse"))
+        try StorageProtection.verify(storage.location(for: .vms))
+        #expect(try FileManager.default.destinationOfSymbolicLink(atPath: alias.path) == target.path)
+    }
+
+    @Test(arguments: ["", "runtime", "vms", "state", "staging", "downloads", "diagnostics", "ssh", "ssh/maintenance"],
+          [false, true])
+    func everyManagedComponentRejectsModeOrACLDriftWithoutRepair(_ suffix: String, _ acl: Bool) async throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let target = suffix.isEmpty ? fixture.storage : fixture.storage.appending(path: suffix)
+        let area: RuntimeStorage.Area = suffix == "ssh" || suffix == "ssh/maintenance" ? .sshMaintenance :
+            RuntimeStorage.Area(rawValue: suffix) ?? .vms
+        let sentinel = fixture.storage.appending(path: "vms/unpublished")
+        try Data("keep me".utf8).write(to: sentinel)
+        if acl { try await fixture.addACL("everyone allow read,list", at: target) }
+        else { try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: target.path) }
+        #expect(throws: StorageFailure.protectionDrift) { _ = try storage.location(for: area) }
+        #expect(throws: StorageFailure.protectionDrift) { _ = try storage.location(for: area) }
+        // Explicit preparation restores only managed metadata; reuse itself never repairs.
+        let reopened = try RuntimeStorage(root: fixture.storage)
+        _ = try reopened.location(for: area)
+        #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
+    }
+
+    @Test(arguments: ["", "vms", "state", "ssh"])
+    func staleBackupExclusionIsRefusedThenClearedOnExplicitPreparation(_ suffix: String) throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let target = suffix.isEmpty ? fixture.storage : fixture.storage.appending(path: suffix)
+        try RuntimeStorage.writeBackupExclusion(target, true)
+        let area: RuntimeStorage.Area = suffix == "ssh" ? .sshMaintenance : .init(rawValue: suffix) ?? .vms
+        #expect(throws: StorageFailure.protectionDrift) { _ = try storage.location(for: area) }
+        #expect(try backupExcluded(target))
+        let reopened = try RuntimeStorage(root: fixture.storage)
+        #expect(try !backupExcluded(target))
+        #expect(try backupExcluded(reopened.location(for: .staging)))
+        #expect(try backupExcluded(reopened.location(for: .downloads)))
+    }
+
+    @Test func postMutationProtectionDriftIsRefused() throws {
+        let fixture = try Fixture()
+        #expect(throws: StorageFailure.protectionDrift) {
+            _ = try RuntimeStorage(root: fixture.storage) { url, excluded in
+                try RuntimeStorage.writeBackupExclusion(url, excluded)
+                try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: url.path)
+            }
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "runtime").path))
+    }
+
+    @Test func opaquePreparationFailureIsFixedAndDoesNotDeleteExistingWork() throws {
+        struct OpaqueFailure: Error {}
+        let fixture = try Fixture()
+        try fixture.directory(fixture.storage)
+        let sentinel = fixture.storage.appending(path: "unpublished")
+        try Data("keep me".utf8).write(to: sentinel)
+        #expect(throws: StorageFailure.preparationFailed) {
+            _ = try RuntimeStorage(root: fixture.storage) { _, _ in throw OpaqueFailure() }
+        }
+        #expect(try Data(contentsOf: sentinel) == Data("keep me".utf8))
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "runtime").path))
+    }
+
+    @Test func inheritedReadACLIsRemovedWithoutChangingTheContainingFolder() async throws {
+        let fixture = try Fixture()
+        try await fixture.addACL("everyone allow read,list,directory_inherit", at: fixture.base)
+        let storage = try RuntimeStorage(root: fixture.storage)
+        try StorageProtection.verify(fixture.storage)
+        try StorageProtection.verify(storage.location(for: .sshMaintenance))
+        #expect(throws: StorageFailure.protectionDrift) { try StorageProtection.verify(fixture.base) }
+    }
+
+    @Test func postMutationACLDriftIsRefused() async throws {
+        let fixture = try Fixture()
+        let donor = fixture.base.appending(path: "acl-donor")
+        try fixture.directory(donor)
+        try await fixture.addACL("everyone allow read,list", at: donor)
+        #expect(throws: StorageFailure.protectionDrift) {
+            _ = try RuntimeStorage(root: fixture.storage) { url, excluded in
+                try RuntimeStorage.writeBackupExclusion(url, excluded)
+                guard let acl = acl_get_file(donor.path, ACL_TYPE_EXTENDED) else { throw StorageFailure.inspectionFailed }
+                defer { acl_free(UnsafeMutableRawPointer(acl)) }
+                guard acl_set_link_np(url.path, ACL_TYPE_EXTENDED, acl) == 0 else { throw StorageFailure.preparationFailed }
+            }
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "runtime").path))
+    }
+
+    @Test func changedDirectoryBindingAfterMetadataWriteIsRefused() throws {
+        let fixture = try Fixture()
+        let preserved = fixture.base.appending(path: "preserved")
+        try fixture.directory(fixture.storage)
+        try Data("keep me".utf8).write(to: fixture.storage.appending(path: "unpublished"))
+        #expect(throws: StorageFailure.unsafeStructure) {
+            _ = try RuntimeStorage(root: fixture.storage) { url, excluded in
+                try RuntimeStorage.writeBackupExclusion(url, excluded)
+                try FileManager.default.moveItem(at: url, to: preserved)
+                try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false, attributes: [.posixPermissions: 0o700])
+            }
+        }
+        #expect(try Data(contentsOf: preserved.appending(path: "unpublished")) == Data("keep me".utf8))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: fixture.storage.path).isEmpty)
+    }
+
+    @Test func ignoredBackupPolicyIsRefused() throws {
+        let fixture = try Fixture()
+        #expect(throws: StorageFailure.protectionDrift) {
+            _ = try RuntimeStorage(root: fixture.storage) { _, _ in }
+        }
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.appending(path: "downloads").path))
+    }
+
+    @Test(arguments: ["Library", "Library/Application Support/Guesthouse/runtime"])
+    func finalPassRechecksEarlierPreparedComponents(_ suffix: String) throws {
+        let fixture = try Fixture()
+        let root = fixture.base.appending(path: "Library/Application Support/Guesthouse")
+        #expect(throws: StorageFailure.protectionDrift) {
+            _ = try RuntimeStorage(root: root) { url, excluded in
+                try RuntimeStorage.writeBackupExclusion(url, excluded)
+                if url.lastPathComponent == "maintenance" {
+                    try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fixture.base.appending(path: suffix).path)
+                }
+            }
+        }
+    }
+
+    @Test func stickyContainingDirectoryRemainsSupported() throws {
+        let fixture = try Fixture()
+        try FileManager.default.setAttributes([.posixPermissions: 0o1777], ofItemAtPath: fixture.base.path)
+        let storage = try RuntimeStorage(root: fixture.storage)
+        _ = try storage.location(for: .vms)
+        #expect((try FileManager.default.attributesOfItem(atPath: fixture.base.path)[.posixPermissions] as? NSNumber)?.intValue == 0o1777)
+    }
+
+    @Test(arguments: [RuntimeStorage.Area.vms, .sshMaintenance]) func replacedLeafIsRefusedOnReuse(_ area: RuntimeStorage.Area) throws {
+        let fixture = try Fixture()
+        let storage = try RuntimeStorage(root: fixture.storage)
+        let leaf = try storage.location(for: area), preserved = fixture.base.appending(path: "preserved")
+        try Data("keep me".utf8).write(to: leaf.appending(path: "unpublished"))
+        try FileManager.default.moveItem(at: leaf, to: preserved)
+        try FileManager.default.createSymbolicLink(at: leaf, withDestinationURL: preserved)
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try storage.location(for: area) }
+        #expect(try Data(contentsOf: preserved.appending(path: "unpublished")) == Data("keep me".utf8))
+    }
+
+    @Test func unsafeMissingAncestorsAndInvalidPathsNeverCreateStorage() throws {
+        let fixture = try Fixture()
+        let dangling = fixture.base.appending(path: "dangling"), missing = fixture.base.appending(path: "missing")
+        try FileManager.default.createSymbolicLink(at: dangling, withDestinationURL: missing)
+        #expect(throws: StorageFailure.unsafeStructure) { _ = try RuntimeStorage(root: dangling.appending(path: "Guesthouse")) }
+        #expect(!FileManager.default.fileExists(atPath: missing.path))
+        let invalid = URL(fileURLWithPath: fixture.storage.path + "\0suffix")
+        #expect(throws: StorageFailure.invalidLocation) { _ = try RuntimeStorage(root: invalid) }
+        #expect(!FileManager.default.fileExists(atPath: fixture.storage.path))
+    }
+
+    @Test func defaultLocationIsResolvedWithoutPreparation() throws {
+        #expect(try RuntimeStorage.defaultRoot().path.hasSuffix("/Library/Application Support/Guesthouse"))
+    }
+
+    private func backupExcluded(_ url: URL) throws -> Bool {
+        try #require(URL(fileURLWithPath: url.path).resourceValues(forKeys: [.isExcludedFromBackupKey]).isExcludedFromBackup as Bool?)
+    }
+    private final class Fixture: Sendable {
+        let base: URL
+        var storage: URL { base.appending(path: "Guesthouse") }
+        init() throws {
+            var template = Array("/private/tmp/guesthouse-runtime-storage-XXXXXX".utf8CString)
+            guard let path = mkdtemp(&template) else { throw StorageFailure.inspectionFailed }
+            base = URL(fileURLWithPath: String(cString: path), isDirectory: true)
+        }
+        deinit { try? FileManager.default.removeItem(at: base) } // Only this mkdtemp-owned fixture.
+        func directory(_ url: URL, mode: Int = 0o700) throws {
+            if url == base { return }
+            try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: [.posixPermissions: mode])
+        }
+        func addACL(_ rule: String, at url: URL) async throws {
+            let run = try await ProcessRunner().run(ProcessInvocation(executable: URL(fileURLWithPath: "/bin/chmod"),
+                arguments: ["+a", rule, url.path], timeout: .seconds(5)))
+            let report = try await run.waitForExit()
+            try #require(try report.childExit?.get() == .status(0) && !report.timedOut && !report.canceled)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Refs #22; migrates shared storage preparation/reuse from retained drafts #70 and #88. Implements MVP-PLAN.md §§3 and 9 under ADRs 0002/0003. The read-only prerequisite #164 is merged.

- Prepare the fixed runtime-owned Application Support layout with whole-existing-layout preflight, private one-component creation, no-follow descriptor-bound mode/ACL repair, and final verification.
- Recheck every selected area's root, intermediates, permissions/ACL and backup policy on reuse. Reuse never silently repairs.
- Keep VM disks/state eligible for backup; exclude only staging/downloads. Preserve existing contents and report potentially partial metadata preparation.
- No GUI root input, provider environment adapter, production caller, process launch or VM activation.

## Review correction — d6d4b45f

Use O_SEARCH when O_RDONLY is refused for a searchable owned leaf; retain O_RDONLY support for readable leaves without search permission. Both paths preserve directory/no-follow/close-on-exec semantics and the existing descriptor identity and protection checks.

A leaf with neither read nor search access is deliberately refused during whole-layout preflight, before modifying earlier directories or creating siblings. No pathname chmod fallback, private entitlement or process-wide policy change is used. See the [review explanation and Darwin evidence](https://github.com/PicoMLX/Guesthouse/pull/165#discussion_r3975449762).

Three added Swift Testing functions cover nine cases: 0300/0100 modes and read-deny ACLs across ordinary/nested leaves, preserved inode/content, 0400 compatibility, and no-mutation refusal for 0000/ACL-denied access. Fixture cleanup uses a descriptor acquired before restricting access.

Current delta against main: 507 additions / one deletion across three files (roughly 500 lines).

## Validation

**Current head d6d4b45fd800d31f447eca32fa1a5faf9757e554:**

- git diff --check passed; native Darwin probe confirmed the descriptor semantics.
- Per the owner's explicit request, use Xcode Cloud for Swift/package/app compilation and testing while local disk is constrained. No new local package/app build or build cache for this correction.
- Exact-head Xcode Cloud passed September 10 at04:49:21 UTC: zero errors, test failures, analysis issues and warnings.
- Codex's matching review completed at04:48:32 UTC with no new findings and the original PR message received its bot thumbs-up at04:48:35 UTC.
- The original finding has an explanatory fixed/rejected-scope disposition and is resolved. Current head is merge-ready; the owner alone merges.

**Historical validation of original head 874ed816 (not the correction):**

- 548 strict package functions: Core392, RuntimeKit84, ClientKit72.
- 33 focused storage functions in Release, five Debug repetitions and Thread Sanitizer.
- Seven CI-hook scenarios and unsigned shared-scheme Xcode build-for-testing.
- Xcode Cloud passed at September 10, 04:22:15 UTC; review found the permissions issue addressed above.

## Limits and remaining work

Returned URLs and Foundation's path-based backup metadata checks are point-in-time observations, not permanent filesystem authority or an atomic tree transaction. Metadata changes are not rolled back. Backup eligibility is not proof of a consistent/restorable VM backup.

No StateStore, provider selection, signed-boundary or hardware acceptance is claimed. #22 and drafts #70/#88 stay open until their complete retained acceptance is reviewed and integrated; #88's unrelated runner fixture scope is tracked separately. Do not restore a Tart-specific environment dictionary or raw error/log payload.

The owner alone merges, after exact-head green Xcode Cloud, a matching completed Codex review/original-message thumbs-up and no unaddressed findings.
