### PR TITLE
Migrate provisioning records to typed resume evidence

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningStage.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningStage.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// The checkpoints of MVP-PLAN.md §9, in order:
+/// Preflight → Runtime ready → macOS installed → Needs guest setup → SSH paired
+/// → Guest secured → Xcode/tools ready → Accounts ready → Workspace validated → Ready.
+///
+/// A stage names the checkpoint an operation is working toward. "Needs guest setup" is a
+/// checkpoint like the others; the fact that it requires the user at the console is expressed
+/// by `StageStatus.needsUserAction`, not by the stage itself.
+public enum ProvisioningStage: String, Codable, Hashable, Sendable, CaseIterable, Comparable {
+    case preflight
+    case runtimeReady
+    case macOSInstalled
+    case needsGuestSetup
+    case sshPaired
+    case guestSecured
+    case xcodeToolsReady
+    case accountsReady
+    case workspaceValidated
+    case ready
+
+    public static let first: ProvisioningStage = .preflight
+
+    /// The stage after this one, or `nil` for `ready`.
+    public var next: ProvisioningStage? {
+        let all = Self.allCases
+        guard let index = all.firstIndex(of: self), index + 1 < all.count else { return nil }
+        return all[index + 1]
+    }
+
+    public static func < (lhs: ProvisioningStage, rhs: ProvisioningStage) -> Bool {
+        let all = Self.allCases
+        return all.firstIndex(of: lhs)! < all.firstIndex(of: rhs)!
+    }
+}
+
+/// Proof, written to the journal, that a stage was reached.
+public struct Checkpoint: Codable, Hashable, Sendable {
+    public let stage: ProvisioningStage
+    public let reachedAt: Date
+
+    public init(stage: ProvisioningStage, reachedAt: Date) {
+        self.stage = stage
+        self.reachedAt = reachedAt
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningState.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningState.swift
@@ -1,0 +1,210 @@
+/// Identity of one start request or effect reserved by the reducer.
+///
+/// Every reservation carries a token and every callback has to echo it. A reply to an earlier
+/// inspection, checkpoint write, cleanup, or start request names a token that is no longer
+/// outstanding and is rejected instead of settling the current one (MVP-PLAN.md §3).
+public struct EffectToken: Hashable, Sendable, CustomStringConvertible {
+    public let value: UInt64
+
+    public init(_ value: UInt64) {
+        self.value = value
+    }
+
+    public var description: String { "effect \(value)" }
+}
+
+extension EffectToken: Codable {
+    public init(from decoder: any Decoder) throws {
+        value = try decoder.singleValueContainer().decode(UInt64.self)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}
+
+/// Where one environment is in provisioning, and what is happening at that stage.
+public struct ProvisioningState: Hashable, Sendable {
+    /// This record's layout version, independent of changes to unrelated persisted formats.
+    /// Version 2 replaces raw resume summaries and legacy error payloads with typed facts.
+    /// Legacy prototype v1 records are refused, not silently reinterpreted. A future store
+    /// must preserve unsupported records and surface recovery rather than overwrite them.
+    public static let currentSchema = SchemaVersion(2)!
+    /// Record schema, so the state store can migrate a persisted state after this type changes.
+    public private(set) var schemaVersion: SchemaVersion
+    /// The checkpoint being worked toward, or the last one completed.
+    public private(set) var stage: ProvisioningStage
+    public private(set) var status: StageStatus
+    /// How many start requests and effects this state has issued. The next token is this plus
+    /// one, and the count is persisted, so a token is never reused after a relaunch either.
+    public private(set) var issuedEffects: UInt64
+
+    /// A status that carries a checkpoint must carry one for `stage`; constructing anything
+    /// else is a programming error, and decoding it is rejected. The fields are read-only
+    /// afterwards: a transition constructs a new validated state, so the
+    /// checkpoint-ordering invariant cannot be broken by assignment.
+    /// The largest effect counter a *persisted* state may carry. A transition mints at most one
+    /// token, so reaching this would take more transitions than a process can perform: a higher
+    /// count is a corrupt or hostile record rather than a state this package wrote, and it is
+    /// refused where it is read. A state that has been minting since it was read may stand above
+    /// the ceiling without being wrong, which is what the other half of the range is for — no
+    /// sequence of transitions can consume that headroom, so the next mint always has a token.
+    public static let maximumIssuedEffects = UInt64.max / 2
+
+    public init(stage: ProvisioningStage, status: StageStatus, issuedEffects: UInt64 = 0) {
+        precondition(Self.isConsistent(stage: stage, status: status), "checkpoint stage does not match \(stage.rawValue)")
+        schemaVersion = Self.currentSchema
+        self.stage = stage
+        self.status = status
+        // The count may never trail the outstanding token, or the next effect would be minted
+        // with a token a late callback from the previous one still names.
+        let count = max(issuedEffects, status.pendingEffect?.value ?? 0)
+        // Deliberately not `maximumIssuedEffects`: that ceiling is a rule about records read
+        // from disk, and a state decoded at the ceiling mints its next token one above it.
+        // Holding this initializer to the same number would trap on that first transition —
+        // the very crash the ceiling exists to prevent — so what is refused here is a count
+        // with no token left above it at all, which the ceiling's headroom puts out of reach.
+        precondition(count < UInt64.max, "effect counter \(count) leaves no token to mint")
+        self.issuedEffects = count
+    }
+
+    /// A brand-new environment: nothing has run yet.
+    public static let initial = ProvisioningState(stage: .first, status: .notStarted)
+
+    /// True only when the final checkpoint has been reached and persisted, and the checkpoint
+    /// itself says so. This is saved checkpoint state, NOT current VM/tool readiness; a
+    /// coordinator must inspect actual state after relaunch (MVP-PLAN.md §3).
+    public var isReady: Bool {
+        if stage == .ready, case .completed(let checkpoint) = status, checkpoint.stage == .ready { return true }
+        return false
+    }
+
+    /// A status that carries a checkpoint must carry one for the outer stage.
+    public var isConsistent: Bool { Self.isConsistent(stage: stage, status: status) }
+
+    static func isConsistent(stage: ProvisioningStage, status: StageStatus) -> Bool {
+        switch status {
+        case .completed(let checkpoint), .persistingCheckpoint(let checkpoint, _, _):
+            checkpoint.stage == stage
+        default:
+            true
+        }
+    }
+}
+
+extension ProvisioningState: Codable {
+    private enum CodingKeys: String, CodingKey {
+        case schemaVersion, stage, status, issuedEffects
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let version = try container.decode(SchemaVersion.self, forKey: .schemaVersion)
+        guard version == Self.currentSchema else {
+            throw DecodingError.dataCorruptedError(forKey: .schemaVersion, in: container, debugDescription: "provisioning state schema \(version) is not \(Self.currentSchema)")
+        }
+        let stage = try container.decode(ProvisioningStage.self, forKey: .stage)
+        let status = try container.decode(StageStatus.self, forKey: .status)
+        guard Self.isConsistent(stage: stage, status: status) else {
+            throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "checkpoint stage does not match \(stage.rawValue)")
+        }
+        let issuedEffects = try container.decode(UInt64.self, forKey: .issuedEffects)
+        guard max(issuedEffects, status.pendingEffect?.value ?? 0) <= Self.maximumIssuedEffects else {
+            throw DecodingError.dataCorruptedError(forKey: .issuedEffects, in: container, debugDescription: "effect counter is beyond \(Self.maximumIssuedEffects)")
+        }
+        self.init(stage: stage, status: status, issuedEffects: issuedEffects)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(schemaVersion, forKey: .schemaVersion)
+        try container.encode(stage, forKey: .stage)
+        try container.encode(status, forKey: .status)
+        try container.encode(issuedEffects, forKey: .issuedEffects)
+    }
+}
+
+/// What is happening at the current stage (MVP-PLAN.md §9: each stage can become canceled,
+/// a recoverable failure, or needs user action; plus the interrupted, inspecting, persisting,
+/// resumable, and cleanup states that §3, §4, and §9 require).
+public enum StageStatus: Codable, Hashable, Sendable {
+    /// Nothing has run for this stage. Safe to start.
+    case notStarted
+    /// A start was requested and the runtime has not yet answered. Reserved synchronously so a
+    /// second start cannot slip in while the first request is in flight. `resuming` is the
+    /// durable partial work the reservation was made from, when there was any: the artifact
+    /// outlives a refused request, and forgetting it here would leave the next start with no
+    /// staging path to continue from (MVP-PLAN.md §9).
+    /// `request` is minted by the reducer and must be captured before asking the runtime;
+    /// every acceptance, rejection, and interruption echoes that same token. It is optional
+    /// for an inspection-only reservation whose acceptance identity is unavailable.
+    /// A restored tokenless reservation accepts no callbacks and must be inspected first.
+    case startRequested(request: EffectToken?, resuming: ResumeEvidence?)
+    /// An operation is running.
+    case inProgress(OperationID)
+    /// The checkpoint was reached but is not yet durable. Nothing may advance until it is.
+    /// `operation` is the operation that reached it, when a live one did, so an interruption
+    /// belonging to some other operation cannot abandon this write; reconciliation, which may
+    /// have found the checkpoint without a live operation, leaves it empty.
+    case persistingCheckpoint(Checkpoint, operation: OperationID?, write: EffectToken)
+    /// The stage's checkpoint was reached and journaled.
+    case completed(Checkpoint)
+    /// The user canceled. Retrying inspects actual state first.
+    case canceled
+    /// The operation failed in a way a retry or repair can address. Retrying inspects first.
+    /// `interrupted` is the operation whose outcome this failure did not settle — an inspection
+    /// that could not answer leaves one — so the retry's inspection stays scoped to it. A
+    /// failure the runtime reported for an operation it had finished with settles that
+    /// operation and leaves it empty.
+    case recoverableFailure(GuesthouseError, interrupted: OperationID?)
+    /// The runtime refused to start the operation before doing anything; the error says why
+    /// and what to do. Nothing ran, so a new start may be requested directly, and it carries
+    /// the same resume evidence the refused request did.
+    case startRejected(GuesthouseError, resuming: ResumeEvidence?)
+    /// The user must do something outside the app (usually at the guest console). The
+    /// operation stays identified so the user can cancel it instead of claiming completion.
+    case needsUserAction(OperationID, GuesthouseError)
+    /// Contact with the runtime was lost mid-operation. The outcome is unknown until the
+    /// inspection this is waiting on reports back.
+    case unknownOutcome(OperationID, inspection: EffectToken)
+    /// Actual state is being inspected before anything is re-run.
+    case awaitingInspection(EffectToken)
+    /// Inspection found durable partial work. Starting the stage resumes from it.
+    case resumable(ResumeEvidence)
+    /// Inspection found a failed attempt that left state behind. It must be cleaned before
+    /// the stage can start again; `cleanup` identifies the cleanup that is running.
+    case cleanupRequired(GuesthouseError, cleanup: EffectToken)
+
+    /// The start request or effect this status is waiting on. Only a callback naming
+    /// this token can move the status along.
+    public var pendingEffect: EffectToken? {
+        switch self {
+        case .startRequested(let token, _):
+            token
+        case .persistingCheckpoint(_, _, let token), .unknownOutcome(_, let token), .awaitingInspection(let token), .cleanupRequired(_, let token):
+            token
+        default:
+            nil
+        }
+    }
+
+    /// A fixed label for tests and presentation; never serialize this whole status as a log.
+    public var caseName: String {
+        switch self {
+        case .notStarted: "notStarted"
+        case .startRequested: "startRequested"
+        case .startRejected: "startRejected"
+        case .inProgress: "inProgress"
+        case .persistingCheckpoint: "persistingCheckpoint"
+        case .completed: "completed"
+        case .canceled: "canceled"
+        case .recoverableFailure: "recoverableFailure"
+        case .needsUserAction: "needsUserAction"
+        case .unknownOutcome: "unknownOutcome"
+        case .awaitingInspection: "awaitingInspection"
+        case .resumable: "resumable"
+        case .cleanupRequired: "cleanupRequired"
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningState.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningState.swift
@@ -36,22 +36,26 @@ public struct ProvisioningState: Hashable, Sendable {
     /// The checkpoint being worked toward, or the last one completed.
     public private(set) var stage: ProvisioningStage
     public private(set) var status: StageStatus
-    /// How many start requests and effects this state has issued. The next token is this plus
-    /// one, and the count is persisted, so a token is never reused after a relaunch either.
+    /// How many start requests and effects this state has issued. Persisted without truncation
+    /// so a token is never reused after relaunch. Use `nextEffectToken` instead of adding one.
     public private(set) var issuedEffects: UInt64
+
+    /// The full representable range is valid both in memory and on disk. Exhaustion prevents
+    /// a new reservation, not restoration or settlement of an already outstanding effect.
+    public static let maximumIssuedEffects = UInt64.max
+
+    /// The next reservation's identity, or nil when no unused identity remains. A coordinator
+    /// must refuse new effects on exhaustion and preserve the record for recovery; never wrap,
+    /// reset, or reuse a token. Construct the next state with this token before executing it.
+    public var nextEffectToken: EffectToken? {
+        guard issuedEffects < Self.maximumIssuedEffects else { return nil }
+        return EffectToken(issuedEffects + 1)
+    }
 
     /// A status that carries a checkpoint must carry one for `stage`; constructing anything
     /// else is a programming error, and decoding it is rejected. The fields are read-only
     /// afterwards: a transition constructs a new validated state, so the
     /// checkpoint-ordering invariant cannot be broken by assignment.
-    /// The largest effect counter a *persisted* state may carry. A transition mints at most one
-    /// token, so reaching this would take more transitions than a process can perform: a higher
-    /// count is a corrupt or hostile record rather than a state this package wrote, and it is
-    /// refused where it is read. A state that has been minting since it was read may stand above
-    /// the ceiling without being wrong, which is what the other half of the range is for — no
-    /// sequence of transitions can consume that headroom, so the next mint always has a token.
-    public static let maximumIssuedEffects = UInt64.max / 2
-
     public init(stage: ProvisioningStage, status: StageStatus, issuedEffects: UInt64 = 0) {
         precondition(Self.isConsistent(stage: stage, status: status), "checkpoint stage does not match \(stage.rawValue)")
         schemaVersion = Self.currentSchema
@@ -59,14 +63,7 @@ public struct ProvisioningState: Hashable, Sendable {
         self.status = status
         // The count may never trail the outstanding token, or the next effect would be minted
         // with a token a late callback from the previous one still names.
-        let count = max(issuedEffects, status.pendingEffect?.value ?? 0)
-        // Deliberately not `maximumIssuedEffects`: that ceiling is a rule about records read
-        // from disk, and a state decoded at the ceiling mints its next token one above it.
-        // Holding this initializer to the same number would trap on that first transition —
-        // the very crash the ceiling exists to prevent — so what is refused here is a count
-        // with no token left above it at all, which the ceiling's headroom puts out of reach.
-        precondition(count < UInt64.max, "effect counter \(count) leaves no token to mint")
-        self.issuedEffects = count
+        self.issuedEffects = max(issuedEffects, status.pendingEffect?.value ?? 0)
     }
 
     /// A brand-new environment: nothing has run yet.
@@ -110,9 +107,6 @@ extension ProvisioningState: Codable {
             throw DecodingError.dataCorruptedError(forKey: .status, in: container, debugDescription: "checkpoint stage does not match \(stage.rawValue)")
         }
         let issuedEffects = try container.decode(UInt64.self, forKey: .issuedEffects)
-        guard max(issuedEffects, status.pendingEffect?.value ?? 0) <= Self.maximumIssuedEffects else {
-            throw DecodingError.dataCorruptedError(forKey: .issuedEffects, in: container, debugDescription: "effect counter is beyond \(Self.maximumIssuedEffects)")
-        }
         self.init(stage: stage, status: status, issuedEffects: issuedEffects)
     }
 

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ResumeEvidence.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ResumeEvidence.swift
@@ -1,0 +1,65 @@
+/// Durable partial work reported by inspection (MVP-PLAN.md §9, ADR 0003).
+/// This operational record is not a diagnostic event or proof that an artifact is usable.
+/// The runtime must revalidate identity, containment and resumability before using it.
+public struct ResumeEvidence: Hashable, Sendable {
+    public enum Kind: String, Codable, Hashable, Sendable, CaseIterable {
+        case partialDownload, installationStaging, unfinishedCopy
+    }
+
+    public let kind: Kind
+    /// A relative operational location, not display text or a host-path capability.
+    /// Do not log or export it as diagnostics, or populate it from authentication output.
+    public let stagingPath: String?
+    public static let stagingPathByteLimit = 1_024
+
+    /// Refuse a malformed path without repairing, truncating or silently dropping it.
+    public init?(kind: Kind, stagingPath: String? = nil) {
+        guard stagingPath.map(Self.isValidStagingPath) ?? true else { return nil }
+        self.kind = kind
+        self.stagingPath = stagingPath
+    }
+
+    /// Only these fixed templates reach presentation; no raw summary is accepted or stored.
+    public var summary: String {
+        switch kind {
+        case .partialDownload: "An interrupted download has partial data to inspect before resuming."
+        case .installationStaging: "An interrupted installation has staging data to inspect before resuming."
+        case .unfinishedCopy: "An interrupted copy has partial data to inspect before resuming."
+        }
+    }
+
+    private static func isValidStagingPath(_ value: String) -> Bool {
+        guard !value.isEmpty, value.utf8.count <= stagingPathByteLimit,
+              !value.hasPrefix("/"), !value.hasPrefix("~") else { return false }
+        guard !value.unicodeScalars.contains(where: { scalar in
+            switch scalar.properties.generalCategory {
+            case .control, .format, .lineSeparator, .paragraphSeparator, .privateUse, .surrogate, .unassigned: true
+            default: false
+            }
+        }) else { return false }
+        return value.split(separator: "/", omittingEmptySubsequences: false)
+            .allSatisfy { !$0.isEmpty && $0 != "." && $0 != ".." }
+    }
+}
+
+extension ResumeEvidence: Codable {
+    private enum CodingKeys: String, CodingKey { case kind, stagingPath }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let kind = try container.decode(Kind.self, forKey: .kind)
+        let path = try container.decodeIfPresent(String.self, forKey: .stagingPath)
+        guard let evidence = Self(kind: kind, stagingPath: path) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .stagingPath, in: container, debugDescription: "invalid relative staging location"
+            )
+        }
+        self = evidence
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        try container.encodeIfPresent(stagingPath, forKey: .stagingPath)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningModelTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningModelTests.swift
@@ -42,27 +42,42 @@ import Testing
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: fixture) }
     }
 
-    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551615", "9223372036854775808"],
+    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551616"],
           [#"{"startRequested":{"request":TOKEN}}"#, #"{"awaitingInspection":{"_0":TOKEN}}"#])
-    func malformedOrExhaustedPendingTokensAreRefused(token: String, status: String) {
+    func malformedOrOutOfRangePendingTokensAreRefused(token: String, status: String) {
         let payload = status.replacingOccurrences(of: "TOKEN", with: token)
         #expect(throws: DecodingError.self) {
             try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "0", status: payload))
         }
     }
 
-    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551615", "9223372036854775808"])
-    func malformedOrExhaustedCountersAreRefused(issued: String) {
+    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551616"])
+    func malformedOrOutOfRangeCountersAreRefused(issued: String) {
         #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: record(issued: issued)) }
     }
 
-    @Test func decodingRaisesTheCounterToThePendingTokenAndRetainsHeadroom() throws {
-        let restored = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "0", status: #"{"startRequested":{"request":9}}"#))
-        #expect(restored.issuedEffects == 9)
-        let ceiling = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "9223372036854775807"))
-        #expect(ceiling.issuedEffects == ProvisioningState.maximumIssuedEffects)
-        let next = ProvisioningState(stage: .first, status: .awaitingInspection(EffectToken(ceiling.issuedEffects + 1)))
-        #expect(next.issuedEffects == 9_223_372_036_854_775_808)
+    @Test(arguments: [UInt64(0), 9, UInt64.max / 2, UInt64.max / 2 + 1, UInt64.max - 1], [false, true])
+    func mintedTokensRemainDecodableAcrossCounterBoundaries(value: UInt64, promotedFromPending: Bool) throws {
+        let status = promotedFromPending ? "{\"startRequested\":{\"request\":\(value)}}" : #"{"notStarted":{}}"#
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: promotedFromPending ? "0" : String(value), status: status))
+        #expect(restored.issuedEffects == value)
+        let token = try #require(restored.nextEffectToken)
+        #expect(token.value == value + 1)
+        let next = ProvisioningState(stage: .first, status: .awaitingInspection(token), issuedEffects: restored.issuedEffects)
+        let relaunched = try JSONDecoder().decode(ProvisioningState.self, from: JSONEncoder().encode(next))
+        #expect(relaunched == next)
+        #expect(relaunched.issuedEffects == token.value)
+        #expect(relaunched.nextEffectToken == (value == UInt64.max - 1 ? nil : EffectToken(value + 2)))
+    }
+
+    @Test(arguments: [false, true])
+    func exhaustedCountersPreserveOutstandingIdentityWithoutMinting(promotedFromPending: Bool) throws {
+        let status = promotedFromPending ? "{\"awaitingInspection\":{\"_0\":\(UInt64.max)}}" : #"{"notStarted":{}}"#
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: promotedFromPending ? "0" : String(UInt64.max), status: status))
+        #expect(restored.issuedEffects == UInt64.max)
+        #expect(restored.nextEffectToken == nil)
+        #expect(restored.status.pendingEffect == (promotedFromPending ? EffectToken(UInt64.max) : nil))
+        #expect(try JSONDecoder().decode(ProvisioningState.self, from: JSONEncoder().encode(restored)) == restored)
     }
 
     @Test(arguments: [UInt64(0), 1, 9, UInt64.max])

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningModelTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningModelTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct ProvisioningModelTests {
+    @Test(arguments: ProvisioningStage.allCases)
+    func readinessRequiresThePersistedFinalCheckpoint(stage: ProvisioningStage) {
+        let checkpoint = Checkpoint(stage: stage, reachedAt: Date(timeIntervalSince1970: 0))
+        let writing = ProvisioningState(stage: stage, status: .persistingCheckpoint(checkpoint, operation: OperationID(), write: EffectToken(1)))
+        #expect(!writing.isReady)
+        #expect(ProvisioningState(stage: stage, status: .completed(checkpoint)).isReady == (stage == .ready))
+        #expect(!ProvisioningState(stage: stage, status: .notStarted).isReady)
+    }
+
+    @Test(arguments: [
+        StageStatus.notStarted, .startRequested(request: nil, resuming: nil),
+        .startRequested(request: EffectToken(9), resuming: ResumeEvidence(kind: .partialDownload)),
+        .inProgress(OperationID()),
+        .persistingCheckpoint(Checkpoint(stage: .first, reachedAt: Date(timeIntervalSince1970: 0)), operation: OperationID(), write: EffectToken(9)),
+        .completed(Checkpoint(stage: .first, reachedAt: Date(timeIntervalSince1970: 0))),
+        .canceled, .recoverableFailure(.runtimeMissing, interrupted: OperationID()),
+        .startRejected(.runtimeMissing, resuming: ResumeEvidence(kind: .installationStaging)),
+        .needsUserAction(OperationID(), .credentialsLocked(.guestKeychain)),
+        .unknownOutcome(OperationID(), inspection: EffectToken(9)), .awaitingInspection(EffectToken(9)),
+        .resumable(ResumeEvidence(kind: .unfinishedCopy)!),
+        .cleanupRequired(.runtimeMissing, cleanup: EffectToken(9)),
+    ])
+    func everyStatusPreservesIdentityAndEvidenceThroughJSON(status: StageStatus) throws {
+        let original = ProvisioningState(stage: .first, status: status, issuedEffects: 5)
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: JSONEncoder().encode(original))
+        #expect(restored == original)
+        #expect(restored.issuedEffects >= (restored.status.pendingEffect?.value ?? 0))
+        #expect(restored.isConsistent)
+    }
+
+    @Test(arguments: [
+        #"{"completed":{"_0":{"stage":"preflight","reachedAt":0}}}"#,
+        #"{"persistingCheckpoint":{"_0":{"stage":"preflight","reachedAt":0},"write":1}}"#,
+    ])
+    func mismatchedCheckpointStagesAreRefused(status: String) {
+        let fixture = Data("{\"schemaVersion\":2,\"stage\":\"ready\",\"issuedEffects\":1,\"status\":\(status)}".utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: fixture) }
+    }
+
+    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551615", "9223372036854775808"],
+          [#"{"startRequested":{"request":TOKEN}}"#, #"{"awaitingInspection":{"_0":TOKEN}}"#])
+    func malformedOrExhaustedPendingTokensAreRefused(token: String, status: String) {
+        let payload = status.replacingOccurrences(of: "TOKEN", with: token)
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "0", status: payload))
+        }
+    }
+
+    @Test(arguments: ["-1", "true", #""1""#, "1.5", "18446744073709551615", "9223372036854775808"])
+    func malformedOrExhaustedCountersAreRefused(issued: String) {
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: record(issued: issued)) }
+    }
+
+    @Test func decodingRaisesTheCounterToThePendingTokenAndRetainsHeadroom() throws {
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "0", status: #"{"startRequested":{"request":9}}"#))
+        #expect(restored.issuedEffects == 9)
+        let ceiling = try JSONDecoder().decode(ProvisioningState.self, from: record(issued: "9223372036854775807"))
+        #expect(ceiling.issuedEffects == ProvisioningState.maximumIssuedEffects)
+        let next = ProvisioningState(stage: .first, status: .awaitingInspection(EffectToken(ceiling.issuedEffects + 1)))
+        #expect(next.issuedEffects == 9_223_372_036_854_775_808)
+    }
+
+    @Test(arguments: [UInt64(0), 1, 9, UInt64.max])
+    func tokensRoundTripWithoutTruncation(value: UInt64) throws {
+        let token = EffectToken(value)
+        #expect(try JSONDecoder().decode(EffectToken.self, from: JSONEncoder().encode(token)) == token)
+    }
+
+    private func record(issued: String, status: String = #"{"notStarted":{}}"#) -> Data {
+        Data("{\"schemaVersion\":2,\"stage\":\"preflight\",\"issuedEffects\":\(issued),\"status\":\(status)}".utf8)
+    }
+}
+
+@Suite struct ProvisioningSchemaTests {
+    @Test func typedProvisioningLayoutKeepsItsOwnVersion() throws {
+        let fixture = Data(#"{"schemaVersion":2,"stage":"preflight","issuedEffects":0,"status":{"notStarted":{}}}"#.utf8)
+        #expect(ProvisioningState.currentSchema.rawValue == 2)
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: fixture)
+        #expect(restored == .initial)
+        let encoded = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(restored)) as? [String: Any])
+        #expect(encoded["schemaVersion"] as? Int == 2)
+    }
+
+    @Test(arguments: ["0", "-1", "1", "3", "999", "true", #""2""#])
+    func unsupportedLayoutsIncludingLegacyPrototypeAreRefused(version: String) {
+        let fixture = Data("{\"schemaVersion\":\(version),\"stage\":\"preflight\",\"issuedEffects\":0,\"status\":{\"notStarted\":{}}}".utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: fixture) }
+    }
+
+    @Test func unversionedAndRawSummaryLegacyRecordsAreNotReinterpreted() {
+        let unversioned = Data(#"{"stage":"preflight","issuedEffects":0,"status":{"notStarted":{}}}"#.utf8)
+        let legacy = Data(#"{"schemaVersion":1,"stage":"preflight","issuedEffects":9,"status":{"startRequested":{"resuming":{"summary":"old raw output","stagingPath":"downloads/restore.partial"}}}}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: unversioned) }
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ProvisioningState.self, from: legacy) }
+    }
+
+    @Test func tokenlessTypedReservationsRemainInspectionOnly() throws {
+        let fixture = Data(#"{"schemaVersion":2,"stage":"preflight","issuedEffects":9,"status":{"startRequested":{"resuming":{"kind":"partialDownload","stagingPath":"downloads/restore.partial"}}}}"#.utf8)
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: fixture)
+        #expect(restored.status == .startRequested(request: nil, resuming: ResumeEvidence(kind: .partialDownload, stagingPath: "downloads/restore.partial")))
+        #expect(restored.status.pendingEffect == nil)
+        #expect(restored.issuedEffects == 9)
+    }
+}
+
+@Suite struct ResumeEvidenceTests {
+    @Test(arguments: [
+        (ResumeEvidence.Kind.partialDownload, "An interrupted download has partial data to inspect before resuming."),
+        (.installationStaging, "An interrupted installation has staging data to inspect before resuming."),
+        (.unfinishedCopy, "An interrupted copy has partial data to inspect before resuming."),
+    ])
+    func presentationUsesOnlyFixedTemplates(kind: ResumeEvidence.Kind, expected: String) throws {
+        let evidence = try #require(ResumeEvidence(kind: kind, stagingPath: "staging/not-display-text"))
+        #expect(evidence.summary == expected)
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(evidence)) as? [String: Any])
+        #expect(Set(object.keys) == ["kind", "stagingPath"])
+    }
+
+    @Test(arguments: [
+        "downloads/Cafe\u{0301} restore.ipsw.partial",
+        "downloads/My Restore Images/Cafe\u{0301} 62%.ipsw.partial", "staging/a b c",
+        "downloads/" + String(repeating: "d", count: 500) + ".partial",
+        "staging/literal%2e%2e.partial", String(repeating: "é", count: 512),
+    ])
+    func stagingLocationsPreserveExactBytes(path: String) throws {
+        let evidence = try #require(ResumeEvidence(kind: .partialDownload, stagingPath: path))
+        let decoded = try JSONDecoder().decode(ResumeEvidence.self, from: JSONEncoder().encode(evidence))
+        #expect(Array(try #require(decoded.stagingPath).utf8) == Array(path.utf8))
+    }
+
+    @Test(arguments: [
+        "", "/Volumes/staging/restore.partial", "~/staging/restore.partial", "../../etc/passwd",
+        "downloads//restore.partial", "downloads/./restore.partial", "downloads/../restore.partial",
+        "downloads/restore.partial/", "downloads/\u{202E}restore.partial", "downloads/restore\npartial",
+        "downloads/\0partial", "downloads/\u{200B}partial", "downloads/\u{E000}partial",
+        String(repeating: "d", count: 1_025), String(repeating: "é", count: 513),
+    ])
+    func invalidLocationsFailInsteadOfBeingSilentlyDropped(path: String) throws {
+        #expect(ResumeEvidence(kind: .partialDownload, stagingPath: path) == nil)
+        let data = try JSONSerialization.data(withJSONObject: ["kind": "partialDownload", "stagingPath": path])
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ResumeEvidence.self, from: data) }
+    }
+
+    @Test func rawSummaryAndUnknownFieldsCannotBeForwarded() throws {
+        let data = Data(#"{"kind":"partialDownload","summary":"test-only-raw-response","extra":{"authorization":"test-only-header"}}"#.utf8)
+        let evidence = try JSONDecoder().decode(ResumeEvidence.self, from: data)
+        #expect(evidence.stagingPath == nil)
+        #expect(evidence.summary == "An interrupted download has partial data to inspect before resuming.")
+        let object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(evidence)) as? [String: Any])
+        #expect(Set(object.keys) == ["kind"])
+    }
+
+    @Test(arguments: [#"{"summary":"old raw response"}"#, #"{"kind":"unknown"}"#, #"{"kind":42}"#, #"{"kind":"partialDownload","stagingPath":42}"#])
+    func malformedEvidenceIsRefused(json: String) {
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(ResumeEvidence.self, from: Data(json.utf8)) }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningStageTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningStageTests.swift
@@ -1,0 +1,16 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+@Suite struct ProvisioningStageTests {
+    @Test func stagesFollowThePlanOrder() {
+        #expect(ProvisioningStage.allCases.map(\.rawValue) == [
+            "preflight", "runtimeReady", "macOSInstalled", "needsGuestSetup", "sshPaired",
+            "guestSecured", "xcodeToolsReady", "accountsReady", "workspaceValidated", "ready",
+        ])
+        #expect(ProvisioningStage.first == .preflight)
+        #expect(ProvisioningStage.preflight.next == .runtimeReady)
+        #expect(ProvisioningStage.ready.next == nil)
+        #expect(ProvisioningStage.preflight < ProvisioningStage.ready)
+    }
+}


### PR DESCRIPTION
## Summary

Refs #6; migrates provisioning records from retained draft #104 under MVP-PLAN.md §§3 and 9 and ADR 0003.

**Stacked on #165. Merge #165 first; do not merge this PR into its feature-branch base.** The reviewed storage prerequisite is included through ordinary forward integration; no history was rewritten.

- Reuse ordered stages, checkpoint/state invariants, persisted effect identities and stage-status records.
- Replace raw resume summaries/redactor coupling with three closed partial-work kinds and fixed presentation text.
- Preserve bounded relative operational staging locations byte-for-byte; refuse malformed input rather than silently changing identity. A location is neither diagnostic text nor filesystem authority.
- Use provisioning schema 2; refuse unsupported schema-1 prototypes without rewriting them. Tokenless schema-2 reservations retain their inspection-only representation.
- Keep minted counters persistable across the old decode ceiling. In-memory and persisted records now share the complete UInt64 range, with checked `nextEffectToken` exhaustion and no wrap/reset/renumbering.
- Add eighteen model/schema/evidence test functions across four suites, including twelve boundary/pending-token-promotion/exhaustion cases.

The provisioner does not run yet. Reducer/callback migration, durable StateStore integration, inspection and UI execution remain later components. A saved checkpoint is not current VM/tool readiness. The unpublished reducer is being adapted to refuse new reservations on exhaustion while preserving existing callback settlement; this model PR executes no effects.

## Composition

Head: `8e60692cccb5a18b58957f1aeb640a19d3798471`. Base: reviewed #165 at `d6d4b45fd800d31f447eca32fa1a5faf9757e554`.

**508 additions in five Core files.** The initial model migration was published at `35c55ada`; the follow-up fixes the valid [counter-persistence P2](https://github.com/PicoMLX/Guesthouse/pull/166#discussion_r3975768686). [Implementation and test rationale](https://github.com/PicoMLX/Guesthouse/pull/166#discussion_r3975837665).

## Validation

- `git diff --check` passes. The full source delta and all published counter consumers were inspected.
- Current-head Codex review completed at September 10,05:30:18 UTC with no new findings; the original PR message received the bot 👍 at05:30:21 UTC.
- **Current-head Xcode Cloud passed at September 10,05:31:44 UTC**, with zero errors, test failures, analysis issues or warnings. The accepted P2 is explained and resolved with [validation evidence](https://github.com/PicoMLX/Guesthouse/pull/166#discussion_r3975867394). All current review/check/reaction pages are complete; the PR is MERGEABLE/CLEAN.
- **Dependency hold only:** #165 is still open. Merge #165 first, then settle this PR on main and recheck composition/current-head gates. Do not merge this PR into its feature-branch base.
- Historical local validation (565 strict package functions, focused Debug/Release, CI-hook checks and unsigned Xcode build-for-testing) belongs to the original prepared migration, not this correction or #165's later regressions.
- Per the owner's instruction, current compilation/package/app tests use origin/Xcode Cloud; no fresh local package/app builds or large build caches were created.

Before merge: require exact-head green CI, matching completed review/original-message thumbs-up, explained/resolved findings, and settled parent composition after #165 lands.

## Preserved scope

#104 and #6 remain open until their complete retained scope is migrated and merged. No host mutation, process invocation, provider selection, or signed/hardware claim. Original source, tests, branches and review history remain preserved.
