### PR TITLE
Migrate inspection-first provisioning reducer and baseline tests

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+/// Pure transition function for `ProvisioningState`.
+///
+/// The rules everything else follows from:
+/// - A start is reserved synchronously with `startRequested` from `notStarted`, `resumable`, or
+///   the previous stage's `completed`, and only then may the runtime be asked; `operationStarted`
+///   is legal solely from `startRequested`. Never from a failure, an unknown outcome, or an
+///   unpersisted checkpoint, and never twice.
+/// - Failure, cancellation, interruption, and user action all lead to an inspection before
+///   anything re-runs, so a retry can never blindly repeat a step whose real outcome is unknown
+///   (MVP-PLAN.md §3, §4, §9). Inspection can be requested again at any time except while a
+///   start request is still live; each request replaces the outstanding one.
+/// - Every start request and effect carries a token, and only the callback naming the outstanding
+///   token is accepted. Lost effects can be reissued without accepting their earlier replies.
+/// - A checkpoint counts only once the journal has it (§3: "Persist ... before updating the UI").
+enum ProvisioningReducer: Sendable {
+    static func reduce(
+        _ state: ProvisioningState,
+        _ event: ProvisioningEvent
+    ) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+        let stage = state.stage
+        var issued = state.issuedEffects
+        func mint() -> EffectToken {
+            issued += 1
+            return EffectToken(issued)
+        }
+        func at(_ status: StageStatus, _ effects: [ProvisioningEffect] = []) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            (ProvisioningState(stage: stage, status: status, issuedEffects: issued), effects)
+        }
+        /// Mints the inspection's token once, so the status and the effect asking for it can
+        /// never name different inspections.
+        func inspect(operation: OperationID? = nil) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            let token = mint()
+            let status = operation.map { StageStatus.unknownOutcome($0, inspection: token) } ?? .awaitingInspection(token)
+            return at(status, [.inspectActualState(stage, token, operation: operation)])
+        }
+        /// Reserves a start for `requested`, carrying forward the durable partial work the
+        /// reservation was made from so a refusal cannot orphan it.
+        func reserve(_ requested: ProvisioningStage, resuming: ResumeEvidence?) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            guard requested == stage else { throw .stageMismatch(expected: stage, actual: requested) }
+            return at(.startRequested(request: mint(), resuming: resuming))
+        }
+        /// Check the request before interpreting its reply: even an acceptance for the wrong
+        /// stage must not abandon a newer reservation. Inspection-only reservations have no request identity,
+        /// so no callback can settle them; explicit inspection is their recovery path.
+        func requireRequest(_ expected: EffectToken?, _ actual: EffectToken) throws(ProvisioningTransitionError) {
+            guard let expected else { throw .illegalTransition(status: state.status.kind, event: event.kind) }
+            guard expected == actual else { throw .staleStartRequest(expected: expected, actual: actual) }
+        }
+        /// Applies what inspection found. `interrupted` is the operation the reducer was
+        /// tracking when contact was lost, when it knows one; a reported identity has to be
+        /// that operation, or a second one would be adopted while the first can still mutate.
+        func adopt(_ outcome: ReconciledOutcome, interrupted: OperationID?) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            switch outcome {
+            case .completed(let checkpoint):
+                // A later checkpoint is adopted: the journal is the durable truth, and pinning
+                // the saved stage would offer a start for a step the runtime already ran.
+                guard checkpoint.stage >= stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
+                let write = mint()
+                // Inspection settled the operation; delayed callbacks cannot abandon this write.
+                let status = StageStatus.persistingCheckpoint(checkpoint, operation: nil, write: write)
+                return (ProvisioningState(stage: checkpoint.stage, status: status, issuedEffects: issued), [.persistCheckpoint(checkpoint, write)])
+            case .stillRunning(let id):
+                if let interrupted { try requireSame(interrupted, id) }
+                return at(.inProgress(id))
+            case .stillNeedsUserAction(let id, let error):
+                if let interrupted { try requireSame(interrupted, id) }
+                return at(.needsUserAction(id, error))
+            case .cleanupRunning(let cleanup, let error):
+                return at(.cleanupRequired(error, cleanup: cleanup))
+            case .resumable(let evidence):
+                return at(.resumable(evidence))
+            case .failedNeedsCleanup(let error):
+                let cleanup = mint()
+                return at(.cleanupRequired(error, cleanup: cleanup), [.cleanUp(stage, cleanup)])
+            case .failed(let error):
+                return at(.recoverableFailure(error, interrupted: nil))
+            case .notStarted:
+                return at(.notStarted)
+            }
+        }
+
+        switch (state.status, event) {
+
+        case (.notStarted, .startRequested(let requested)):
+            return try reserve(requested, resuming: nil)
+
+        case (.resumable(let evidence), .startRequested(let requested)):
+            return try reserve(requested, resuming: evidence)
+
+        case (.startRejected(_, let resuming), .startRequested(let requested)):
+            return try reserve(requested, resuming: resuming)
+
+        case (.completed, .startRequested(let requested)):
+            guard let next = stage.next else { throw .alreadyReady }
+            guard requested == next else { throw .stageMismatch(expected: next, actual: requested) }
+            let request = mint()
+            return (ProvisioningState(stage: next, status: .startRequested(request: request, resuming: nil), issuedEffects: issued), [])
+
+        case (.startRequested(let request, _), .operationStarted(let id, let requested, let token)):
+            try requireRequest(request, token)
+            // This request has answered, so its reservation is no longer live. An acceptance
+            // at the wrong stage may already be mutating. Inspect its identity across all stages
+            // before reconciling the reserved stage; only that inspection can establish its stage.
+            guard requested == stage else { return inspect(operation: id) }
+            return at(.inProgress(id))
+
+        case (.startRequested(let request, let resuming), .startRequestRejected(let error, let token)):
+            try requireRequest(request, token)
+            // The refusal did nothing, so whatever durable partial work the reservation was made
+            // from is still there and still has to be resumed from once the refusal is dealt with.
+            return at(.startRejected(error, resuming: resuming))
+
+        case (.startRequested(let request, _), .startRequestInterrupted(let token)):
+            try requireRequest(request, token)
+            return inspect()
+
+        case (.startRequested(nil, _), .inspectionRequested):
+            // A tokenless saved reservation is inspection-only. No uncorrelated callback
+            // can settle it or authorize another start in its place.
+            return inspect()
+
+        case (.startRequested, .inspectionRequested):
+            // The reservation stays held: the request is still live, so the runtime may still
+            // accept it, and an inspection that reported `notStarted` would let a second start
+            // race the first. A dropped connection is reported as `startRequestInterrupted`,
+            // which ends the request and does inspect.
+            throw .inspectionWhileStartRequestLive
+
+        case (.inProgress(let current), .checkpointReached(let id, let checkpoint)),
+             (.needsUserAction(let current, _), .checkpointReached(let id, let checkpoint)):
+            // A paused operation resumes as soon as the user does the out-of-app step, which can
+            // be before the GUI reports it; refusing its checkpoint would drop a reached one.
+            try requireSame(current, id)
+            guard checkpoint.stage == stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
+            let write = mint()
+            return at(.persistingCheckpoint(checkpoint, operation: current, write: write), [.persistCheckpoint(checkpoint, write)])
+
+        case (.persistingCheckpoint(let pending, _, let write), .checkpointPersisted(let token, let persisted)):
+            try requireOutstanding(write, token)
+            guard pending == persisted else { throw .checkpointMismatch(expected: pending, actual: persisted) }
+            return at(.completed(persisted))
+
+        case (.persistingCheckpoint(_, let writer, let write), .checkpointPersistenceFailed(let token, let error)):
+            // Reality is ahead of the journal. The failure is shown with its recovery actions;
+            // the user's retry inspects, finds the checkpoint reached, and persists it again.
+            // A failed write does not settle its operation, so recovery must keep that identity.
+            try requireOutstanding(write, token)
+            return at(.recoverableFailure(error, interrupted: writer))
+
+        case (.persistingCheckpoint(_, let writer, _), .connectionInterrupted(let id)):
+            // The write's result is unknown; the journal is inspected before anything else.
+            // An interruption belonging to another operation says nothing about this write, and
+            // a write reconciliation started has no operation behind it at all, so no
+            // operation-scoped interruption is about it either: taking one as relevant would
+            // abandon a live write and make its own successful callback stale.
+            guard let writer else { throw .illegalTransition(status: state.status.kind, event: event.kind) }
+            try requireSame(writer, id)
+            return inspect(operation: writer)
+
+        case (.persistingCheckpoint(_, let writer, _), .userRetried),
+             (.persistingCheckpoint(_, let writer, _), .inspectionRequested):
+            // The operation that reached the checkpoint keeps its identity through the check,
+            // for the same reason every other live operation does: it may still be mutating,
+            // and an unscoped inspection would adopt a `stillRunning(B)` naming another one
+            // without `requireSame`, leaving the first unaccounted for while the reducer follows
+            // the second (MVP-PLAN.md §3). A checkpoint restored after a relaunch is exactly
+            // that case: the write is lost, the operation behind it need not be. The unscoped
+            // status is left to a reconciled write, which has no operation behind it.
+            return inspect(operation: writer)
+
+        case (.inProgress(let current), .operationFailed(let id, let error)),
+             (.needsUserAction(let current, _), .operationFailed(let id, let error)):
+            // A reported failure is not proof that the operation can no longer mutate.
+            // Keep its identity through persistence/retry, regardless of the error category;
+            // only correlated inspection may settle it or resume monitoring (MVP-PLAN.md §3).
+            try requireSame(current, id)
+            return at(.recoverableFailure(error, interrupted: current))
+
+        case (.inProgress(let current), .operationCanceled(let id)):
+            try requireSame(current, id)
+            return at(.canceled)
+
+        case (.inProgress(let current), .userActionRequired(let id, let error)):
+            try requireSame(current, id)
+            return at(.needsUserAction(id, error))
+
+        case (.needsUserAction(let current, _), .operationCanceled(let id)):
+            try requireSame(current, id)
+            return at(.canceled)
+
+        case (.needsUserAction(let current, _), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.inProgress(let current), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.unknownOutcome(let current, _), .connectionInterrupted(let id)):
+            try requireSame(current, id)
+            return inspect(operation: id)
+
+        case (.unknownOutcome(let current, _), .userRetried), (.unknownOutcome(let current, _), .inspectionRequested):
+            // A fresh inspection replaces the outstanding one rather than joining it: the reply
+            // to the earlier one describes a state that may already be obsolete, and its token
+            // is no longer accepted.
+            return inspect(operation: current)
+
+        case (.awaitingInspection, .userRetried), (.awaitingInspection, .inspectionRequested):
+            // Reissued rather than suppressed: an inspection whose request was never submitted,
+            // whose reply was lost, or that was still outstanding when the app was relaunched
+            // would otherwise leave no event that can produce a `reconciled` result.
+            return inspect()
+
+        case (.cleanupRequired, .userRetried):
+            // The cleanup's result is unknown; inspect rather than clean up blindly again. If
+            // it turns out to still be running, `cleanupRunning` resumes monitoring it.
+            //
+            // `connectionInterrupted` is deliberately not here. A cleanup is an effect, not an
+            // operation, so no operation-scoped interruption is about it — the same reason the
+            // checkpoint write refuses one that names another operation. Accepting any would
+            // let an interruption belonging to an unrelated operation, delivered late, replace
+            // this cleanup's token with an inspection and make its own `cleanupFinished` stale.
+            // A coordinator that loses contact while a cleanup is pending asks for the
+            // inspection by name with `inspectionRequested`, which lands in the same place.
+            return inspect()
+
+        case (.inProgress(let current), .inspectionRequested), (.needsUserAction(let current, _), .inspectionRequested):
+            // The operation is still live, so its identity is carried through the inspection:
+            // an unscoped one would adopt a `stillRunning` naming some other operation, or a
+            // `notStarted` that permits a second mutation while this one keeps going.
+            return inspect(operation: current)
+
+        case (.recoverableFailure(_, .some(let interrupted)), .inspectionRequested),
+             (.recoverableFailure(_, .some(let interrupted)), .userRetried):
+            // This failure is a check that could not answer for `interrupted`, so that
+            // operation's outcome is exactly as unknown as it was and the replacement
+            // inspection stays scoped to it. An unscoped one would adopt whatever identity the
+            // next answer happens to name while the first operation may still be mutating
+            // (MVP-PLAN.md §3).
+            return inspect(operation: interrupted)
+
+        case (_, .inspectionRequested):
+            return inspect()
+
+        case (.recoverableFailure, .userRetried), (.canceled, .userRetried):
+            return inspect()
+
+        case (.needsUserAction(let current, _), .userActionCompleted):
+            // The operation the user was asked to unblock may still be running, so the
+            // inspection stays scoped to it rather than accepting whatever it reports.
+            return inspect(operation: current)
+
+        case (.unknownOutcome(let interrupted, let inspection), .operationReconciled(let token, let operation, let outcome)):
+            try requireOutstanding(inspection, token)
+            try requireSame(interrupted, operation)
+            switch outcome {
+            case .stillRunning(let actualStage):
+                // Identity checks above make this inspection authoritative about where the
+                // operation is working, so its next checkpoint must be checked at that stage.
+                return (ProvisioningState(stage: actualStage, status: .inProgress(operation), issuedEffects: issued), [])
+            case .stillNeedsUserAction(let error, let actualStage):
+                return (ProvisioningState(stage: actualStage, status: .needsUserAction(operation, error), issuedEffects: issued), [])
+            case .quiescent(.stillRunning), .quiescent(.stillNeedsUserAction):
+                throw .illegalTransition(status: state.status.kind, event: event.kind)
+            case .quiescent(let reconciled):
+                return try adopt(reconciled, interrupted: interrupted)
+            }
+
+        case (.awaitingInspection(let inspection), .reconciled(let token, let outcome)):
+            try requireOutstanding(inspection, token)
+            // Nothing here knows which operation was in flight, so a reported identity is the
+            // only one there is.
+            return try adopt(outcome, interrupted: nil)
+
+        case (.awaitingInspection(let inspection), .inspectionFailed(let token, let error)):
+            // The inspection could not answer, so nothing is known that was not known before.
+            // Keeping the error rather than dropping it is what lets the coordinator show why
+            // the check failed and what to do; a retry from a recoverable failure inspects
+            // again, so no mutation can be repeated on the strength of a failed check.
+            try requireOutstanding(inspection, token)
+            return at(.recoverableFailure(error, interrupted: nil))
+
+        case (.unknownOutcome(let interrupted, let inspection), .inspectionFailed(let token, let error)):
+            // The same, except that this state knows which operation is unaccounted for. It
+            // travels with the error: a failed check settles nothing, so forgetting the
+            // operation here would let the retry's inspection adopt a different one while this
+            // one may still be mutating.
+            try requireOutstanding(inspection, token)
+            return at(.recoverableFailure(error, interrupted: interrupted))
+
+        case (.cleanupRequired(_, let cleanup), .cleanupFinished(let token)):
+            try requireOutstanding(cleanup, token)
+            return at(.notStarted)
+
+        case (.cleanupRequired(_, let cleanup), .cleanupFailed(let token, let error)):
+            try requireOutstanding(cleanup, token)
+            return at(.recoverableFailure(error, interrupted: nil))
+
+        default:
+            throw .illegalTransition(status: state.status.kind, event: event.kind)
+        }
+    }
+
+    private static func requireSame(_ expected: OperationID, _ actual: OperationID) throws(ProvisioningTransitionError) {
+        guard expected == actual else { throw .operationMismatch(expected: expected, actual: actual) }
+    }
+
+    private static func requireOutstanding(_ expected: EffectToken, _ actual: EffectToken) throws(ProvisioningTransitionError) {
+        guard expected == actual else { throw .staleEffect(expected: expected, actual: actual) }
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Provisioning/ProvisioningReducer.swift
@@ -21,17 +21,19 @@ enum ProvisioningReducer: Sendable {
     ) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
         let stage = state.stage
         var issued = state.issuedEffects
-        func mint() -> EffectToken {
-            issued += 1
-            return EffectToken(issued)
+        func mint() throws(ProvisioningTransitionError) -> EffectToken {
+            let current = ProvisioningState(stage: stage, status: state.status, issuedEffects: issued)
+            guard let token = current.nextEffectToken else { throw .effectCounterExhausted }
+            issued = token.value
+            return token
         }
         func at(_ status: StageStatus, _ effects: [ProvisioningEffect] = []) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
             (ProvisioningState(stage: stage, status: status, issuedEffects: issued), effects)
         }
         /// Mints the inspection's token once, so the status and the effect asking for it can
         /// never name different inspections.
-        func inspect(operation: OperationID? = nil) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
-            let token = mint()
+        func inspect(operation: OperationID? = nil) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
+            let token = try mint()
             let status = operation.map { StageStatus.unknownOutcome($0, inspection: token) } ?? .awaitingInspection(token)
             return at(status, [.inspectActualState(stage, token, operation: operation)])
         }
@@ -39,7 +41,7 @@ enum ProvisioningReducer: Sendable {
         /// reservation was made from so a refusal cannot orphan it.
         func reserve(_ requested: ProvisioningStage, resuming: ResumeEvidence?) throws(ProvisioningTransitionError) -> (state: ProvisioningState, effects: [ProvisioningEffect]) {
             guard requested == stage else { throw .stageMismatch(expected: stage, actual: requested) }
-            return at(.startRequested(request: mint(), resuming: resuming))
+            return try at(.startRequested(request: mint(), resuming: resuming))
         }
         /// Check the request before interpreting its reply: even an acceptance for the wrong
         /// stage must not abandon a newer reservation. Inspection-only reservations have no request identity,
@@ -57,7 +59,7 @@ enum ProvisioningReducer: Sendable {
                 // A later checkpoint is adopted: the journal is the durable truth, and pinning
                 // the saved stage would offer a start for a step the runtime already ran.
                 guard checkpoint.stage >= stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
-                let write = mint()
+                let write = try mint()
                 // Inspection settled the operation; delayed callbacks cannot abandon this write.
                 let status = StageStatus.persistingCheckpoint(checkpoint, operation: nil, write: write)
                 return (ProvisioningState(stage: checkpoint.stage, status: status, issuedEffects: issued), [.persistCheckpoint(checkpoint, write)])
@@ -72,7 +74,7 @@ enum ProvisioningReducer: Sendable {
             case .resumable(let evidence):
                 return at(.resumable(evidence))
             case .failedNeedsCleanup(let error):
-                let cleanup = mint()
+                let cleanup = try mint()
                 return at(.cleanupRequired(error, cleanup: cleanup), [.cleanUp(stage, cleanup)])
             case .failed(let error):
                 return at(.recoverableFailure(error, interrupted: nil))
@@ -95,7 +97,7 @@ enum ProvisioningReducer: Sendable {
         case (.completed, .startRequested(let requested)):
             guard let next = stage.next else { throw .alreadyReady }
             guard requested == next else { throw .stageMismatch(expected: next, actual: requested) }
-            let request = mint()
+            let request = try mint()
             return (ProvisioningState(stage: next, status: .startRequested(request: request, resuming: nil), issuedEffects: issued), [])
 
         case (.startRequested(let request, _), .operationStarted(let id, let requested, let token)):
@@ -103,7 +105,7 @@ enum ProvisioningReducer: Sendable {
             // This request has answered, so its reservation is no longer live. An acceptance
             // at the wrong stage may already be mutating. Inspect its identity across all stages
             // before reconciling the reserved stage; only that inspection can establish its stage.
-            guard requested == stage else { return inspect(operation: id) }
+            guard requested == stage else { return try inspect(operation: id) }
             return at(.inProgress(id))
 
         case (.startRequested(let request, let resuming), .startRequestRejected(let error, let token)):
@@ -114,12 +116,12 @@ enum ProvisioningReducer: Sendable {
 
         case (.startRequested(let request, _), .startRequestInterrupted(let token)):
             try requireRequest(request, token)
-            return inspect()
+            return try inspect()
 
         case (.startRequested(nil, _), .inspectionRequested):
             // A tokenless saved reservation is inspection-only. No uncorrelated callback
             // can settle it or authorize another start in its place.
-            return inspect()
+            return try inspect()
 
         case (.startRequested, .inspectionRequested):
             // The reservation stays held: the request is still live, so the runtime may still
@@ -134,7 +136,7 @@ enum ProvisioningReducer: Sendable {
             // be before the GUI reports it; refusing its checkpoint would drop a reached one.
             try requireSame(current, id)
             guard checkpoint.stage == stage else { throw .stageMismatch(expected: stage, actual: checkpoint.stage) }
-            let write = mint()
+            let write = try mint()
             return at(.persistingCheckpoint(checkpoint, operation: current, write: write), [.persistCheckpoint(checkpoint, write)])
 
         case (.persistingCheckpoint(let pending, _, let write), .checkpointPersisted(let token, let persisted)):
@@ -157,7 +159,7 @@ enum ProvisioningReducer: Sendable {
             // abandon a live write and make its own successful callback stale.
             guard let writer else { throw .illegalTransition(status: state.status.kind, event: event.kind) }
             try requireSame(writer, id)
-            return inspect(operation: writer)
+            return try inspect(operation: writer)
 
         case (.persistingCheckpoint(_, let writer, _), .userRetried),
              (.persistingCheckpoint(_, let writer, _), .inspectionRequested):
@@ -168,7 +170,7 @@ enum ProvisioningReducer: Sendable {
             // the second (MVP-PLAN.md §3). A checkpoint restored after a relaunch is exactly
             // that case: the write is lost, the operation behind it need not be. The unscoped
             // status is left to a reconciled write, which has no operation behind it.
-            return inspect(operation: writer)
+            return try inspect(operation: writer)
 
         case (.inProgress(let current), .operationFailed(let id, let error)),
              (.needsUserAction(let current, _), .operationFailed(let id, let error)):
@@ -192,27 +194,27 @@ enum ProvisioningReducer: Sendable {
 
         case (.needsUserAction(let current, _), .connectionInterrupted(let id)):
             try requireSame(current, id)
-            return inspect(operation: id)
+            return try inspect(operation: id)
 
         case (.inProgress(let current), .connectionInterrupted(let id)):
             try requireSame(current, id)
-            return inspect(operation: id)
+            return try inspect(operation: id)
 
         case (.unknownOutcome(let current, _), .connectionInterrupted(let id)):
             try requireSame(current, id)
-            return inspect(operation: id)
+            return try inspect(operation: id)
 
         case (.unknownOutcome(let current, _), .userRetried), (.unknownOutcome(let current, _), .inspectionRequested):
             // A fresh inspection replaces the outstanding one rather than joining it: the reply
             // to the earlier one describes a state that may already be obsolete, and its token
             // is no longer accepted.
-            return inspect(operation: current)
+            return try inspect(operation: current)
 
         case (.awaitingInspection, .userRetried), (.awaitingInspection, .inspectionRequested):
             // Reissued rather than suppressed: an inspection whose request was never submitted,
             // whose reply was lost, or that was still outstanding when the app was relaunched
             // would otherwise leave no event that can produce a `reconciled` result.
-            return inspect()
+            return try inspect()
 
         case (.cleanupRequired, .userRetried):
             // The cleanup's result is unknown; inspect rather than clean up blindly again. If
@@ -225,13 +227,13 @@ enum ProvisioningReducer: Sendable {
             // this cleanup's token with an inspection and make its own `cleanupFinished` stale.
             // A coordinator that loses contact while a cleanup is pending asks for the
             // inspection by name with `inspectionRequested`, which lands in the same place.
-            return inspect()
+            return try inspect()
 
         case (.inProgress(let current), .inspectionRequested), (.needsUserAction(let current, _), .inspectionRequested):
             // The operation is still live, so its identity is carried through the inspection:
             // an unscoped one would adopt a `stillRunning` naming some other operation, or a
             // `notStarted` that permits a second mutation while this one keeps going.
-            return inspect(operation: current)
+            return try inspect(operation: current)
 
         case (.recoverableFailure(_, .some(let interrupted)), .inspectionRequested),
              (.recoverableFailure(_, .some(let interrupted)), .userRetried):
@@ -240,18 +242,18 @@ enum ProvisioningReducer: Sendable {
             // inspection stays scoped to it. An unscoped one would adopt whatever identity the
             // next answer happens to name while the first operation may still be mutating
             // (MVP-PLAN.md §3).
-            return inspect(operation: interrupted)
+            return try inspect(operation: interrupted)
 
         case (_, .inspectionRequested):
-            return inspect()
+            return try inspect()
 
         case (.recoverableFailure, .userRetried), (.canceled, .userRetried):
-            return inspect()
+            return try inspect()
 
         case (.needsUserAction(let current, _), .userActionCompleted):
             // The operation the user was asked to unblock may still be running, so the
             // inspection stays scoped to it rather than accepting whatever it reports.
-            return inspect(operation: current)
+            return try inspect(operation: current)
 
         case (.unknownOutcome(let interrupted, let inspection), .operationReconciled(let token, let operation, let outcome)):
             try requireOutstanding(inspection, token)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+private let uncertainOperation = OperationID()
+
+@Suite struct ProvisioningReducerTests {
+    typealias Reducer = ProvisioningReducer
+
+    let op = OperationID()
+    let other = OperationID()
+    let now = Date(timeIntervalSince1970: 1_800_000_000)
+    let failure = GuesthouseError.guestNotReachable(EnvironmentID())
+    let consoleNeeded = GuesthouseError.credentialsLocked(.guestKeychain)
+    let evidence = ResumeEvidence(kind: .partialDownload, stagingPath: "downloads/restore.ipsw.partial")!
+    let pending = EffectToken(1)
+    let next = EffectToken(2)
+
+    func checkpoint(_ stage: ProvisioningStage) -> Checkpoint { Checkpoint(stage: stage, reachedAt: now) }
+    func state(_ stage: ProvisioningStage, _ status: StageStatus) -> ProvisioningState { ProvisioningState(stage: stage, status: status) }
+
+    /// The token the reducer stamped on the effect it just asked for. The coordinator echoes it
+    /// in the callback, and so do these tests.
+    func token(of effects: [ProvisioningEffect]) throws -> EffectToken {
+        switch try #require(effects.first) {
+        case .inspectActualState(_, let token, _), .persistCheckpoint(_, let token), .cleanUp(_, let token): token
+        }
+    }
+
+    struct LegalTransition {
+        let name: String
+        let from: ProvisioningState
+        let event: ProvisioningEvent
+        let expectedStatus: String
+        let expectedEffects: [ProvisioningEffect]
+    }
+
+    var legalTransitions: [LegalTransition] {
+        [
+            .init(name: "request first stage", from: .initial, event: .startRequested(stage: .preflight), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "runtime accepts the requested start", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .operationStarted(op, stage: .preflight, request: pending), expectedStatus: "inProgress", expectedEffects: []),
+            .init(name: "runtime rejects the request: error kept, nothing ran", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .startRequestRejected(failure, request: pending), expectedStatus: "startRejected", expectedEffects: []),
+            .init(name: "a new request after a rejection needs no inspection", from: state(.preflight, .startRejected(failure, resuming: nil)), event: .startRequested(stage: .preflight), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "user cancels while a console step is pending", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .operationCanceled(op), expectedStatus: "canceled", expectedEffects: []),
+            .init(name: "request interrupted: inspect", from: state(.preflight, .startRequested(request: pending, resuming: nil)), event: .startRequestInterrupted(request: pending), expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.preflight, next, operation: nil)]),
+            .init(name: "checkpoint reached waits for persistence", from: state(.preflight, .inProgress(op)), event: .checkpointReached(op, checkpoint(.preflight)), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.preflight), pending)]),
+            .init(name: "persisted checkpoint completes the stage", from: state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending)), event: .checkpointPersisted(pending, checkpoint(.preflight)), expectedStatus: "completed", expectedEffects: []),
+            .init(name: "persistence failure is shown with its recovery", from: state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending)), event: .checkpointPersistenceFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "request next stage after completion", from: state(.preflight, .completed(checkpoint(.preflight))), event: .startRequested(stage: .runtimeReady), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "request resumes from durable partial work", from: state(.runtimeReady, .resumable(evidence)), event: .startRequested(stage: .runtimeReady), expectedStatus: "startRequested", expectedEffects: []),
+            .init(name: "failure is recoverable", from: state(.sshPaired, .inProgress(op)), event: .operationFailed(op, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "cancel", from: state(.sshPaired, .inProgress(op)), event: .operationCanceled(op), expectedStatus: "canceled", expectedEffects: []),
+            .init(name: "user action required", from: state(.needsGuestSetup, .inProgress(op)), event: .userActionRequired(op, consoleNeeded), expectedStatus: "needsUserAction", expectedEffects: []),
+            .init(name: "interruption becomes unknown and inspects", from: state(.macOSInstalled, .inProgress(op)), event: .connectionInterrupted(op), expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, pending, operation: op)]),
+            .init(name: "still disconnected: inspect again", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .connectionInterrupted(op), expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: op)]),
+            .init(name: "user asks to check again while unknown", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .userRetried, expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: op)]),
+            .init(name: "user asks to check again while inspecting", from: state(.macOSInstalled, .awaitingInspection(pending)), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.macOSInstalled, next, operation: nil)]),
+            .init(name: "retry after failure inspects first", from: state(.sshPaired, .recoverableFailure(failure, interrupted: nil)), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.sshPaired, pending, operation: nil)]),
+            .init(name: "retry after cancel inspects first", from: state(.sshPaired, .canceled), event: .userRetried, expectedStatus: "awaitingInspection", expectedEffects: [.inspectActualState(.sshPaired, pending, operation: nil)]),
+            .init(name: "user finished console step, inspect under the paused operation's identity", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .userActionCompleted, expectedStatus: "unknownOutcome", expectedEffects: [.inspectActualState(.needsGuestSetup, pending, operation: op)]),
+            .init(name: "a paused operation that fails is a recoverable failure", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .operationFailed(op, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "a paused operation's checkpoint is persisted", from: state(.needsGuestSetup, .needsUserAction(op, consoleNeeded)), event: .checkpointReached(op, checkpoint(.needsGuestSetup)), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.needsGuestSetup), pending)]),
+            .init(name: "a failed inspection is a recoverable failure, not a silent loop", from: state(.sshPaired, .awaitingInspection(pending)), event: .inspectionFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "reconciled: actually completed, persist it", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .quiescent(.completed(checkpoint(.macOSInstalled)))), expectedStatus: "persistingCheckpoint", expectedEffects: [.persistCheckpoint(checkpoint(.macOSInstalled), next)]),
+            .init(name: "reconciled: still running, resume monitoring", from: state(.macOSInstalled, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .stillRunning(stage: .macOSInstalled)), expectedStatus: "inProgress", expectedEffects: []),
+            .init(name: "reconciled: still waiting on the user", from: state(.needsGuestSetup, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .stillNeedsUserAction(consoleNeeded, stage: .needsGuestSetup)), expectedStatus: "needsUserAction", expectedEffects: []),
+            .init(name: "reconciled: resumable partial work", from: state(.runtimeReady, .unknownOutcome(op, inspection: pending)), event: .operationReconciled(pending, op, .quiescent(.resumable(evidence))), expectedStatus: "resumable", expectedEffects: []),
+            .init(name: "reconciled: failed and needs cleanup", from: state(.runtimeReady, .awaitingInspection(pending)), event: .reconciled(pending, .failedNeedsCleanup(failure)), expectedStatus: "cleanupRequired", expectedEffects: [.cleanUp(.runtimeReady, next)]),
+            .init(name: "reconciled: the earlier cleanup is still running", from: state(.runtimeReady, .awaitingInspection(next)), event: .reconciled(next, .cleanupRunning(pending, failure)), expectedStatus: "cleanupRequired", expectedEffects: []),
+            .init(name: "reconciled: failed, user must act", from: state(.sshPaired, .awaitingInspection(pending)), event: .reconciled(pending, .failed(failure)), expectedStatus: "recoverableFailure", expectedEffects: []),
+            .init(name: "reconciled: nothing happened, safe to start", from: state(.sshPaired, .awaitingInspection(pending)), event: .reconciled(pending, .notStarted), expectedStatus: "notStarted", expectedEffects: []),
+            .init(name: "cleanup finished, safe to start", from: state(.runtimeReady, .cleanupRequired(failure, cleanup: pending)), event: .cleanupFinished(pending), expectedStatus: "notStarted", expectedEffects: []),
+            .init(name: "cleanup failed, back to recoverable", from: state(.runtimeReady, .cleanupRequired(failure, cleanup: pending)), event: .cleanupFailed(pending, failure), expectedStatus: "recoverableFailure", expectedEffects: []),
+        ]
+    }
+
+    @Test func everyLegalTransition() throws {
+        for transition in legalTransitions {
+            let (state, effects) = try Reducer.reduce(transition.from, transition.event)
+            #expect(state.status.caseName == transition.expectedStatus, Comment(rawValue: transition.name))
+            #expect(effects == transition.expectedEffects, Comment(rawValue: transition.name))
+            if case .startRequested(let stage) = transition.event {
+                #expect(state.stage == stage, Comment(rawValue: transition.name))
+            } else {
+                #expect(state.stage == transition.from.stage, Comment(rawValue: transition.name))
+            }
+            #expect(state.isConsistent, Comment(rawValue: transition.name))
+        }
+    }
+
+    @Test func nothingAdvancesUntilTheCheckpointIsPersisted() {
+        let writing = state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending))
+        #expect(throws: ProvisioningTransitionError.illegalTransition(status: .persistingCheckpoint, event: .startRequested)) {
+            try Reducer.reduce(writing, .startRequested(stage: .runtimeReady))
+        }
+        #expect(throws: ProvisioningTransitionError.checkpointMismatch(expected: checkpoint(.preflight), actual: checkpoint(.runtimeReady))) {
+            try Reducer.reduce(writing, .checkpointPersisted(pending, checkpoint(.runtimeReady)))
+        }
+    }
+
+    @Test func startingFromAFailureUnknownOrInspectionIsIllegal() {
+        for status in [StageStatus.recoverableFailure(failure, interrupted: nil), .unknownOutcome(op, inspection: pending), .awaitingInspection(pending), .cleanupRequired(failure, cleanup: pending), .needsUserAction(op, consoleNeeded), .startRequested(request: pending, resuming: nil), .inProgress(op)] {
+            #expect(throws: ProvisioningTransitionError.self, Comment(rawValue: status.caseName)) {
+                try Reducer.reduce(state(.sshPaired, status), .startRequested(stage: .sshPaired))
+            }
+        }
+        for status in [StageStatus.notStarted, .resumable(evidence), .completed(checkpoint(.sshPaired))] {
+            #expect(throws: ProvisioningTransitionError.self, Comment(rawValue: status.caseName)) {
+                try Reducer.reduce(state(.sshPaired, status), .operationStarted(other, stage: .sshPaired, request: pending))
+            }
+        }
+    }
+
+    @Test func confirmedFailureWithLeftoversReachesASafeStart() throws {
+        let verification = GuesthouseError.downloadVerificationFailed(check: .digest)
+        var state = state(.runtimeReady, .recoverableFailure(verification, interrupted: nil))
+        let inspecting = try Reducer.reduce(state, .userRetried)
+        state = inspecting.state
+        let (afterInspection, effects) = try Reducer.reduce(state, .reconciled(try token(of: inspecting.effects), .failedNeedsCleanup(verification)))
+        #expect(effects == [.cleanUp(.runtimeReady, EffectToken(2))])
+        let clean = try Reducer.reduce(afterInspection, .cleanupFinished(try token(of: effects))).state
+        #expect(clean.status == .notStarted)
+        let reserved = try Reducer.reduce(clean, .startRequested(stage: .runtimeReady)).state
+        let started = try Reducer.reduce(reserved, .operationStarted(other, stage: .runtimeReady, request: #require(reserved.status.pendingEffect))).state
+        #expect(started.status == .inProgress(other))
+    }
+
+    @Test func stagesMustBeSequential() {
+        #expect(throws: ProvisioningTransitionError.stageMismatch(expected: .runtimeReady, actual: .sshPaired)) {
+            try Reducer.reduce(state(.preflight, .completed(checkpoint(.preflight))), .startRequested(stage: .sshPaired))
+        }
+        #expect(throws: ProvisioningTransitionError.stageMismatch(expected: .preflight, actual: .ready)) {
+            try Reducer.reduce(state(.preflight, .inProgress(op)), .checkpointReached(op, checkpoint(.ready)))
+        }
+        #expect(throws: ProvisioningTransitionError.alreadyReady) {
+            try Reducer.reduce(state(.ready, .completed(checkpoint(.ready))), .startRequested(stage: .ready))
+        }
+    }
+
+    @Test func retryingWhileInProgressOrCompletedIsIllegal() {
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(state(.preflight, .inProgress(op)), .userRetried) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(state(.preflight, .completed(checkpoint(.preflight))), .userRetried) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(.initial, .reconciled(pending, .notStarted)) }
+        #expect(throws: ProvisioningTransitionError.self) { try Reducer.reduce(.initial, .cleanupFinished(pending)) }
+    }
+
+    @Test func happyPathReachesReadyOnlyAfterEveryCheckpointIsPersisted() throws {
+        var state = ProvisioningState.initial
+        for stage in ProvisioningStage.allCases {
+            let id = OperationID()
+            state = try Reducer.reduce(state, .startRequested(stage: stage)).state
+            state = try Reducer.reduce(state, .operationStarted(id, stage: stage, request: #require(state.status.pendingEffect))).state
+            let reached = try Reducer.reduce(state, .checkpointReached(id, checkpoint(stage)))
+            state = reached.state
+            #expect(!state.isReady)
+            state = try Reducer.reduce(state, .checkpointPersisted(try token(of: reached.effects), checkpoint(stage))).state
+        }
+        #expect(state.isReady)
+        #expect(state.stage == .ready)
+    }
+
+    @Test func interruptedThenCompletedContinuesToNextStage() throws {
+        var state = state(.macOSInstalled, .inProgress(op))
+        let inspecting = try Reducer.reduce(state, .connectionInterrupted(op))
+        let reconciled = try Reducer.reduce(inspecting.state, .operationReconciled(try token(of: inspecting.effects), op, .quiescent(.completed(checkpoint(.macOSInstalled)))))
+        #expect(reconciled.state.status == .persistingCheckpoint(checkpoint(.macOSInstalled), operation: nil, write: try token(of: reconciled.effects)))
+        for delayed in [op, other] {
+            #expect(throws: ProvisioningTransitionError.self) {
+                try Reducer.reduce(reconciled.state, .connectionInterrupted(delayed))
+            }
+        }
+        state = try Reducer.reduce(reconciled.state, .checkpointPersisted(try token(of: reconciled.effects), checkpoint(.macOSInstalled))).state
+        state = try Reducer.reduce(state, .startRequested(stage: .needsGuestSetup)).state
+        state = try Reducer.reduce(state, .operationStarted(other, stage: .needsGuestSetup, request: #require(state.status.pendingEffect))).state
+        #expect(state.stage == .needsGuestSetup)
+        #expect(state.status == .inProgress(other))
+    }
+
+    @Test(arguments: ProvisioningStage.allCases)
+    func everyStageRefusesAcceptanceWithoutAReservation(stage: ProvisioningStage) {
+        #expect(throws: ProvisioningTransitionError.illegalTransition(status: .notStarted, event: .operationStarted)) {
+            try Reducer.reduce(state(stage, .notStarted), .operationStarted(op, stage: stage, request: pending))
+        }
+    }
+
+    @Test(arguments: [
+        StageStatus.inProgress(uncertainOperation),
+        .needsUserAction(uncertainOperation, .credentialsLocked(.guestKeychain)),
+    ], [
+        GuesthouseError.canceled, .operationOutcomeUnknown(uncertainOperation),
+        .guestNotReachable(EnvironmentID()), .invalidRuntimeReply(.malformed),
+    ])
+    func reportedFailureRetainsIdentityUntilInspection(status: StageStatus, error: GuesthouseError) throws {
+        let failed = try Reducer.reduce(state(.first, status), .operationFailed(uncertainOperation, error))
+        #expect(failed.state.status == .recoverableFailure(error, interrupted: uncertainOperation))
+        #expect(failed.effects.isEmpty)
+        let restored = try JSONDecoder().decode(ProvisioningState.self, from: JSONEncoder().encode(failed.state))
+        let retry = try Reducer.reduce(restored, .userRetried)
+        let inspection = try token(of: retry.effects)
+        #expect(retry.effects == [.inspectActualState(.first, inspection, operation: uncertainOperation)])
+        #expect(throws: ProvisioningTransitionError.operationMismatch(expected: uncertainOperation, actual: other)) {
+            try Reducer.reduce(retry.state, .operationReconciled(inspection, other, .stillRunning(stage: .first)))
+        }
+        #expect(try Reducer.reduce(retry.state, .operationReconciled(inspection, uncertainOperation, .stillRunning(stage: .first))).state.status == .inProgress(uncertainOperation))
+        let settled = try Reducer.reduce(retry.state, .operationReconciled(inspection, uncertainOperation, .quiescent(.notStarted)))
+        #expect(settled.state.status == .notStarted)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Provisioning/ProvisioningReducerTests.swift
@@ -88,6 +88,36 @@ private let uncertainOperation = OperationID()
         }
     }
 
+    @Test(arguments: [UInt64.max / 2, UInt64.max - 1, UInt64.max])
+    func everyLegalTransitionHandlesCounterBoundariesWithoutLosingState(issued: UInt64) throws {
+        for transition in legalTransitions {
+            let original = ProvisioningState(stage: transition.from.stage, status: transition.from.status, issuedEffects: issued)
+            let source = try JSONEncoder().encode(original)
+            let restored = try JSONDecoder().decode(ProvisioningState.self, from: source)
+            let reservesIdentity: Bool
+            if case .startRequested = transition.event {
+                reservesIdentity = true
+            } else {
+                reservesIdentity = !transition.expectedEffects.isEmpty
+            }
+            if issued == UInt64.max && reservesIdentity {
+                #expect(throws: ProvisioningTransitionError.effectCounterExhausted, Comment(rawValue: transition.name)) {
+                    try Reducer.reduce(restored, transition.event)
+                }
+                #expect(restored == original)
+                #expect(try JSONDecoder().decode(ProvisioningState.self, from: source) == original)
+            } else {
+                let result = try Reducer.reduce(restored, transition.event)
+                #expect(result.state.issuedEffects == (reservesIdentity ? issued + 1 : issued))
+                #expect(result.state.status.caseName == transition.expectedStatus)
+                #expect(try JSONDecoder().decode(ProvisioningState.self, from: JSONEncoder().encode(result.state)) == result.state)
+                if !result.effects.isEmpty {
+                    #expect(try token(of: result.effects).value == issued + 1)
+                }
+            }
+        }
+    }
+
     @Test func nothingAdvancesUntilTheCheckpointIsPersisted() {
         let writing = state(.preflight, .persistingCheckpoint(checkpoint(.preflight), operation: op, write: pending))
         #expect(throws: ProvisioningTransitionError.illegalTransition(status: .persistingCheckpoint, event: .startRequested)) {


### PR DESCRIPTION
## Summary

Migrate the existing internal provisioning reducer from preserved reference #106 onto the structured contracts in #168. This is the next focused implementation slice for #6, not a second state machine or a provider activation.

- Reserve starts before accepting runtime callbacks; retain partial-work resume evidence after an explicit rejection.
- Correlate start, inspection, checkpoint-write and cleanup callbacks. A matching wrong-stage acceptance requests operation-scoped inspection; it does not abandon a newer reservation or enable a blind retry.
- Preserve known operation identity across failures and relaunch until inspection establishes its outcome.
- Advance only after the exact checkpoint is acknowledged as persisted.
- Use checked effect-token minting over the full UInt64 range; exhaustion preserves the saved record and does not block callbacks that need no new identity.

Specification: `MVP-PLAN.md` §§3, 4 and 9. Shared/provider-neutral work follows ADR 0002; fixed typed errors and no raw-output logging follow ADR 0003.

## Stack and scope

**Base: #168 (`mvp/provisioning-contract`).** The owner-merge order is #165 → #166 → #168 → this PR; #167 is independent. Do not merge this PR into its feature-branch base. After its parents merge, settle it onto main and recheck the resulting composition before the owner merges it.

Two changed files, 554 additions against the parent: one 316-line pure reducer plus its 238-line baseline suite. Keeping the transition function and its baseline tests together makes this a single reviewable unit despite being slightly over the approximate 500-line guideline. No GUI/runtime effect execution, persistence adapter, credentials, VM/provider process, or hardware procedure is activated.

Existing identity/callback and remaining recovery regression suites are preserved in the prepared follow-ups to #107/#56. Those broader audits and public activation are not claimed complete here. #6 and reference #106 remain open.

## Validation

Published head: `0695e9e70c4ae8c7b56b7a01b6ad666edaa1d0a3`, including the reviewed #168 correction by ordinary forward merge.

- Source review and `git diff --check`: passed.
- `bash Tests/CI/test-package-hook.sh`: all 7 shell-only scenarios passed; this validates hook behavior, not Swift compilation.
- Baseline tests cover the 34-transition table, sequential checkpoints, invalid starts, inspection-first recovery, retained failure identity, all stages, and high/final counter cases.
- **No local Swift/Xcode build or package-test run for this composed head.** At the owner's request, compilation and tests use the origin push and Xcode Cloud, avoiding new local build caches.
- **Exact-head Xcode Cloud passed September 10, 2026 at09:30:50 UTC:** zero errors, test failures, analysis issues or warnings.
- **Matching Codex review completed at09:29:58 UTC; original PR message bot thumbs-up at09:30:01.** No inline or standalone findings; all comment/thread/reaction pages checked. No second push or review cycle was needed.
- **Dependency hold remains:** parents #165, #166 and #168 are still open. Settle this PR on main and recheck composition after those merge; do not merge it into the feature base.

Review findings will receive an explained fix or evidence-backed rejection. Readiness additionally requires the original PR message's Codex thumbs-up and no unresolved actionable findings.
