### PR TITLE
Migrate typed preflight observations and resource guards

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeError.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Typed reasons adapted from retained #61. No path or underlying error can become the
+/// message, encoded payload or recovery text (ADR 0003). The concrete probe stays in RuntimeKit.
+public enum HostProbeError: String, Error, Codable, Hashable, Sendable, LocalizedError, CaseIterable {
+    case storageRootUnknown
+    case volumeUnavailable
+    case volumeIdentityChanged
+    case notADirectory
+    case destinationNotWritable
+    case capacityUnavailable
+
+    public var userMessage: String {
+        switch self {
+        case .storageRootUnknown:
+            "Guesthouse could not determine this account's runtime storage location. Check again before starting setup."
+        case .volumeUnavailable:
+            "The volume selected for the development Mac is unavailable. Reconnect it before checking again."
+        case .volumeIdentityChanged:
+            "The storage location no longer refers to the selected volume. Inspect the original volume before continuing."
+        case .notADirectory:
+            "The development Mac's storage location is not a folder. Inspect the location before starting setup."
+        case .destinationNotWritable:
+            "Guesthouse's runtime cannot write to the development Mac's storage folder. Check the folder's permissions and volume access."
+        case .capacityUnavailable:
+            "Guesthouse could not determine available disk space. Check again before downloading or importing files."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .storageRootUnknown, .capacityUnavailable: [.retry, .openSettings, .cancel]
+        case .volumeUnavailable: [.retry, .inspectState, .cancel]
+        case .volumeIdentityChanged: [.inspectState, .cancel]
+        case .notADirectory: [.inspectState, .openSettings, .cancel]
+        case .destinationNotWritable: [.openSettings, .retry, .cancel]
+        }
+    }
+
+    public var errorDescription: String? { userMessage }
+    public var recoverySuggestion: String? { recoveryActions.map(\.title).joined(separator: "; ") }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeError.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Typed reasons adapted from retained #61. No path or underlying error can become the
-/// message, encoded payload or recovery text (ADR 0003). The concrete probe stays in RuntimeKit.
+/// message, encoded payload or recovery text (ADR 0003). Concrete probing belongs in RuntimeKit.
 public enum HostProbeError: String, Error, Codable, Hashable, Sendable, LocalizedError, CaseIterable {
     case storageRootUnknown
     case volumeUnavailable

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeSnapshot.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/HostProbeSnapshot.swift
@@ -1,0 +1,51 @@
+/// Host facts supplied by the runtime-owned probe (#12, MVP-PLAN.md §§2–3).
+/// No syscalls, app lookup, filesystem access or automatic diagnostics are performed here.
+public enum PowerSource: String, Codable, Hashable, Sendable {
+    case externalPower, battery, unknown
+}
+
+/// The selected runtime storage root's capacity, not the GUI container's proxy volume.
+/// A numeric observation is not retained volume identity or authority to mutate a path.
+public enum HostDiskObservation: Codable, Hashable, Sendable {
+    case available(bytes: UInt64)
+    case unavailable(HostProbeError)
+}
+
+/// Discovery and metadata are different facts: missing metadata does not mean missing app.
+/// Versions are bounded dotted numeric observations, not opaque bundle text. Nonconforming
+/// metadata is unknown. Exact private compatibility identity remains in ObservedTuple; this
+/// summary is not evidence of a verified desktop connection and carries no application path.
+public enum CodexDesktopObservation: Codable, Hashable, Sendable {
+    case notFound
+    case unavailable
+    case installed(version: SemanticVersion?, build: SemanticVersion?)
+}
+
+/// Immutable input to the pure preflight evaluator. Every default means unobserved, never
+/// a fabricated healthy host. Missing OS/memory observations remain distinct from version 0
+/// or zero bytes. Decoders reject unknown enum cases; ignored fields are not re-exported.
+/// This is not a native-message size/admission validator or a persisted compatibility record.
+public struct HostProbeSnapshot: Codable, Hashable, Sendable {
+    public let cpuArchitecture: CPUArchitecture
+    public let operatingSystemVersion: SemanticVersion?
+    public let physicalMemoryBytes: UInt64?
+    public let powerSource: PowerSource
+    public let disk: HostDiskObservation
+    public let codexDesktop: CodexDesktopObservation
+
+    public init(
+        cpuArchitecture: CPUArchitecture = .unknown,
+        operatingSystemVersion: SemanticVersion? = nil,
+        physicalMemoryBytes: UInt64? = nil,
+        powerSource: PowerSource = .unknown,
+        disk: HostDiskObservation = .unavailable(.storageRootUnknown),
+        codexDesktop: CodexDesktopObservation = .unavailable
+    ) {
+        self.cpuArchitecture = cpuArchitecture
+        self.operatingSystemVersion = operatingSystemVersion
+        self.physicalMemoryBytes = physicalMemoryBytes
+        self.powerSource = powerSource
+        self.disk = disk
+        self.codexDesktop = codexDesktop
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePolicy.swift
@@ -1,0 +1,44 @@
+/// Typed architecture observation only; this type performs no host inspection.
+public enum CPUArchitecture: String, Codable, Hashable, Sendable {
+    case appleSilicon, intel, unknown
+}
+
+/// Every threshold the preflight and the large-operation checks use, in one place.
+///
+/// Numbers come from MVP-PLAN.md §4 ("Version and resource policy") and are planning
+/// estimates until phase 0 records measured peaks. Change them here, nowhere else.
+public struct ResourcePolicy: Hashable, Sendable {
+    public var requiredArchitecture: CPUArchitecture = .appleSilicon
+    /// The app's deployment target; older hosts cannot run it anyway, but a preflight that
+    /// somehow runs on one must say so plainly.
+    public var minimumMacOS = SemanticVersion([26, 4])
+    /// Below this the host cannot run a development Mac alongside anything else.
+    public var minimumMemoryBytes: UInt64 = 16 * ResourcePreset.gibibyte
+    /// What the host keeps for itself beside the guest's allocation. A Mac whose memory is
+    /// below the guest allocation plus this headroom is blocked, not warned (MVP-PLAN.md §4).
+    public var hostMemoryHeadroomBytes: UInt64 = 8 * ResourcePreset.gibibyte
+    /// Below this the preflight warns; the reference Mac has 32 GB.
+    public var recommendedMemoryBytes: UInt64 = 32 * ResourcePreset.gibibyte
+    /// Free space needed for the first setup: runtime, restore image, temporary extraction,
+    /// and the sparse guest disk's early growth (§4: "roughly 200 GB").
+    public var firstSetupAllowanceBytes: UInt64 = 200 * ResourcePreset.gigabyte
+    /// Headroom added to every large operation's own requirement.
+    public var largeOperationMarginBytes: UInt64 = 10 * ResourcePreset.gigabyte
+    /// Download estimates shown before the first setup starts. Estimates, not measurements.
+    public var runtimeDownloadEstimateBytes: UInt64 = 50 * ResourcePreset.megabyte
+    public var restoreImageEstimateBytes: UInt64 = 16 * ResourcePreset.gigabyte
+    // Application lookup identifiers belong to the runtime-owned probe, not resource policy.
+
+    public init() {}
+
+    public static let standard = ResourcePolicy()
+
+    /// A policy whose blocking minimum exceeds its recommendation is contradictory; the
+    /// preflight evaluates the minimum first regardless, and this check makes the mistake
+    /// visible in tests.
+    public var isWellFormed: Bool { minimumMemoryBytes <= recommendedMemoryBytes }
+}
+
+extension ResourcePreset {
+    public static let megabyte: UInt64 = 1_000_000
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePreflight.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/ResourcePreflight.swift
@@ -1,0 +1,35 @@
+/// Pure resource checks migrated from retained #61 (MVP-PLAN.md §§2 and 4).
+/// A caller supplies observations; these functions neither probe the host nor authorize a
+/// mutation. The runtime must remeasure its actual destination before each large operation.
+public enum LargeOperationPreflight: Sendable {
+    public static func check(
+        freeBytes: UInt64,
+        requiredBytes: UInt64,
+        policy: ResourcePolicy = .standard
+    ) throws(GuesthouseError) {
+        let (sum, overflow) = requiredBytes.addingReportingOverflow(policy.largeOperationMarginBytes)
+        let needed = overflow ? UInt64.max : sum
+        // Even UInt64.max available bytes cannot satisfy an unrepresentable requirement.
+        guard !overflow, freeBytes >= needed else {
+            throw .insufficientDisk(requiredBytes: needed, availableBytes: freeBytes)
+        }
+    }
+}
+
+/// Blocking memory floor extracted from #61's evaluator. Passing this check does not imply
+/// recommended performance; a report still warns below policy.recommendedMemoryBytes.
+/// This evaluates one selected guest, not admission or the combined cost of two running VMs.
+public enum MemoryPreflight: Sendable {
+    public static func check(
+        physicalMemoryBytes: UInt64,
+        preset: ResourcePreset = .recommended,
+        policy: ResourcePolicy = .standard
+    ) throws(GuesthouseError) {
+        let (required, overflow) = preset.memoryBytes.addingReportingOverflow(policy.hostMemoryHeadroomBytes)
+        let floor = overflow ? UInt64.max : max(policy.minimumMemoryBytes, required)
+        // Test overflow itself: comparing UInt64.max against a saturated floor is insufficient.
+        guard !overflow, physicalMemoryBytes >= floor else {
+            throw .unsupportedHost(.insufficientMemory(foundBytes: physicalMemoryBytes, minimumBytes: floor))
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/HostProbeSnapshotTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/HostProbeSnapshotTests.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct HostProbeSnapshotTests {
+    @Test func defaultsRepresentMissingEvidenceRatherThanAHealthyHost() throws {
+        let snapshot = HostProbeSnapshot()
+        #expect(snapshot.cpuArchitecture == .unknown)
+        #expect(snapshot.operatingSystemVersion == nil)
+        #expect(snapshot.physicalMemoryBytes == nil)
+        #expect(snapshot.powerSource == .unknown)
+        #expect(snapshot.disk == .unavailable(.storageRootUnknown))
+        #expect(snapshot.codexDesktop == .unavailable)
+        #expect(try roundTrip(snapshot) == snapshot)
+    }
+
+    @Test func observedZeroAndFullRangeMemoryRemainDistinctFromMissing() throws {
+        let zero = HostProbeSnapshot(operatingSystemVersion: SemanticVersion([0]), physicalMemoryBytes: 0,
+                                     disk: .available(bytes: 0), codexDesktop: .notFound)
+        let full = HostProbeSnapshot(physicalMemoryBytes: .max, disk: .available(bytes: .max))
+        #expect(zero != HostProbeSnapshot())
+        #expect(try roundTrip(zero) == zero)
+        #expect(try roundTrip(full) == full)
+    }
+
+    @Test(arguments: [CodexDesktopObservation.notFound, .unavailable,
+                      .installed(version: nil, build: nil),
+                      .installed(version: SemanticVersion([1, 2, 3]), build: SemanticVersion([456]))])
+    func discoveryAndMetadataCasesSurviveEncoding(_ observation: CodexDesktopObservation) throws {
+        let snapshot = HostProbeSnapshot(codexDesktop: observation)
+        #expect(try roundTrip(snapshot).codexDesktop == observation)
+    }
+
+    @Test(arguments: [CPUArchitecture.appleSilicon, .intel, .unknown],
+          [PowerSource.externalPower, .battery, .unknown])
+    func typedArchitectureAndPowerAreIndependent(architecture: CPUArchitecture, power: PowerSource) throws {
+        let snapshot = HostProbeSnapshot(cpuArchitecture: architecture, powerSource: power)
+        #expect(try roundTrip(snapshot) == snapshot)
+    }
+
+    @Test(arguments: HostProbeError.allCases)
+    func storageFailuresKeepTheirCauseAndFixedRecovery(_ failure: HostProbeError) throws {
+        let snapshot = HostProbeSnapshot(disk: .unavailable(failure))
+        #expect(try roundTrip(snapshot).disk == .unavailable(failure))
+        #expect(!failure.userMessage.isEmpty)
+        #expect(!failure.recoveryActions.isEmpty)
+        #expect(failure.errorDescription == failure.userMessage)
+        #expect(failure.recoverySuggestion?.isEmpty == false)
+    }
+
+    @Test func replacedVolumeOffersInspectionInsteadOfBlindRetry() {
+        #expect(HostProbeError.volumeIdentityChanged.recoveryActions == [.inspectState, .cancel])
+        #expect(HostProbeError.volumeUnavailable.recoveryActions.contains(.retry))
+    }
+
+    @Test func extraRawFieldsCannotBecomeSnapshotOrErrorOutput() throws {
+        let snapshot = HostProbeSnapshot(cpuArchitecture: .appleSilicon, operatingSystemVersion: SemanticVersion([26, 4]),
+                                         physicalMemoryBytes: 32, disk: .unavailable(.capacityUnavailable))
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(snapshot)) as? [String: Any])
+        let marker = "untrusted raw path / credentials / error text"
+        object["storageRootPath"] = marker
+        object["operatingSystemBuild"] = marker
+        object["underlyingError"] = marker
+        object["detail"] = marker
+        let restored = try JSONDecoder().decode(HostProbeSnapshot.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(restored == snapshot)
+        #expect(!String(decoding: try JSONEncoder().encode(restored), as: UTF8.self).contains(marker))
+        #expect(!HostProbeError.capacityUnavailable.userMessage.contains(marker))
+    }
+
+    @Test(arguments: ["cpuArchitecture", "powerSource"])
+    func unknownScalarCasesAreRefused(field: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(HostProbeSnapshot())) as? [String: Any])
+        object[field] = "future-value"
+        let data = try JSONSerialization.data(withJSONObject: object)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(HostProbeSnapshot.self, from: data) }
+    }
+
+    @Test(arguments: ["disk", "codexDesktop"])
+    func unknownObservationCasesAreRefused(field: String) throws {
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(HostProbeSnapshot())) as? [String: Any])
+        object[field] = ["future-value": [String: String]()]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(HostProbeSnapshot.self, from: data) }
+    }
+
+    @Test(arguments: ["1.2\n.3", "Bearer unrelated-text", String(repeating: "1", count: 257)])
+    func rawVersionPayloadsAreNotAcceptedAsApplicationMetadata(version: String) throws {
+        let object: [String: Any] = ["installed": ["version": version, "build": "456"]]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(CodexDesktopObservation.self, from: data) }
+    }
+
+    @Test func unknownStorageFailureIsNotCollapsedIntoAnAvailableDisk() throws {
+        let data = try JSONEncoder().encode("future-failure")
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(HostProbeError.self, from: data) }
+    }
+
+    private func roundTrip(_ snapshot: HostProbeSnapshot) throws -> HostProbeSnapshot {
+        try JSONDecoder().decode(HostProbeSnapshot.self, from: JSONEncoder().encode(snapshot))
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/ResourcePreflightTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/ResourcePreflightTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+/// #61's arithmetic regressions are independent of host I/O and the later report/wizard.
+struct ResourcePreflightTests {
+    @Test func standardPolicyRetainsThePlansExplicitPlanningAllowances() {
+        let policy = ResourcePolicy.standard
+        #expect(policy.requiredArchitecture == .appleSilicon)
+        #expect(policy.minimumMacOS == SemanticVersion([26, 4]))
+        #expect(policy.minimumMemoryBytes == 17_179_869_184)
+        #expect(policy.hostMemoryHeadroomBytes == 8_589_934_592)
+        #expect(policy.recommendedMemoryBytes == 34_359_738_368)
+        #expect(policy.firstSetupAllowanceBytes == 200_000_000_000)
+        #expect(policy.largeOperationMarginBytes == 10_000_000_000)
+        #expect(policy.runtimeDownloadEstimateBytes == 50_000_000)
+        #expect(policy.restoreImageEstimateBytes == 16_000_000_000)
+        #expect(policy.isWellFormed)
+    }
+
+    @Test func selectedGuestMustLeaveTheConfiguredHostHeadroom() {
+        #expect(throws: GuesthouseError.unsupportedHost(.insufficientMemory(
+            foundBytes: 17_179_869_184, minimumBytes: 25_769_803_776
+        ))) { try MemoryPreflight.check(physicalMemoryBytes: 16 * ResourcePreset.gibibyte) }
+    }
+
+    @Test(arguments: [UInt64(24), 32, 64])
+    func satisfyingTheBlockingFloorDoesNotRequireTheRecommendation(gibibytes: UInt64) throws {
+        try MemoryPreflight.check(physicalMemoryBytes: gibibytes * ResourcePreset.gibibyte)
+    }
+
+    @Test func aContradictoryRecommendationCannotBypassTheBlockingMinimum() {
+        var policy = ResourcePolicy.standard
+        policy.minimumMemoryBytes = 48 * ResourcePreset.gibibyte
+        #expect(!policy.isWellFormed)
+        #expect(throws: GuesthouseError.unsupportedHost(.insufficientMemory(
+            foundBytes: 34_359_738_368, minimumBytes: 51_539_607_552
+        ))) { try MemoryPreflight.check(physicalMemoryBytes: 32 * ResourcePreset.gibibyte, policy: policy) }
+    }
+
+    @Test(arguments: [UInt64(0), 32 * ResourcePreset.gibibyte, .max])
+    func memoryAdditionOverflowAlwaysBlocks(available: UInt64) {
+        var policy = ResourcePolicy.standard
+        policy.hostMemoryHeadroomBytes = .max
+        #expect(throws: GuesthouseError.unsupportedHost(.insufficientMemory(
+            foundBytes: available, minimumBytes: .max
+        ))) { try MemoryPreflight.check(physicalMemoryBytes: available, policy: policy) }
+    }
+
+    @Test func exactlyRepresentableMaximumMemoryIsNotMistakenForOverflow() throws {
+        var policy = ResourcePolicy.standard
+        policy.hostMemoryHeadroomBytes = 8
+        let preset = try #require(ResourcePreset(name: "Boundary fixture", memoryBytes: .max - 8,
+                                                cpuCount: 1, diskBytes: 1, verification: .experimental))
+        try MemoryPreflight.check(physicalMemoryBytes: .max, preset: preset, policy: policy)
+        #expect(throws: GuesthouseError.unsupportedHost(.insufficientMemory(
+            foundBytes: .max - 1, minimumBytes: .max
+        ))) { try MemoryPreflight.check(physicalMemoryBytes: .max - 1, preset: preset, policy: policy) }
+    }
+
+    @Test(arguments: [
+        (UInt64(49), UInt64(40), UInt64(10), UInt64(50)),
+        (0, 0, 1, 1), (.max, .max, 1, .max), (.max, .max - 1, 2, .max),
+    ])
+    func diskRefusalsPreserveTheFullRequirement(_ values: (UInt64, UInt64, UInt64, UInt64)) {
+        let (available, required, margin, needed) = values
+        var policy = ResourcePolicy.standard
+        policy.largeOperationMarginBytes = margin
+        #expect(throws: GuesthouseError.insufficientDisk(requiredBytes: needed, availableBytes: available)) {
+            try LargeOperationPreflight.check(freeBytes: available, requiredBytes: required, policy: policy)
+        }
+    }
+
+    @Test(arguments: [
+        (UInt64(50), UInt64(40), UInt64(10)),
+        (51, 40, 10), (0, 0, 0), (.max, .max, 0), (.max, .max - 1, 1),
+    ])
+    func exactAndLargerDiskBudgetsPass(_ values: (UInt64, UInt64, UInt64)) throws {
+        let (available, required, margin) = values
+        var policy = ResourcePolicy.standard
+        policy.largeOperationMarginBytes = margin
+        try LargeOperationPreflight.check(freeBytes: available, requiredBytes: required, policy: policy)
+    }
+
+    @Test func theDefaultLargeOperationMarginIsAppliedInBytes() throws {
+        try LargeOperationPreflight.check(freeBytes: 60_000_000_000, requiredBytes: 40_000_000_000)
+        #expect(throws: GuesthouseError.insufficientDisk(requiredBytes: 50_000_000_000, availableBytes: 45_000_000_000)) {
+            try LargeOperationPreflight.check(freeBytes: 45_000_000_000, requiredBytes: 40_000_000_000)
+        }
+    }
+
+    @Test func overflowFailureKeepsTypedRecoveryAndFullRangeEncoding() throws {
+        let thrown = #expect(throws: GuesthouseError.self) {
+            try LargeOperationPreflight.check(freeBytes: 512, requiredBytes: .max)
+        }
+        let failure = try #require(thrown)
+        #expect(failure.userMessage.contains("18446744073709551615"))
+        #expect(failure.recoveryActions == [.freeDiskSpace, .inspectState, .cancel])
+        #expect(try JSONDecoder().decode(GuesthouseError.self, from: JSONEncoder().encode(failure)) == failure)
+    }
+}


### PR DESCRIPTION
## Summary

Migrate the pure resource guards and typed host-observation values from retained #61 onto current main. This is one independent, focused replacement: six files / 375 additions. It does not include #61's old ancestry.

Part of #12 and the #48 migration plan; implements the pure input/resource-policy portion of `MVP-PLAN.md` §§2–4 under ADR 0003. It does **not** close #12 or #61.

## Changes

- Preserve the planning resource thresholds and extract overflow-safe memory and per-operation disk guards using current typed Guesthouse errors. Passing a numeric check neither authorizes a mutation nor admits a second VM.
- Add immutable host observations with explicit unknown values. Unknown memory/OS is distinct from observed zero; missing Codex is distinct from failed discovery and installed-with-unknown-version.
- Carry bounded dotted numeric version/build summaries and closed storage-failure causes. Errors use fixed Guesthouse messages/recovery, never host paths, raw bundle metadata or underlying error descriptions.
- Add 21 test functions / 52 cases covering literal byte thresholds, headroom, exact/overflowing UInt64 boundaries, round trips, observation distinctions, malformed cases and unknown-field non-propagation.

## Validation

- Passed `git diff --check`.
- Passed all seven shell-only `Tests/CI/test-package-hook.sh` scenarios.
- Reviewed the full change against current Core contracts and the retained behavior.
- Per the owner's request, **no local Swift/Xcode build or test run** and no new build cache. Exact head `f20f0a3e785b104b9a7a9dd22f75b63b2917373a` passed Xcode Cloud at 14:09:51 UTC. Matching Codex review completed at 14:09:30 UTC; the original PR message received the bot thumbs-up at 14:09:33 UTC. No inline or standalone findings; all check/review/comment/reaction pages are complete. Base main is settled and composition is MERGEABLE/CLEAN. **#170 is merge-ready independently of the provisioning stack; the owner alone merges.**

Published head: `f20f0a3e785b104b9a7a9dd22f75b63b2917373a`.

## Boundaries and follow-up

No actual host probe, application lookup, volume-identity verification, XPC operation, report evaluator, wizard, provider or VM operation is enabled. In particular, a typed `volumeIdentityChanged` failure is not proof that a volume check exists.

The next slice adapts the retained report/evaluator to these inputs. Concrete probing must then live in RuntimeKit behind a named authenticated, bounded query with service-selected storage/policy; retain the saved-volume identity obligation and the wizard's refresh/stale-result protection. App identity and exact private connect-time compatibility remain separate from this summary. No generic redactor is restored.

Base is `main`; independent of the current provisioning stack. The owner alone merges.