### PR TITLE
Migrate typed host-preflight evaluation and reports

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Planning summary for MVP-PLAN.md §2. This is not a verified path, download quote,
+/// storage authorization, or proof of sparse-disk physical consumption.
+public struct StorageSummary: Codable, Hashable, Sendable {
+    public let runtimeDownloadEstimateBytes: UInt64
+    public let restoreImageEstimateBytes: UInt64
+    public let guestDiskBytes: UInt64
+    public let firstSetupAllowanceBytes: UInt64
+
+    public init(policy: ResourcePolicy = .standard, preset: ResourcePreset = .recommended) {
+        runtimeDownloadEstimateBytes = policy.runtimeDownloadEstimateBytes
+        restoreImageEstimateBytes = policy.restoreImageEstimateBytes
+        guestDiskBytes = preset.diskBytes
+        firstSetupAllowanceBytes = policy.firstSetupAllowanceBytes
+    }
+
+    public var locationDescription: String {
+        "VM files are planned for Guesthouse's runtime-managed Application Support folder for this account. The runtime must verify the storage location before setup."
+    }
+}
+
+/// A display/evaluation result, not runtime mutation admission or a native framing validator.
+/// Immutable values preserve the checked snapshot; callers must refresh before proceeding.
+/// Codable preserves typed facts, not trust: only an authenticated runtime may supply them.
+public struct PreflightReport: Codable, Hashable, Sendable {
+    public let results: [PreflightResult]
+    public let storage: StorageSummary
+    public let powerSource: PowerSource
+    public let checkedAt: Date
+
+    public init(results: [PreflightResult], storage: StorageSummary, powerSource: PowerSource, checkedAt: Date) {
+        self.results = results
+        self.storage = storage
+        self.powerSource = powerSource
+        self.checkedAt = checkedAt
+    }
+
+    /// Empty, partial, duplicated and blocking reports cannot proceed. A warning is an answer;
+    /// an unavailable observation is not. Actual runtime safety checks remain mandatory.
+    public var canProceed: Bool {
+        results.count == PreflightCheckKind.allCases.count
+            && Set(results.map(\.kind)) == Set(PreflightCheckKind.allCases)
+            && !results.contains(where: \.isBlocking)
+    }
+
+    public func result(_ kind: PreflightCheckKind) -> PreflightResult? {
+        results.first { $0.kind == kind }
+    }
+}
+
+/// #61's retained evaluator adapted to #170's runtime-supplied observations. This pure
+/// function performs no host I/O; policy and observations must come from the runtime boundary.
+public enum PreflightCheck: Sendable {
+    public static func run(
+        snapshot: HostProbeSnapshot,
+        policy: ResourcePolicy = .standard,
+        preset: ResourcePreset = .recommended,
+        now: Date = Date()
+    ) -> PreflightReport {
+        let architecture: PreflightResult
+        if snapshot.cpuArchitecture == .unknown {
+            architecture = .architectureUnknown
+        } else if snapshot.cpuArchitecture == policy.requiredArchitecture {
+            architecture = .architectureSupported(snapshot.cpuArchitecture)
+        } else {
+            architecture = .architectureMismatch(found: snapshot.cpuArchitecture, required: policy.requiredArchitecture)
+        }
+
+        let operatingSystem: PreflightResult
+        if let version = snapshot.operatingSystemVersion {
+            operatingSystem = version >= policy.minimumMacOS
+                ? .macOSSupported(version) : .macOSTooOld(found: version, minimum: policy.minimumMacOS)
+        } else {
+            operatingSystem = .macOSUnknown
+        }
+
+        let memory: PreflightResult
+        if let bytes = snapshot.physicalMemoryBytes {
+            do {
+                try MemoryPreflight.check(physicalMemoryBytes: bytes, preset: preset, policy: policy)
+                memory = bytes >= policy.recommendedMemoryBytes
+                    ? .memorySufficient(bytes: bytes)
+                    : .memoryLimited(foundBytes: bytes, recommendedBytes: policy.recommendedMemoryBytes)
+            } catch {
+                memory = .memoryFailure(error)
+            }
+        } else {
+            memory = .memoryUnknown
+        }
+
+        let disk: PreflightResult = switch snapshot.disk {
+        case .available(let bytes):
+            bytes >= policy.firstSetupAllowanceBytes
+                ? .diskSufficient(bytes: bytes)
+                : .insufficientDisk(requiredBytes: policy.firstSetupAllowanceBytes, availableBytes: bytes)
+        case .unavailable(let error): .diskUnavailable(error)
+        }
+        let codex: PreflightResult = switch snapshot.codexDesktop {
+        case .installed(let version, let build): .codexInstalled(version: version, build: build)
+        case .notFound: .codexNotFound
+        case .unavailable: .codexUnavailable
+        }
+        return PreflightReport(
+            results: [architecture, operatingSystem, memory, disk, codex],
+            storage: StorageSummary(policy: policy, preset: preset),
+            powerSource: snapshot.powerSource,
+            checkedAt: now
+        )
+    }
+}

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightResult.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightResult.swift
@@ -1,0 +1,108 @@
+public enum PreflightCheckKind: String, Codable, Hashable, Sendable, CaseIterable {
+    case architecture, macOSVersion, memory, freeDisk, codexDesktop
+}
+
+/// Closed facts replace #61's arbitrary detail strings (ADR 0003). The check kind and
+/// severity are derived, so a decoded unknown disk cannot be relabeled as a passing check.
+public enum PreflightResult: Codable, Hashable, Sendable {
+    case architectureSupported(CPUArchitecture)
+    case architectureUnknown
+    case architectureMismatch(found: CPUArchitecture, required: CPUArchitecture)
+    case macOSSupported(SemanticVersion)
+    case macOSUnknown
+    case macOSTooOld(found: SemanticVersion, minimum: SemanticVersion)
+    case memorySufficient(bytes: UInt64)
+    case memoryLimited(foundBytes: UInt64, recommendedBytes: UInt64)
+    case memoryUnknown
+    case memoryFailure(GuesthouseError)
+    case diskSufficient(bytes: UInt64)
+    case insufficientDisk(requiredBytes: UInt64, availableBytes: UInt64)
+    case diskUnavailable(HostProbeError)
+    case codexInstalled(version: SemanticVersion?, build: SemanticVersion?)
+    case codexNotFound
+    case codexUnavailable
+
+    public enum Severity: String, Codable, Hashable, Sendable {
+        case pass, warn, undetermined, fail
+    }
+
+    public var kind: PreflightCheckKind {
+        switch self {
+        case .architectureSupported, .architectureUnknown, .architectureMismatch: .architecture
+        case .macOSSupported, .macOSUnknown, .macOSTooOld: .macOSVersion
+        case .memorySufficient, .memoryLimited, .memoryUnknown, .memoryFailure: .memory
+        case .diskSufficient, .insufficientDisk, .diskUnavailable: .freeDisk
+        case .codexInstalled, .codexNotFound, .codexUnavailable: .codexDesktop
+        }
+    }
+
+    public var severity: Severity {
+        switch self {
+        case .architectureSupported, .macOSSupported, .memorySufficient, .diskSufficient, .codexInstalled: .pass
+        case .memoryLimited, .codexNotFound: .warn
+        case .macOSUnknown, .memoryUnknown, .diskUnavailable, .codexUnavailable: .undetermined
+        case .architectureUnknown, .architectureMismatch, .macOSTooOld, .memoryFailure, .insufficientDisk: .fail
+        }
+    }
+
+    public var isBlocking: Bool { severity == .fail || severity == .undetermined }
+
+    /// Fixed templates and typed numeric observations only, not a diagnostic-history input.
+    public var userMessage: String {
+        switch self {
+        case .architectureSupported(let architecture):
+            "Processor: \(Self.name(architecture))."
+        case .architectureUnknown:
+            GuesthouseError.unsupportedHost(.unknownArchitecture).userMessage
+        case .architectureMismatch(let found, let required):
+            "This Mac uses \(Self.name(found)); the selected policy requires \(Self.name(required))."
+        case .macOSSupported(let version):
+            "macOS \(version) meets the selected host version requirement."
+        case .macOSUnknown:
+            "Guesthouse could not determine this Mac's macOS version. Check again before starting setup."
+        case .macOSTooOld(let found, let minimum):
+            "This Mac runs macOS \(found); macOS \(minimum) or later is required."
+        case .memorySufficient(let bytes):
+            "This Mac has \(bytes) bytes of memory and meets the recommendation."
+        case .memoryLimited(let found, let recommended):
+            "This Mac has \(found) bytes of memory; \(recommended) bytes are recommended. Run one development Mac at a time and expect memory pressure during large builds."
+        case .memoryUnknown:
+            "Guesthouse could not determine this Mac's memory. Check again before starting setup."
+        case .memoryFailure(let error):
+            error.userMessage
+        case .diskSufficient(let bytes):
+            "The selected runtime storage volume has \(bytes) bytes available for the planned setup."
+        case .insufficientDisk(let required, let available):
+            GuesthouseError.insufficientDisk(requiredBytes: required, availableBytes: available).userMessage
+        case .diskUnavailable(let error):
+            error.userMessage
+        case .codexInstalled(let version, let build):
+            "Codex desktop is installed. Version: \(version?.description ?? "unknown"); build: \(build?.description ?? "unknown"). Connection compatibility still needs verification."
+        case .codexNotFound:
+            "Codex desktop is not installed. Guesthouse can prepare a development Mac without it, but opening a workspace in Codex will require it."
+        case .codexUnavailable:
+            "Guesthouse could not check whether Codex desktop is installed. Check again before continuing."
+        }
+    }
+
+    public var recoveryActions: [RecoveryAction] {
+        switch self {
+        case .architectureSupported, .macOSSupported, .memorySufficient, .memoryLimited,
+             .diskSufficient, .codexInstalled, .codexNotFound: []
+        case .architectureUnknown, .architectureMismatch, .macOSTooOld: [.openSettings, .cancel]
+        case .macOSUnknown, .memoryUnknown, .codexUnavailable: [.retry, .cancel]
+        case .memoryFailure(let error): error.recoveryActions
+        case .insufficientDisk(let required, let available):
+            GuesthouseError.insufficientDisk(requiredBytes: required, availableBytes: available).recoveryActions
+        case .diskUnavailable(let error): error.recoveryActions
+        }
+    }
+
+    private static func name(_ architecture: CPUArchitecture) -> String {
+        switch architecture {
+        case .appleSilicon: "Apple silicon"
+        case .intel: "Intel"
+        case .unknown: "an unknown processor architecture"
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -1,0 +1,224 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct PreflightCheckTests {
+    @Test func completeBaselinePreservesTypedFactsAndPlanningSummary() {
+        let now = Date(timeIntervalSince1970: 123)
+        let report = PreflightCheck.run(snapshot: healthy(), now: now)
+        #expect(report.canProceed)
+        #expect(report.results.map(\.kind) == [.architecture, .macOSVersion, .memory, .freeDisk, .codexDesktop])
+        #expect(report.results.allSatisfy { $0.severity == .pass })
+        #expect(report.checkedAt == now)
+        #expect(report.powerSource == .externalPower)
+        #expect(report.storage.runtimeDownloadEstimateBytes == 50_000_000)
+        #expect(report.storage.restoreImageEstimateBytes == 16_000_000_000)
+        #expect(report.storage.guestDiskBytes == 160_000_000_000)
+        #expect(report.storage.firstSetupAllowanceBytes == 200_000_000_000)
+        #expect(report.storage.locationDescription.contains("must verify"))
+    }
+
+    @Test func anUnobservedHostNeverPasses() {
+        let report = PreflightCheck.run(snapshot: HostProbeSnapshot())
+        #expect(!report.canProceed)
+        #expect(report.results.allSatisfy(\.isBlocking))
+        #expect(report.result(.architecture) == .architectureUnknown)
+        #expect(report.result(.macOSVersion) == .macOSUnknown)
+        #expect(report.result(.memory) == .memoryUnknown)
+        #expect(report.result(.freeDisk) == .diskUnavailable(.storageRootUnknown))
+        #expect(report.result(.codexDesktop) == .codexUnavailable)
+    }
+
+    @Test(arguments: [
+        (CPUArchitecture.appleSilicon, CPUArchitecture.appleSilicon, PreflightResult.Severity.pass),
+        (.intel, .intel, .pass), (.intel, .appleSilicon, .fail), (.appleSilicon, .intel, .fail),
+        (.unknown, .appleSilicon, .fail), (.unknown, .intel, .fail), (.unknown, .unknown, .fail),
+        (.appleSilicon, .unknown, .fail), (.intel, .unknown, .fail),
+    ])
+    func architecturePoliciesRemainTruthful(_ values: (CPUArchitecture, CPUArchitecture, PreflightResult.Severity)) throws {
+        var policy = ResourcePolicy.standard
+        policy.requiredArchitecture = values.1
+        let result = try #require(PreflightCheck.run(snapshot: healthy(architecture: values.0), policy: policy).result(.architecture))
+        #expect(result.severity == values.2)
+    }
+
+    @Test func nondefaultArchitectureMessageNamesBothObservedAndRequired() throws {
+        var policy = ResourcePolicy.standard
+        policy.requiredArchitecture = .intel
+        let result = try #require(PreflightCheck.run(snapshot: healthy(), policy: policy).result(.architecture))
+        #expect(result == .architectureMismatch(found: .appleSilicon, required: .intel))
+        #expect(result.userMessage == "This Mac uses Apple silicon; the selected policy requires Intel.")
+    }
+
+    @Test(arguments: [
+        (nil as SemanticVersion?, PreflightResult.Severity.undetermined),
+        (SemanticVersion([0]), .fail), (SemanticVersion([26, 3]), .fail),
+        (SemanticVersion([26, 4]), .pass), (SemanticVersion([27]), .pass),
+    ])
+    func operatingSystemBoundaries(_ values: (SemanticVersion?, PreflightResult.Severity)) throws {
+        let result = try #require(PreflightCheck.run(snapshot: healthy(version: values.0)).result(.macOSVersion))
+        #expect(result.severity == values.1)
+    }
+
+    @Test(arguments: [
+        (nil as UInt64?, PreflightResult.Severity.undetermined), (0, .fail), (17_179_869_184, .fail),
+        (25_769_803_776, .warn), (34_359_738_368, .pass), (68_719_476_736, .pass),
+    ])
+    func memoryFloorPrecedesRecommendation(_ values: (UInt64?, PreflightResult.Severity)) throws {
+        let result = try #require(PreflightCheck.run(snapshot: healthy(memory: values.0)).result(.memory))
+        #expect(result.severity == values.1)
+    }
+
+    @Test func limitedMemoryWarningDoesNotBlockAnOtherwiseReadyHost() {
+        let report = PreflightCheck.run(snapshot: healthy(memory: 25_769_803_776))
+        #expect(report.canProceed)
+        #expect(report.result(.memory) == .memoryLimited(foundBytes: 25_769_803_776, recommendedBytes: 34_359_738_368))
+    }
+
+    @Test func contradictoryRecommendationCannotHideARequiredMemoryFailure() {
+        var policy = ResourcePolicy.standard
+        policy.minimumMemoryBytes = 51_539_607_552
+        let report = PreflightCheck.run(snapshot: healthy(), policy: policy)
+        #expect(!report.canProceed)
+        #expect(report.result(.memory) == .memoryFailure(.unsupportedHost(
+            .insufficientMemory(foundBytes: 34_359_738_368, minimumBytes: 51_539_607_552))))
+    }
+
+    @Test func overflowStillBlocksWhenAvailableMemoryIsMaximum() {
+        var policy = ResourcePolicy.standard
+        policy.hostMemoryHeadroomBytes = .max
+        let report = PreflightCheck.run(snapshot: healthy(memory: .max), policy: policy)
+        #expect(!report.canProceed)
+        #expect(report.result(.memory) == .memoryFailure(.unsupportedHost(
+            .insufficientMemory(foundBytes: .max, minimumBytes: .max))))
+    }
+
+    @Test(arguments: [
+        (UInt64(0), PreflightResult.Severity.fail), (199_999_999_999, .fail),
+        (200_000_000_000, .pass), (.max, .pass),
+    ])
+    func firstSetupDiskThresholdIsNotThePerOperationMargin(_ values: (UInt64, PreflightResult.Severity)) throws {
+        let result = try #require(PreflightCheck.run(snapshot: healthy(disk: .available(bytes: values.0))).result(.freeDisk))
+        #expect(result.severity == values.1)
+    }
+
+    @Test(arguments: HostProbeError.allCases)
+    func everyUnavailableDiskBlocksAndPreservesRecovery(failure: HostProbeError) throws {
+        let report = PreflightCheck.run(snapshot: healthy(disk: .unavailable(failure)))
+        let result = try #require(report.result(.freeDisk))
+        #expect(!report.canProceed)
+        #expect(result == .diskUnavailable(failure))
+        #expect(result.severity == .undetermined)
+        #expect(result.recoveryActions == failure.recoveryActions)
+    }
+
+    @Test(arguments: [
+        (CodexDesktopObservation.notFound, PreflightResult.Severity.warn, true),
+        (.unavailable, .undetermined, false), (.installed(version: nil, build: nil), .pass, true),
+        (.installed(version: SemanticVersion([2]), build: SemanticVersion([456])), .pass, true),
+    ])
+    func missingApplicationIsNotFailedDiscovery(_ values: (CodexDesktopObservation, PreflightResult.Severity, Bool)) throws {
+        let report = PreflightCheck.run(snapshot: healthy(codex: values.0))
+        let result = try #require(report.result(.codexDesktop))
+        #expect(result.severity == values.1)
+        #expect(report.canProceed == values.2)
+    }
+
+    @Test(arguments: [
+        PreflightResult.architectureSupported(.appleSilicon), .architectureUnknown,
+        .architectureMismatch(found: .intel, required: .appleSilicon),
+        .macOSSupported(SemanticVersion([26, 4])), .macOSUnknown,
+        .macOSTooOld(found: SemanticVersion([26, 3]), minimum: SemanticVersion([26, 4])),
+        .memorySufficient(bytes: .max), .memoryLimited(foundBytes: 24, recommendedBytes: 32), .memoryUnknown,
+        .memoryFailure(.unsupportedHost(.insufficientMemory(foundBytes: 0, minimumBytes: .max))),
+        .diskSufficient(bytes: .max), .insufficientDisk(requiredBytes: .max, availableBytes: 0),
+        .diskUnavailable(.capacityUnavailable), .codexInstalled(version: nil, build: nil),
+        .codexNotFound, .codexUnavailable,
+    ])
+    func everyResultCasePreservesItsFactsAndFixedMessage(result: PreflightResult) throws {
+        let restored = try JSONDecoder().decode(PreflightResult.self, from: JSONEncoder().encode(result))
+        #expect(restored == result)
+        #expect(restored.kind == result.kind)
+        #expect(restored.severity == result.severity)
+        #expect(!restored.userMessage.isEmpty)
+        #expect(!restored.isBlocking || !restored.recoveryActions.isEmpty)
+    }
+
+    @Test func anUnknownResultCannotAcquirePassingSeverity() throws {
+        let data = Data(#"{"futureCheck": {}}"#.utf8)
+        #expect(throws: DecodingError.self) { try JSONDecoder().decode(PreflightResult.self, from: data) }
+    }
+
+    @Test(arguments: PreflightCheckKind.allCases)
+    func omittingAnyRequiredCheckBlocks(kind: PreflightCheckKind) {
+        let complete = PreflightCheck.run(snapshot: healthy())
+        let partial = replacingResults(in: complete, with: complete.results.filter { $0.kind != kind })
+        #expect(!partial.canProceed)
+        #expect(partial.result(kind) == nil)
+    }
+
+    @Test func emptyAndDuplicatedReportsDoNotProceed() {
+        let complete = PreflightCheck.run(snapshot: healthy())
+        #expect(!replacingResults(in: complete, with: []).canProceed)
+        #expect(!replacingResults(in: complete, with: complete.results + [.architectureSupported(.appleSilicon)]).canProceed)
+        let duplicated = Array(repeating: PreflightResult.architectureSupported(.appleSilicon), count: 5)
+        #expect(!replacingResults(in: complete, with: duplicated).canProceed)
+    }
+
+    @Test(arguments: [PowerSource.externalPower, .battery, .unknown])
+    func powerIsPreservedWithoutFabricatingResourceReadiness(power: PowerSource) {
+        let report = PreflightCheck.run(snapshot: healthy(power: power))
+        #expect(report.powerSource == power)
+        #expect(report.canProceed)
+    }
+
+    @Test func reportRoundTripDoesNotAcceptAnEncodedContinueOverrideOrRawDetail() throws {
+        let report = PreflightCheck.run(snapshot: HostProbeSnapshot(), now: Date(timeIntervalSince1970: 123))
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(report)) as? [String: Any])
+        object["canProceed"] = true
+        object["detail"] = "untrusted report text"
+        object["storageRootPath"] = "/untrusted/private/path"
+        let restored = try JSONDecoder().decode(PreflightReport.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(restored == report)
+        #expect(!restored.canProceed)
+        #expect(!String(decoding: try JSONEncoder().encode(restored), as: UTF8.self).contains("untrusted"))
+    }
+
+    @Test func diskFailureCannotBeRelabeledWithEncodedKindOrSeverity() throws {
+        let result = PreflightResult.diskUnavailable(.volumeIdentityChanged)
+        var object = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(result)) as? [String: Any])
+        object["kind"] = "codexDesktop"
+        object["severity"] = "pass"
+        let restored = try JSONDecoder().decode(PreflightResult.self, from: JSONSerialization.data(withJSONObject: object))
+        #expect(restored == result)
+        #expect(restored.kind == .freeDisk)
+        #expect(restored.isBlocking)
+        #expect(restored.recoveryActions == [.inspectState, .cancel])
+    }
+
+    @Test func nondefaultPlanningAmountsArePreservedWithoutAPathField() {
+        var policy = ResourcePolicy.standard
+        policy.runtimeDownloadEstimateBytes = 1
+        policy.restoreImageEstimateBytes = 2
+        policy.firstSetupAllowanceBytes = 3
+        let summary = StorageSummary(policy: policy, preset: .dualVMExperiment)
+        #expect(summary.runtimeDownloadEstimateBytes == 1)
+        #expect(summary.restoreImageEstimateBytes == 2)
+        #expect(summary.firstSetupAllowanceBytes == 3)
+        #expect(summary.guestDiskBytes == 160_000_000_000)
+    }
+
+    private func healthy(
+        architecture: CPUArchitecture = .appleSilicon, version: SemanticVersion? = SemanticVersion([26, 4]),
+        memory: UInt64? = 34_359_738_368, disk: HostDiskObservation = .available(bytes: 200_000_000_000),
+        codex: CodexDesktopObservation = .installed(version: SemanticVersion([1, 2]), build: nil),
+        power: PowerSource = .externalPower
+    ) -> HostProbeSnapshot {
+        HostProbeSnapshot(cpuArchitecture: architecture, operatingSystemVersion: version,
+                          physicalMemoryBytes: memory, powerSource: power, disk: disk, codexDesktop: codex)
+    }
+
+    private func replacingResults(in report: PreflightReport, with results: [PreflightResult]) -> PreflightReport {
+        PreflightReport(results: results, storage: report.storage, powerSource: report.powerSource, checkedAt: report.checkedAt)
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Preflight/PreflightCheckTests.swift
@@ -21,7 +21,7 @@ struct PreflightCheckTests {
     @Test func anUnobservedHostNeverPasses() {
         let report = PreflightCheck.run(snapshot: HostProbeSnapshot())
         #expect(!report.canProceed)
-        #expect(report.results.allSatisfy(\.isBlocking))
+        #expect(report.results.allSatisfy { $0.isBlocking })
         #expect(report.result(.architecture) == .architectureUnknown)
         #expect(report.result(.macOSVersion) == .macOSUnknown)
         #expect(report.result(.memory) == .memoryUnknown)


### PR DESCRIPTION
## Summary

Publish the prepared host-preflight evaluator for Xcode Cloud validation. This is the next focused migration from retained PR #61 toward issue #12, implementing the planning checks in `MVP-PLAN.md` §§2 and 4 under ADRs 0002 and 0003.

- Evaluate the five required checks from typed runtime observations, preserving unknown-state blocking, resource boundaries, memory warnings, and absent-versus-unavailable Codex discovery.
- Derive result kind, severity, messages, and recovery from closed result cases. No arbitrary host text, paths, or raw error descriptions enter the report.
- Keep reports immutable and reject empty, incomplete, or duplicated check sets before reporting readiness. Storage amounts remain planning estimates, not verified storage locations or mutation authorization.

## Dependency and merge order

**Stacked on #170**, base `mvp/preflight-observations` at `f20f0a3e785b104b9a7a9dd22f75b63b2917373a`. The evaluator head is `d11120e7d24a8ce685a6f7d82eaf5184dff54935`. Its own diff is three files / 443 additions.

The owner requested origin pushes and Xcode Cloud validation. This publishes one prepared follow-up without publishing the larger unfinished probe stack. Merge #170 first; then retarget this PR to main, settle the dependency composition, and recheck its exact-head gates. **Do not merge this PR into its feature-branch base.** The owner alone merges.

## Validation

- Full changed source and tests reviewed; `git diff --check` passes.
- `bash Tests/CI/test-package-hook.sh`: all seven shell-only scenarios pass.
- Twenty test functions / 69 cases are authored for the evaluator and result/report contract.
- Swift compilation and test execution are delegated to Xcode Cloud, per owner direction. No local Swift/Xcode builds or new large caches were created. The original Cloud build 1421 failed in a Swift Testing macro expansion for a key-path allSatisfy predicate. [The diagnosed one-line fix](https://github.com/PicoMLX/Guesthouse/pull/171#issuecomment-5622699623) is pushed as `d11120e7`; the equivalent explicit closure preserves every assertion. Fresh matching Codex review completed at 17:22:56 UTC and the original-message bot thumbs-up at 17:22:59 UTC, with no findings. The exact-head Xcode Cloud Test check completed SUCCESS at 19:05:52 UTC on September 10. Its matching review and original-message thumbs-up are complete with no findings. No local Swift/Xcode build or cache was created. Only the dependency/composition hold remains: #170 must land before #171 settles on main. Cloud and review gates have passed for this head; the parent and settled-main composition remain outstanding.

## Remaining scope

This does not close #12 or supersede the whole of #61. Native host observations, retained storage-volume selection, a bounded authenticated named query, and fresh-result fencing in the wizard still need integration. The report is not a wire-size validator, compatibility attestation, resource reservation, or runtime mutation admission. No provider, VM, signing, or hardware gate is activated or passed.
