### PR TITLE
Migrate runtime storage capacity and volume identity checks

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/StorageVolumeProbe.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/StorageVolumeProbe.swift
@@ -14,7 +14,8 @@ enum StorageVolumeProbe {
     // Darwin getattrlist(2): length, returned attribute_set_t, off_t, uuid_t, aligned
     // to four bytes. PACK_INVAL fixes offsets; the returned masks still determine validity.
     static let bufferSize = 48
-    private static let requestedVolume = UInt32(ATTR_VOL_SPACEAVAIL | ATTR_VOL_UUID | ATTR_VOL_INFO)
+    private static let requestedVolume = UInt32(ATTR_VOL_SPACEAVAIL)
+        | UInt32(ATTR_VOL_UUID) | UInt32(ATTR_VOL_INFO)
 
     /// Borrows an open directory; the caller owns its lifetime, selection and path checks.
     static func snapshot(descriptor: Int32) throws(HostProbeError) -> Snapshot {

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/StorageVolumeProbe.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/StorageVolumeProbe.swift
@@ -1,0 +1,62 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+
+/// Runtime-only, descriptor-bound observations for #12 (MVP-PLAN.md §§2–3). UUID and
+/// capacity come from one volume-attribute request, never a mount-name/container guess.
+/// No path, attribute buffer or volume UUID belongs in diagnostics or the public report.
+enum StorageVolumeProbe {
+    struct Snapshot: Equatable, Sendable {
+        let identity: UUID
+        let availableBytes: UInt64
+    }
+
+    // Darwin getattrlist(2): length, returned attribute_set_t, off_t, uuid_t, aligned
+    // to four bytes. PACK_INVAL fixes offsets; the returned masks still determine validity.
+    static let bufferSize = 48
+    private static let requestedVolume = UInt32(ATTR_VOL_SPACEAVAIL | ATTR_VOL_UUID | ATTR_VOL_INFO)
+
+    /// Borrows an open directory; the caller owns its lifetime, selection and path checks.
+    static func snapshot(descriptor: Int32) throws(HostProbeError) -> Snapshot {
+        var info = stat()
+        guard fstat(descriptor, &info) == 0 else { throw .volumeUnavailable }
+        guard info.st_mode & S_IFMT == S_IFDIR else { throw .notADirectory }
+        var request = attrlist()
+        request.bitmapcount = UInt16(ATTR_BIT_MAP_COUNT)
+        request.commonattr = UInt32(ATTR_CMN_RETURNED_ATTRS)
+        request.volattr = requestedVolume
+        var data = Data(count: bufferSize)
+        let result = data.withUnsafeMutableBytes {
+            fgetattrlist(descriptor, &request, $0.baseAddress, $0.count,
+                UInt32(FSOPT_PACK_INVAL_ATTRS | FSOPT_REPORT_FULLSIZE))
+        }
+        guard result == 0 else { throw .volumeUnavailable }
+        return try decode(data)
+    }
+
+    static func decode(_ data: Data) throws(HostProbeError) -> Snapshot {
+        guard data.count == bufferSize else { throw .volumeUnavailable }
+        let fields = data.withUnsafeBytes { bytes in
+            (bytes.loadUnaligned(as: UInt32.self),
+             bytes.loadUnaligned(fromByteOffset: 4, as: attribute_set_t.self),
+             bytes.loadUnaligned(fromByteOffset: 24, as: Int64.self),
+             bytes.loadUnaligned(fromByteOffset: 32, as: uuid_t.self))
+        }
+        let (length, returned, capacity, identifier) = fields
+        guard length == UInt32(bufferSize),
+              returned.commonattr == UInt32(ATTR_CMN_RETURNED_ATTRS),
+              returned.volattr & ~requestedVolume == 0,
+              returned.dirattr == 0, returned.fileattr == 0, returned.forkattr == 0,
+              returned.volattr & UInt32(ATTR_VOL_UUID) != 0 else { throw .volumeUnavailable }
+        let identity = UUID(uuid: identifier)
+        guard identity != UUID(uuid: (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)) else {
+            throw .volumeUnavailable
+        }
+        guard returned.volattr & UInt32(ATTR_VOL_SPACEAVAIL) != 0, capacity >= 0 else {
+            throw .capacityUnavailable
+        }
+        // Actual nonprivileged free bytes; deliberately excludes optimistic purgeable-space
+        // estimates. Zero is an observation. Missing/negative capacity is not zero or infinity.
+        return Snapshot(identity: identity, availableBytes: UInt64(capacity))
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/SystemStorageProbe.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/SystemStorageProbe.swift
@@ -1,0 +1,95 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+
+/// Runtime-internal preflight only. The service must retain the selected volume identity
+/// separately and supply it on EVERY refresh, not recapture identity from the current path.
+/// Selection/persistence, authenticated query and private-layout admission are not activated.
+/// All checks are point-in-time; a report is neither a capacity reservation nor write authority.
+struct SystemStorageProbe: Sendable {
+    let storageRoot: URL?
+    let expectedVolume: UUID?
+
+    func observe() -> HostDiskObservation {
+        guard let storageRoot, let expectedVolume else { return .unavailable(.storageRootUnknown) }
+        do {
+            return try Self.withDirectory(at: storageRoot, allowMissingSuffix: true) { descriptor in
+                let value = try StorageVolumeProbe.snapshot(descriptor: descriptor)
+                guard value.identity == expectedVolume else { throw HostProbeError.volumeIdentityChanged }
+                try Self.requireWritable(faccessat(descriptor, ".", W_OK | X_OK, AT_EACCESS))
+                return .available(bytes: value.availableBytes)
+            }
+        } catch let error as HostProbeError { return .unavailable(error) }
+        catch { return .unavailable(.volumeUnavailable) }
+    }
+
+    /// Initial selection may identify an EXISTING service-chosen directory (for example,
+    /// its home-volume anchor). Never infer a missing external volume's identity by ascending.
+    /// The result is runtime-private selection metadata, not a GUI-requested replacement ID.
+    static func identifyVolume(atExistingDirectory url: URL) throws -> UUID {
+        try withDirectory(at: url, allowMissingSuffix: false) {
+            try StorageVolumeProbe.snapshot(descriptor: $0).identity
+        }
+    }
+
+    /// Every failure, including EPERM, blocks. The old sandboxed-GUI permission bypass
+    /// is invalid here: these checks run in the process that will actually use storage.
+    static func requireWritable(_ result: Int32) throws(HostProbeError) {
+        guard result == 0 else { throw .destinationNotWritable }
+    }
+
+    // Internal closure seam permits deterministic namespace-drift tests on isolated fixtures.
+    static func withDirectory<T>(
+        at url: URL, allowMissingSuffix: Bool, body: (Int32) throws -> T
+    ) throws -> T {
+        let name: String
+        do { name = try StorageProtection.path(url) }
+        catch { throw HostProbeError.storageRootUnknown }
+        var candidate = name
+        var lastMissing: String?
+        var inspected = stat()
+        while lstat(candidate, &inspected) != 0 {
+            let failure = errno
+            guard failure == ENOENT, allowMissingSuffix, candidate != "/" else {
+                throw inspectionFailure(failure)
+            }
+            lastMissing = candidate
+            candidate = (candidate as NSString).deletingLastPathComponent
+        }
+        // Final links (including dangling ones) are never replaced with an ancestor answer.
+        guard inspected.st_mode & S_IFMT != S_IFLNK else { throw HostProbeError.volumeUnavailable }
+        guard inspected.st_mode & S_IFMT == S_IFDIR else { throw HostProbeError.notADirectory }
+        let descriptor = open(candidate, O_SEARCH | O_NOFOLLOW | O_CLOEXEC)
+        guard descriptor >= 0 else { throw inspectionFailure(errno) }
+        defer { close(descriptor) }
+        var opened = stat()
+        guard fstat(descriptor, &opened) == 0, sameDirectory(inspected, opened) else {
+            throw HostProbeError.volumeUnavailable
+        }
+        let result = try body(descriptor)
+        var current = stat()
+        guard lstat(candidate, &current) == 0, sameDirectory(opened, current) else {
+            throw HostProbeError.volumeUnavailable
+        }
+        if let lastMissing {
+            // A new suffix component could redirect the destination while we inspected its
+            // ancestor. Refuse that changed binding; do not measure or create a replacement.
+            guard lstat(lastMissing, &current) != 0, errno == ENOENT else {
+                throw HostProbeError.volumeUnavailable
+            }
+        }
+        return result
+    }
+
+    private static func sameDirectory(_ a: stat, _ b: stat) -> Bool {
+        a.st_dev == b.st_dev && a.st_ino == b.st_ino && b.st_mode & S_IFMT == S_IFDIR
+    }
+
+    static func inspectionFailure(_ error: Int32) -> HostProbeError {
+        switch error {
+        case EACCES, EPERM, EROFS: .destinationNotWritable
+        case ENOTDIR: .notADirectory
+        default: .volumeUnavailable
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageVolumeProbeTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/StorageVolumeProbeTests.swift
@@ -1,0 +1,92 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import GuesthouseRuntimeKit
+
+struct StorageVolumeProbeTests {
+    private let identity = UUID(uuid: (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16))
+
+    @Test(arguments: [Int64(0), 1, 200_000_000_000, Int64.max])
+    func validNonprivilegedCapacity(_ capacity: Int64) throws {
+        let result = try StorageVolumeProbe.decode(packet(capacity: capacity))
+        #expect(result.identity == identity)
+        #expect(result.availableBytes == UInt64(capacity))
+    }
+
+    @Test(arguments: [UInt32(0x00040010), 0x80040010])
+    func infoFlagCarriesNoAdditionalBytes(_ flags: UInt32) throws {
+        let data = replacing(packet(), offset: 8, with: flags)
+        #expect(try StorageVolumeProbe.decode(data).availableBytes == 42)
+    }
+
+    @Test(arguments: Array(0..<48) + [49, 256])
+    func refusesIncompleteOrOversizedPackets(_ count: Int) {
+        var data = packet()
+        data.count = count
+        #expect(throws: HostProbeError.volumeUnavailable) { try StorageVolumeProbe.decode(data) }
+    }
+
+    @Test(arguments: [UInt32(0), 24, 47, 49, UInt32.max])
+    func refusesIncorrectDeclaredLength(_ length: UInt32) {
+        let data = replacing(packet(), offset: 0, with: length)
+        #expect(throws: HostProbeError.volumeUnavailable) { try StorageVolumeProbe.decode(data) }
+    }
+
+    @Test(arguments: [
+        (4, UInt32(0)), (4, 0x80000001), (8, 0), (8, 0x10), (8, 0x40011),
+        (12, 1), (16, 1), (20, 1),
+    ])
+    func refusesMissingIdentityOrUnexpectedAttributes(_ offset: Int, _ value: UInt32) {
+        let data = replacing(packet(), offset: offset, with: value)
+        #expect(throws: HostProbeError.volumeUnavailable) { try StorageVolumeProbe.decode(data) }
+    }
+
+    @Test func missingCapacityIsNotAZeroObservation() {
+        let data = replacing(packet(capacity: 0), offset: 8, with: UInt32(0x40000))
+        #expect(throws: HostProbeError.capacityUnavailable) { try StorageVolumeProbe.decode(data) }
+    }
+
+    @Test(arguments: [Int64(-1), Int64.min])
+    func negativeCapacityIsNotClamped(_ value: Int64) {
+        #expect(throws: HostProbeError.capacityUnavailable) {
+            try StorageVolumeProbe.decode(packet(capacity: value))
+        }
+    }
+
+    @Test func zeroUUIDIsNotRetainedIdentity() {
+        var data = packet()
+        data.replaceSubrange(32..<48, with: repeatElement(UInt8(0), count: 16))
+        #expect(throws: HostProbeError.volumeUnavailable) { try StorageVolumeProbe.decode(data) }
+    }
+
+    @Test func invalidDescriptorIsUnavailable() {
+        #expect(throws: HostProbeError.volumeUnavailable) { try StorageVolumeProbe.snapshot(descriptor: -1) }
+    }
+
+    @Test func nonDirectoryDescriptorIsNotStorage() throws {
+        let url = FileManager.default.temporaryDirectory.appending(path: "GuesthouseVolume-\(UUID()).file")
+        let descriptor = open(url.path, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC, 0o600)
+        try #require(descriptor >= 0)
+        defer { close(descriptor); try? FileManager.default.removeItem(at: url) }
+        #expect(throws: HostProbeError.notADirectory) { try StorageVolumeProbe.snapshot(descriptor: descriptor) }
+        #expect(fcntl(descriptor, F_GETFD) >= 0) // A borrowed descriptor is not consumed.
+    }
+
+    private func packet(capacity: Int64 = 42) -> Data {
+        // Independent ABI fixture: length, five returned masks, off_t, UUID bytes.
+        var data = Data()
+        for field in [UInt32(48), 0x80000000, 0x40010, 0, 0, 0] {
+            withUnsafeBytes(of: field) { data.append(contentsOf: $0) }
+        }
+        withUnsafeBytes(of: capacity) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: identity.uuid) { data.append(contentsOf: $0) }
+        return data
+    }
+
+    private func replacing(_ data: Data, offset: Int, with value: UInt32) -> Data {
+        var result = data
+        withUnsafeBytes(of: value) { result.replaceSubrange(offset..<(offset + 4), with: $0) }
+        return result
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SystemStorageProbeTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SystemStorageProbeTests.swift
@@ -154,7 +154,8 @@ struct SystemStorageProbeTests {
                         withIntermediateDirectories: false)
                 }
             }
-            #expect(try FileManager.default.contentsOfDirectory(atPath: root.appending(path: "appeared").path).isEmpty)
+            let contents = try FileManager.default.contentsOfDirectory(atPath: root.appending(path: "appeared").path)
+            #expect(contents.isEmpty)
         }
     }
 

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SystemStorageProbeTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/SystemStorageProbeTests.swift
@@ -1,0 +1,190 @@
+import Darwin
+import Foundation
+import GuesthouseCore
+import Testing
+@testable import GuesthouseRuntimeKit
+
+struct SystemStorageProbeTests {
+    @Test func unknownLocationOrUnretainedIdentityBlocks() {
+        #expect(SystemStorageProbe(storageRoot: nil, expectedVolume: UUID()).observe() == .unavailable(.storageRootUnknown))
+        #expect(SystemStorageProbe(storageRoot: URL(fileURLWithPath: "/"), expectedVolume: nil).observe()
+            == .unavailable(.storageRootUnknown))
+    }
+
+    @Test func nativeExistingDirectoryObservationAndBorrowedLifetime() throws {
+        try withFixture { root in
+            let descriptor = open(root.path, O_SEARCH | O_CLOEXEC)
+            try #require(descriptor >= 0)
+            defer { close(descriptor) }
+            let value = try StorageVolumeProbe.snapshot(descriptor: descriptor)
+            #expect(value.availableBytes <= UInt64(Int64.max))
+            #expect(fcntl(descriptor, F_GETFD) >= 0)
+            let reported = try #require(root.resourceValues(forKeys: [.volumeUUIDStringKey]).volumeUUIDString)
+            let foundationIdentity = try #require(UUID(uuidString: reported))
+            #expect(value.identity == foundationIdentity)
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            #expect(value.identity == selected)
+            let result = SystemStorageProbe(storageRoot: root, expectedVolume: selected).observe()
+            guard case .available = result else { Issue.record("Expected this writable fixture's volume capacity."); return }
+            #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+        }
+    }
+
+    @Test func missingFirstLaunchSuffixUsesOnlyTheSelectedVolumeAndCreatesNothing() throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let missing = root.appending(path: "Library/Application Support/Guesthouse")
+            let result = SystemStorageProbe(storageRoot: missing, expectedVolume: selected).observe()
+            guard case .available = result else { Issue.record("Expected the retained writable ancestor's capacity."); return }
+            #expect(try FileManager.default.contentsOfDirectory(atPath: root.path).isEmpty)
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func differentRetainedVolumeCannotUseTheSamePathOrAncestor(_ missing: Bool) throws {
+        try withFixture { root in
+            let actual = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let different = UUID()
+            try #require(actual != different)
+            let target = missing ? root.appending(path: "Guesthouse") : root
+            #expect(SystemStorageProbe(storageRoot: target, expectedVolume: different).observe()
+                == .unavailable(.volumeIdentityChanged))
+        }
+    }
+
+    @Test func initialIdentitySelectionDoesNotAscendPastAMissingDirectory() throws {
+        try withFixture { root in
+            #expect(throws: HostProbeError.volumeUnavailable) {
+                try SystemStorageProbe.identifyVolume(atExistingDirectory: root.appending(path: "not-mounted"))
+            }
+        }
+    }
+
+    @Test(arguments: [false, true])
+    func regularFileOrFileAncestorIsRefused(_ descendant: Bool) throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let file = root.appending(path: "file")
+            try Data().write(to: file)
+            let target = descendant ? file.appending(path: "Guesthouse") : file
+            #expect(SystemStorageProbe(storageRoot: target, expectedVolume: selected).observe()
+                == .unavailable(.notADirectory))
+        }
+    }
+
+    @Test(arguments: [false, true], [false, true])
+    func finalOrDanglingLinkIsNotAnAncestorFallback(_ dangling: Bool, _ trailingSlash: Bool) throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let link = root.appending(path: "linked")
+            try FileManager.default.createSymbolicLink(at: link,
+                withDestinationURL: dangling ? root.appending(path: "absent") : root)
+            let target = URL(fileURLWithPath: link.path, isDirectory: trailingSlash)
+            #expect(SystemStorageProbe(storageRoot: target, expectedVolume: selected).observe()
+                == .unavailable(.volumeUnavailable))
+        }
+    }
+
+    @Test func missingSuffixBelowDanglingLinkDoesNotMeasureStartupDisk() throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let link = root.appending(path: "linked")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: root.appending(path: "absent"))
+            #expect(SystemStorageProbe(storageRoot: link.appending(path: "Guesthouse"), expectedVolume: selected).observe()
+                == .unavailable(.volumeUnavailable))
+        }
+    }
+
+    @Test(arguments: [Int32(-1), 1, Int32.min, Int32.max])
+    func everyFailedWriteAccessCheckBlocks(_ result: Int32) {
+        #expect(throws: HostProbeError.destinationNotWritable) { try SystemStorageProbe.requireWritable(result) }
+    }
+
+    @Test(arguments: [
+        (EACCES, HostProbeError.destinationNotWritable), (EPERM, .destinationNotWritable),
+        (EROFS, .destinationNotWritable), (ENOTDIR, .notADirectory),
+        (ENOENT, .volumeUnavailable), (ELOOP, .volumeUnavailable), (EIO, .volumeUnavailable),
+    ])
+    func inspectionFailuresNeverIgnoreEPERM(_ code: Int32, _ expected: HostProbeError) {
+        #expect(SystemStorageProbe.inspectionFailure(code) == expected)
+    }
+
+    @Test func unwritableDirectoryIsNotCapacity() throws {
+        try #require(geteuid() != 0, "This permission regression requires the unprivileged Cloud test account.")
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            try #require(chmod(root.path, 0o500) == 0)
+            defer { _ = chmod(root.path, 0o700) }
+            #expect(SystemStorageProbe(storageRoot: root, expectedVolume: selected).observe()
+                == .unavailable(.destinationNotWritable))
+        }
+    }
+
+    @Test func searchableWritableDirectoryDoesNotRequireListingPermission() throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            try #require(chmod(root.path, 0o300) == 0)
+            defer { _ = chmod(root.path, 0o700) }
+            let result = SystemStorageProbe(storageRoot: root, expectedVolume: selected).observe()
+            guard case .available = result else { Issue.record("Search/write access should permit this observation."); return }
+        }
+    }
+
+    @Test func replacedDirectoryBindingIsRefusedWithoutRemovingEitherDirectory() throws {
+        try withFixture { root in
+            let target = root.appending(path: "selected"), preserved = root.appending(path: "preserved")
+            try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+            #expect(throws: HostProbeError.volumeUnavailable) {
+                try SystemStorageProbe.withDirectory(at: target, allowMissingSuffix: false) { descriptor in
+                    try FileManager.default.moveItem(at: target, to: preserved)
+                    try FileManager.default.createDirectory(at: target, withIntermediateDirectories: false)
+                    #expect(fcntl(descriptor, F_GETFD) >= 0)
+                }
+            }
+            #expect(Set(try FileManager.default.contentsOfDirectory(atPath: root.path)) == ["selected", "preserved"])
+        }
+    }
+
+    @Test func newlyAppearedMissingSuffixInvalidatesTheAncestorObservation() throws {
+        try withFixture { root in
+            let target = root.appending(path: "appeared/Guesthouse")
+            #expect(throws: HostProbeError.volumeUnavailable) {
+                try SystemStorageProbe.withDirectory(at: target, allowMissingSuffix: true) { _ in
+                    try FileManager.default.createDirectory(at: root.appending(path: "appeared"),
+                        withIntermediateDirectories: false)
+                }
+            }
+            #expect(try FileManager.default.contentsOfDirectory(atPath: root.appending(path: "appeared").path).isEmpty)
+        }
+    }
+
+    @Test func existingAncestorLinkMeasuresItsTargetVolumeNotItsSpelling() throws {
+        try withFixture { root in
+            let selected = try SystemStorageProbe.identifyVolume(atExistingDirectory: root)
+            let directory = root.appending(path: "directory")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            let alias = root.appending(path: "alias")
+            try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: root)
+            let result = SystemStorageProbe(storageRoot: alias.appending(path: "directory"), expectedVolume: selected).observe()
+            guard case .available = result else { Issue.record("Expected the existing target volume's capacity."); return }
+        }
+    }
+
+    @Test(arguments: [
+        URL(string: "https://example.invalid/storage")!, URL(string: "file://other-host/storage")!,
+        URL(string: "file:///storage?query=1")!, URL(string: "file:///storage#fragment")!,
+        URL(fileURLWithPath: "/bad\0path"), URL(fileURLWithPath: "/" + String(repeating: "a", count: 1024)),
+    ])
+    func malformedLocationsNeverReachVolumeSelection(_ url: URL) {
+        #expect(SystemStorageProbe(storageRoot: url, expectedVolume: UUID()).observe()
+            == .unavailable(.storageRootUnknown))
+    }
+
+    private func withFixture(_ body: (URL) throws -> Void) throws {
+        let root = FileManager.default.temporaryDirectory.appending(path: "GuesthouseStorageProbe-\(UUID())")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: false,
+            attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: root) }
+        try body(root)
+    }
+}


### PR DESCRIPTION
## Summary

Publishes the next focused migration from #61 for #12: runtime-owned storage capacity and retained-volume identity checks. Implements MVP-PLAN.md §§2–3 and §4's repeated free-space checks, following ADR 0002's shared-infrastructure priority and ADR 0003's typed diagnostics.

**Stacked on #172.** Merge its ancestors first, then settle this PR on main and recheck the resulting head. Do not merge it into the current feature-branch base.

## Changes

- Read nonprivileged available bytes and the volume UUID together through a borrowed directory descriptor and one bounded Darwin attribute buffer.
- Require the service's previously retained volume UUID on every observation. Unknown selection, changed volume, invalid metadata and write-access failures block; they are never reported as sufficient capacity.
- Permit a missing first-launch suffix only above an existing directory on that same selected volume. Initial identity capture requires an existing directory and never ascends past a missing mount.
- Check directory binding before and after observation, reject final/dangling links and newly appeared missing suffixes, and leave files and directories untouched.
- Keep paths, volume identifiers and raw OS errors out of public reports and diagnostics.

This PR does **not** choose/persist the initial storage volume, activate a native preflight query or wizard, reserve disk capacity, authorize writes, adopt existing VMs, or pass any hardware/provider gate. Those integration steps remain tracked in #12.

## Validation

- Four files, 441 additions; 26 Swift Testing functions / 110 parameterized cases.
- Reviewed the focused source/test diff; `git diff --check` passed.
- `bash Tests/CI/test-package-hook.sh`: all seven shell-only scenarios passed.
- Per the owner's instruction, Swift compilation and test execution are delegated to **Xcode Cloud**, not a local build or new cache. Exact-head Cloud validation has now passed.
- Head `cab1c5c6f4a5b1d3c2a391846d49a45df0f94337`: Xcode Cloud Test **SUCCESS** at 22:06:06 UTC on September 10; matching Codex review completed at 22:03:07 UTC and the original-message thumbs-up at 22:03:10 UTC, with no inline or standalone findings.
- **Dependency-held, not merge-ready:** settle the ancestors on main and recheck the resulting composition before recommending merge.

Tests cover native UUID comparison and borrowed-descriptor lifetime, malformed attribute buffers, unavailable/negative capacity, retained-identity mismatch, missing paths, permission failures, symlinks and namespace changes. Native filesystem tests use isolated temporary fixtures, not Guesthouse's real managed storage.

### CI follow-up

Cloud build 1423 exposed mixed Int32/UInt32 attribute flags; build 1424 then exposed a throwing fixture-read inference error in #expect. Both scoped fixes are pushed at `cab1c5c6f4a5b1d3c2a391846d49a45df0f94337`; the attribute mask, behavior and assertions remain unchanged. [Flag diagnosis](https://github.com/PicoMLX/Guesthouse/pull/173#issuecomment-5625972420), [test diagnosis](https://github.com/PicoMLX/Guesthouse/pull/173#issuecomment-5626022628). Cloud build 1425 passed on the corrected head, and its matching Codex review/original-message thumbs-up completed without findings. Both earlier compiler failures are resolved.
