### PR TITLE
Compose runtime preflight and retain exactly-once replies

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
@@ -52,21 +52,21 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
 
     public func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
         guard let others = gate.began() else { return nil }
-        // Finish every counted callback once, AFTER explicit reply handoff (or send failure).
-        // Refusal stops new admission immediately; only already counted callbacks may drain.
-        defer { if gate.finished() { cancel() } }
         let authorized = authenticate(message) // ORIGINAL, before context/header/payload access.
         let context = RawRuntimeReplyContext(receivedMessage: message)
+        let reply = RuntimeReplyObligation(
+            gate: gate, answer: { [self] event in answer(event, context: context) }, cancel: cancel
+        )
         guard authorized else {
-            answer(refusing(.unauthorizedCaller), context: context)
+            reply.finish(refusing(.unauthorizedCaller))
             return nil
         }
         // One-way messages never decode/register: no acceptance could be observed or canceled.
-        guard let context else {
-            record(.failed(OperationID(), .invalidRequest(.malformed)))
+        guard context != nil else {
+            reply.finish(.failed(OperationID(), .invalidRequest(.malformed)))
             return nil
         }
-        if let refusal = gate.refusal { answer(refusal, context: context); return nil }
+        if let refusal = gate.refusal { reply.finish(refusal); return nil }
         let decision: RuntimeDispatcher.Decision
         if let capped = RuntimeDispatcher.admit(inFlight: others, clientVersion: {
             message.withUnsafeUnderlyingDictionary { dictionary in
@@ -103,7 +103,7 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
             event = gate.refusal ?? refusal
         case .dispatch(let request): event = gate.commit(request, register: register)
         }
-        answer(event, context: context)
+        reply.finish(event)
         return nil // No implicit second reply/context creation.
     }
 

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/RuntimeHostPreflight.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/Preflight/RuntimeHostPreflight.swift
@@ -1,0 +1,56 @@
+import Foundation
+import GuesthouseCore
+
+/// Runtime-owned composition for #12/#61 (MVP-PLAN.md §§2–3). No GUI-selected path,
+/// bundle identifier or policy crosses into this helper. It neither selects/persists a
+/// replacement volume nor prepares storage. The owner supplies retained selection metadata.
+/// Scheduling/admission is separate: native reads must run OUTSIDE RuntimeSessionGate and
+/// native callbacks on an appropriate runtime worker, never the GUI or cooperative executor.
+struct RuntimeHostPreflight: Sendable {
+    struct Source: Sendable {
+        let hostFacts: @Sendable () -> HostProbeSnapshot
+        let disk: @Sendable () -> HostDiskObservation
+        let codex: @Sendable () -> CodexDesktopObservation
+        let now: @Sendable () -> Date
+    }
+
+    private let source: Source
+    private let policy: ResourcePolicy
+    private let preset: ResourcePreset
+
+    /// Construction does no I/O. Missing selection remains unavailable on every check.
+    init(storageRoot: URL?, expectedVolume: UUID?,
+         policy: ResourcePolicy = .standard, preset: ResourcePreset = .recommended) {
+        let storage = SystemStorageProbe(storageRoot: storageRoot, expectedVolume: expectedVolume)
+        self.init(source: Source(
+            hostFacts: { SystemHostFactsProbe().snapshot() },
+            disk: { storage.observe() },
+            codex: { SystemCodexDesktopProbe().observe() },
+            now: { Date() }
+        ), policy: policy, preset: preset)
+    }
+
+    // Typed fixture injection, not a replacement public/native dispatch interface.
+    init(source: Source, policy: ResourcePolicy = .standard, preset: ResourcePreset = .recommended) {
+        self.source = source
+        self.policy = policy
+        self.preset = preset
+    }
+
+    /// Each call rereads all three sources. The timestamp marks collection completion,
+    /// not an atomic host snapshot, freshness lease or authorization to create/start a VM.
+    func check() -> PreflightReport {
+        let facts = source.hostFacts()
+        let disk = source.disk()
+        let codex = source.codex()
+        let snapshot = HostProbeSnapshot(
+            cpuArchitecture: facts.cpuArchitecture,
+            operatingSystemVersion: facts.operatingSystemVersion,
+            physicalMemoryBytes: facts.physicalMemoryBytes,
+            powerSource: facts.powerSource,
+            disk: disk,
+            codexDesktop: codex
+        )
+        return PreflightCheck.run(snapshot: snapshot, policy: policy, preset: preset, now: source.now())
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeReplyObligation.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeReplyObligation.swift
@@ -1,0 +1,41 @@
+import GuesthouseCore
+import Synchronization
+
+/// Retains one ALREADY counted reply for a future bounded worker (#12, MVP-PLAN.md §3).
+/// The caller must own one successful gate.began(), retain this object, and explicitly finish
+/// it on every path. This does not admit work, create a native context, or cancel on deinit.
+/// A worker registry must settle/remove every obligation before releasing its session owner.
+final class RuntimeReplyObligation: Sendable {
+    private struct Pending: Sendable {
+        let gate: RuntimeSessionGate
+        let answer: @Sendable (RuntimeEvent) -> Void
+        let cancel: @Sendable () -> Void
+    }
+    private let pending: Mutex<Pending?>
+
+    init(
+        gate: RuntimeSessionGate,
+        answer: @escaping @Sendable (RuntimeEvent) -> Void,
+        cancel: @escaping @Sendable () -> Void
+    ) {
+        pending = Mutex(Pending(gate: gate, answer: answer, cancel: cancel))
+    }
+
+    /// Only the winner answers and balances accounting. `answer` must complete explicit
+    /// handoff (or handle its send/encoding failure) before returning; it must not enqueue
+    /// a later send. No callback runs under this mutex or the session gate's mutex.
+    /// A duplicate returns false even while the winning answer is still executing.
+    @discardableResult
+    func finish(_ event: RuntimeEvent) -> Bool {
+        let obligation = pending.withLock { value -> Pending? in
+            defer { value = nil }
+            return value
+        }
+        guard let obligation else { return false }
+        // Clearing pending also releases captured context/session owners after this call,
+        // even if a late completion source still retains the now-settled obligation.
+        defer { if obligation.gate.finished() { obligation.cancel() } }
+        obligation.answer(event)
+        return true
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeHostPreflightTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeHostPreflightTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+struct RuntimeHostPreflightTests {
+    @Test func composesAllFiveResultsUsingRuntimeDefaults() {
+        let report = RuntimeHostPreflight(source: source()).check()
+        #expect(report.results == [
+            .architectureSupported(.appleSilicon), .macOSSupported(SemanticVersion([26, 4, 1])),
+            .memorySufficient(bytes: 34_359_738_368), .diskSufficient(bytes: 300_000_000_000),
+            .codexInstalled(version: SemanticVersion([1, 2]), build: nil),
+        ])
+        #expect(report.canProceed)
+        #expect(report.powerSource == .battery)
+        #expect(report.checkedAt == Date(timeIntervalSince1970: 10))
+        #expect(report.storage.runtimeDownloadEstimateBytes == 50_000_000)
+        #expect(report.storage.restoreImageEstimateBytes == 16_000_000_000)
+        #expect(report.storage.guestDiskBytes == 160_000_000_000)
+        #expect(report.storage.firstSetupAllowanceBytes == 200_000_000_000)
+    }
+
+    @Test func basicFactsCannotSubstituteForUnavailableDedicatedProbes() {
+        let misleading = HostProbeSnapshot(cpuArchitecture: .appleSilicon,
+            operatingSystemVersion: SemanticVersion([26, 4, 1]), physicalMemoryBytes: 34_359_738_368,
+            disk: .available(bytes: .max), codexDesktop: .installed(version: nil, build: nil))
+        let report = RuntimeHostPreflight(source: source(facts: misleading,
+            disk: .unavailable(.storageRootUnknown), codex: .unavailable)).check()
+        #expect(report.result(.freeDisk) == .diskUnavailable(.storageRootUnknown))
+        #expect(report.result(.codexDesktop) == .codexUnavailable)
+        #expect(!report.canProceed)
+    }
+
+    @Test func healthyDiskAndAppCannotInventMissingOSFacts() {
+        let report = RuntimeHostPreflight(source: source(facts: HostProbeSnapshot())).check()
+        #expect(report.result(.architecture) == .architectureUnknown)
+        #expect(report.result(.macOSVersion) == .macOSUnknown)
+        #expect(report.result(.memory) == .memoryUnknown)
+        #expect(report.powerSource == .unknown)
+        #expect(!report.canProceed)
+    }
+
+    @Test(arguments: HostProbeError.allCases)
+    func preservesEveryStorageFailure(_ failure: HostProbeError) {
+        let report = RuntimeHostPreflight(source: source(disk: .unavailable(failure), codex: .notFound)).check()
+        #expect(report.result(.freeDisk) == .diskUnavailable(failure))
+        #expect(report.result(.codexDesktop) == .codexNotFound)
+        #expect(!report.canProceed)
+    }
+
+    @Test(arguments: [
+        (CodexDesktopObservation.notFound, PreflightResult.codexNotFound, true),
+        (.unavailable, .codexUnavailable, false),
+        (.installed(version: nil, build: nil), .codexInstalled(version: nil, build: nil), true),
+        (.installed(version: SemanticVersion([3]), build: SemanticVersion([9])),
+         .codexInstalled(version: SemanticVersion([3]), build: SemanticVersion([9])), true),
+    ])
+    func retainsDiscoveryVersusMetadataMeaning(_ observed: CodexDesktopObservation,
+                                              _ expected: PreflightResult, _ canProceed: Bool) {
+        let report = RuntimeHostPreflight(source: source(codex: observed)).check()
+        #expect(report.result(.codexDesktop) == expected)
+        #expect(report.canProceed == canProceed)
+    }
+
+    @Test func servicePolicyAndPresetAreCapturedTogether() throws {
+        var policy = ResourcePolicy()
+        policy.firstSetupAllowanceBytes = 400_000_000_000
+        policy.restoreImageEstimateBytes = 7
+        let preset = try #require(ResourcePreset(name: "Service choice", memoryBytes: 8_589_934_592,
+            cpuCount: 2, diskBytes: 99, verification: .planBaseline))
+        let check = RuntimeHostPreflight(source: source(), policy: policy, preset: preset)
+        policy.firstSetupAllowanceBytes = 1 // Caller changes cannot rewrite an existing check.
+        let report = check.check()
+        #expect(report.result(.freeDisk) == .insufficientDisk(requiredBytes: 400_000_000_000,
+                                                           availableBytes: 300_000_000_000))
+        #expect(report.storage.firstSetupAllowanceBytes == 400_000_000_000)
+        #expect(report.storage.restoreImageEstimateBytes == 7)
+        #expect(report.storage.guestDiskBytes == 99)
+        #expect(!report.canProceed)
+    }
+
+    @Test func everyRefreshRereadsSourcesAndDatesOnlyTheCompletedCollection() {
+        let trace = Trace()
+        let facts = Self.facts
+        let check = RuntimeHostPreflight(source: .init(
+            hostFacts: { trace.record(.host); return facts },
+            disk: { trace.record(.disk); return trace.disk.withLock { $0 } },
+            codex: { trace.record(.codex); return .notFound },
+            now: { trace.record(.clock); return trace.date.withLock { $0 } }
+        ))
+        #expect(trace.steps.withLock { $0.isEmpty })
+        let first = check.check()
+        trace.disk.withLock { $0 = .available(bytes: 0) }
+        trace.date.withLock { $0 = Date(timeIntervalSince1970: 20) }
+        let second = check.check()
+        #expect(trace.steps.withLock { $0 } == [.host, .disk, .codex, .clock, .host, .disk, .codex, .clock])
+        #expect(first.canProceed)
+        #expect(first.checkedAt == Date(timeIntervalSince1970: 10))
+        #expect(second.result(.freeDisk) == .insufficientDisk(requiredBytes: 200_000_000_000, availableBytes: 0))
+        #expect(second.checkedAt == Date(timeIntervalSince1970: 20))
+        #expect(!second.canProceed)
+    }
+
+    @Test func reportEncodingExposesOnlyTheDisplayContract() throws {
+        let report = RuntimeHostPreflight(source: source()).check()
+        let bytes = try JSONEncoder().encode(report)
+        let object = try #require(JSONSerialization.jsonObject(with: bytes) as? [String: Any])
+        #expect(Set(object.keys) == ["results", "storage", "powerSource", "checkedAt"])
+        #expect(try JSONDecoder().decode(PreflightReport.self, from: bytes) == report)
+        #expect(bytes.count < 4_096) // Example payload, not the future native admission bound.
+    }
+
+    private static var facts: HostProbeSnapshot {
+        HostProbeSnapshot(cpuArchitecture: .appleSilicon, operatingSystemVersion: SemanticVersion([26, 4, 1]),
+            physicalMemoryBytes: 34_359_738_368, powerSource: .battery)
+    }
+    private func source(facts: HostProbeSnapshot = RuntimeHostPreflightTests.facts,
+                        disk: HostDiskObservation = .available(bytes: 300_000_000_000),
+                        codex: CodexDesktopObservation = .installed(version: SemanticVersion([1, 2]), build: nil))
+        -> RuntimeHostPreflight.Source {
+        .init(hostFacts: { facts }, disk: { disk }, codex: { codex }, now: { Date(timeIntervalSince1970: 10) })
+    }
+
+    private final class Trace: Sendable {
+        enum Step: Equatable, Sendable { case host, disk, codex, clock }
+        let steps = Mutex<[Step]>([])
+        let disk = Mutex<HostDiskObservation>(.available(bytes: 300_000_000_000))
+        let date = Mutex(Date(timeIntervalSince1970: 10))
+        func record(_ step: Step) { steps.withLock { $0.append(step) } }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReplyObligationTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReplyObligationTests.swift
@@ -1,0 +1,154 @@
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+/// Accounting only. The existing native-handler suite covers actual context/send failures.
+@Suite(.timeLimit(.minutes(1))) struct RuntimeReplyObligationTests {
+    private enum Step: Equatable, Sendable { case answer, returning, canceled, released }
+    private final class Trace: Sendable {
+        let steps = Mutex<[Step]>([])
+        let events = Mutex<[RuntimeEvent]>([])
+        func add(_ step: Step) { steps.withLock { $0.append(step) } }
+        func record(_ event: RuntimeEvent) {
+            events.withLock { $0.append(event) }
+            add(.answer)
+        }
+    }
+    private final class Slot: Sendable {
+        let value = Mutex<RuntimeReplyObligation?>(nil)
+    }
+    private final class Sentinel: Sendable {
+        let trace: Trace
+        init(_ trace: Trace) { self.trace = trace }
+        deinit { trace.add(.released) }
+    }
+
+    @Test func exactlyOneFinishBalancesAnAlreadyCountedCallback() throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        let initial = try #require(gate.began())
+        #expect(initial == 0)
+        let reply = RuntimeReplyObligation(gate: gate, answer: { trace.record($0) }, cancel: { trace.add(.canceled) })
+        // Construction does not call began again, and an unsettled reply remains counted.
+        let whilePending = try #require(gate.began())
+        #expect(whilePending == 1)
+        #expect(!gate.finished()) // Balance just the synthetic second callback.
+        let event = RuntimeEvent.completed(OperationID())
+        #expect(reply.finish(event))
+        #expect(!reply.finish(.completed(OperationID())))
+        #expect(trace.events.withLock { $0 } == [event])
+        #expect(trace.steps.withLock { $0 } == [.answer])
+        let afterFinishing = try #require(gate.began())
+        #expect(afterFinishing == 0)
+        #expect(!gate.finished())
+    }
+
+    @Test func refusedSessionCancelsOnlyAfterItsAnswerReturns() throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        _ = try #require(gate.began())
+        let reply = RuntimeReplyObligation(gate: gate, answer: { event in
+            trace.record(event)
+            #expect(gate.began() == nil)
+            #expect(trace.steps.withLock { $0 } == [.answer])
+            trace.add(.returning)
+        }, cancel: { trace.add(.canceled) })
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        gate.refuse(refusal)
+        #expect(reply.finish(refusal))
+        #expect(!reply.finish(refusal))
+        #expect(trace.steps.withLock { $0 } == [.answer, .returning, .canceled])
+        #expect(trace.events.withLock { $0 } == [refusal])
+    }
+
+    @Test func allAlreadyCountedAnswersDrainBeforeOneCancel() throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        _ = try #require(gate.began())
+        _ = try #require(gate.began())
+        let first = RuntimeReplyObligation(gate: gate, answer: { trace.record($0) }, cancel: { trace.add(.canceled) })
+        let second = RuntimeReplyObligation(gate: gate, answer: { trace.record($0) }, cancel: { trace.add(.canceled) })
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        gate.refuse(refusal)
+        #expect(first.finish(refusal))
+        #expect(trace.steps.withLock { $0 } == [.answer])
+        #expect(!first.finish(refusal))
+        #expect(second.finish(refusal))
+        #expect(!second.finish(refusal))
+        #expect(trace.steps.withLock { $0 } == [.answer, .answer, .canceled])
+    }
+
+    @Test func anotherCompletionCannotCancelAnAnswerStillExecuting() throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        _ = try #require(gate.began())
+        _ = try #require(gate.began())
+        let second = RuntimeReplyObligation(gate: gate, answer: { trace.record($0) }, cancel: { trace.add(.canceled) })
+        let first = RuntimeReplyObligation(gate: gate, answer: { event in
+            trace.record(event)
+            #expect(second.finish(event))
+            // Both callbacks have claimed their answers, but the first still owes handoff.
+            #expect(trace.steps.withLock { $0 } == [.answer, .answer])
+            trace.add(.returning)
+        }, cancel: { trace.add(.canceled) })
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        gate.refuse(refusal)
+        #expect(first.finish(refusal))
+        #expect(trace.steps.withLock { $0 } == [.answer, .answer, .returning, .canceled])
+        #expect(!second.finish(refusal))
+    }
+
+    @Test func reentrantAnswerAndCancelCannotFinishAgainOrDeadlock() throws {
+        let gate = RuntimeSessionGate(), trace = Trace(), slot = Slot()
+        _ = try #require(gate.began())
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        let reply = RuntimeReplyObligation(gate: gate, answer: { event in
+            trace.record(event)
+            let sameReply = slot.value.withLock { $0 }
+            #expect(sameReply?.finish(event) == false)
+            gate.refuse(refusal)
+            trace.add(.returning)
+        }, cancel: {
+            let sameReply = slot.value.withLock { $0 }
+            #expect(sameReply?.finish(refusal) == false)
+            #expect(gate.began() == nil)
+            trace.add(.canceled)
+        })
+        slot.value.withLock { $0 = reply }
+        #expect(reply.finish(.completed(OperationID())))
+        #expect(trace.steps.withLock { $0 } == [.answer, .returning, .canceled])
+        #expect(trace.events.withLock { $0.count } == 1)
+    }
+
+    @Test func competingCompletionsHaveOneAnswerAndOneCancel() async throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        _ = try #require(gate.began())
+        let reply = RuntimeReplyObligation(gate: gate, answer: { trace.record($0) }, cancel: { trace.add(.canceled) })
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        let winners = await withTaskGroup(of: Bool.self, returning: Int.self) { group in
+            for _ in 0..<32 { group.addTask { reply.finish(.completed(OperationID())) } }
+            var count = 0
+            for await won in group { if won { count += 1 } }
+            return count
+        }
+        #expect(winners == 1)
+        #expect(trace.events.withLock { $0.count } == 1)
+        #expect(trace.steps.withLock { $0 } == [.answer, .canceled])
+        #expect(gate.began() == nil)
+    }
+
+    @Test func settledObligationDoesNotRetainItsAnswerCapture() throws {
+        let gate = RuntimeSessionGate(), trace = Trace()
+        _ = try #require(gate.began())
+        let reply = retainingSentinel(gate: gate, trace: trace)
+        #expect(trace.steps.withLock { $0.isEmpty })
+        #expect(reply.finish(.completed(OperationID())))
+        withExtendedLifetime(reply) {
+            #expect(trace.steps.withLock { $0 } == [.answer, .released])
+        }
+    }
+
+    private func retainingSentinel(gate: RuntimeSessionGate, trace: Trace) -> RuntimeReplyObligation {
+        let sentinel = Sentinel(trace)
+        return RuntimeReplyObligation(gate: gate, answer: { [sentinel] event in
+            withExtendedLifetime(sentinel) { trace.record(event) }
+        }, cancel: { trace.add(.canceled) })
+    }
+}


### PR DESCRIPTION
## Summary

Continues the retained #61 migration for #12, implementing MVP-PLAN.md §§2–3 under ADR 0002/0003. Publishes two already-prepared related slices together: runtime-owned preflight composition and explicit reply accounting needed before host observations can move onto a bounded worker.

**Stacked on #173. Do not merge into the current feature-branch base.** The owner alone merges: land/settle #170 → #171 → #172 → #173 on main, then settle this PR on main and recheck the resulting head.

## Changes

- Compose fresh host facts, selected-volume capacity and Codex discovery into the existing typed evaluator. Dedicated probe failures cannot be hidden by partial host snapshots.
- Capture service-owned policy/preset together; construction does no I/O, each check rereads observations, and the timestamp denotes collection completion rather than an authorization/freshness lease.
- Retain a previously counted native reply in an internal exactly-once obligation. Only one completion answers and balances accounting; refused sessions cancel after every counted reply has handed off or handled its send failure.
- Clear retained callbacks on settlement and invoke them outside both obligation and session locks. Adapt every existing synchronous native-handler path without changing authentication, framing, refusal or query dispatch.
- Keep diagnostics typed; no raw output, error description, host path or volume identifier is added to the public report.

## Validation

- Head: `13e86b286de4be33e82cd23e19bcd1a30b057857`.
- Five files: 391 additions / 8 deletions (399 changed lines).
- Fifteen Swift Testing functions / 23 cases cover all report outcomes, source precedence/freshness, fixed service policy, report encoding, duplicate/reentrant/concurrent completion, reply-before-cancel, draining siblings and captured-owner release. Existing native-handler tests retain one-way/authentication/framing/encoding/send-failure coverage.
- Full focused source/test diff reviewed; `git diff --check` passes.
- `bash Tests/CI/test-package-hook.sh`: all seven shell-only scenarios pass.
- No local Swift/Xcode build/test or new cache. **Exact-head Xcode Cloud Test SUCCESS at 22:50:56 UTC September 10.** Matching Codex review completed at 22:48:07 UTC and the original-message bot thumbs-up at 22:48:11 UTC, with no inline or standalone findings and complete pagination. Only dependency/composition holds remain; do not merge into the feature-branch base.

## Still outside this PR

No bounded-worker/native deferred execution or new query is enabled here. The public production service remains runtimeVersion-only. Initial storage-volume capture, durable selection loading/composition, native hostPreflight activation, wizard stale-result fencing, VM/provider operations and hardware gates remain unfinished. #12 and reference #61 stay open until their full retained scope lands. No identity recapture, second store or GUI-provided path authority is introduced.