### PR TITLE
Bound runtime read-only work and return typed registration

### DIFF
--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeSessionGate.swift
@@ -6,6 +6,13 @@ import Synchronization
 /// suspension or reentry. Register identity/cancellation here; perform work outside the gate.
 /// Mutex fits the native synchronous callback boundary without unchecked Sendable or actors.
 public final class RuntimeSessionGate: Sendable {
+    /// In-process registration outcome, NOT a wire acknowledgement or completed operation.
+    /// A deferred worker returns its ticket here without fabricating a RuntimeEvent.
+    public enum Registration<Value: Sendable>: Sendable {
+        case registered(Value)
+        case refused(RuntimeEvent)
+    }
+
     // Internal so tests can nonblockingly verify registration shares the refusal lock.
     let state = Mutex(RuntimeDispatcher.SessionLifetime())
 
@@ -27,9 +34,23 @@ public final class RuntimeSessionGate: Sendable {
         _ request: RuntimeRequest,
         register: (RuntimeRequest) throws -> RuntimeEvent
     ) rethrows -> RuntimeEvent {
+        switch try commitRegistration(request, register: register) {
+        case .registered(let event), .refused(let event): return event
+        }
+    }
+
+    /// The same authenticated/admitted boundary as commit, with a typed in-process value.
+    /// Only register identity/ownership here; start a deferred ticket AFTER this returns,
+    /// even if refusal follows registration. Refusal/throw does not settle the counted reply.
+    /// Keep callback captures alive outside this gate; no I/O, reply delivery or reentrant deinit
+    /// may run under its mutex (MVP-PLAN.md §3). A registered nil is distinct from refusal.
+    public func commitRegistration<Value: Sendable>(
+        _ request: RuntimeRequest,
+        register: (RuntimeRequest) throws -> Value
+    ) rethrows -> Registration<Value> {
         try state.withLock { lifetime in
-            if let refusal = lifetime.refusal { return refusal }
-            return try register(request)
+            if let refusal = lifetime.refusal { return .refused(refusal) }
+            return .registered(try register(request))
         }
     }
 

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRegistrationTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRegistrationTests.swift
@@ -1,0 +1,61 @@
+import Synchronization
+import Testing
+@testable import GuesthouseCore
+
+struct RuntimeRegistrationTests {
+    @Test func typedRegistrationReturnsOwnershipWithoutAnsweringOrFinishing() {
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        var received: RuntimeRequest?
+        let result = gate.commitRegistration(.runtimeVersion) { request in
+            received = request
+            return UInt64(42)
+        }
+        guard case .registered(let ticket) = result else { Issue.record("Registration refused"); return }
+        #expect(ticket == 42)
+        #expect(received == .runtimeVersion)
+        #expect(gate.state.withLock { $0.inFlight } == 1)
+        // Reading/reentering the gate is safe after returning the registration value.
+        #expect(gate.refusal == nil)
+        #expect(!gate.finished())
+    }
+
+    @Test func priorRefusalDoesNotRunRegistrationOrConsumeTheCountedReply() {
+        let gate = RuntimeSessionGate()
+        let first = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        #expect(gate.began() == 0)
+        gate.refuse(first)
+        gate.refuse(.failed(OperationID(), .invalidRuntimeReply(.malformed)))
+        var registrations = 0
+        let result = gate.commitRegistration(.runtimeVersion) { _ in registrations += 1; return 42 }
+        guard case .refused(let event) = result else { Issue.record("Refusal was bypassed"); return }
+        #expect(event == first)
+        #expect(registrations == 0)
+        #expect(gate.state.withLock { $0.inFlight } == 1)
+        #expect(gate.finished())
+        #expect(gate.began() == nil)
+    }
+
+    @Test func registeredNilIsNotRefusalAndLaterRefusalCannotRewriteTheValue() {
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        let result = gate.commitRegistration(.runtimeVersion) { _ -> Int? in nil }
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        guard case .registered(let ticket) = result else { Issue.record("Registration rewritten"); return }
+        #expect(ticket == nil)
+        #expect(gate.state.withLock { $0.inFlight } == 1)
+        #expect(gate.finished())
+    }
+
+    @Test func thrownTypedRegistrationUnlocksAndKeepsItsReplyObligation() {
+        enum Failure: Error { case rejected }
+        let gate = RuntimeSessionGate()
+        #expect(gate.began() == 0)
+        #expect(throws: Failure.self) {
+            try gate.commitRegistration(.runtimeVersion) { _ -> Int in throw Failure.rejected }
+        }
+        #expect(gate.state.withLockIfAvailable { $0.inFlight } == 1)
+        gate.refuse(.failed(OperationID(), .unauthorizedCaller))
+        #expect(gate.finished())
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeReadOnlyWorker.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/RuntimeReadOnlyWorker.swift
@@ -1,0 +1,112 @@
+import Dispatch
+import Foundation
+import GuesthouseCore
+import Synchronization
+
+/// Process-wide bounded scheduling for read-only probes (#12, MVP-PLAN.md §3).
+/// Initialize shared during service setup, outside registration. This is not a command
+/// interface, authorization boundary, or cancellation of a blocking OS call.
+final class RuntimeReadOnlyWorker: Sendable {
+    static let shared = RuntimeReadOnlyWorker()
+    static let maximumOutstanding = 4
+    struct Ticket: Hashable, Sendable {
+        fileprivate let worker: UUID
+        fileprivate let sequence: UInt64
+    }
+    typealias Enqueue = @Sendable (@escaping @Sendable () -> Void) -> Void
+    private struct State: Sendable {
+        var nextSequence: UInt64 = 0
+        var jobs: [UInt64: Job] = [:]
+    }
+    private let identity = UUID()
+    private let state: Mutex<State>
+    private let enqueue: Enqueue
+
+    private convenience init() {
+        // Synchronous filesystem/OS probes must not occupy Swift's cooperative pool.
+        let queue = DispatchQueue(label: "Guesthouse.Runtime.ReadOnly", qos: .utility)
+        self.init(enqueue: { queue.async(execute: $0) })
+    }
+
+    // Deterministic executor/sequence seam only. Production uses the shared serial queue.
+    init(enqueue: @escaping Enqueue, nextSequence: UInt64 = 0) {
+        self.enqueue = enqueue
+        state = Mutex(State(nextSequence: nextSequence))
+    }
+
+    /// Call ONLY inside the authenticated session's bounded gate.commit registration.
+    /// No gate reads, scheduling or callbacks here: registration's lock order is gate → worker.
+    /// Nil transfers nothing; the caller still owes the supplied reply. A successful ticket
+    /// MUST be started outside gate.commit, even if refusal arrives before start.
+    func reserve(
+        gate: RuntimeSessionGate, reply: RuntimeReplyObligation,
+        work: @escaping @Sendable () -> RuntimeEvent
+    ) -> Ticket? {
+        let job = Job(gate: gate, reply: reply, work: work)
+        defer { withExtendedLifetime(job) {} } // Release rejected captures outside the mutex.
+        return state.withLock { state in
+            guard state.jobs.count < Self.maximumOutstanding else { return nil }
+            let (next, overflow) = state.nextSequence.addingReportingOverflow(1)
+            guard !overflow else { return nil } // Never reuse a ticket, including at exhaustion.
+            let ticket = Ticket(worker: identity, sequence: state.nextSequence)
+            state.nextSequence = next
+            state.jobs[ticket.sequence] = job
+            return ticket
+        }
+    }
+
+    /// Scheduling only; the production executor never invokes work inline in this callback.
+    /// Canceled reservations still drain once. Do not free capacity on reply cancellation:
+    /// an unreturned OS read or queued closure still consumes the process-wide bound.
+    @discardableResult
+    func start(_ ticket: Ticket) -> Bool {
+        guard ticket.worker == identity,
+              let job = state.withLock({ $0.jobs[ticket.sequence] }), job.schedule() else { return false }
+        enqueue { [self, job] in
+            job.run()
+            let removed = state.withLock { $0.jobs.removeValue(forKey: ticket.sequence) }
+            withExtendedLifetime(removed) {} // Captured-owner destruction must stay outside locks.
+        }
+        return true
+    }
+
+    /// Stop registration before taking the bounded job snapshot. Never hold the worker lock
+    /// while acquiring the gate or handing replies/canceling the session. The first refusal
+    /// stays authoritative. A started read can finish later; its result cannot answer twice.
+    func refuse(_ gate: RuntimeSessionGate, with event: RuntimeEvent) {
+        gate.refuse(event)
+        let refusal = gate.refusal ?? event
+        let jobs = state.withLock { $0.jobs.values.filter { $0.gate === gate } }
+        for job in jobs { job.cancel(with: refusal) }
+    }
+
+    private final class Job: Sendable {
+        private struct Phase: Sendable { var scheduled = false; var canceled = false }
+        let gate: RuntimeSessionGate
+        private let reply: RuntimeReplyObligation
+        private let work: @Sendable () -> RuntimeEvent
+        private let phase = Mutex(Phase())
+
+        init(gate: RuntimeSessionGate, reply: RuntimeReplyObligation, work: @escaping @Sendable () -> RuntimeEvent) {
+            self.gate = gate; self.reply = reply; self.work = work
+        }
+        func schedule() -> Bool {
+            phase.withLock {
+                guard !$0.scheduled else { return false }
+                $0.scheduled = true
+                return true
+            }
+        }
+        func cancel(with event: RuntimeEvent) {
+            phase.withLock { $0.canceled = true }
+            reply.finish(event)
+        }
+        func run() {
+            // This is the read-start boundary. Refusal before it skips the probe; refusal
+            // afterward settles the reply but does not pretend to interrupt synchronous I/O.
+            guard phase.withLock({ !$0.canceled }) else { return }
+            let result = gate.refusal ?? work()
+            reply.finish(gate.refusal ?? result)
+        }
+    }
+}

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
@@ -40,12 +40,13 @@ import Testing
         }
         func reserve(_ worker: RuntimeReadOnlyWorker, work: (@Sendable () -> RuntimeEvent)? = nil) -> RuntimeReadOnlyWorker.Ticket? {
             let probe: @Sendable () -> RuntimeEvent = work ?? { [trace] in trace.run() }
-            var ticket: RuntimeReadOnlyWorker.Ticket?
-            _ = gate.commit(.runtimeVersion) { _ in
-                ticket = worker.reserve(gate: gate, reply: reply, work: probe)
-                return trace.success // Test registration marker, not a delivered reply.
+            let registration = gate.commitRegistration(.runtimeVersion) { _ in
+                worker.reserve(gate: gate, reply: reply, work: probe)
             }
-            return ticket
+            switch registration {
+            case .registered(let ticket): return ticket
+            case .refused(let event): reply.finish(event); return nil
+            }
         }
         func reject() { reply.finish(.failed(OperationID(), .invalidRequest(.tooManyInFlight))) }
     }
@@ -67,6 +68,19 @@ import Testing
         let count = try #require(call.gate.began())
         #expect(count == 0)
         #expect(!call.gate.finished())
+    }
+
+    @Test func priorSessionRefusalPreventsReservationAndStillAnswersOnce() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let call = try Call()
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        worker.refuse(call.gate, with: refusal)
+        #expect(call.reserve(worker) == nil)
+        #expect(executor.pending.withLock { $0.isEmpty })
+        #expect(call.trace.state.withLock { $0.replies } == [refusal])
+        #expect(call.trace.state.withLock { $0.runs == 0 && $0.cancels == 1 })
+        #expect(call.gate.began() == nil)
     }
 
     @Test func admissionIsBoundedAcrossDifferentSessionsAndRejectionTransfersNothing() throws {

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
@@ -131,14 +131,17 @@ import Testing
         let running = try Call(), premature = try Call(), later = try Call()
         let others = try (0..<3).map { _ in try Call() }
         let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
-        let ticket = try #require(running.reserve(worker, work: {
+        let readWork: @Sendable () -> RuntimeEvent = {
             _ = running.trace.run()
             worker.refuse(running.gate, with: refusal)
             #expect(running.trace.state.withLock { $0.replies } == [refusal])
             #expect(premature.reserve(worker) == nil) // The read has not returned yet.
             premature.reject()
             return running.trace.success
-        }))
+        }
+        // Keep the @Sendable closure out of #require's diagnostic autoclosure boundary.
+        let reservedTicket = running.reserve(worker, work: readWork)
+        let ticket = try #require(reservedTicket)
         let otherTickets = try others.map { try #require($0.reserve(worker)) }
         #expect(worker.start(ticket))
         executor.runOne()

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/RuntimeReadOnlyWorkerTests.swift
@@ -1,0 +1,222 @@
+import GuesthouseCore
+import Synchronization
+import Testing
+@testable import GuesthouseRuntimeKit
+
+/// Deterministic scheduling/ownership tests, not live OS-read or hardware evidence.
+@Suite(.timeLimit(.minutes(1))) struct RuntimeReadOnlyWorkerTests {
+    private final class Executor: Sendable {
+        let pending = Mutex<[@Sendable () -> Void]>([])
+        func enqueue(_ work: @escaping @Sendable () -> Void) { pending.withLock { $0.append(work) } }
+        func runOne() {
+            let work = pending.withLock { $0.isEmpty ? nil : $0.removeFirst() }
+            work?() // Never execute a callback under the executor's bookkeeping mutex.
+        }
+        func drain() { while pending.withLock({ !$0.isEmpty }) { runOne() } }
+    }
+    private final class Trace: Sendable {
+        struct State: Sendable { var runs = 0; var replies: [RuntimeEvent] = []; var cancels = 0; var released = false }
+        let state = Mutex(State())
+        let success = RuntimeEvent.completed(OperationID())
+        func run() -> RuntimeEvent { state.withLock { $0.runs += 1 }; return success }
+    }
+    private final class Sentinel: Sendable {
+        let trace: Trace
+        init(_ trace: Trace) { self.trace = trace }
+        deinit { trace.state.withLock { $0.released = true } }
+    }
+    private final class Call: Sendable {
+        let gate: RuntimeSessionGate
+        let trace: Trace
+        let reply: RuntimeReplyObligation
+        init(gate: RuntimeSessionGate = RuntimeSessionGate()) throws {
+            self.gate = gate
+            let trace = Trace()
+            self.trace = trace
+            _ = try #require(gate.began())
+            reply = RuntimeReplyObligation(gate: gate, answer: { event in
+                trace.state.withLock { $0.replies.append(event) }
+            }, cancel: { trace.state.withLock { $0.cancels += 1 } })
+        }
+        func reserve(_ worker: RuntimeReadOnlyWorker, work: (@Sendable () -> RuntimeEvent)? = nil) -> RuntimeReadOnlyWorker.Ticket? {
+            let probe: @Sendable () -> RuntimeEvent = work ?? { [trace] in trace.run() }
+            var ticket: RuntimeReadOnlyWorker.Ticket?
+            _ = gate.commit(.runtimeVersion) { _ in
+                ticket = worker.reserve(gate: gate, reply: reply, work: probe)
+                return trace.success // Test registration marker, not a delivered reply.
+            }
+            return ticket
+        }
+        func reject() { reply.finish(.failed(OperationID(), .invalidRequest(.tooManyInFlight))) }
+    }
+
+    @Test func registrationDoesNotScheduleOrRunAndStartingIsExactlyOnce() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let call = try Call(), ticket = try #require(call.reserve(worker))
+        #expect(executor.pending.withLock { $0.isEmpty })
+        #expect(call.trace.state.withLock { $0.runs == 0 && $0.replies.isEmpty })
+        #expect(worker.start(ticket))
+        #expect(!worker.start(ticket))
+        #expect(executor.pending.withLock { $0.count } == 1)
+        #expect(call.trace.state.withLock { $0.runs } == 0)
+        executor.drain()
+        #expect(call.trace.state.withLock { $0.runs } == 1)
+        #expect(call.trace.state.withLock { $0.replies } == [call.trace.success])
+        #expect(!worker.start(ticket))
+        let count = try #require(call.gate.began())
+        #expect(count == 0)
+        #expect(!call.gate.finished())
+    }
+
+    @Test func admissionIsBoundedAcrossDifferentSessionsAndRejectionTransfersNothing() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let calls = try (0..<4).map { _ in try Call() }
+        let tickets = try calls.map { try #require($0.reserve(worker)) }
+        let rejected = try Call()
+        #expect(rejected.reserve(worker) == nil)
+        #expect(rejected.trace.state.withLock { $0.replies.isEmpty && $0.runs == 0 })
+        #expect(executor.pending.withLock { $0.isEmpty })
+        rejected.reject() // No ownership was transferred; the caller must still answer.
+        for ticket in tickets { #expect(worker.start(ticket)) }
+        executor.drain()
+        for call in calls { #expect(call.trace.state.withLock { $0.replies } == [call.trace.success]) }
+        let next = try Call(), nextTicket = try #require(next.reserve(worker))
+        #expect(worker.start(nextTicket))
+        executor.drain()
+    }
+
+    @Test func refusalBeforeStartSettlesRepliesButKeepsCanceledReservationsBounded() throws {
+        let executor = Executor(), gate = RuntimeSessionGate()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let calls = try (0..<4).map { _ in try Call(gate: gate) }
+        let tickets = try calls.map { try #require($0.reserve(worker)) }
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        worker.refuse(gate, with: refusal)
+        worker.refuse(gate, with: .failed(OperationID(), .invalidRuntimeReply(.malformed)))
+        for call in calls { #expect(call.trace.state.withLock { $0.replies } == [refusal]) }
+        #expect(calls.reduce(0) { $0 + $1.trace.state.withLock { $0.cancels } } == 1)
+        #expect(gate.began() == nil)
+        let rejected = try Call()
+        #expect(rejected.reserve(worker) == nil)
+        rejected.reject()
+        for ticket in tickets { #expect(worker.start(ticket)) }
+        #expect(executor.pending.withLock { $0.count } == 4)
+        executor.drain()
+        #expect(calls.allSatisfy { $0.trace.state.withLock { $0.runs == 0 } })
+        let next = try Call(), nextTicket = try #require(next.reserve(worker))
+        #expect(worker.start(nextTicket))
+        executor.drain()
+        #expect(next.trace.state.withLock { $0.runs } == 1)
+    }
+
+    @Test func refusalDuringAReadDoesNotFreeItsSlotOrDeliverItsLateResult() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let running = try Call(), premature = try Call(), later = try Call()
+        let others = try (0..<3).map { _ in try Call() }
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        let ticket = try #require(running.reserve(worker, work: {
+            _ = running.trace.run()
+            worker.refuse(running.gate, with: refusal)
+            #expect(running.trace.state.withLock { $0.replies } == [refusal])
+            #expect(premature.reserve(worker) == nil) // The read has not returned yet.
+            premature.reject()
+            return running.trace.success
+        }))
+        let otherTickets = try others.map { try #require($0.reserve(worker)) }
+        #expect(worker.start(ticket))
+        executor.runOne()
+        #expect(running.trace.state.withLock { $0.replies } == [refusal])
+        #expect(running.trace.state.withLock { $0.runs == 1 && $0.cancels == 1 })
+        let laterTicket = try #require(later.reserve(worker))
+        for next in otherTickets + [laterTicket] { #expect(worker.start(next)) }
+        executor.drain()
+        #expect(later.trace.state.withLock { $0.replies } == [later.trace.success])
+    }
+
+    @Test func refusingOneSessionDoesNotCancelAnotherSessionsRead() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let first = try Call(), second = try Call()
+        let one = try #require(first.reserve(worker)), two = try #require(second.reserve(worker))
+        let refusal = RuntimeEvent.failed(OperationID(), .unauthorizedCaller)
+        worker.refuse(first.gate, with: refusal)
+        #expect(second.trace.state.withLock { $0.replies.isEmpty && $0.cancels == 0 })
+        #expect(worker.start(one))
+        #expect(worker.start(two))
+        executor.drain()
+        #expect(first.trace.state.withLock { $0.runs } == 0)
+        #expect(second.trace.state.withLock { $0.replies } == [second.trace.success])
+    }
+
+    @Test func ticketsDoNotAliasAcrossWorkersOrAfterCompletion() throws {
+        let executor = Executor()
+        let firstWorker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let secondWorker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let first = try Call(), second = try Call(), later = try Call()
+        let firstTicket = try #require(first.reserve(firstWorker))
+        let secondTicket = try #require(second.reserve(secondWorker))
+        #expect(!firstWorker.start(secondTicket))
+        #expect(!secondWorker.start(firstTicket))
+        #expect(firstWorker.start(firstTicket))
+        #expect(secondWorker.start(secondTicket))
+        executor.drain()
+        let laterTicket = try #require(later.reserve(firstWorker))
+        #expect(laterTicket != firstTicket)
+        #expect(!firstWorker.start(firstTicket))
+        #expect(firstWorker.start(laterTicket))
+        executor.drain()
+        #expect(later.trace.state.withLock { $0.runs } == 1)
+    }
+
+    @Test func exhaustedTicketSequenceRefusesWithoutWrappingOrTakingReply() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) }, nextSequence: .max)
+        let call = try Call()
+        #expect(call.reserve(worker) == nil)
+        #expect(call.trace.state.withLock { $0.replies.isEmpty && $0.runs == 0 })
+        #expect(executor.pending.withLock { $0.isEmpty })
+        call.reject()
+    }
+
+    @Test func drainedWorkReleasesItsCaptureWhileWorkerAndTicketRemainAlive() throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let call = try Call()
+        let ticket = try #require(reservingSentinel(call, worker: worker))
+        #expect(!call.trace.state.withLock { $0.released })
+        #expect(worker.start(ticket))
+        executor.drain()
+        withExtendedLifetime((worker, ticket)) {
+            #expect(call.trace.state.withLock { $0.released })
+        }
+    }
+
+    private func reservingSentinel(_ call: Call, worker: RuntimeReadOnlyWorker) -> RuntimeReadOnlyWorker.Ticket? {
+        let sentinel = Sentinel(call.trace)
+        return call.reserve(worker, work: { [sentinel] in
+            withExtendedLifetime(sentinel) { call.trace.run() }
+        })
+    }
+
+    @Test func competingSessionsCannotOverbookTheWorker() async throws {
+        let executor = Executor()
+        let worker = RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        let calls = try (0..<32).map { _ in try Call() }
+        let accepted = await withTaskGroup(of: (Int, RuntimeReadOnlyWorker.Ticket?).self) { group in
+            for (index, call) in calls.enumerated() { group.addTask { (index, call.reserve(worker)) } }
+            var tickets: [RuntimeReadOnlyWorker.Ticket] = []
+            for await (index, ticket) in group {
+                if let ticket { tickets.append(ticket) } else { calls[index].reject() }
+            }
+            return tickets
+        }
+        #expect(accepted.count == 4)
+        for ticket in accepted { #expect(worker.start(ticket)) }
+        executor.drain()
+        #expect(calls.allSatisfy { $0.trace.state.withLock { $0.replies.count == 1 } })
+        #expect(calls.reduce(0) { $0 + $1.trace.state.withLock { $0.runs } } == 4)
+    }
+}


### PR DESCRIPTION
Runtime probes need a shared limit that includes canceled work until its queue entry drains or its synchronous read returns. This adds a four-reservation runtime worker and a typed registration result so the session gate can register ownership before scheduling work.

Continues #12 and retained #61 under MVP-PLAN.md §3 and ADR 0002/0003. Prerequisites #170–#174 are merged; this PR now targets main.

## Behavior

- Reserve under the authenticated session gate, then start once outside it. Tickets identify their worker and never wrap or alias.
- Canceled queued work skips the probe; a running read retains its slot until it returns. Refusal settles each reply once, with callbacks and capture release outside worker locks.
- Typed registration distinguishes a registered value (including nil) from refusal. The existing event-returning API uses the same boundary, and refusal or a throw retains the caller's reply obligation.

## Validation

Commit `65d8774a7008ac493a20d9f4bb9a5518e245254c` passed [Xcode Cloud Test - macOS](https://appstoreconnect.apple.com/teams/0058e16c-9fb5-4feb-bd74-b8fb804da137/apps/6808105813/ci/builds/2541a268-bc85-4770-bbd5-e6998a6e6831/action/f08809b6-45be-44cb-b6fc-159a7419faa1) on September 12 at 05:24:15 UTC (5m20s). Both Cloud checks are green. Diff checks and all seven shell-only CI-hook scenarios pass.

Fourteen Swift Testing functions cover ownership/refusal/throws, cross-session capacity, cancellation before/during reads, retained slots, duplicate completion, ticket identity/exhaustion, capture release and 32 competing reservations. Fixtures use manually advanced executors and structured task groups.

The compiler fix evaluates the reservation outside `#require`, preserving the closure's explicit `@Sendable` type. `try #require(reservedTicket)` remains because optional unwrapping can fail. Production behavior and assertions are unchanged.

**Review pending:** Codex's completed review and thumbs-up apply to `3d91de3`. Review of `65d8774a` was blocked by the account's review quota. The owner merges after a review covering the current commit.

## Remaining scope

Production still supports runtimeVersion only. Native deferred request wiring, the host-preflight query, persisted storage selection and wizard freshness remain separate work. This PR performs no filesystem/VM mutation or provider/hardware validation. #12/#61 remain open.
