### PR TITLE
Retain deferred native replies through bounded read-only work

### DIFF
--- a/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
+++ b/Packages/GuesthouseRuntimeKit/Sources/GuesthouseRuntimeKit/NativeRuntimeRequestHandler.swift
@@ -6,10 +6,20 @@ import XPC
 /// Only runtimeVersion is implemented: mutations stay unavailable until streaming and
 /// operation correlation/unknown-outcome handling migrate across all native consumers.
 public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
+    // In-process service policy only. Neither closures nor worker tickets cross XPC.
+    enum ReplyPlan: Sendable {
+        case immediate(RuntimeEvent)
+        case readOnly(@Sendable () -> RuntimeEvent)
+    }
+    private enum Delivery: Sendable {
+        case immediate(RuntimeEvent)
+        case deferred(RuntimeReadOnlyWorker.Ticket)
+    }
     private let gate: RuntimeSessionGate
+    private let worker: RuntimeReadOnlyWorker
     private let authenticate: @Sendable (XPCDictionary) -> Bool
     private let decode: @Sendable (Data, Int) -> RuntimeDispatcher.Decision
-    private let register: @Sendable (RuntimeRequest) -> RuntimeEvent
+    private let plan: @Sendable (RuntimeRequest) -> ReplyPlan
     private let send: @Sendable (XPCDictionary) throws -> Void
     private let cancel: @Sendable () -> Void
     private let diagnostic: @Sendable (DiagnosticEvent) -> Void
@@ -37,7 +47,7 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
 
     // Internal test seam only. Public construction never permits replacement authentication
     // or operation dispatch. Registration must stay bounded/in-memory with no I/O or reentry.
-    init(
+    convenience init(
         gate: RuntimeSessionGate = RuntimeSessionGate(),
         authenticate: @escaping @Sendable (XPCDictionary) -> Bool,
         decode: @escaping @Sendable (Data, Int) -> RuntimeDispatcher.Decision = RuntimeDispatcher.decide,
@@ -46,8 +56,23 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
         cancel: @escaping @Sendable () -> Void,
         diagnostic: @escaping @Sendable (DiagnosticEvent) -> Void
     ) {
+        self.init(gate: gate, worker: .shared, authenticate: authenticate, decode: decode,
+                  plan: { .immediate(register($0)) }, send: send, cancel: cancel, diagnostic: diagnostic)
+    }
+
+    // Only named read-only service policy may select deferred work. Construct the worker
+    // and probe owners outside the gate. This seam does not activate a new public operation.
+    init(
+        gate: RuntimeSessionGate, worker: RuntimeReadOnlyWorker,
+        authenticate: @escaping @Sendable (XPCDictionary) -> Bool,
+        decode: @escaping @Sendable (Data, Int) -> RuntimeDispatcher.Decision = RuntimeDispatcher.decide,
+        plan: @escaping @Sendable (RuntimeRequest) -> ReplyPlan,
+        send: @escaping @Sendable (XPCDictionary) throws -> Void,
+        cancel: @escaping @Sendable () -> Void,
+        diagnostic: @escaping @Sendable (DiagnosticEvent) -> Void
+    ) {
         self.gate = gate; self.authenticate = authenticate; self.decode = decode
-        self.register = register; self.send = send; self.cancel = cancel; self.diagnostic = diagnostic
+        self.worker = worker; self.plan = plan; self.send = send; self.cancel = cancel; self.diagnostic = diagnostic
     }
 
     public func handleIncomingRequest(_ message: XPCDictionary) -> XPCDictionary? {
@@ -95,21 +120,45 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
                 }
             }
         }
-        let event: RuntimeEvent
         switch decision {
-        case .reply(let reply): event = reply
+        case .reply(let event): reply.finish(event)
         case .replyAndClose(let refusal):
-            gate.refuse(refusal)
-            event = gate.refusal ?? refusal
-        case .dispatch(let request): event = gate.commit(request, register: register)
+            worker.refuse(gate, with: refusal)
+            reply.finish(gate.refusal ?? refusal)
+        case .dispatch(let request): dispatch(request, reply: reply)
         }
-        reply.finish(event)
         return nil // No implicit second reply/context creation.
+    }
+
+    private func dispatch(_ request: RuntimeRequest, reply: RuntimeReplyObligation) {
+        // A rejected reservation may release its Job inside the gate. Retain the plan's
+        // captured owners until AFTER unlocking, including when the worker is full.
+        var retainedPlan: ReplyPlan?
+        defer { withExtendedLifetime(retainedPlan) {} }
+        let registration = gate.commitRegistration(request) { request -> Delivery in
+            let selected = plan(request)
+            retainedPlan = selected
+            switch selected {
+            case .immediate(let event): return .immediate(event)
+            case .readOnly(let work):
+                guard let ticket = worker.reserve(gate: gate, reply: reply, work: work) else {
+                    return .immediate(.failed(OperationID(), .invalidRequest(.tooManyInFlight)))
+                }
+                return .deferred(ticket)
+            }
+        }
+        switch registration {
+        case .refused(let event), .registered(.immediate(let event)): reply.finish(event)
+        case .registered(.deferred(let ticket)):
+            // Start even after an intervening refusal so the canceled reservation drains.
+            // The production executor enqueues, never runs a probe in this native callback.
+            worker.start(ticket)
+        }
     }
 
     private func refusing(_ error: GuesthouseError) -> RuntimeEvent {
         let refusal = RuntimeEvent.failed(OperationID(), error)
-        gate.refuse(refusal)
+        worker.refuse(gate, with: refusal)
         return gate.refusal ?? refusal
     }
 
@@ -146,7 +195,8 @@ public final class NativeRuntimeRequestHandler: XPCPeerHandler, Sendable {
 
     public func handleCancellation(error: XPCRichError) {
         // Opaque native error text is not a diagnostic input. Stop new registration now;
-        // counted callbacks still finish themselves, without inventing operation outcomes.
+        // queued reads settle without probing; already-started OS calls retain their bounded
+        // capacity until return, but cannot send a second answer. No mutation is retried.
         _ = refusing(.invalidRuntimeReply(.malformed))
     }
 }

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
@@ -151,6 +151,99 @@ import XPC
         #expect(fixture.trace.steps.withLock { $0 } == before)
     }
 
+    @Test func deferredReplyRetainsOriginalContextAfterNativeCallbackReturns() async throws {
+        let fixture = try Fixture(deferredReplies: true)
+        defer { fixture.cancel() }
+        let response = fixture.request(try message(.current))
+        _ = try await next(fixture.processed)
+        #expect(fixture.trace.steps.withLock { $0 } == [.authenticated, .decoded, .registered])
+        #expect(fixture.executor.pending.withLock { $0.count } == 1)
+        #expect(fixture.gate.began() == 1, "the original callback still owes its reply")
+        #expect(!fixture.gate.finished()) // Balance only this synthetic observation.
+        fixture.executor.drain()
+        #expect(try await next(response) == .runtimeVersion(version))
+        #expect(fixture.trace.steps.withLock { Array($0.suffix(3)) } == [.probed, .sendAttempt, .sent])
+        #expect(fixture.gate.began() == 0)
+        #expect(!fixture.gate.finished())
+    }
+
+    @Test func deferredWorkerCapSpansNativeSessionsWithoutClosingEither() async throws {
+        let first = try Fixture(deferredReplies: true)
+        defer { first.cancel() }
+        let second = try Fixture(deferredReplies: true, sharedWorker: first.worker)
+        defer { second.cancel() }
+        var responses: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        for fixture in [first, second, first, second] {
+            responses.append(fixture.request(try message(.current)))
+            _ = try await next(fixture.processed)
+        }
+        #expect(first.executor.pending.withLock { $0.count } == 4)
+        #expect(failure(try await next(first.request(try message(.current)))) == .invalidRequest(.tooManyInFlight))
+        _ = try await next(first.processed)
+        #expect(first.gate.refusal == nil && second.gate.refusal == nil)
+        #expect(first.executor.pending.withLock { $0.count } == 4)
+        first.executor.drain()
+        for response in responses { #expect(try await next(response) == .runtimeVersion(version)) }
+        #expect(first.trace.steps.withLock { $0.filter { $0 == .probed }.count } == 2)
+        #expect(second.trace.steps.withLock { $0.filter { $0 == .probed }.count } == 2)
+    }
+
+    @Test func terminalNativeRefusalAnswersQueuedReadsBeforeCancelWithoutProbing() async throws {
+        let fixture = try Fixture(deferredReplies: true)
+        defer { fixture.cancel() }
+        var responses: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        for _ in 0..<2 {
+            responses.append(fixture.request(try message(.current)))
+            _ = try await next(fixture.processed)
+        }
+        responses.append(fixture.request(try message(.foreignHeader)))
+        _ = try await next(fixture.processed)
+        for response in responses {
+            #expect(failure(try await next(response)) == .protocolMismatch(client: 99, service: RuntimeProtocolVersion.current.rawValue))
+        }
+        let before = fixture.trace.steps.withLock { $0 }
+        #expect(before.filter { $0 == .sent }.count == 3)
+        #expect(before.filter { $0 == .canceled }.count == 1 && before.last == .canceled)
+        fixture.executor.drain() // Canceled queue entries still consume capacity until drained.
+        #expect(fixture.trace.steps.withLock { $0 } == before)
+        #expect(!before.contains(.probed))
+        #expect(fixture.gate.began() == nil)
+    }
+
+    @Test(arguments: [false, true])
+    func deferredEncodingOrSendFailureDrainsSiblingRepliesOnce(failSend: Bool) async throws {
+        let fixture = try Fixture(badVersion: !failSend, failSend: failSend, deferredReplies: true)
+        defer { fixture.cancel() }
+        var responses: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        for _ in 0..<3 {
+            responses.append(fixture.request(try message(.current)))
+            _ = try await next(fixture.processed)
+        }
+        fixture.executor.drain()
+        for response in responses {
+            if failSend { await #expect(throws: FixtureFailure.transport) { try await next(response) } }
+            else { #expect(failure(try await next(response)) == .invalidRuntimeReply(.malformed)) }
+        }
+        let trace = fixture.trace.steps.withLock { $0 }
+        #expect(trace.filter { $0 == .probed }.count == 1, "the remaining queued reads were refused")
+        #expect(trace.filter { $0 == .sendAttempt }.count == 3, "each original context is attempted only once")
+        #expect(trace.filter { $0 == .canceled }.count == 1 && trace.last == .canceled)
+        #expect(fixture.gate.began() == nil)
+    }
+
+    @Test func oneWayNeverPlansDeferredWorkOrConsumesTheFollowingReplyContext() async throws {
+        let fixture = try Fixture(deferredReplies: true)
+        defer { fixture.cancel() }
+        try fixture.client.send(message: try message(.current))
+        _ = try await next(fixture.processed)
+        #expect(fixture.executor.pending.withLock { $0.isEmpty })
+        #expect(fixture.trace.steps.withLock { $0 } == [.authenticated, .diagnostic])
+        let response = fixture.request(try message(.current))
+        _ = try await next(fixture.processed)
+        fixture.executor.drain()
+        #expect(try await next(response) == .runtimeVersion(version))
+    }
+
     private func message(_ shape: Shape) throws -> XPCDictionary {
         var result = XPCDictionary()
         result["protocolVersion"] = Int64(RuntimeProtocolVersion.current.rawValue)
@@ -182,7 +275,7 @@ import XPC
 }
 
 private let version = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
-private enum Step { case authenticated, decoded, registered, diagnostic, sendAttempt, sent, canceled }
+private enum Step { case authenticated, decoded, registered, probed, diagnostic, sendAttempt, sent, canceled }
 private final class Trace: Sendable {
     let steps = Mutex<[Step]>([])
     let diagnostics = Mutex<[DiagnosticEvent]>([])
@@ -192,14 +285,22 @@ private final class Trace: Sendable {
 private final class Fixture: Sendable {
     let trace = Trace()
     let state = SessionState()
+    let gate: RuntimeSessionGate
+    let executor = DeferredExecutor()
+    let worker: RuntimeReadOnlyWorker
     let listener: XPCListener
     let client: XPCSession
     let processed: AsyncThrowingStream<Bool, any Error>
 
     init(authorized: Bool = true, usePublicPolicy: Bool = false, gate: RuntimeSessionGate = RuntimeSessionGate(),
-         refuseDuringDecode: Bool = false, badVersion: Bool = false, failSend: Bool = false) throws {
+         refuseDuringDecode: Bool = false, badVersion: Bool = false, failSend: Bool = false,
+         deferredReplies: Bool = false, sharedWorker: RuntimeReadOnlyWorker? = nil) throws {
         let (stream, completion) = AsyncThrowingStream<Bool, any Error>.makeStream()
         processed = stream
+        self.gate = gate
+        let executor = executor
+        let worker = sharedWorker ?? RuntimeReadOnlyWorker(enqueue: { executor.enqueue($0) })
+        self.worker = worker
         let trace = trace, state = state
         let listener = XPCListener { request in
             request.accept { session in
@@ -210,17 +311,18 @@ private final class Fixture: Sendable {
                 let native: NativeRuntimeRequestHandler
                 if usePublicPolicy { native = NativeRuntimeRequestHandler(session: session, version: version, diagnostic: log) }
                 else {
-                    native = NativeRuntimeRequestHandler(gate: gate,
+                    native = NativeRuntimeRequestHandler(gate: gate, worker: worker,
                         authenticate: { _ in trace.record(.authenticated); return authorized },
                         decode: { bytes, count in
                             trace.record(.decoded)
                             if refuseDuringDecode { gate.refuse(.failed(OperationID(), .unauthorizedCaller)) }
                             return RuntimeDispatcher.decide(bytes, inFlight: count)
                         },
-                        register: { request in
+                        plan: { request in
                             trace.record(.registered)
-                            return NativeRuntimeRequestHandler.queryReply(request, version: badVersion
+                            let result = NativeRuntimeRequestHandler.queryReply(request, version: badVersion
                                 ? RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(99)) : version)
+                            return deferredReplies ? .readOnly { trace.record(.probed); return result } : .immediate(result)
                         },
                         send: { reply in
                             trace.record(.sendAttempt)
@@ -251,9 +353,21 @@ private final class Fixture: Sendable {
     }
 
     func cancel() {
+        // Explicitly settle/drain queued fixtures even when an earlier assertion throws.
+        // Synthetic read closures never touch the host or launch work during cleanup.
+        worker.refuse(gate, with: .failed(OperationID(), .invalidRuntimeReply(.malformed)))
+        executor.drain()
         client.cancel(reason: "test completed")
         state.accepted.withLock { $0 }?.cancel(reason: "test completed")
         listener.cancel()
+    }
+}
+
+private final class DeferredExecutor: Sendable {
+    let pending = Mutex<[@Sendable () -> Void]>([])
+    func enqueue(_ work: @escaping @Sendable () -> Void) { pending.withLock { $0.append(work) } }
+    func drain() {
+        while let work = pending.withLock({ $0.isEmpty ? nil : $0.removeFirst() }) { work() }
     }
 }
 

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
@@ -244,6 +244,45 @@ import XPC
         #expect(try await next(response) == .runtimeVersion(version))
     }
 
+    @Test func rejectedPlanReleasesCapturedOwnerAfterUnlockAndReplyHandoff() async throws {
+        let fixture = try Fixture(deferredReplies: true, captureLifetime: true)
+        defer { fixture.cancel() }
+        var responses: [AsyncThrowingStream<RuntimeEvent, any Error>] = []
+        for _ in 0..<4 {
+            responses.append(fixture.request(try message(.current)))
+            _ = try await next(fixture.processed)
+        }
+        #expect(!fixture.trace.steps.withLock { $0.contains(.released) })
+        #expect(failure(try await next(fixture.request(try message(.current)))) == .invalidRequest(.tooManyInFlight))
+        _ = try await next(fixture.processed)
+        #expect(fixture.trace.steps.withLock { Array($0.suffix(2)) } == [.sent, .released])
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .released }.count } == 1)
+        #expect(fixture.gate.refusal == nil)
+        fixture.executor.drain()
+        for response in responses { #expect(try await next(response) == .runtimeVersion(version)) }
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .released }.count } == 5)
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .probed }.count } == 4)
+    }
+
+    @Test(arguments: [false, true])
+    func acceptedPlanRetainsItsOwnerUntilActualQueueDrain(refuse: Bool) async throws {
+        let fixture = try Fixture(deferredReplies: true, captureLifetime: true)
+        defer { fixture.cancel() }
+        let response = fixture.request(try message(.current))
+        _ = try await next(fixture.processed)
+        if refuse {
+            let expected = GuesthouseError.protocolMismatch(client: 99, service: RuntimeProtocolVersion.current.rawValue)
+            #expect(failure(try await next(fixture.request(try message(.foreignHeader)))) == expected)
+            _ = try await next(fixture.processed)
+            #expect(failure(try await next(response)) == expected)
+        }
+        #expect(!fixture.trace.steps.withLock { $0.contains(.released) })
+        fixture.executor.drain()
+        if !refuse { #expect(try await next(response) == .runtimeVersion(version)) }
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .released }.count } == 1)
+        #expect(fixture.trace.steps.withLock { $0.filter { $0 == .probed }.count } == (refuse ? 0 : 1))
+    }
+
     private func message(_ shape: Shape) throws -> XPCDictionary {
         var result = XPCDictionary()
         result["protocolVersion"] = Int64(RuntimeProtocolVersion.current.rawValue)
@@ -275,7 +314,7 @@ import XPC
 }
 
 private let version = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
-private enum Step { case authenticated, decoded, registered, probed, diagnostic, sendAttempt, sent, canceled }
+private enum Step { case authenticated, decoded, registered, probed, released, diagnostic, sendAttempt, sent, canceled }
 private final class Trace: Sendable {
     let steps = Mutex<[Step]>([])
     let diagnostics = Mutex<[DiagnosticEvent]>([])
@@ -294,7 +333,8 @@ private final class Fixture: Sendable {
 
     init(authorized: Bool = true, usePublicPolicy: Bool = false, gate: RuntimeSessionGate = RuntimeSessionGate(),
          refuseDuringDecode: Bool = false, badVersion: Bool = false, failSend: Bool = false,
-         deferredReplies: Bool = false, sharedWorker: RuntimeReadOnlyWorker? = nil) throws {
+         deferredReplies: Bool = false, sharedWorker: RuntimeReadOnlyWorker? = nil,
+         captureLifetime: Bool = false) throws {
         let (stream, completion) = AsyncThrowingStream<Bool, any Error>.makeStream()
         processed = stream
         self.gate = gate
@@ -322,7 +362,11 @@ private final class Fixture: Sendable {
                             trace.record(.registered)
                             let result = NativeRuntimeRequestHandler.queryReply(request, version: badVersion
                                 ? RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(99)) : version)
-                            return deferredReplies ? .readOnly { trace.record(.probed); return result } : .immediate(result)
+                            guard deferredReplies else { return .immediate(result) }
+                            let owner = captureLifetime ? PlanOwner(gate: gate, trace: trace) : nil
+                            return .readOnly {
+                                withExtendedLifetime(owner) { trace.record(.probed); return result }
+                            }
                         },
                         send: { reply in
                             trace.record(.sendAttempt)
@@ -368,6 +412,17 @@ private final class DeferredExecutor: Sendable {
     func enqueue(_ work: @escaping @Sendable () -> Void) { pending.withLock { $0.append(work) } }
     func drain() {
         while let work = pending.withLock({ $0.isEmpty ? nil : $0.removeFirst() }) { work() }
+    }
+}
+
+private final class PlanOwner: Sendable {
+    let gate: RuntimeSessionGate
+    let trace: Trace
+    init(gate: RuntimeSessionGate, trace: Trace) { self.gate = gate; self.trace = trace }
+    deinit {
+        // Observable reentry: destroying the last captured owner under the gate would fail.
+        _ = gate.refusal
+        trace.record(.released)
     }
 }
 


### PR DESCRIPTION
## Summary

Connect the merged bounded read-only worker to native XPC reply ownership. This is the next focused migration for #12 / reference #61 and the shared runtime boundary in #19 / #112, implementing `MVP-PLAN.md` §§3 and 11 under ADR 0002 and ADR 0003.

- Select an internal immediate/deferred reply plan under the authenticated registration gate; reserve there and schedule only after unlocking.
- Retain the original native reply context until explicit, exactly-once handoff. Terminal refusal settles queued replies before session cancellation; queued/running reads keep their bounded capacity until actual drain/return.
- Keep captured owners alive outside registration locks, including worker-full rejection. Preserve fixed caller authentication, message admission, one-way rejection, typed diagnostics and no retry after uncertain send.

Public production dispatch still supports **runtimeVersion only**. No host-preflight operation, storage preparation, provider/VM operation, arbitrary command, credential flow or new logging surface is enabled.

## Scope and ancestry

Reuses the existing `mvp/native-deferred-replies` implementation and regressions, with an ordinary merge of current main `8790d03e804fdfa0cc6b4eb9bb516d8017437388`. The PR diff is two files, 235 additions / 16 deletions (251 changed lines). No force-push or legacy-history removal.

The owner merged prerequisite #175 at September 12, 17:30:06 UTC. Its final commit passed Cloud; its old thumbs-up covered an earlier commit and the correction review was quota-blocked. That history is not a matching review for this new PR. This PR requires its own exact-head Cloud and Codex review gates.

## Verification

- `git diff --check origin/main...HEAD`: passed.
- All seven shell-only `Tests/CI/test-package-hook.sh` fixture scenarios: passed.
- Seven additional Swift Testing functions / nine cases cover deferred context/accounting, process-wide capacity across native sessions, queued refusal before cancel, encoding/send failure, one-way messages, and captured-owner lifetime on rejection and drain.
- No local Swift/Xcode compilation or package-test execution: the owner requested origin/Xcode Cloud validation. On exact head `3dc4bfa98d9b120e9cf1f2898da836de8c101c03`, Cloud completed SUCCESS at September 12, 17:43:49 UTC; matching Codex review completed at 17:41:00 UTC and the original-message thumbs-up arrived at 17:41:03 UTC. No findings, all requested pages complete, MERGEABLE/CLEAN on main and subscription verified. **Ready for the owner to merge.** [Gate evidence](https://github.com/PicoMLX/Guesthouse/pull/176#issuecomment-5647657722).

The Swift Concurrency and Swift Testing checks focused on explicit Sendable captures, synchronous lock boundaries, deterministic queue control and bounded asynchronous response waits. No unsafe concurrency exemption or scheduling sleep was added.

## Remaining work

Keep #12/#61 open. The existing named preflight query/client slice follows this PR; service-owned volume selection/persistence and wizard freshness still need integration. Lume remains a candidate, and signed/hardware/complete-path gates are not established by these tests. The owner alone merges after green exact-head CI, matching completed review, an original-message Codex thumbs-up, and explained/resolved findings.
