### PR TITLE
Add named host-preflight protocol and one-shot client

### DIFF
--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeClient.swift
@@ -38,7 +38,9 @@ public final class RuntimeClient: RuntimeBackend {
             inbox.ended(key, reason) // End callback only enqueues; never performs native cleanup.
         }
         do {
-            if !permitsOperations, request != .runtimeVersion { throw GuesthouseError.invalidRequest(.unsupportedOperation) }
+            if !permitsOperations, request != .runtimeVersion, request != .hostPreflight {
+                throw GuesthouseError.invalidRequest(.unsupportedOperation)
+            }
             let envelope = RuntimeRequestEnvelope(request: request)
             try RequestValidator.validate(envelope)
             try RequestValidator.validateEncodedSize(JSONEncoder().encode(envelope))

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventRouter.swift
@@ -130,7 +130,7 @@ struct RuntimeEventRouter: Sendable {
     mutating func incoming(_ event: RuntimeEvent) -> [Effect] {
         guard !requiresRetirement else { return [] }
         switch event {
-        case .accepted, .runtimeVersion: return fault(.malformedResponse)
+        case .accepted, .runtimeVersion, .hostPreflight: return fault(.malformedResponse)
         case .status(let status) where status.inFlightOperation == nil:
             for entry in requests.values where entry.operation != nil && entry.request.environment == status.environmentID {
                 entry.producer.push(event)
@@ -211,18 +211,18 @@ struct RuntimeEventRouter: Sendable {
 
 extension RuntimeRequest {
     var mayMutate: Bool {
-        switch self { case .runtimeVersion, .environmentStatus: false; default: true }
+        switch self { case .runtimeVersion, .hostPreflight, .environmentStatus: false; default: true }
     }
     var environment: EnvironmentID? {
         switch self {
         case .environmentStatus(let id), .startEnvironment(let id, _), .stopEnvironment(let id, _), .importXcode(let id, _): id
-        case .runtimeVersion, .cancelOperation: nil
+        case .runtimeVersion, .hostPreflight, .cancelOperation: nil
         }
     }
     var acceptsOperation: Bool {
         switch self {
         case .startEnvironment, .stopEnvironment, .importXcode: true
-        case .runtimeVersion, .environmentStatus, .cancelOperation: false
+        case .runtimeVersion, .hostPreflight, .environmentStatus, .cancelOperation: false
         }
     }
     var cancellationTarget: OperationID? {
@@ -232,6 +232,7 @@ extension RuntimeRequest {
         if case .failed = event { return true } // Correlated service rejection, not a live registration.
         switch (self, event) {
         case (.runtimeVersion, .runtimeVersion(let info)): return info.protocolVersion == .current
+        case (.hostPreflight, .hostPreflight(let report)): return report.isComplete
         case (.environmentStatus(let id), .status(let status)): return status.environmentID == id
         case (.cancelOperation, .completed): return true // Cancel-request acknowledgement, not proof its target stopped.
         case (_, .accepted): return acceptsOperation
@@ -245,7 +246,7 @@ extension RuntimeEvent {
         case .accepted(let id), .progress(let id, _), .completed(let id), .failed(let id, _): id
         case .diagnostic(let event): OperationID(uuid: event.operationID)
         case .status(let status): status.inFlightOperation
-        case .runtimeVersion: nil
+        case .runtimeVersion, .hostPreflight: nil
         }
     }
     var isTerminal: Bool {

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeEventStream.swift
@@ -57,7 +57,7 @@ final class RuntimeEventStream: Sendable {
             state.receivedReply = true
             switch event {
             case .accepted(let id): state.operation = id; state.queue.append(event); return false
-            case .runtimeVersion, .status, .completed, .failed:
+            case .runtimeVersion, .hostPreflight, .status, .completed, .failed:
                 state.queue.append(event); state.end = .finished; return true
             case .progress, .diagnostic:
                 state.end = .failed(failure(.malformedResponse, state: state)); return true
@@ -82,7 +82,7 @@ final class RuntimeEventStream: Sendable {
             case .status(let status):
                 guard status.inFlightOperation == nil || status.inFlightOperation == id else { return false }
                 terminal = false // Unscoped environment snapshots must be filtered by the client.
-            case .runtimeVersion, .accepted:
+            case .runtimeVersion, .hostPreflight, .accepted:
                 state.end = .failed(failure(.malformedResponse, state: state)); return true
             }
             // Nonterminal traffic can never consume the last terminal slot.

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeHostPreflightQuery.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/RuntimeHostPreflightQuery.swift
@@ -1,0 +1,70 @@
+import GuesthouseCore
+
+/// One read-only host check (#12, MVP-PLAN.md §§2–3), using the existing backend owner.
+/// A report is not mutation admission. The GUI must still fence superseded check results.
+public enum RuntimeHostPreflightQuery {
+    public enum Failure: Error, Hashable, Sendable {
+        case runtime(GuesthouseError), connection(RuntimeSessionFailure), timedOut, canceled
+
+        public var userMessage: String {
+            switch self {
+            case .runtime(let error): error.userMessage
+            case .connection(let error): error.userMessage
+            case .timedOut: "The runtime service did not answer the host check within 10 seconds."
+            case .canceled: "The host check was canceled."
+            }
+        }
+        public var recoveryMessage: String {
+            switch self {
+            case .runtime(let error): error.recoveryMessage
+            case .connection(let error): error.recoveryActions.map(\.title).joined(separator: "; ")
+            case .timedOut: "Try this read-only check again. If it keeps timing out, quit and reopen Guesthouse."
+            case .canceled: "You can run another read-only host check when ready."
+            }
+        }
+    }
+    public typealias Outcome = Result<PreflightReport, Failure>
+
+    @concurrent public static func run() async -> Outcome {
+        let deadline = ContinuousClock.now + .seconds(10)
+        return await perform(connect: nil, deadline: { try await ContinuousClock().sleep(until: deadline) })
+    }
+
+    // Session/deadline injection is package-only, not caller-selected paths, policy or commands.
+    static func perform(connect: XPCRuntimeTransport.Connect?,
+                        deadline: @escaping @Sendable () async throws -> Void) async -> Outcome {
+        guard !Task.isCancelled else { return .failure(.canceled) }
+        // As in RuntimeVersionQuery, disable the client's second timer. Await both structured
+        // children and explicit close before another user-requested check can reuse the UI.
+        let client = RuntimeClient(connect: connect, permitsOperations: false, deadline: nil)
+        let stream = client.send(.hostPreflight)
+        await client.flush()
+        let outcome = await withTaskGroup(of: Outcome.self) { group in
+            group.addTask {
+                do {
+                    for try await event in stream {
+                        switch event {
+                        case .hostPreflight(let report) where report.isComplete: return .success(report)
+                        case .failed(_, let error): return .failure(.runtime(error))
+                        default: return .failure(.connection(.init(cause: .malformedResponse, operationID: event.routingID)))
+                        }
+                    }
+                    return .failure(.canceled)
+                } catch let failure as RuntimeSessionFailure { return .failure(.connection(failure)) }
+                catch GuesthouseError.canceled { return .failure(.canceled) }
+                catch GuesthouseError.runtimeIncompatible { return .failure(.connection(.init(cause: .connectionLost))) }
+                catch let error as GuesthouseError { return .failure(.runtime(error)) }
+                catch { return .failure(.connection(.init(cause: .connectionLost))) }
+            }
+            group.addTask {
+                do { try await deadline(); return .failure(.timedOut) }
+                catch { return .failure(.canceled) }
+            }
+            defer { group.cancelAll() }
+            let value = await group.next() ?? .failure(.canceled)
+            return Task.isCancelled ? .failure(.canceled) : value
+        }
+        await client.close()
+        return Task.isCancelled ? .failure(.canceled) : outcome
+    }
+}

--- a/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
+++ b/Packages/GuesthouseClientKit/Sources/GuesthouseClientKit/XPCRuntimeTransport.swift
@@ -55,7 +55,7 @@ public final class XPCRuntimeTransport: Sendable {
         let lease = try activeSession()
         let mayMutate: Bool
         switch envelope.request {
-        case .runtimeVersion, .environmentStatus: mayMutate = false
+        case .runtimeVersion, .hostPreflight, .environmentStatus: mayMutate = false
         case .startEnvironment, .stopEnvironment, .importXcode, .cancelOperation: mayMutate = true
         }
         // Retain the registry, not self: deinit can cancel pending work, while late callbacks

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeClientTests.swift
@@ -34,6 +34,39 @@ import Testing
         #expect(await client.reconciliation().0.isEmpty)
     }
 
+    @Test func publicQueryPolicyAllowsPreflightButDoesNotOpenTheOperationAPI() async throws {
+        let fixture = OwnerFixture(), client = fixture.client(permitsOperations: false)
+        var query = client.send(.hostPreflight).makeAsyncIterator()
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        #expect(peer.requests == [.hostPreflight])
+        let report = PreflightCheck.run(snapshot: HostProbeSnapshot())
+        peer.answer(0, .success(.hostPreflight(report)))
+        #expect(try await query.next() == .hostPreflight(report))
+        #expect(try await query.next() == nil)
+        var mutation = client.send(Self.start).makeAsyncIterator()
+        await #expect(throws: GuesthouseError.invalidRequest(.unsupportedOperation)) { try await mutation.next() }
+        #expect(peer.requests == [.hostPreflight])
+        #expect(await client.reconciliation().0.isEmpty)
+        await client.close()
+        #expect(peer.cancelCount == 1)
+    }
+
+    @Test func preflightTransportFailureDoesNotInventAnUnknownMutationOrReplay() async throws {
+        let fixture = OwnerFixture(), client = fixture.client(permitsOperations: false)
+        var query = client.send(.hostPreflight).makeAsyncIterator()
+        await client.flush()
+        let peer = try #require(fixture.latest)
+        peer.answer(0, .failure(.init(cause: .connectionLost)))
+        await #expect(throws: RuntimeSessionFailure(cause: .connectionLost)) { try await query.next() }
+        await client.flush()
+        #expect(await client.reconciliation().0.isEmpty)
+        #expect(await client.reconciliation().1.isEmpty)
+        #expect(peer.requests == [.hostPreflight])
+        #expect(fixture.connectionCount == 1)
+        await client.close()
+    }
+
     @Test(arguments: [false, true])
     func abandoningAnOperationSendsOneTrackedCancellation(beforeReply: Bool) async throws {
         let fixture = OwnerFixture(), client = fixture.client()
@@ -207,11 +240,12 @@ private final class OwnerFixture: Sendable {
     private let peers = Mutex<[OwnerPeer]>([])
     var latest: OwnerPeer? { peers.withLock { $0.last } }
     var connectionCount: Int { peers.withLock { $0.count } }
-    func client(deadline: @escaping RuntimeClient.Deadline = { try await Task.sleep(for: .seconds(10)) }) -> RuntimeClient {
+    func client(permitsOperations: Bool = true,
+                deadline: @escaping RuntimeClient.Deadline = { try await Task.sleep(for: .seconds(10)) }) -> RuntimeClient {
         RuntimeClient(connect: { [self] incoming, dropped in
             let peer = OwnerPeer(incoming: incoming, dropped: dropped)
             peers.withLock { $0.append(peer) }; return peer
-        }, deadline: deadline)
+        }, permitsOperations: permitsOperations, deadline: deadline)
     }
 }
 private final class OwnerPeer: RuntimeClientSession {

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventRouterTests.swift
@@ -5,6 +5,7 @@ import Testing
 @Suite(.timeLimit(.minutes(1))) struct RuntimeEventRouterTests {
     static let environment = EnvironmentID(), id = OperationID()
     static let info = RuntimeVersionInfo(serviceVersion: "1", serviceBuild: "1")
+    static let preflight = PreflightCheck.run(snapshot: HostProbeSnapshot())
     static let traffic: [RuntimeEvent] = [
         .progress(id, .init(kind: .copying)),
         .diagnostic(.init(operation: .startEnvironment, outcome: .started, operationID: id.uuid)),
@@ -51,6 +52,7 @@ import Testing
     @Test func queryRepliesAndKnownLocalRejectionsSettleWithoutCancellation() async throws {
         let cases: [(RuntimeRequest, RuntimeEvent)] = [
             (.runtimeVersion, .runtimeVersion(Self.info)),
+            (.hostPreflight, .hostPreflight(Self.preflight)),
             (.environmentStatus(Self.environment), .status(.init(environmentID: Self.environment, vm: .stopped, readiness: .checking))),
             (.cancelOperation(Self.id), .completed(OperationID())),
             (.startEnvironment(Self.environment, .init()), .failed(Self.id, .runtimeMissing)),
@@ -68,10 +70,10 @@ import Testing
         #expect(router.isIdle)
     }
 
-    @Test(arguments: [false, true])
-    func unexpectedReplyRetainsIdentityAndRetires(accepted: Bool) async throws {
+    @Test(arguments: [false, true], [RuntimeRequest.runtimeVersion, .hostPreflight])
+    func unexpectedReplyRetainsIdentityAndRetires(accepted: Bool, request: RuntimeRequest) async throws {
         var router = RuntimeEventRouter()
-        let fixture = try start(&router, request: .runtimeVersion)
+        let fixture = try start(&router, request: request)
         let event: RuntimeEvent = accepted ? .accepted(Self.id) : .progress(Self.id, .init(kind: .copying))
         let failure = RuntimeSessionFailure(cause: .malformedResponse, operationID: Self.id)
         #expect(router.reply(.success(event), to: fixture.key) == [unknown(fixture, failure, environment: nil), .retireConnection])
@@ -92,6 +94,10 @@ import Testing
             #expect(try await collectRouting(fixture.stream) == [.accepted(Self.id), .completed(Self.id)])
         }
         let cases: [(RuntimeRequest, RuntimeEvent, RuntimeSessionFailure.Cause)] = [
+            (.hostPreflight, .runtimeVersion(Self.info), .malformedResponse),
+            (.runtimeVersion, .hostPreflight(Self.preflight), .malformedResponse),
+            (.hostPreflight, .hostPreflight(.init(results: [], storage: Self.preflight.storage,
+                                                powerSource: .unknown, checkedAt: Self.preflight.checkedAt)), .malformedResponse),
             (.environmentStatus(Self.environment), .status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)), .malformedResponse),
             (.runtimeVersion, .runtimeVersion(.init(serviceVersion: "1", serviceBuild: "1", protocolVersion: .init(11))), .protocolMismatch(service: 11)),
         ]
@@ -101,6 +107,38 @@ import Testing
             #expect(router.reply(.success(event), to: fixture.key) == [.retireConnection])
             await #expect(throws: RuntimeSessionFailure(cause: cause)) { try await collectRouting(fixture.stream) }
         }
+    }
+
+    @Test func preflightRepliesKeepTheirOwningRequestAndNeverBecomePushes() async throws {
+        var router = RuntimeEventRouter()
+        let first = try start(&router, request: .hostPreflight)
+        let second = try start(&router, request: .hostPreflight)
+        let other = PreflightReport(results: Self.preflight.results, storage: Self.preflight.storage,
+                                    powerSource: .battery, checkedAt: Self.preflight.checkedAt)
+        #expect(router.reply(.success(.hostPreflight(other)), to: second.key).isEmpty)
+        #expect(router.reply(.success(.hostPreflight(Self.preflight)), to: first.key).isEmpty)
+        #expect(try await collectRouting(first.stream) == [.hostPreflight(Self.preflight)])
+        #expect(try await collectRouting(second.stream) == [.hostPreflight(other)])
+        #expect(router.isIdle)
+        #expect(router.incoming(.hostPreflight(other)) == [.retireConnection])
+        #expect(router.pendingIDCount == 0)
+    }
+
+    @Test func preflightCannotAcknowledgeOrCompleteAnOperation() async throws {
+        let request = RuntimeRequest.startEnvironment(Self.environment, .init())
+        #expect(!request.acceptsReply(.hostPreflight(Self.preflight)))
+        #expect(!RuntimeRequest.hostPreflight.mayMutate)
+        #expect(!RuntimeRequest.hostPreflight.acceptsOperation)
+        #expect(RuntimeRequest.hostPreflight.environment == nil)
+        #expect(RuntimeRequest.hostPreflight.cancellationTarget == nil)
+        #expect(RuntimeEvent.hostPreflight(Self.preflight).routingID == nil)
+        var router = RuntimeEventRouter()
+        let fixture = try start(&router, request: request)
+        let failure = RuntimeSessionFailure(cause: .malformedResponse, mayHaveMutated: true)
+        #expect(router.reply(.success(.hostPreflight(Self.preflight)), to: fixture.key) == [
+            unknown(fixture, failure), .retireConnection,
+        ])
+        await #expect(throws: failure) { try await collectRouting(fixture.stream) }
     }
 
     @Test func pendingIDOverflowFailsClosedAndKeepsTheLateOwningReply() async throws {
@@ -245,7 +283,7 @@ private struct Fixture {
 private func start(_ router: inout RuntimeEventRouter,
                    request: RuntimeRequest = .startEnvironment(RuntimeEventRouterTests.environment, .init())) throws -> Fixture {
     let mutating: Bool
-    switch request { case .runtimeVersion, .environmentStatus: mutating = false; default: mutating = true }
+    switch request { case .runtimeVersion, .hostPreflight, .environmentStatus: mutating = false; default: mutating = true }
     let fixture = Fixture(mutating: mutating)
     try #require(router.register(fixture.key, request: request, producer: fixture.producer) == .admitted)
     return fixture

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeEventStreamTests.swift
@@ -61,6 +61,7 @@ import Testing
     }
 
     @Test(arguments: [RuntimeEvent.runtimeVersion(info),
+                       .hostPreflight(PreflightCheck.run(snapshot: HostProbeSnapshot())),
                        .status(.init(environmentID: EnvironmentID(), vm: .stopped, readiness: .checking)),
                        .completed(id), .failed(id, .unauthorizedCaller)])
     func queryReplyFinishesOnce(event: RuntimeEvent) async throws {
@@ -68,6 +69,18 @@ import Testing
         pair.producer.reply(event)
         pair.producer.reply(.accepted(Self.id))
         #expect(try await collect(pair.stream) == [event])
+    }
+
+    @Test func unsolicitedPreflightCannotFinishALiveOperation() async throws {
+        let pair = RuntimeEventStream.make(mayHaveMutated: true) { _ in }
+        pair.producer.reply(.accepted(Self.id))
+        pair.producer.push(.hostPreflight(PreflightCheck.run(snapshot: HostProbeSnapshot())))
+        var iterator = pair.stream.makeAsyncIterator()
+        #expect(try await iterator.next() == .accepted(Self.id))
+        await #expect(throws: RuntimeSessionFailure(cause: .malformedResponse,
+                                                  operationID: Self.id, mayHaveMutated: true)) {
+            try await iterator.next()
+        }
     }
 
     @Test(arguments: [false, true])

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeTransportTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeTransportTests.swift
@@ -6,6 +6,19 @@ import Testing
 @testable import GuesthouseClientKit
 
 @Suite struct RuntimeTransportTests {
+    @Test func preflightFailureIsClassifiedReadOnlyAtTheTransportBoundary() throws {
+        let fixture = TransportFixture(.replyFails)
+        defer { fixture.releaseCallbacks() }
+        let client = fixture.client()
+        try client.send(.init(request: .hostPreflight)) { result in
+            fixture.replies.withLock { $0.append(result) }
+        }
+        let result = try #require(fixture.replies.withLock { $0.first })
+        #expect(throws: RuntimeSessionFailure(cause: .malformedResponse, mayHaveMutated: false)) {
+            try result.get()
+        }
+    }
+
     @Test func invalidOutgoingOptionsNeverConnect() {
         let fixture = TransportFixture()
         defer { fixture.releaseCallbacks() }

--- a/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
+++ b/Packages/GuesthouseClientKit/Tests/GuesthouseClientKitTests/RuntimeVersionQueryTests.swift
@@ -113,6 +113,105 @@ import Testing
     }
 }
 
+@Suite(.timeLimit(.minutes(1))) struct RuntimeHostPreflightQueryTests {
+    static let report = PreflightCheck.run(snapshot: HostProbeSnapshot())
+    static let id = OperationID()
+    static let cases: [(RuntimeEvent, RuntimeHostPreflightQuery.Outcome)] = [
+        (.hostPreflight(report), .success(report)),
+        (.failed(id, .invalidRequest(.unsupportedOperation)), .failure(.runtime(.invalidRequest(.unsupportedOperation)))),
+        (.runtimeVersion(.init(serviceVersion: "1", serviceBuild: "1")), .failure(.connection(.init(cause: .malformedResponse)))),
+        (.accepted(id), .failure(.connection(.init(cause: .malformedResponse, operationID: id)))),
+        (.hostPreflight(.init(results: [], storage: report.storage, powerSource: .unknown, checkedAt: report.checkedAt)),
+         .failure(.connection(.init(cause: .malformedResponse)))),
+    ]
+
+    @Test(arguments: cases)
+    func onlyACompleteOwningReportSucceeds(event: RuntimeEvent, expected: RuntimeHostPreflightQuery.Outcome) async {
+        let session = QuerySession([.success(event)], expectedRequest: .hostPreflight)
+        defer { session.releaseReply() }
+        #expect(await runPreflight(session) == expected)
+        #expect(session.cancellations.withLock { $0 } == 1)
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test(arguments: [RuntimeSessionFailure.Cause.connectionLost, .malformedResponse,
+                      .oversizedResponse, .protocolMismatch(service: 12)])
+    func nativeFailureRemainsReadOnlyAndKeepsItsCause(cause: RuntimeSessionFailure.Cause) async {
+        let session = QuerySession([.failure(.init(cause: cause))], expectedRequest: .hostPreflight)
+        defer { session.releaseReply() }
+        #expect(await runPreflight(session) == .failure(.connection(.init(cause: cause))))
+        #expect(session.cancellations.withLock { $0 } == 1)
+    }
+
+    @Test func setupFailureHasOnlyGuesthouseOwnedGuidance() async {
+        let value = await RuntimeHostPreflightQuery.perform(connect: { _, _ in
+            throw NSError(domain: "private-marker", code: 1)
+        }, deadline: waitForCancellation)
+        #expect(value == .failure(.connection(.init(cause: .connectionLost))))
+        if case .failure(let error) = value {
+            #expect(!(error.userMessage + error.recoveryMessage).contains("private-marker"))
+        }
+    }
+
+    @Test func aBlockedReportStillFinishesAndCancelsTheDeadline() async {
+        let canceled = Mutex(false)
+        let session = QuerySession([.success(.hostPreflight(Self.report))], expectedRequest: .hostPreflight)
+        defer { session.releaseReply() }
+        let result = await runPreflight(session, deadline: {
+            try await withTaskCancellationHandler { try await waitForCancellation() }
+            onCancel: { canceled.withLock { $0 = true } }
+        })
+        #expect(result == .success(Self.report))
+        #expect(!Self.report.canProceed)
+        #expect(canceled.withLock { $0 })
+        #expect(session.cancellations.withLock { $0 } == 1)
+    }
+
+    @Test(arguments: [0, 11])
+    func onlyTheSuppliedDeadlineTimesOutAndLateRepliesNeverReplay(seconds: Int) async {
+        let session = QuerySession([], expectedRequest: .hostPreflight)
+        defer { session.releaseReply() }
+        // Eleven seconds deliberately crosses the disabled inner client's ten-second timer.
+        #expect(await runPreflight(session, deadline: {
+            try await ContinuousClock().sleep(for: .seconds(seconds))
+        }) == .failure(.timedOut))
+        #expect(session.cancellations.withLock { $0 } == 1)
+        session.answerLate(.success(.hostPreflight(Self.report)))
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test func cancelingAPendingCheckAwaitsCleanupAndNeverReplays() async {
+        let (started, signal) = AsyncStream<Void>.makeStream(bufferingPolicy: .bufferingOldest(1))
+        let session = QuerySession([], expectedRequest: .hostPreflight, didSend: { signal.yield(()); signal.finish() })
+        defer { session.releaseReply(); signal.finish() }
+        let task = Task { await runPreflight(session) }
+        for await _ in started { break }
+        task.cancel()
+        #expect(await task.value == .failure(.canceled))
+        #expect(session.cancellations.withLock { $0 } == 1)
+        session.answerLate(.success(.hostPreflight(Self.report)))
+        #expect(session.sends.withLock { $0 } == 1)
+    }
+
+    @Test func anAlreadyCanceledCheckDoesNotCreateASession() async {
+        let (gate, finish) = AsyncStream<Void>.makeStream()
+        defer { finish.finish() }
+        let task = Task {
+            for await _ in gate { break }
+            return await RuntimeHostPreflightQuery.perform(connect: { _, _ in
+                Issue.record("Canceled preflight must not connect.")
+                return QuerySession([], expectedRequest: .hostPreflight)
+            }, deadline: waitForCancellation)
+        }
+        task.cancel()
+        #expect(await task.value == .failure(.canceled))
+    }
+}
+
+private func runPreflight(_ session: QuerySession,
+                         deadline: @escaping @Sendable () async throws -> Void = waitForCancellation) async -> RuntimeHostPreflightQuery.Outcome {
+    await RuntimeHostPreflightQuery.perform(connect: { _, _ in session }, deadline: deadline)
+}
 private func waitForCancellation() async throws { try await ContinuousClock().sleep(for: .seconds(60)) }
 private func run(_ session: QuerySession,
                  deadline: @escaping @Sendable () async throws -> Void = waitForCancellation) async -> RuntimeVersionQuery.Outcome {
@@ -122,16 +221,18 @@ private func run(_ session: QuerySession,
 private final class QuerySession: RuntimeClientSession {
     typealias Reply = @Sendable (Result<RuntimeEvent, RuntimeSessionFailure>) -> Void
     let responses: [Result<RuntimeEvent, RuntimeSessionFailure>]
+    let expectedRequest: RuntimeRequest
     let didSend: @Sendable () -> Void
     let cancellations = Mutex(0), sends = Mutex(0), reply = Mutex<Reply?>(nil)
-    init(_ responses: [Result<RuntimeEvent, RuntimeSessionFailure>], didSend: @escaping @Sendable () -> Void = {}) {
-        self.responses = responses; self.didSend = didSend
+    init(_ responses: [Result<RuntimeEvent, RuntimeSessionFailure>], expectedRequest: RuntimeRequest = .runtimeVersion,
+         didSend: @escaping @Sendable () -> Void = {}) {
+        self.responses = responses; self.expectedRequest = expectedRequest; self.didSend = didSend
     }
     func activate() throws {}
     func cancel() { cancellations.withLock { $0 += 1 } }
     func send(_ payload: Data, reply: @escaping Reply) {
-        do { let request = try RequestValidator.decode(payload); #expect(request.request == .runtimeVersion) }
-        catch { Issue.record("The connection check must send a valid read-only version request.") }
+        do { let request = try RequestValidator.decode(payload); #expect(request.request == expectedRequest) }
+        catch { Issue.record("The check must send its expected valid read-only request.") }
         sends.withLock { $0 += 1 }
         self.reply.withLock { $0 = reply }
         didSend()

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RequestValidator.swift
@@ -37,7 +37,7 @@ public enum RequestValidator: Sendable {
             throw .protocolMismatch(client: envelope.protocolVersion, service: .current)
         }
         switch envelope.request {
-        case .runtimeVersion, .environmentStatus, .cancelOperation, .stopEnvironment(_, .force): break
+        case .runtimeVersion, .hostPreflight, .environmentStatus, .cancelOperation, .stopEnvironment(_, .force): break
         case .startEnvironment(_, let options):
             guard options.ipWait >= .zero, options.ipWait <= maximumIPWait else {
                 throw .optionOutOfRange(.ipWait)

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEvent.swift
@@ -1,6 +1,8 @@
 /// Named service-to-GUI events (#9, MVP-PLAN.md §3). Private status is not a diagnostic.
 public enum RuntimeEvent: Codable, Hashable, Sendable {
     case runtimeVersion(RuntimeVersionInfo)
+    /// Terminal reply to its owning query, never an unsolicited operation event.
+    case hostPreflight(PreflightReport)
     /// The service must journal/register the operation before acknowledging acceptance.
     case accepted(OperationID)
     case progress(OperationID, ProgressPhase)
@@ -13,6 +15,7 @@ public enum RuntimeEvent: Codable, Hashable, Sendable {
     public var caseName: String {
         switch self {
         case .runtimeVersion: "runtimeVersion"
+        case .hostPreflight: "hostPreflight"
         case .accepted: "accepted"
         case .progress: "progress"
         case .diagnostic: "diagnostic"

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeEventEnvelope.swift
@@ -19,6 +19,9 @@ public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
         if case .runtimeVersion(let info) = decoded, info.protocolVersion != version {
             throw GuesthouseError.invalidRuntimeReply(.malformed)
         }
+        if case .hostPreflight(let report) = decoded, !report.isComplete {
+            throw GuesthouseError.invalidRuntimeReply(.malformed)
+        }
         protocolVersion = version
         event = decoded
     }
@@ -53,6 +56,9 @@ public struct RuntimeEventEnvelope: Codable, Hashable, Sendable {
             throw ProtocolMismatch(service: protocolVersion).error
         }
         if case .runtimeVersion(let info) = event, info.protocolVersion != protocolVersion {
+            throw .invalidRuntimeReply(.malformed)
+        }
+        if case .hostPreflight(let report) = event, !report.isComplete {
             throw .invalidRuntimeReply(.malformed)
         }
         do {

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeProtocolVersion.swift
@@ -4,9 +4,9 @@ public struct RuntimeProtocolVersion: Hashable, Sendable, Comparable, CustomStri
 
     public init(_ rawValue: Int) { self.rawValue = rawValue }
 
-    /// Epoch 12 activates bounded native frames and structured diagnostics on both endpoints.
-    /// Historical prototypes used 1–11. None is a compatible production fallback (ADR 0003).
-    public static let current = RuntimeProtocolVersion(12)
+    /// Epoch 13 adds the named host-preflight request/report to epoch 12's bounded frames.
+    /// Earlier epochs are not compatible fallbacks; GUI/service upgrade together (ADR 0003).
+    public static let current = RuntimeProtocolVersion(13)
 
     public static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
     public var description: String { "protocol \(rawValue)" }

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Contract/RuntimeRequest.swift
@@ -4,6 +4,8 @@ import Foundation
 /// private selection metadata is not a command, a diagnostic attachment, or access authority.
 public enum RuntimeRequest: Codable, Hashable, Sendable {
     case runtimeVersion
+    /// Read-only report; policy and storage identity are selected and retained by the service.
+    case hostPreflight
     case environmentStatus(EnvironmentID)
     case startEnvironment(EnvironmentID, StartOptions)
     case stopEnvironment(EnvironmentID, StopMode)
@@ -13,6 +15,7 @@ public enum RuntimeRequest: Codable, Hashable, Sendable {
     public var caseName: String {
         switch self {
         case .runtimeVersion: "runtimeVersion"
+        case .hostPreflight: "hostPreflight"
         case .environmentStatus: "environmentStatus"
         case .startEnvironment: "startEnvironment"
         case .stopEnvironment: "stopEnvironment"

--- a/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
+++ b/Packages/GuesthouseCore/Sources/GuesthouseCore/Preflight/PreflightCheck.swift
@@ -36,12 +36,16 @@ public struct PreflightReport: Codable, Hashable, Sendable {
         self.checkedAt = checkedAt
     }
 
+    /// Structural completeness is separate from success: a blocked report is still a valid reply.
+    public var isComplete: Bool {
+        results.count == PreflightCheckKind.allCases.count
+            && Set(results.map(\.kind)) == Set(PreflightCheckKind.allCases)
+    }
+
     /// Empty, partial, duplicated and blocking reports cannot proceed. A warning is an answer;
     /// an unavailable observation is not. Actual runtime safety checks remain mandatory.
     public var canProceed: Bool {
-        results.count == PreflightCheckKind.allCases.count
-            && Set(results.map(\.kind)) == Set(PreflightCheckKind.allCases)
-            && !results.contains(where: \.isBlocking)
+        isComplete && !results.contains(where: \.isBlocking)
     }
 
     public func result(_ kind: PreflightCheckKind) -> PreflightResult? {

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/HostPreflightWireTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/HostPreflightWireTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+@testable import GuesthouseCore
+
+struct HostPreflightWireTests {
+    static let blocked = PreflightCheck.run(snapshot: HostProbeSnapshot(), now: Date(timeIntervalSince1970: 0))
+    static let ready = PreflightCheck.run(snapshot: HostProbeSnapshot(
+        cpuArchitecture: .appleSilicon, operatingSystemVersion: SemanticVersion([99]),
+        physicalMemoryBytes: .max, powerSource: .externalPower, disk: .available(bytes: .max),
+        codexDesktop: .installed(version: nil, build: nil)
+    ), now: Date(timeIntervalSince1970: 0))
+
+    @Test func queryCarriesNoCallerSelectedPathPolicyOrIdentity() throws {
+        let input = Data(#"{"protocolVersion":13,"request":{"hostPreflight":{"path":"private-marker","volumeUUID":"private-marker","policy":"private-marker"}}}"#.utf8)
+        let envelope = try RequestValidator.decode(input)
+        #expect(envelope.request == .hostPreflight)
+        #expect(envelope.request.caseName == "hostPreflight")
+        let encoded = try JSONEncoder().encode(envelope.request)
+        let object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: [String: String]])
+        #expect(object == ["hostPreflight": [:]])
+    }
+
+    @Test(arguments: [blocked, ready])
+    func completeReportsRoundTripWithoutBecomingDiagnostics(report: PreflightReport) throws {
+        #expect(report.isComplete)
+        #expect(Self.ready.canProceed)
+        #expect(!Self.blocked.canProceed)
+        let envelope = RuntimeEventEnvelope(event: .hostPreflight(report))
+        #expect(try RuntimeEventEnvelope.decode(envelope.encoded()) == envelope)
+        #expect(envelope.event.caseName == "hostPreflight")
+        #expect(envelope.event.diagnosticEvent == nil)
+    }
+
+    @Test(arguments: [
+        [PreflightResult](), [.architectureUnknown],
+        Array(blocked.results.dropLast()),
+        Array(repeating: .architectureUnknown, count: 5),
+        blocked.results + [.architectureUnknown],
+    ])
+    func incompleteOrDuplicatedReportsAreRefusedOnBothWirePaths(results: [PreflightResult]) throws {
+        let report = PreflightReport(results: results, storage: Self.blocked.storage,
+                                    powerSource: .unknown, checkedAt: Self.blocked.checkedAt)
+        #expect(!report.isComplete)
+        #expect(!report.canProceed)
+        let envelope = RuntimeEventEnvelope(event: .hostPreflight(report))
+        let forged = try JSONEncoder().encode(envelope)
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try envelope.encoded() }
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(forged) }
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
+            try JSONDecoder().decode(RuntimeEventEnvelope.self, from: forged)
+        }
+    }
+
+    @Test func reportAttachmentsAreNotForwardedOrExported() throws {
+        var report = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.blocked)) as? [String: Any])
+        report["path"] = "private-marker"
+        report["error"] = ["Authorization": "private-marker"]
+        let object: [String: Any] = ["protocolVersion": 13, "event": ["hostPreflight": ["_0": report]]]
+        let decoded = try RuntimeEventEnvelope.decode(JSONSerialization.data(withJSONObject: object))
+        #expect(decoded.event == .hostPreflight(Self.blocked))
+        #expect(!String(decoding: try decoded.encoded(), as: UTF8.self).contains("private-marker"))
+    }
+
+    @Test func reportUsesTheExistingBoundBeforeParsing() throws {
+        var bytes = try RuntimeEventEnvelope(event: .hostPreflight(Self.blocked)).encoded()
+        bytes.append(Data(repeating: 32, count: 65_536 - bytes.count))
+        #expect(try RuntimeEventEnvelope.decode(bytes).event == .hostPreflight(Self.blocked))
+        bytes.append(0)
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.oversized)) { try RuntimeEventEnvelope.decode(bytes) }
+    }
+
+    @Test func nonfiniteCompletionTimeCannotLeaveTheEnvelope() {
+        let report = PreflightReport(results: Self.blocked.results, storage: Self.blocked.storage,
+                                    powerSource: .unknown, checkedAt: Date(timeIntervalSince1970: .infinity))
+        #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
+            try RuntimeEventEnvelope(event: .hostPreflight(report)).encoded()
+        }
+    }
+}

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeEventTests.swift
@@ -7,6 +7,7 @@ import Testing
     static let diagnostic = DiagnosticEvent(operation: .startEnvironment, outcome: .started, operationID: operation.uuid)
     static let events: [RuntimeEvent] = [
         .runtimeVersion(RuntimeVersionInfo(serviceVersion: "0.1.0", serviceBuild: "12")),
+        .hostPreflight(PreflightCheck.run(snapshot: HostProbeSnapshot())),
         .accepted(operation), .progress(operation, ProgressPhase(kind: .copying, fraction: 0.5)),
         .diagnostic(diagnostic), .status(RuntimeStatusTests.status()),
         .completed(operation), .failed(operation, .operationOutcomeUnknown(operation))
@@ -19,7 +20,7 @@ import Testing
         #expect(try RuntimeEventEnvelope.decode(data) == envelope)
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(Set(object.keys) == ["protocolVersion", "event"])
-        #expect(object["protocolVersion"] as? Int == 12)
+        #expect(object["protocolVersion"] as? Int == 13)
     }
 
     @Test(arguments: events)
@@ -28,10 +29,10 @@ import Testing
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(data) }
     }
 
-    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, Int.max])
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, Int.max])
     func foreignHeaderPrecedesUnknownEvent(version: Int) {
         let data = Data("{\"event\":{\"futureReply\":{}},\"protocolVersion\":\(version)}".utf8)
-        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: version)) {
+        #expect(throws: GuesthouseError.protocolMismatch(client: 13, service: version)) {
             try RuntimeEventEnvelope.decode(data)
         }
     }
@@ -41,7 +42,7 @@ import Testing
         let mismatch = try #require(throws: RuntimeEventEnvelope.ProtocolMismatch.self) {
             try JSONDecoder().decode(RuntimeEventEnvelope.self, from: data)
         }
-        #expect(mismatch.error == .protocolMismatch(client: 12, service: 7))
+        #expect(mismatch.error == .protocolMismatch(client: 13, service: 7))
     }
 
     @Test func contradictoryNestedVersionIsMalformedOnBothPaths() throws {
@@ -51,15 +52,15 @@ import Testing
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try RuntimeEventEnvelope.decode(forged) }
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) { try envelope.encoded() }
         let foreign = RuntimeEventEnvelope(protocolVersion: RuntimeProtocolVersion(7), event: Self.events[0])
-        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: 7)) { try foreign.encoded() }
+        #expect(throws: GuesthouseError.protocolMismatch(client: 13, service: 7)) { try foreign.encoded() }
         let foreignBytes = try JSONEncoder().encode(foreign)
-        #expect(throws: GuesthouseError.protocolMismatch(client: 12, service: 7)) { try RuntimeEventEnvelope.decode(foreignBytes) }
+        #expect(throws: GuesthouseError.protocolMismatch(client: 13, service: 7)) { try RuntimeEventEnvelope.decode(foreignBytes) }
     }
 
-    @Test(arguments: ["{}", "null", "not-json", #"{"protocolVersion":12}"#,
-                      #"{"protocolVersion":"12","event":{}}"#,
-                      #"{"protocolVersion":12,"event":{"log":{"_0":null,"_1":"private-marker"}}}"#,
-                      #"{"protocolVersion":12,"event":{"futureReply":{}}}"#])
+    @Test(arguments: ["{}", "null", "not-json", #"{"protocolVersion":13}"#,
+                      #"{"protocolVersion":"13","event":{}}"#,
+                      #"{"protocolVersion":13,"event":{"log":{"_0":null,"_1":"private-marker"}}}"#,
+                      #"{"protocolVersion":13,"event":{"futureReply":{}}}"#])
     func malformedOrRawLogRepliesAreFixedErrors(json: String) {
         #expect(throws: GuesthouseError.invalidRuntimeReply(.malformed)) {
             try RuntimeEventEnvelope.decode(Data(json.utf8))
@@ -105,7 +106,7 @@ import Testing
         var event = try #require(JSONSerialization.jsonObject(with: JSONEncoder().encode(Self.diagnostic)) as? [String: Any])
         event["message"] = "private-marker"
         event["stderr"] = "private-marker"
-        let object: [String: Any] = ["protocolVersion": 12, "event": ["diagnostic": ["_0": event]]]
+        let object: [String: Any] = ["protocolVersion": 13, "event": ["diagnostic": ["_0": event]]]
         let decoded = try RuntimeEventEnvelope.decode(JSONSerialization.data(withJSONObject: object))
         #expect(decoded.event.diagnosticEvent == Self.diagnostic)
         #expect(!String(decoding: try decoded.encoded(), as: UTF8.self).contains("private-marker"))
@@ -138,7 +139,7 @@ import Testing
 
     @Test(arguments: ["", "private marker", "0.1\u{1B}[31m", String(repeating: "1", count: 257)])
     func malformedMetadataBecomesUnknownWithoutInventingIdentity(value: String) throws {
-        let raw: [String: Any] = ["serviceVersion": value, "serviceBuild": value, "protocolVersion": 12,
+        let raw: [String: Any] = ["serviceVersion": value, "serviceBuild": value, "protocolVersion": 13,
                                   "runtime": ["provider": "lume", "version": value, "verified": true]]
         let info = try JSONDecoder().decode(RuntimeVersionInfo.self, from: JSONSerialization.data(withJSONObject: raw))
         #expect(info.serviceVersion == nil)
@@ -156,7 +157,7 @@ import Testing
         let failed = RuntimeIdentityInfo(provider: .lume, version: "0.5.3", verified: true, problem: .runtimeMissing)
         #expect(!failed.verified)
         #expect(failed.problem == .runtimeMissing)
-        let missing = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(#"{"protocolVersion":12}"#.utf8))
+        let missing = try JSONDecoder().decode(RuntimeVersionInfo.self, from: Data(#"{"protocolVersion":13}"#.utf8))
         #expect(missing.runtime == nil)
         #expect(missing.serviceVersion == nil)
         #expect(missing.serviceBuild == nil)

--- a/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
+++ b/Packages/GuesthouseCore/Tests/GuesthouseCoreTests/Contract/RuntimeRequestTests.swift
@@ -6,7 +6,7 @@ import Testing
     static let environment = EnvironmentID()
     static let operation = OperationID()
     static let requests: [RuntimeRequest] = [
-        .runtimeVersion, .environmentStatus(environment), .cancelOperation(operation),
+        .runtimeVersion, .hostPreflight, .environmentStatus(environment), .cancelOperation(operation),
         .startEnvironment(environment, StartOptions()),
         .startEnvironment(environment, StartOptions(console: .native, ipWait: .seconds(120))),
         .stopEnvironment(environment, .graceful(deadline: .seconds(60))),
@@ -21,7 +21,7 @@ import Testing
         let envelope = RuntimeRequestEnvelope(request: request)
         let data = try JSONEncoder().encode(envelope)
         #expect(try RequestValidator.decode(data) == envelope)
-        #expect(envelope.protocolVersion.rawValue == 12)
+        #expect(envelope.protocolVersion.rawValue == 13)
     }
 
     @Test(arguments: requests, ["executable", "arguments", "command", "shell", "--", "/bin/"])
@@ -30,12 +30,12 @@ import Testing
         #expect(!String(decoding: data, as: UTF8.self).lowercased().contains(forbidden))
     }
 
-    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 13, Int.max])
+    @Test(arguments: [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 14, Int.max])
     func foreignVersionPrecedesUnknownPayload(version: Int) {
         let data = Data("{\"protocolVersion\":\(version),\"request\":{\"futureRequest\":{}}}".utf8)
         let expected = RequestValidationError.protocolMismatch(client: RuntimeProtocolVersion(version), service: .current)
         #expect(throws: expected) { try RequestValidator.decode(data) }
-        #expect(expected.guesthouseError == .protocolMismatch(client: version, service: 12))
+        #expect(expected.guesthouseError == .protocolMismatch(client: version, service: 13))
     }
 
     @Test func directEnvelopeDecoderAlsoChecksHeaderFirst() throws {
@@ -43,12 +43,12 @@ import Testing
         let error = try #require(throws: RuntimeRequestEnvelope.ProtocolMismatch.self) {
             try JSONDecoder().decode(RuntimeRequestEnvelope.self, from: data)
         }
-        #expect(error.error == .protocolMismatch(client: 7, service: 12))
+        #expect(error.error == .protocolMismatch(client: 7, service: 13))
     }
 
     @Test(arguments: ["{}", "null", #"{"request":{"runtimeVersion":{}}}"#,
-                      #"{"protocolVersion":"12","request":{}}"#, #"{"protocolVersion":12}"#,
-                      #"{"protocolVersion":12,"request":{"runCommand":{"command":"private-marker"}}}"#])
+                      #"{"protocolVersion":"13","request":{}}"#, #"{"protocolVersion":13}"#,
+                      #"{"protocolVersion":13,"request":{"runCommand":{"command":"private-marker"}}}"#])
     func malformedRequestsAreTyped(json: String) {
         #expect(throws: RequestValidationError.malformed) { try RequestValidator.decode(Data(json.utf8)) }
     }
@@ -134,13 +134,13 @@ import Testing
     }
 
     @Test func unknownMetadataIsNotForwarded() throws {
-        let data = Data(#"{"protocolVersion":12,"private":"private-marker","request":{"runtimeVersion":{}}}"#.utf8)
+        let data = Data(#"{"protocolVersion":13,"private":"private-marker","request":{"runtimeVersion":{}}}"#.utf8)
         let encoded = try JSONEncoder().encode(RequestValidator.decode(data))
         #expect(!String(decoding: encoded, as: UTF8.self).contains("private-marker"))
     }
 
     @Test func malformedInputCannotReachStructuredErrorsOrExports() throws {
-        let data = Data(#"{"protocolVersion":12,"request":{"private-marker":{}}}"#.utf8)
+        let data = Data(#"{"protocolVersion":13,"request":{"private-marker":{}}}"#.utf8)
         let rejection = try #require(throws: RequestValidationError.self) { try RequestValidator.decode(data) }
         #expect(rejection.guesthouseError == .invalidRequest(.malformed))
         let event = DiagnosticEvent(operation: .importXcode, outcome: .init(error: rejection.guesthouseError), operationID: UUID())

--- a/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
+++ b/Packages/GuesthouseRuntimeKit/Tests/GuesthouseRuntimeKitTests/NativeRuntimeRequestHandlerTests.swift
@@ -68,7 +68,7 @@ import XPC
     @Test func productionRegistrationSupportsOnlyTheReadOnlyVersionQuery() {
         let environment = EnvironmentID()
         let requests: [RuntimeRequest] = [
-            .environmentStatus(environment), .startEnvironment(environment, StartOptions()),
+            .hostPreflight, .environmentStatus(environment), .startEnvironment(environment, StartOptions()),
             .stopEnvironment(environment, .force), .cancelOperation(OperationID()),
             .importXcode(environment, FileHandoff(kind: .fileDescriptor(token: UUID()), displayName: "Xcode.app")),
         ]


### PR DESCRIPTION
## Summary

Publish the existing named host-preflight protocol/client slice for #12 / retained reference #61, implementing `MVP-PLAN.md` §§2–3 and 11 under ADR 0002 and ADR 0003.

- Add parameterless `hostPreflight` request/report cases and bump the shared wire epoch to 13. No caller-supplied host path, volume UUID or policy is accepted; old epochs have no fallback.
- Validate complete, distinct report checks independently of readiness: a complete blocked report is a valid answer, while missing/duplicate checks fail closed. Preserve bounded framing, safe typed errors and non-propagation of unknown attachments.
- Route a report only to its owning query; it cannot acknowledge/complete an operation or arrive as an unsolicited push. Transport failures remain read-only and never imply an unknown mutation or authorize replay.
- Add a one-shot client with one ten-second deadline, explicit cancellation and awaited connection cleanup. Retain typed failure causes and Guesthouse-written recovery guidance.

**The public native handler still refuses hostPreflight.** This PR adds the protocol and client side, not probe activation, service-owned storage selection/persistence, a wizard, provider readiness or a VM operation. No GUI or Core host inspection, arbitrary command surface, raw-output diagnostics or credential flow is introduced.

## Dependency and size

Stacked on #176 (`mvp/native-deferred-replies`, reviewed head `3dc4bfa98d9b120e9cf1f2898da836de8c101c03`). The owner must merge #176 first; then settle this PR on main and recheck its own gates. **Never merge this child into its feature-branch base.**

Reuses `mvp/host-preflight-wire` at `92ed5358907a43f4706b3c7915c83a2970e53a22`: 20 files, 417 additions / 49 deletions (466 changed lines) above #176. Ordinary ancestry merges preserve the previous tests and source. The main-integration conflict retains both #167's missing-version regression and the epoch-13 foreign-version rejection cases.

## Verification

- Full source/test diff review and `git diff --check`: passed.
- Seven shell-only `Tests/CI/test-package-hook.sh` scenarios: passed.
- Nineteen new Swift Testing functions plus expanded existing cases cover parameterless requests, wire completeness/size/epoch checks, request correlation, read-only failure classification, timeout, cancellation, late replies and connection cleanup.
- No local Swift/Xcode compilation or package-test execution: the owner requested origin/Xcode Cloud validation. On exact head `92ed5358907a43f4706b3c7915c83a2970e53a22`, Cloud Test completed SUCCESS at September 12, 18:01:01 UTC and the aggregate workflow is SUCCESS. Matching Codex review completed 17:57:38 UTC; the original PR message received the bot thumbs-up at 17:57:41 UTC. No inline or standalone findings, all requested pages complete, and subscription verified. **Dependency-held:** #176 must merge first, then this PR must settle on main and have composition/gates rechecked. [Gate evidence](https://github.com/PicoMLX/Guesthouse/pull/177#issuecomment-5647748980).

The concurrency/test review preserves explicit Sendable captures, structured deadline cancellation, deterministic event coordination, and existing regression assertions. The 11-second timer case intentionally proves the inner client's disabled timer cannot win; it is not a scheduling delay used to guess callback completion.

## Remaining acceptance

#12/#61 stay open. Next is service-owned initial volume selection/persistence and read-only loading through the existing state-store migration, then bounded native probe activation and wizard freshness/stale-result fencing. Missing/damaged prior state must not be treated as a fresh install or permission to adopt a replacement volume. Lume remains a candidate and no signed/hardware/complete-path gate is established here.

The owner alone merges after exact-head green Cloud, matching completed Codex review, the original-message bot thumbs-up, explained/resolved findings and settled main composition. [Issue #48](https://github.com/PicoMLX/Guesthouse/issues/48) is the live queue.
